### PR TITLE
Troubleshoot memory in molpro better

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -627,8 +627,11 @@ $end
                     if 'molpro calculation terminated' in line.lower()\
                             or 'variable memory released' in line.lower():
                         return 'done'
-                    if 'No convergence' in line:
+                    elif 'No convergence' in line:
                         return 'unconverged'
+                    elif 'A further' in line and 'Mwords of memory are needed' in line and 'Increase memory to' in line:
+                        # e.g.: `A further 246.03 Mwords of memory are needed for the triples to run. Increase memory to 996.31 Mwords.`
+                        return 'errored: memory {0}'.format(line.split()[-2])
                 for line in lines[::-1]:
                     if 'the problem occurs' in line:
                         return 'errored: ' + line
@@ -652,7 +655,7 @@ $end
                         self.server_nodes.append(node)
                         break
                 else:
-                    logging.error('Cold not find an available node on the server')
+                    logging.error('Could not find an available node on the server')
                     # TODO: continue troubleshooting; if all else fails, put job to sleep for x min and try again searching for a node
                     return
                 # modify submit file

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -7,6 +7,7 @@ import time
 import os
 import datetime
 import numpy as np
+import math
 
 import cclib
 
@@ -967,10 +968,10 @@ class Scheduler(object):
             else:
                 logging.error('Could not troubleshoot geometry optimization for {label}! Tried'
                               ' troubleshooting with the following methods: {methods}'.format(
-                    label=label, methods=job.ess_trsh_methods))
+                               label=label, methods=job.ess_trsh_methods))
                 raise SchedulerError('Could not troubleshoot geometry optimization for {label}! Tried'
                                      ' troubleshooting with the following methods: {methods}'.format(
-                    label=label, methods=job.ess_trsh_methods))
+                                      label=label, methods=job.ess_trsh_methods))
         elif job.software == 'qchem':
             if 'max opt cycles reached' in job.job_status[1] and 'max_cycles' not in job.ess_trsh_methods:
                 # this is a common error, increase max cycles and continue running from last geometry
@@ -1029,7 +1030,21 @@ class Scheduler(object):
                                      ' troubleshooting with the following methods: {methods}'.format(
                     label=label, methods=job.ess_trsh_methods))
         elif 'molpro' in job.software:
-            if 'shift' not in job.ess_trsh_methods:
+            if 'memory' in job.job_status[1]:
+                # Increase memory allocation.
+                # job.job_status[1] will be for example `'errored: memory 996.31'`. The number is in Mwords
+                logging.info('Troubleshooting {type} job in {software} using memory'.format(
+                    type=job_type, software=job.software))
+                job.ess_trsh_methods.append('memory')
+                memory = 5000
+                if len(job.job_status[1].split()) == 3:
+                    memory = float(job.job_status[1].split()[-1])  # parse Molpro's requirement
+                    memory = int(math.ceil(memory / 100.0)) * 100  # round up to the next hundred
+                    memory += 250
+                self.run_job(label=label, xyz=xyz, level_of_theory=job.level_of_theory, software=job.software,
+                             job_type=job_type, fine=job.fine, shift=job.shift, memory=memory,
+                             ess_trsh_methods=job.ess_trsh_methods, conformer=conformer)
+            elif 'shift' not in job.ess_trsh_methods:
                 # try adding a level shift for alpha- and beta-spin orbitals
                 logging.info('Troubleshooting {type} job in {software} using shift'.format(
                     type=job_type, software=job.software))


### PR DESCRIPTION
Parsing the required memory from an output file that ends with:
```

 SCS-DF-MP2 energies (F_SING= 1.20000  F_TRIP= 0.62222  F_PARALLEL= 0.33333):
 ============================================================================
 SCS-DF-MP2                            -1.511923349079   -349.457644602169
 SCS-DF-MP2-F12/3*C(DX,FIX)            -1.646031120764   -349.591752373854
 SCS-DF-MP2-F12/3*C(FIX)               -1.643140654279   -349.588861907369
 SCS-DF-MP2-F12/3C(FIX)                -1.643759977583   -349.589481230673
 Symmetry transformation completed.

 Number of N-1 electron functions:              24
 Number of N-2 electron functions:             300
 Number of singly external CSFs:             15840
 Number of doubly external CSFs:         125460720
 Total number of CSFs:                   125476561

 Length of J-op  integral file:              16.73 GB
 Length of K-op  integral file:              19.05 GB
 Length of 3-ext integral record:             0.00 MB

 A further 246.03 Mwords of memory are needed for the triples to run. Increase memory to 996.31 Mwords.
```