### PR TITLE
Thermo Calculations for Hydrogen Bonded Conformers

### DIFF
--- a/arc/parser.py
+++ b/arc/parser.py
@@ -70,3 +70,52 @@ def parse_e0(path):
     except Exception:
         e0 = None
     return e0
+
+def parse_lines(path,start,stop=None,time=1):
+    """
+    Return the list of lines from the time-th occurance of start
+    to the next occurance of stop
+    """
+    if not os.path.isfile(path):
+        raise InputError('Could not find file {0}'.format(path))
+    f = open(path)
+    line = f.readline()
+    lines = []
+    boo = False
+    c = 1
+    while line != '':
+        if start in line:
+            if time == c:
+                boo = True
+                line = f.readline()
+                continue
+            else:
+                c += 1
+
+        if boo and stop in line:
+            break
+        if boo:
+            lines.append(line)
+        line = f.readline()
+    return lines
+
+def parse_scan_coords(path,point_index,software):
+    """
+    Parse the coordinates of the point_index-th point
+    in a rotor scan
+    """
+    if software == 'gaussian':
+        start = 'Optimization completed'
+        stop = 'Distance matrix (angstroms):'
+        lines = parse_lines(path,start,stop=stop,time=point_index+1)
+        atoms = int(lines[-2].split()[0])
+        lines = lines[-atoms-1:-1]
+        coords = []
+        for line in lines:
+            vals = line.split()
+            coords.append([float(x) for x in vals[3:]])
+        coords = np.array(coords)
+        return coords
+    else:
+        raise ValueError('parse_scan_coords() can currently only parse gaussian files,'
+                         ' got {0}'.format(software))

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -120,6 +120,9 @@ class Processor(object):
             rotors = '\n\nrotors = ['
             rotors_description = '1D rotors:\n'
             for i in range(species.number_of_rotors):
+                if 'HBonded' in species.rotors_dict[i].keys() and species.rotors_dict[i]['HBonded']: #skip H-bonded rotors
+                    logging.info("skipping H-bonded rotor of species {0} between pivots {1}".format(species.label,species.rotors_dict[i]['pivots']))
+                    continue
                 pivots = str(species.rotors_dict[i]['pivots'])
                 scan = str(species.rotors_dict[i]['scan'])
                 if species.rotors_dict[i]['success']:

--- a/arc/species.py
+++ b/arc/species.py
@@ -538,9 +538,16 @@ class ARCSpecies(object):
                 mol_list = self.mol_list
             for mol in mol_list:
                 if get_Hbonds(mol): #We need the rotor scans of the H-bonded molecule later for determining when the H-bond breaks
-                    mol = mol.copy(deep=True)
-                    mol.remove_H_bonds()
-                rotors = find_internal_rotors(mol)
+                    mol2 = mol.copy(deep=True)
+                    mol2.remove_H_bonds()
+                    rotors_H = find_internal_rotors(mol)
+                    rotors = find_internal_rotors(mol2)
+                    for rot in rotors:
+                        for rotH in rotors_H:
+                            if rot['pivots'] == rotH['pivots']:
+                                rot['HBonded'] = True
+                else:
+                    rotors = find_internal_rotors(mol)
                 for new_rotor in rotors:
                     for existing_rotor in self.rotors_dict.values():
                         if existing_rotor['pivots'] == new_rotor['pivots']:

--- a/arc/species.py
+++ b/arc/species.py
@@ -508,11 +508,19 @@ class ARCSpecies(object):
             rd_xyzs, rd_energies = _get_possible_conformers_rdkit(mol)
             if rd_xyzs:
                 rd_xyz = get_min_energy_conformer(xyzs=rd_xyzs, energies=rd_energies,hbonds=hbonds)
-                self.xyzs.append(get_xyz_string(xyz=rd_xyz, mol=mol))
+                if rd_xyz:
+                    self.xyzs.append(get_xyz_string(xyz=rd_xyz, mol=mol))
+                else:
+                    logging.warn("did not find a hydrogen bonded conformer for {} from RDKit search".format(self.label))
         if opnbbl:
             ob_xyzs, ob_energies = _get_possible_conformers_openbabel(mol)
             ob_xyz = get_min_energy_conformer(xyzs=ob_xyzs, energies=ob_energies,hbonds=hbonds)
-            self.xyzs.append(get_xyz_string(xyz=ob_xyz, mol=mol))
+            if ob_xyz:
+                self.xyzs.append(get_xyz_string(xyz=ob_xyz, mol=mol))
+            else:
+                logging.warn("did not find a hydrogen bonded conformer for {} from OpenBabel search".format(self.label))
+        if self.xyzs == []:
+            raise ValueError("Did not find any hydrogen bonded conformers corresponding to {}".format(self.label))
         logging.debug('Considering {actual} conformers for {label} out of {total} total ran using a force field'.format(
             actual=len(self.xyzs), total=len(rd_xyzs+ob_xyzs), label=self.label))
 

--- a/arc/species.py
+++ b/arc/species.py
@@ -529,6 +529,9 @@ class ARCSpecies(object):
             else:
                 mol_list = self.mol_list
             for mol in mol_list:
+                if get_Hbonds(mol): #We need the rotor scans of the H-bonded molecule later for determining when the H-bond breaks
+                    mol = mol.copy(deep=True)
+                    mol.remove_H_bonds()
                 rotors = find_internal_rotors(mol)
                 for new_rotor in rotors:
                     for existing_rotor in self.rotors_dict.values():

--- a/arc/species.py
+++ b/arc/species.py
@@ -1423,3 +1423,25 @@ def check_xyz(xyz):
     """
     if xyz is not None:
         return os.linesep.join(line for line in xyz.splitlines() if (line and any([char != ' ' for char in line])))
+
+def get_Hbonds(mol):
+    """
+    returns a list of 2-tuples of 0-indexed indices for the atoms involved in each
+    hydrogen bond in the molecule
+    """
+    hbonds = []
+    for bd in mol.getAllEdges():
+        if bd.isHydrogenBond():
+            hbonds.append((mol.atoms.index(bd.atom1),mol.atoms.index(bd.atom2)))
+    return hbonds
+
+def is_Hbonded(xyz,hbonds,hbthresh=2.31):
+    """
+    Returns True if for the given xyz coordinates with the hydrogen bonds in the list of 2-tuples hbonds
+    the hydrogen bonds are all shorter than hbthresh (Angstorms)
+    """
+    for hb in hbonds:
+        if np.linalg.norm(xyz[hb[0],:]-xyz[hb[1],:]) > hbthresh:
+            return False
+
+    return True

--- a/arc/species.py
+++ b/arc/species.py
@@ -1100,7 +1100,9 @@ def _get_possible_conformers_openbabel(mol):
     return xyzs, energies
 
 
-def get_min_energy_conformer(xyzs, energies, hbonds=[]):
+def get_min_energy_conformer(xyzs, energies, hbonds=None):
+    if hbonds is None:
+        hbonds = []
     conformer_valid = False
     while not conformer_valid:
         conformer_valid = True


### PR DESCRIPTION
This PR enables ARC to calculate thermo for RMG molecules with hydrogen bonds.  In order to do this it finds the lowest energy conformer and the lowest energy hydrogen bonded conformer and calculates them both with all rotors.  The hydrogen bonded conformer is then calculated without any rotors that break a hydrogen bond and the rotors that break the hydrogen bond are used to estimate the barrier to breaking the hydrogen bond which is used to calculate a characteristic temperature for the hydrogen bonding.  The hydrogen bonded conformer thermo and the lowest energy conformer with all rotor's thermo is then fused using thermodynamic properties of the hydrogen bonded conformer below Tchar and the other above Tchar.  

This should be functional right now, but not final (tests will be added after this is finalized), but I thought I'd put it up for programmatic and technical discussion now.  