### PR TITLE
Consistent atom order throughout 2D and 3D representations of a species

### DIFF
--- a/arc/__init__.py
+++ b/arc/__init__.py
@@ -9,6 +9,6 @@ import plotter
 import processor
 import scheduler
 import settings
-import species
 
+import species
 import job

--- a/arc/__init__.py
+++ b/arc/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import exceptions
+import arc_exceptions
 import main
 from main import ARC
 import parser

--- a/arc/arc_exceptions.py
+++ b/arc/arc_exceptions.py
@@ -5,11 +5,13 @@
 This module contains classes which extend Exception for usage in the RMG module
 """
 
+
 class InputError(Exception):
     """
     An exception raised when parsing an input file for any module
     """
     pass
+
 
 class OutputError(Exception):
     """
@@ -17,11 +19,13 @@ class OutputError(Exception):
     """
     pass
 
+
 class SettingsError(Exception):
     """
     An exception raised when dealing with settings
     """
     pass
+
 
 class SpeciesError(Exception):
     """
@@ -29,11 +33,13 @@ class SpeciesError(Exception):
     """
     pass
 
+
 class TSError(Exception):
     """
     An exception class for exceptional behavior that occurs while working with transition states
     """
     pass
+
 
 class ReactionError(Exception):
     """
@@ -41,11 +47,13 @@ class ReactionError(Exception):
     """
     pass
 
+
 class RotorError(Exception):
     """
     An exception class for exceptional behavior that occurs while working with rotors
     """
     pass
+
 
 class SchedulerError(Exception):
     """
@@ -53,14 +61,23 @@ class SchedulerError(Exception):
     """
     pass
 
+
 class JobError(Exception):
     """
     An exception class for exceptional behavior that occurs while working with jobs
     """
     pass
 
+
 class ServerError(Exception):
     """
     An exception class for exceptional behavior that occurs while working with servers
+    """
+    pass
+
+
+class SanitizationError(Exception):
+    """
+    Exception class to handle errors during SMILES perception.
     """
     pass

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -12,7 +12,7 @@ from arc.settings import arc_path, servers, submit_filename, delete_command,\
 from arc.job.submit import submit_scripts
 from arc.job.inputs import input_files
 from arc.job.ssh import SSH_Client
-from arc.exceptions import JobError, SpeciesError
+from arc.arc_exceptions import JobError, SpeciesError
 
 ##################################################################
 

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -9,7 +9,7 @@ import time
 import paramiko
 
 from arc.settings import servers, check_status_command, submit_command, submit_filename, delete_command
-from arc.exceptions import InputError, ServerError
+from arc.arc_exceptions import InputError, ServerError
 
 ##################################################################
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -24,7 +24,7 @@ import arc.rmgdb as rmgdb
 from arc.settings import arc_path, default_levels_of_theory, check_status_command, servers, valid_chars
 from arc.scheduler import Scheduler, time_lapse
 from arc.exceptions import InputError, SettingsError, SpeciesError
-from arc.species import ARCSpecies
+from arc.species.species import ARCSpecies
 from arc.reaction import ARCReaction
 from arc.processor import Processor
 from arc.job.ssh import SSH_Client

--- a/arc/main.py
+++ b/arc/main.py
@@ -23,7 +23,7 @@ from rmgpy.reaction import Reaction
 import arc.rmgdb as rmgdb
 from arc.settings import arc_path, default_levels_of_theory, check_status_command, servers, valid_chars
 from arc.scheduler import Scheduler, time_lapse
-from arc.exceptions import InputError, SettingsError, SpeciesError
+from arc.arc_exceptions import InputError, SettingsError, SpeciesError
 from arc.species.species import ARCSpecies
 from arc.reaction import ARCReaction
 from arc.processor import Processor

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -38,7 +38,7 @@ class TestARC(unittest.TestCase):
         restart_dict = arc0.as_dict()
         expected_dict = {'composite_method': '',
                          'conformer_level': 'b97-d3/6-311+g(d,p)',
-                         'ts_guess_level': 'b3lyp/6-311+g(d,p)',
+                         'ts_guess_level': 'b3lyp/6-31+g(d,p)',
                          'ess_settings': {'ssh': True},
                          'fine': True,
                          'opt_level': 'wb97xd/6-311++g(d,p)',

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -18,7 +18,7 @@ from rmgpy.molecule.molecule import Molecule
 from arc.main import ARC
 from arc.species.species import ARCSpecies
 from arc.settings import arc_path
-from arc.exceptions import InputError
+from arc.arc_exceptions import InputError
 
 ################################################################################
 

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -16,7 +16,7 @@ from rmgpy.species import Species
 from rmgpy.molecule.molecule import Molecule
 
 from arc.main import ARC
-from arc.species import ARCSpecies
+from arc.species.species import ARCSpecies
 from arc.settings import arc_path
 from arc.exceptions import InputError
 

--- a/arc/parser.py
+++ b/arc/parser.py
@@ -9,7 +9,7 @@ import os
 from rmgpy.molecule.element import getElement
 from arkane.statmech import Log
 
-from arc.exceptions import InputError
+from arc.arc_exceptions import InputError
 
 """
 Various ESS parsing tools

--- a/arc/parser.py
+++ b/arc/parser.py
@@ -6,9 +6,9 @@ import logging
 import numpy as np
 import os
 
-from rmgpy.molecule.element import getElement
 from arkane.statmech import Log
 
+from arc.species.converter import get_xyz_string
 from arc.arc_exceptions import InputError
 
 """
@@ -71,82 +71,6 @@ def parse_e0(path):
     except Exception:
         e0 = None
     return e0
-
-
-def get_xyz_string(xyz, mol=None, number=None, symbol=None):
-    """
-    Convert list of lists xyz form:
-    [[0.6616514836, 0.4027481525, -0.4847382281],
-    [-0.6039793084, 0.6637270105, 0.0671637135],
-    [-1.4226865648, -0.4973210697, -0.2238712255],
-    [-0.4993010635, 0.6531020442, 1.0853092315],
-    [-2.2115796924, -0.4529256762, 0.4144516252],
-    [-1.8113671395, -0.3268900681, -1.1468957003]]
-    into a geometry form read by ESS:
-    C    0.6616514836    0.4027481525   -0.4847382281
-    N   -0.6039793084    0.6637270105    0.0671637135
-    H   -1.4226865648   -0.4973210697   -0.2238712255
-    H   -0.4993010635    0.6531020442    1.0853092315
-    H   -2.2115796924   -0.4529256762    0.4144516252
-    H   -1.8113671395   -0.3268900681   -1.1468957003
-    The atom symbol is derived from either an RMG Molecule object (`mol`) or atom numbers ('number`)
-    or explicitly given (`symbol`).
-    `number` and `symbol` are lists (optional parameters)
-    `xyz` is an array of arrays, as shown in the example above.
-    This function isn't defined as a method of ARCSpecies since it is also used when parsing opt geometry in Scheduler
-    """
-    result = ''
-    if symbol is not None:
-        elements = symbol
-    elif number is not None:
-        elements = []
-        for num in number:
-            elements.append(getElement(int(num)).symbol)
-    elif mol is not None:
-        elements = []
-        for atom in mol.atoms:
-            elements.append(atom.element.symbol)
-    else:
-        raise ValueError("Must have either an RMG:Molecule object input as `mol`, or atomic numbers \ symbols.")
-    for i, coord in enumerate(xyz):
-        result += elements[i] + ' ' * (4 - len(elements[i]))
-        for c in coord:
-            result += '{0:14.8f}'.format(c)
-        result += '\n'
-    return result
-
-
-def get_xyz_matrix(xyz):
-    """
-    Convert a string xyz form:
-    C    0.6616514836    0.4027481525   -0.4847382281
-    N   -0.6039793084    0.6637270105    0.0671637135
-    H   -1.4226865648   -0.4973210697   -0.2238712255
-    H   -0.4993010635    0.6531020442    1.0853092315
-    H   -2.2115796924   -0.4529256762    0.4144516252
-    H   -1.8113671395   -0.3268900681   -1.1468957003
-    into a list of lists xyz form:
-    [[0.6616514836, 0.4027481525, -0.4847382281],
-    [-0.6039793084, 0.6637270105, 0.0671637135],
-    [-1.4226865648, -0.4973210697, -0.2238712255],
-    [-0.4993010635, 0.6531020442, 1.0853092315],
-    [-2.2115796924, -0.4529256762, 0.4144516252],
-    [-1.8113671395, -0.3268900681, -1.1468957003]]
-
-    Returns xyz as well as atoms, x, y, z seperately
-    """
-    x, y, z, atoms = [], [], [], []
-    for line in xyz.split('\n'):
-        if line:
-            atom, xx, yy, zz = line.split()
-            x.append(float(xx))
-            y.append(float(yy))
-            z.append(float(zz))
-            atoms.append(atom)
-    xyz = []
-    for i, _ in enumerate(x):
-        xyz.append([x[i], y[i], z[i]])
-    return xyz, atoms, x, y, z
 
 
 def parse_xyz_from_file(path):

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -25,8 +25,8 @@ from rmgpy.data.base import Entry
 from rmgpy.quantity import ScalarQuantity
 from rmgpy.species import Species
 
-from arc.parser import get_xyz_matrix
 from arc.species.species import ARCSpecies
+from arc.species.converter import get_xyz_matrix, rdkit_conf_from_mol, molecules_from_xyz
 from arc.arc_exceptions import InputError
 
 

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -26,8 +26,8 @@ from rmgpy.quantity import ScalarQuantity
 from rmgpy.species import Species
 
 from arc.parser import get_xyz_matrix
-from arc.exceptions import InputError
 from arc.species.species import ARCSpecies
+from arc.arc_exceptions import InputError
 
 
 ##################################################################

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -18,7 +18,6 @@ from ase.visualize import view
 from ase import Atom, Atoms
 from ase.io import write as ase_write
 
-from rmgpy.exceptions import AtomTypeError
 from rmgpy.data.thermo import ThermoLibrary
 from rmgpy.data.kinetics.library import KineticsLibrary
 from rmgpy.data.base import Entry
@@ -65,10 +64,9 @@ def show_sticks(xyz=None, species=None, project_directory=None):
     If successful, save an image using draw_3d
     """
     xyz = check_xyz_species_for_drawing(xyz, species)
-    try:
-        mol, coordinates = mol_from_xyz(xyz)
-    except AtomTypeError:
-        return False
+    coordinates, _, _, _, _ = get_xyz_matrix(xyz)
+    s_mol, b_mol = molecules_from_xyz(xyz)
+    mol = b_mol if b_mol is not None else s_mol
     try:
         _, rd_mol, _ = rdkit_conf_from_mol(mol, coordinates)
     except ValueError:

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -25,9 +25,9 @@ from rmgpy.data.base import Entry
 from rmgpy.quantity import ScalarQuantity
 from rmgpy.species import Species
 
-from arc.species import ARCSpecies, mol_from_xyz, rdkit_conf_from_mol
 from arc.parser import get_xyz_matrix
 from arc.exceptions import InputError
+from arc.species.species import ARCSpecies
 
 
 ##################################################################

--- a/arc/plotterTest.py
+++ b/arc/plotterTest.py
@@ -12,7 +12,7 @@ import shutil
 
 from arc.settings import arc_path
 from arc import plotter
-from arc.species import ARCSpecies
+from arc.species.species import ARCSpecies
 
 ################################################################################
 

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -18,7 +18,7 @@ import arc.rmgdb as rmgdb
 from arc.job.inputs import input_files
 from arc import plotter
 from arc.exceptions import SchedulerError, RotorError
-from arc.species import determine_rotor_symmetry, determine_rotor_type
+from arc.species.species import determine_rotor_symmetry, determine_rotor_type
 
 ##################################################################
 

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -17,7 +17,7 @@ from rmgpy.species import Species
 import arc.rmgdb as rmgdb
 from arc.job.inputs import input_files
 from arc import plotter
-from arc.exceptions import SchedulerError, RotorError
+from arc.arc_exceptions import SchedulerError, RotorError
 from arc.species.species import determine_rotor_symmetry, determine_rotor_type
 
 ##################################################################

--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -8,8 +8,8 @@ from rmgpy.species import Species
 from rmgpy.reaction import Reaction
 
 import arc.rmgdb as rmgdb
-from arc.exceptions import ReactionError, InputError
 from arc.species.species import ARCSpecies
+from arc.arc_exceptions import ReactionError, InputError
 from arc.settings import default_ts_methods
 
 ##################################################################

--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -8,8 +8,8 @@ from rmgpy.species import Species
 from rmgpy.reaction import Reaction
 
 import arc.rmgdb as rmgdb
-from arc.species import ARCSpecies
 from arc.exceptions import ReactionError, InputError
+from arc.species.species import ARCSpecies
 from arc.settings import default_ts_methods
 
 ##################################################################

--- a/arc/rmgdb.py
+++ b/arc/rmgdb.py
@@ -10,7 +10,7 @@ from rmgpy.data.rmg import RMGDatabase
 from rmgpy.reaction import isomorphic_species_lists
 from rmgpy.data.kinetics.common import find_degenerate_reactions
 
-from arc.exceptions import InputError
+from arc.arc_exceptions import InputError
 
 ##################################################################
 

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -25,7 +25,7 @@ from rmgpy.reaction import Reaction
 import arc.rmgdb as rmgdb
 from arc import plotter
 from arc import parser
-from arc.parser import get_xyz_string
+from arc.species.converter import get_xyz_string
 from arc.job.job import Job
 from arc.arc_exceptions import SpeciesError, SchedulerError
 from arc.job.ssh import SSH_Client

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -27,7 +27,7 @@ from arc import plotter
 from arc import parser
 from arc.parser import get_xyz_string
 from arc.job.job import Job
-from arc.exceptions import SpeciesError, SchedulerError
+from arc.arc_exceptions import SpeciesError, SchedulerError
 from arc.job.ssh import SSH_Client
 from arc.species.species import ARCSpecies, TSGuess, determine_rotor_symmetry
 from arc.ts.atst import autotst

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -26,11 +26,10 @@ import arc.rmgdb as rmgdb
 from arc import plotter
 from arc import parser
 from arc.parser import get_xyz_string
-from arc.species import determine_rotor_symmetry
 from arc.job.job import Job
 from arc.exceptions import SpeciesError, SchedulerError
 from arc.job.ssh import SSH_Client
-from arc.species import ARCSpecies, TSGuess
+from arc.species.species import ARCSpecies, TSGuess, determine_rotor_symmetry
 from arc.ts.atst import autotst
 from arc.settings import rotor_scan_resolution, inconsistency_ab, inconsistency_az, maximum_barrier
 

--- a/arc/schedulerTest.py
+++ b/arc/schedulerTest.py
@@ -12,7 +12,7 @@ import os
 import arc.rmgdb as rmgdb
 from arc.scheduler import Scheduler
 from arc.job.job import Job
-from arc.species import ARCSpecies
+from arc.species.species import ARCSpecies
 import arc.parser as parser
 from arc.settings import arc_path, default_levels_of_theory
 

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -70,14 +70,12 @@ output_filename = {'gaussian': 'input.log',
 }
 
 default_levels_of_theory = {'conformer': 'b97-d3/6-311+g(d,p)',
-                            'ts_guesses': 'b3lyp/6-311+g(d,p)',
+                            'ts_guesses': 'b3lyp/6-31+g(d,p)',  # used for IRC as well
                             'opt': 'wb97xd/6-311++g(d,p)',
                             'freq': 'wb97xd/6-311++g(d,p)',
                             'sp': 'ccsd(t)-f12/cc-pvtz-f12',  # This should be a level for which BAC is available
                             # 'sp': 'b3lyp/6-311+g(3df,2p)',
                             'scan': 'b3lyp/6-311+g(d,p)',
-                            'irc': 'b3lyp/6-31+g(d)',
-                            'gsm': 'b3lyp/6-31+g(d)',
                             'scan_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
                             'freq_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
 }

--- a/arc/species/__init__.py
+++ b/arc/species/__init__.py
@@ -3,3 +3,4 @@
 
 import species
 from species import ARCSpecies
+import xyz_to_2d

--- a/arc/species/__init__.py
+++ b/arc/species/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import species
+from species import ARCSpecies

--- a/arc/species/__init__.py
+++ b/arc/species/__init__.py
@@ -3,4 +3,5 @@
 
 import species
 from species import ARCSpecies
+import converter
 import xyz_to_2d

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+import os
+
+from rdkit import Chem
+import pybel
+
+from rmgpy.molecule.molecule import Atom, Bond, Molecule
+from rmgpy.molecule.element import getElement
+from rmgpy.exceptions import AtomTypeError
+
+from arc.arc_exceptions import SpeciesError, SanitizationError
+from arc.species.xyz_to_2d import MolGraph
+
+##################################################################
+
+
+def get_xyz_string(xyz, mol=None, number=None, symbol=None):
+    """
+    Convert list of lists xyz form:
+    [[0.6616514836, 0.4027481525, -0.4847382281],
+    [-0.6039793084, 0.6637270105, 0.0671637135],
+    [-1.4226865648, -0.4973210697, -0.2238712255],
+    [-0.4993010635, 0.6531020442, 1.0853092315],
+    [-2.2115796924, -0.4529256762, 0.4144516252],
+    [-1.8113671395, -0.3268900681, -1.1468957003]]
+    into a geometry form read by ESS:
+    C    0.6616514836    0.4027481525   -0.4847382281
+    N   -0.6039793084    0.6637270105    0.0671637135
+    H   -1.4226865648   -0.4973210697   -0.2238712255
+    H   -0.4993010635    0.6531020442    1.0853092315
+    H   -2.2115796924   -0.4529256762    0.4144516252
+    H   -1.8113671395   -0.3268900681   -1.1468957003
+    The atom symbols are derived from either an RMG Molecule object (`mol`) or atom numbers ('number`)
+    or explicitly given (`symbol`).
+    `number` and `symbol` are lists (optional parameters)
+    `xyz` is an array of arrays, as shown in the example above.
+    This function isn't defined as a method of ARCSpecies since it is also used when parsing opt geometry in Scheduler
+    """
+    result = ''
+    if symbol is not None:
+        elements = symbol
+    elif number is not None:
+        elements = []
+        for num in number:
+            elements.append(getElement(int(num)).symbol)
+    elif mol is not None:
+        elements = []
+        for atom in mol.atoms:
+            elements.append(atom.element.symbol)
+    else:
+        raise ValueError("Must have either an RMG:Molecule object input as `mol`, or atomic numbers \ symbols.")
+    for i, coord in enumerate(xyz):
+        result += elements[i] + ' ' * (4 - len(elements[i]))
+        for c in coord:
+            result += '{0:14.8f}'.format(c)
+        result += '\n'
+    return result
+
+
+def get_xyz_matrix(xyz):
+    """
+    Convert a string xyz form:
+    C    0.6616514836    0.4027481525   -0.4847382281
+    N   -0.6039793084    0.6637270105    0.0671637135
+    H   -1.4226865648   -0.4973210697   -0.2238712255
+    H   -0.4993010635    0.6531020442    1.0853092315
+    H   -2.2115796924   -0.4529256762    0.4144516252
+    H   -1.8113671395   -0.3268900681   -1.1468957003
+    into a list of lists xyz form:
+    [[0.6616514836, 0.4027481525, -0.4847382281],
+    [-0.6039793084, 0.6637270105, 0.0671637135],
+    [-1.4226865648, -0.4973210697, -0.2238712255],
+    [-0.4993010635, 0.6531020442, 1.0853092315],
+    [-2.2115796924, -0.4529256762, 0.4144516252],
+    [-1.8113671395, -0.3268900681, -1.1468957003]]
+
+    Returns xyz as well as atom symbols, x, y, and z seperately
+    """
+    xyz = check_xyz(xyz)
+    x, y, z, symbols = [], [], [], []
+    for line in xyz.split('\n'):
+        if line:
+            atom, xx, yy, zz = line.split()
+            x.append(float(xx))
+            y.append(float(yy))
+            z.append(float(zz))
+            symbols.append(atom)
+    xyz = []
+    for i, _ in enumerate(x):
+        xyz.append([x[i], y[i], z[i]])
+    return xyz, symbols, x, y, z
+
+
+def xyz_string_to_xyz_file_format(xyz, comment=''):
+    """
+    Convert the ARC xyz string format into the XYZ file format: https://en.wikipedia.org/wiki/XYZ_file_format
+    """
+    xyz = check_xyz(xyz)
+    num = int(len(xyz.split()) / 4)
+    return str(num) + '\n' + comment + '\n' + xyz + '\n'
+
+
+def check_xyz(xyz):
+    """
+    A helper function to correct xyz string format input
+    Usually empty lines are added by the user either in the beginning or the end, and we'd like to remove them
+    """
+    return os.linesep.join(line for line in xyz.splitlines() if (line and any([char != ' ' for char in line])))
+
+
+def xyz_to_pybel_mol(xyz):
+    """
+    Convert xyz in string format into an Open Babel molecule object
+    """
+    if not isinstance(xyz, (str, unicode)):
+        raise SpeciesError('xyz must be a string format, got: {0}'.format(type(xyz)))
+    pybel_mol = pybel.readstring('xyz', xyz_string_to_xyz_file_format(xyz))
+    return pybel_mol
+
+
+def pybel_to_inchi(pybel_mol):
+    """
+    Convert an Open Babel molecule object to InChI
+    """
+    inchi = pybel_mol.write('inchi', opt={'F': None}).strip()  # Add fixed H layer
+    return inchi
+
+
+def rmg_mol_from_inchi(inchi):
+    """
+    Generate an RMG Molecule object from InChI
+    """
+    try:
+        rmg_mol = Molecule().fromInChI(str(inchi))
+    except AtomTypeError:
+        return None
+    return rmg_mol
+
+
+def elementize(atom):
+    """
+    Convert the atomType of an RMG:Atom object into its general parent element atomType (e.g., `S4d` into `S`)
+    `atom` is an RMG:Atom object
+    Written by Matt Johnson
+    """
+    atom_type = atom.atomType
+    atom_type = [at for at in atom_type.generic if at.label != 'R' and at.label != 'R!H' and not 'Val' in at.label]
+    if atom_type:
+        atom.atomType = atom_type[0]
+
+
+def molecules_from_xyz(xyz):
+    """
+    Creating RMG:Molecule objects from xyz with correct atom labeling
+    `xyz` is in a string format
+    returns `s_mol` (with only single bonds) and `b_mol` (with best guesses for bond orders)
+    This function is based on the MolGraph.perceive_smiles method
+    Returns None for b_mol is unsuccessful to infer bond orders
+    """
+    if not isinstance(xyz, (str, unicode)):
+        raise SpeciesError('xyz must be a string format, got: {0}'.format(type(xyz)))
+    xyz = check_xyz(xyz)
+    pybel_mol = xyz_to_pybel_mol(xyz)
+    coords, symbols, _, _, _ = get_xyz_matrix(xyz)
+    mol_graph = MolGraph(symbols=symbols, coords=coords)
+    mol_graph.infer_connections()
+    mol_s1 = mol_graph.to_rmg_mol()  # An RMG Molecule with single bonds, atom order corresponds to xyz
+    mol_s1_updated = update_molecule(mol_s1, to_single_bonds=True)
+    inchi = pybel_to_inchi(pybel_mol)
+    mol_bo = rmg_mol_from_inchi(inchi)  # An RMG Molecule with bond orders, but without preserved atom order
+    order_atoms(ref_mol=mol_s1_updated, mol=mol_bo)
+    s_mol, b_mol = mol_s1_updated, mol_bo
+    return s_mol, b_mol
+
+
+def order_atoms_in_mol_list(ref_mol, mol_list):
+    """Order the atoms in all molecules of mol_list by the atom order in ref_mol"""
+    for mol in mol_list:
+        order_atoms(ref_mol, mol)
+
+
+def order_atoms(ref_mol, mol):
+    """Order the atoms in `mol` by the atom order in ref_mol"""
+    if mol is not None:
+        ref_mol_is_iso_copy = ref_mol.copy(deep=True)
+        mol_is_iso_copy = mol.copy(deep=True)
+        ref_mol_find_iso_copy = ref_mol.copy(deep=True)
+        mol_find_iso_copy = mol.copy(deep=True)
+
+        ref_mol_is_iso_copy = update_molecule(ref_mol_is_iso_copy, to_single_bonds=True)
+        mol_is_iso_copy = update_molecule(mol_is_iso_copy, to_single_bonds=True)
+        ref_mol_find_iso_copy = update_molecule(ref_mol_find_iso_copy, to_single_bonds=True)
+        mol_find_iso_copy = update_molecule(mol_find_iso_copy, to_single_bonds=True)
+
+        if mol_is_iso_copy.isIsomorphic(ref_mol_is_iso_copy, saveOrder=True):
+            mapping = mol_find_iso_copy.findIsomorphism(ref_mol_find_iso_copy, saveOrder=True)
+            if len(mapping):
+                if isinstance(mapping, list):
+                    mapping = mapping[0]
+                index_map = {ref_mol_find_iso_copy.atoms.index(val): mol_find_iso_copy.atoms.index(key)
+                             for key, val in mapping.items()}
+                mol.atoms = [mol.atoms[index_map[i]] for i, _ in enumerate(mol.atoms)]
+            else:
+                raise SanitizationError('Could not map molecules {0}, {1}:\n\n{2}\n\n{3}'.format(
+                    ref_mol.toSMILES(), mol.toSMILES(), ref_mol.toAdjacencyList(), mol.toAdjacencyList()))
+        else:
+            raise SanitizationError('Could not map non isomorphic molecules {0}, {1}:\n\n{2}\n\n{3}'.format(
+                ref_mol.toSMILES(), mol.toSMILES(), ref_mol.toAdjacencyList(), mol.toAdjacencyList()))
+
+
+def update_molecule(mol, to_single_bonds=False):
+    """
+    Returns a copy of the current molecule with updated atomTypes
+    if to_single_bonds is True, the returned mol contains only single bonds.
+    This is useful for isomorphism comparison
+    """
+    new_mol = Molecule()
+    atoms = mol.atoms
+    atom_mapping = dict()
+    for atom1 in atoms:
+        new_atom = new_mol.addAtom(Atom(atom1.element))
+        atom_mapping[atom1] = new_atom
+    for atom1 in atoms:
+        for atom2 in atom1.bonds.keys():
+            bond_order = 1.0 if to_single_bonds else atom1.bonds[atom2].getOrderNum()
+            bond = Bond(atom_mapping[atom1], atom_mapping[atom2], bond_order)
+            new_mol.addBond(bond)
+    new_mol.updateAtomTypes()
+    return new_mol
+
+
+# def s_bonds_mol_from_xyz(xyz):
+#     """DEPRECATED"""
+#     mol = Molecule()
+#     coordinates = list()
+#     if not isinstance(xyz, (str, unicode)):
+#         raise SpeciesError('xyz must be a string format, got: {0}'.format(type(xyz)))
+#     for line in xyz.split('\n'):
+#         if line:
+#             atom = Atom(element=str(line.split()[0]))
+#             coordinates.append([float(line.split()[1]), float(line.split()[2]), float(line.split()[3])])
+#             atom.coords = np.array(coordinates[-1], np.float64)
+#             mol.addAtom(atom)
+#     mol.connectTheDots()  # only adds single bonds, but we don't care
+#     return mol, coordinates
+
+
+def rdkit_conf_from_mol(mol, coordinates):
+    """A helper function generating an RDKit:Conformer object from an RMG:Molecule object"""
+    rd_mol, rd_inds = mol.toRDKitMol(removeHs=False, returnMapping=True)
+    Chem.AllChem.EmbedMolecule(rd_mol)  # unfortunately, this mandatory embedding changes the coordinates
+    indx_map = dict()
+    for xyz_index, atom in enumerate(mol.atoms):  # generate an atom index mapping dictionary
+        rd_index = rd_inds[atom]
+        indx_map[xyz_index] = rd_index
+    conf = rd_mol.GetConformer(id=0)
+    for i in range(rd_mol.GetNumAtoms()):  # reset atom coordinates
+        conf.SetAtomPosition(indx_map[i], coordinates[i])
+    return conf, rd_mol, indx_map

--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This module contains unit tests of the arc.species.converter module
+"""
+
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+import unittest
+
+from rmgpy.molecule.molecule import Molecule
+
+import arc.species.converter as converter
+from arc.species.species import ARCSpecies
+
+################################################################################
+
+
+class TestConverter(unittest.TestCase):
+    """
+    Contains unit tests for the converter module
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.maxDiff = None
+        cls.xyz1 = """C       0.00000000    0.00000000    0.00000000
+H       0.63003260    0.63003260    0.63003260
+H      -0.63003260   -0.63003260    0.63003260
+H      -0.63003260    0.63003260   -0.63003260
+H       0.63003260   -0.63003260   -0.63003260"""
+
+        cls.xyz2 = """O       1.17464110   -0.15309781    0.00000000
+N       0.06304988    0.35149648    0.00000000
+C      -1.12708952   -0.11333971    0.00000000
+H      -1.93800144    0.60171738    0.00000000
+H      -1.29769464   -1.18742971    0.00000000"""
+
+        cls.xyz3 = """S       1.02558264   -0.04344404   -0.07343859
+O      -0.25448248    1.10710477    0.18359696
+N      -1.30762173    0.15796567   -0.10489290
+C      -0.49011438   -1.03704380    0.15365747
+H      -0.64869950   -1.85796321   -0.54773423
+H      -0.60359153   -1.37304859    1.18613964
+H      -1.43009127    0.23517346   -1.11797908
+"""
+
+        cls.xyz4 = """S      -0.06618943   -0.12360663   -0.07631983
+O      -0.79539707    0.86755487    1.02675668
+O      -0.68919931    0.25421823   -1.34830853
+N       0.01546439   -1.54297548    0.44580391
+C       1.59721519    0.47861334    0.00711000
+H       1.94428095    0.40772394    1.03719428
+H       2.20318015   -0.14715186   -0.64755729
+H       1.59252246    1.51178950   -0.33908352
+H      -0.87856890   -2.02453514    0.38494433
+H      -1.34135876    1.49608206    0.53295071"""
+
+        cls.xyz5 = """O       2.64631000   -0.59546000    0.29327900
+O       2.64275300    2.05718500   -0.72942300
+C       1.71639100    1.97990400    0.33793200
+C      -3.48200000    1.50082200    0.03091100
+C      -3.85550400   -1.05695100   -0.03598300
+C       3.23017500   -1.88003900    0.34527100
+C      -2.91846400    0.11144600    0.02829400
+C       0.76935400    0.80820200    0.23396500
+C      -1.51123800   -0.09830700    0.09199100
+C       1.28495500   -0.50051800    0.22531700
+C      -0.59550400    0.98573400    0.16444900
+C      -0.94480400   -1.39242500    0.08331900
+C       0.42608700   -1.59172200    0.14650400
+H       2.24536500    1.93452800    1.29979800
+H       1.14735500    2.91082400    0.31665700
+H      -3.24115200    2.03800800    0.95768700
+H      -3.08546100    2.10616100   -0.79369800
+H      -4.56858900    1.48636200   -0.06630800
+H      -4.89652000   -0.73067200   -0.04282300
+H      -3.69325500   -1.65970000   -0.93924100
+H      -3.72742500   -1.73294900    0.81894100
+H       3.02442400   -2.44854700   -0.56812500
+H       4.30341500   -1.72127600    0.43646000
+H       2.87318600   -2.44236600    1.21464900
+H      -0.97434200    2.00182800    0.16800300
+H      -1.58581300   -2.26344700    0.02264400
+H       0.81122400   -2.60336100    0.13267800
+H       3.16280800    1.25020800   -0.70346900
+"""
+
+        cls.xyz6 = """N      -1.1997440839    -0.1610052059     0.0274738287
+        H      -1.4016624407    -0.6229695533    -0.8487034080
+        H      -0.0000018759     1.2861082773     0.5926077870
+        N       0.0000008520     0.5651072858    -0.1124621525
+        H      -1.1294692206    -0.8709078271     0.7537518889
+        N       1.1997613019    -0.1609980472     0.0274604887
+        H       1.1294795781    -0.8708998550     0.7537444446
+        H       1.4015274689    -0.6230592706    -0.8487058662"""
+
+    def test_get_xyz_string(self):
+        """Test conversion of xyz array to string format"""
+        xyz_array = [[-0.06618943, -0.12360663, -0.07631983],
+                     [-0.79539707, 0.86755487, 1.02675668],
+                     [-0.68919931, 0.25421823, -1.34830853],
+                     [0.01546439, -1.54297548, 0.44580391],
+                     [1.59721519, 0.47861334, 0.00711],
+                     [1.94428095, 0.40772394, 1.03719428],
+                     [2.20318015, -0.14715186, -0.64755729],
+                     [1.59252246, 1.5117895, -0.33908352],
+                     [-0.8785689, -2.02453514, 0.38494433],
+                     [-1.34135876, 1.49608206, 0.53295071]]
+        symbols = ['S', 'O', 'O', 'N', 'C', 'H', 'H', 'H', 'H', 'H']
+        xyz_expected = """S      -0.06618943   -0.12360663   -0.07631983
+O      -0.79539707    0.86755487    1.02675668
+O      -0.68919931    0.25421823   -1.34830853
+N       0.01546439   -1.54297548    0.44580391
+C       1.59721519    0.47861334    0.00711000
+H       1.94428095    0.40772394    1.03719428
+H       2.20318015   -0.14715186   -0.64755729
+H       1.59252246    1.51178950   -0.33908352
+H      -0.87856890   -2.02453514    0.38494433
+H      -1.34135876    1.49608206    0.53295071
+"""
+        xyz1 = converter.get_xyz_string(xyz=xyz_array, symbol=symbols)
+        self.assertEqual(xyz1, xyz_expected)
+        number = [16, 8, 8, 7, 6, 1, 1, 1, 1, 1]
+        xyz2 = converter.get_xyz_string(xyz=xyz_array, number=number)
+        self.assertEqual(xyz2, xyz_expected)
+        mol = Molecule().fromAdjacencyList(str("""1  S u0 p0 c0 {2,D} {3,S} {4,D} {5,S}
+2  O u0 p2 c0 {1,D}
+3  O u0 p2 c0 {1,S} {6,S}
+4  N u0 p1 c0 {1,D} {7,S}
+5  C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}"""))
+        xyz3 = converter.get_xyz_string(xyz=xyz_array, mol=mol)
+        self.assertEqual(xyz3, xyz_expected)
+
+    def test_get_xyz_matrix(self):
+        """Test conversion of xyz string to array format"""
+        xyz, symbols, x, y, z = converter.get_xyz_matrix(self.xyz2)
+        self.assertEqual(xyz, [[1.1746411, -0.15309781, 0.0],
+                               [0.06304988, 0.35149648, 0.0],
+                               [-1.12708952, -0.11333971, 0.0],
+                               [-1.93800144, 0.60171738, 0.0],
+                               [-1.29769464, -1.18742971, 0.0]])
+        self.assertEqual(symbols, ['O', 'N', 'C', 'H', 'H'])
+        self.assertEqual(x, [1.1746411, 0.06304988, -1.12708952, -1.93800144, -1.29769464])
+        self.assertEqual(y, [-0.15309781, 0.35149648, -0.11333971, 0.60171738, -1.18742971])
+        self.assertEqual(z, [0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def test_xyz_string_to_xyz_file_format(self):
+        """Test generating the XYZ file format from xyz string format"""
+        xyzf = converter.xyz_string_to_xyz_file_format(xyz=self.xyz1, comment='test methane xyz conversion')
+        expected_xyzf = """5
+test methane xyz conversion
+C       0.00000000    0.00000000    0.00000000
+H       0.63003260    0.63003260    0.63003260
+H      -0.63003260   -0.63003260    0.63003260
+H      -0.63003260    0.63003260   -0.63003260
+H       0.63003260   -0.63003260   -0.63003260
+"""
+        self.assertEqual(xyzf, expected_xyzf)
+        xyzf = converter.xyz_string_to_xyz_file_format(xyz=self.xyz3, comment='test xyz3')
+        expected_xyzf = """7
+test xyz3
+S       1.02558264   -0.04344404   -0.07343859
+O      -0.25448248    1.10710477    0.18359696
+N      -1.30762173    0.15796567   -0.10489290
+C      -0.49011438   -1.03704380    0.15365747
+H      -0.64869950   -1.85796321   -0.54773423
+H      -0.60359153   -1.37304859    1.18613964
+H      -1.43009127    0.23517346   -1.11797908
+"""
+        self.assertEqual(xyzf, expected_xyzf)
+        xyzf = converter.xyz_string_to_xyz_file_format(xyz=self.xyz4, comment='test xyz4')
+        expected_xyzf = """10
+test xyz4
+S      -0.06618943   -0.12360663   -0.07631983
+O      -0.79539707    0.86755487    1.02675668
+O      -0.68919931    0.25421823   -1.34830853
+N       0.01546439   -1.54297548    0.44580391
+C       1.59721519    0.47861334    0.00711000
+H       1.94428095    0.40772394    1.03719428
+H       2.20318015   -0.14715186   -0.64755729
+H       1.59252246    1.51178950   -0.33908352
+H      -0.87856890   -2.02453514    0.38494433
+H      -1.34135876    1.49608206    0.53295071
+"""
+        self.assertEqual(xyzf, expected_xyzf)
+
+    def test_check_species_xyz(self):
+        """Test the check_xyz function"""
+        xyz = """
+        
+        
+ C                 -0.67567701    1.18507660    0.04672449
+ H                 -0.25592948    1.62415961    0.92757746
+ H                 -2.26870864    1.38030564    0.05865317
+ O                 -0.36671999   -0.21081064    0.01630374
+ H                 -0.73553821   -0.63718986    0.79332805
+ C                 -0.08400571    1.86907236   -1.19973252
+ 
+ H                 -0.50375517    1.42998100   -2.08057962
+ H                 -0.31518819    2.91354759   -1.17697025
+ H                  0.97802159    1.73893214   -1.20769117
+ O                 -3.69788377    1.55609096    0.07050345
+ O                 -4.28667752    0.37487691    0.04916102
+ H                 -4.01978712   -0.12970163    0.82103635
+ 
+ """
+        expected_xyz = """ C                 -0.67567701    1.18507660    0.04672449
+ H                 -0.25592948    1.62415961    0.92757746
+ H                 -2.26870864    1.38030564    0.05865317
+ O                 -0.36671999   -0.21081064    0.01630374
+ H                 -0.73553821   -0.63718986    0.79332805
+ C                 -0.08400571    1.86907236   -1.19973252
+ H                 -0.50375517    1.42998100   -2.08057962
+ H                 -0.31518819    2.91354759   -1.17697025
+ H                  0.97802159    1.73893214   -1.20769117
+ O                 -3.69788377    1.55609096    0.07050345
+ O                 -4.28667752    0.37487691    0.04916102
+ H                 -4.01978712   -0.12970163    0.82103635"""
+        new_xyz = converter.check_xyz(xyz)
+        self.assertEqual(new_xyz, expected_xyz)
+
+    def test_xyz_to_pybel_mol(self):
+        """Test xyz conversion into Open Babel"""
+        pbmol1 = converter.xyz_to_pybel_mol(self.xyz1)
+        pbmol2 = converter.xyz_to_pybel_mol(self.xyz2)
+        pbmol3 = converter.xyz_to_pybel_mol(self.xyz3)
+        pbmol4 = converter.xyz_to_pybel_mol(self.xyz4)
+
+        # These tests check that the atoms we expect appear in the correct order:
+
+        self.assertEqual(pbmol1.atoms[0].idx, 1)  # C
+        self.assertAlmostEqual(pbmol1.atoms[0].atomicmass, 12.0107, 2)
+        self.assertEqual(pbmol1.atoms[0].coords, (0.0, 0.0, 0.0))
+        self.assertAlmostEqual(pbmol1.atoms[1].atomicmass, 1.00794, 2)  # H
+        self.assertEqual(pbmol1.atoms[1].coords, (0.6300326, 0.6300326, 0.6300326))
+
+        self.assertAlmostEqual(pbmol2.atoms[0].atomicmass, 15.9994, 2)  # O
+        self.assertEqual(pbmol2.atoms[0].coords, (1.1746411, -0.15309781, 0.0))
+        self.assertAlmostEqual(pbmol2.atoms[1].atomicmass, 14.0067, 2)  # N
+        self.assertEqual(pbmol2.atoms[1].coords, (0.06304988, 0.35149648, 0.0))
+        self.assertAlmostEqual(pbmol2.atoms[2].atomicmass, 12.0107, 2)  # C
+        self.assertEqual(pbmol2.atoms[2].coords, (-1.12708952, -0.11333971, 0.0))
+        self.assertAlmostEqual(pbmol2.atoms[3].atomicmass, 1.00794, 2)  # H
+        self.assertEqual(pbmol2.atoms[3].coords, (-1.93800144, 0.60171738, 0.0))
+
+        self.assertAlmostEqual(pbmol3.atoms[0].atomicmass, 32.065, 2)  # S
+        self.assertEqual(pbmol3.atoms[0].coords, (1.02558264, -0.04344404, -0.07343859))
+        self.assertAlmostEqual(pbmol3.atoms[1].atomicmass, 15.9994, 2)  # O
+        self.assertEqual(pbmol3.atoms[1].coords, (-0.25448248, 1.10710477, 0.18359696))
+        self.assertAlmostEqual(pbmol3.atoms[2].atomicmass, 14.0067, 2)  # N
+        self.assertEqual(pbmol3.atoms[2].coords, (-1.30762173, 0.15796567, -0.1048929))
+        self.assertAlmostEqual(pbmol3.atoms[3].atomicmass, 12.0107, 2)  # C
+        self.assertEqual(pbmol3.atoms[3].coords, (-0.49011438, -1.0370438, 0.15365747))
+        self.assertAlmostEqual(pbmol3.atoms[-1].atomicmass, 1.00794, 2)  # H
+        self.assertEqual(pbmol3.atoms[-1].coords, (-1.43009127, 0.23517346, -1.11797908))
+
+        self.assertAlmostEqual(pbmol4.atoms[0].atomicmass, 32.065, 2)  # S
+        self.assertEqual(pbmol4.atoms[0].coords, (-0.06618943, -0.12360663, -0.07631983))
+        self.assertAlmostEqual(pbmol4.atoms[3].atomicmass, 14.0067, 2)  # N
+        self.assertEqual(pbmol4.atoms[3].coords, (0.01546439, -1.54297548, 0.44580391))
+
+    def test_pybel_to_inchi(self):
+        """Tests the conversion of Open Babel molecules to InChI"""
+        pbmol1 = converter.xyz_to_pybel_mol(self.xyz1)
+        pbmol2 = converter.xyz_to_pybel_mol(self.xyz2)
+        pbmol3 = converter.xyz_to_pybel_mol(self.xyz3)
+        pbmol4 = converter.xyz_to_pybel_mol(self.xyz4)
+
+        inchi1 = converter.pybel_to_inchi(pbmol1)
+        inchi2 = converter.pybel_to_inchi(pbmol2)
+        inchi3 = converter.pybel_to_inchi(pbmol3)
+        inchi4 = converter.pybel_to_inchi(pbmol4)
+
+        self.assertEqual(inchi1, 'InChI=1/CH4/h1H4')
+        self.assertEqual(inchi2, 'InChI=1/CH2NO/c1-2-3/h1H2')
+        self.assertEqual(inchi3, 'InChI=1/CH3NOS/c1-2-3-4-1/h2H,1H2')
+        self.assertEqual(inchi4, 'InChI=1/CH5NO2S/c1-5(2,3)4/h2-3H,1H3')
+
+    def test_rmg_mol_from_inchi(self):
+        """Test generating RMG Molecule objects from InChI's"""
+        mol1 = converter.rmg_mol_from_inchi('InChI=1S/NO2/c2-1-3')
+        mol2 = converter.rmg_mol_from_inchi('InChI=1/CH3NOS/c1-2-3-4-1/h2H,1H2')
+
+        self.assertTrue(isinstance(mol1, Molecule))
+        self.assertTrue(isinstance(mol2, Molecule))
+
+        smi1 = mol1.toSMILES()
+        smi2 = mol2.toSMILES()
+
+        self.assertEqual(smi1, '[O]N=O')
+        self.assertEqual(smi2, 'C1NOS1')
+
+    def test_elementize(self):
+        """Test converting an RMG:Atom's atomType to its elemental atomType"""
+        mol = Molecule(SMILES=str('O=C=O'))
+        atom1 = mol.atoms[0]
+        atom2 = mol.atoms[1]
+        self.assertEqual(atom1.atomType.label, 'O2d')
+        self.assertEqual(atom2.atomType.label, 'Cdd')
+        converter.elementize(atom1)
+        converter.elementize(atom2)
+        self.assertEqual(atom1.atomType.label, 'O')
+        self.assertEqual(atom2.atomType.label, 'C')
+
+    def test_molecules_from_xyz(self):
+        """Tests that atom orders are preserved when converting xyz's into RMG Molecules"""
+        s_mol, b_mol = converter.molecules_from_xyz(self.xyz4)
+
+        # check that the atom order is the same
+        self.assertTrue(s_mol.atoms[0].isSulfur())
+        self.assertTrue(b_mol.atoms[0].isSulfur())
+        self.assertTrue(s_mol.atoms[1].isOxygen())
+        self.assertTrue(b_mol.atoms[1].isOxygen())
+        self.assertTrue(s_mol.atoms[2].isOxygen())
+        self.assertTrue(b_mol.atoms[2].isOxygen())
+        self.assertTrue(s_mol.atoms[3].isNitrogen())
+        self.assertTrue(b_mol.atoms[3].isNitrogen())
+        self.assertTrue(s_mol.atoms[4].isCarbon())
+        self.assertTrue(b_mol.atoms[4].isCarbon())
+        self.assertTrue(s_mol.atoms[5].isHydrogen())
+        self.assertTrue(b_mol.atoms[5].isHydrogen())
+        self.assertTrue(s_mol.atoms[6].isHydrogen())
+        self.assertTrue(b_mol.atoms[6].isHydrogen())
+        self.assertTrue(s_mol.atoms[7].isHydrogen())
+        self.assertTrue(b_mol.atoms[7].isHydrogen())
+        self.assertTrue(s_mol.atoms[8].isHydrogen())
+        self.assertTrue(b_mol.atoms[8].isHydrogen())
+        self.assertTrue(s_mol.atoms[9].isHydrogen())
+        self.assertTrue(b_mol.atoms[9].isHydrogen())
+
+        s_mol, b_mol = converter.molecules_from_xyz(self.xyz5)
+        self.assertTrue(s_mol.atoms[0].isOxygen())
+        self.assertTrue(b_mol.atoms[0].isOxygen())
+        self.assertTrue(s_mol.atoms[2].isCarbon())
+        self.assertTrue(b_mol.atoms[2].isCarbon())
+
+        expected_bonded_adjlist = """multiplicity 2
+1  O u0 p2 c0 {6,S} {10,S}
+2  O u0 p2 c0 {3,S} {28,S}
+3  C u0 p0 c0 {2,S} {8,S} {14,S} {15,S}
+4  C u0 p0 c0 {7,S} {16,S} {17,S} {18,S}
+5  C u0 p0 c0 {7,S} {19,S} {20,S} {21,S}
+6  C u0 p0 c0 {1,S} {22,S} {23,S} {24,S}
+7  C u1 p0 c0 {4,S} {5,S} {9,S}
+8  C u0 p0 c0 {3,S} {10,D} {11,S}
+9  C u0 p0 c0 {7,S} {11,D} {12,S}
+10 C u0 p0 c0 {1,S} {8,D} {13,S}
+11 C u0 p0 c0 {8,S} {9,D} {25,S}
+12 C u0 p0 c0 {9,S} {13,D} {26,S}
+13 C u0 p0 c0 {10,S} {12,D} {27,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {3,S}
+16 H u0 p0 c0 {4,S}
+17 H u0 p0 c0 {4,S}
+18 H u0 p0 c0 {4,S}
+19 H u0 p0 c0 {5,S}
+20 H u0 p0 c0 {5,S}
+21 H u0 p0 c0 {5,S}
+22 H u0 p0 c0 {6,S}
+23 H u0 p0 c0 {6,S}
+24 H u0 p0 c0 {6,S}
+25 H u0 p0 c0 {11,S}
+26 H u0 p0 c0 {12,S}
+27 H u0 p0 c0 {13,S}
+28 H u0 p0 c0 {2,S}
+"""
+        expected_mol = Molecule().fromAdjacencyList(str(expected_bonded_adjlist))
+        self.assertEqual(b_mol.toAdjacencyList(), expected_bonded_adjlist)
+        # the isIsomorphic test must come after the adjlist test since it changes the atom order
+        self.assertTrue(b_mol.isIsomorphic(expected_mol))
+
+    def test_unsorted_xyz_mol_from_xyz(self):
+        """Test atom order conservation when xyz isn't sorted with heavy atoms first"""
+        n3h5 = ARCSpecies(label=str('N3H5'), xyz=self.xyz6, smiles=str('NNN'))
+        expected_adjlist = """1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {4,S}
+4 N u0 p1 c0 {1,S} {3,S} {6,S}
+5 H u0 p0 c0 {1,S}
+6 N u0 p1 c0 {4,S} {7,S} {8,S}
+7 H u0 p0 c0 {6,S}
+8 H u0 p0 c0 {6,S}
+"""
+        self.assertEqual(n3h5.mol.toAdjacencyList(), expected_adjlist)
+        self.assertEqual(n3h5.initial_xyz, self.xyz6)
+
+    def test_xyz_to_smiles(self):
+        """Test xyz to SMILES conversion and inferring correct bond orders"""
+        xyz1 = """S      -0.06618943   -0.12360663   -0.07631983
+O      -0.79539707    0.86755487    1.02675668
+O      -0.68919931    0.25421823   -1.34830853
+N       0.01546439   -1.54297548    0.44580391
+C       1.59721519    0.47861334    0.00711000
+H       1.94428095    0.40772394    1.03719428
+H       2.20318015   -0.14715186   -0.64755729
+H       1.59252246    1.51178950   -0.33908352
+H      -0.87856890   -2.02453514    0.38494433
+H      -1.34135876    1.49608206    0.53295071"""  # CS(=O)(=N)O
+
+        xyz2 = """O       2.64631000   -0.59546000    0.29327900
+O       2.64275300    2.05718500   -0.72942300
+C       1.71639100    1.97990400    0.33793200
+C      -3.48200000    1.50082200    0.03091100
+C      -3.85550400   -1.05695100   -0.03598300
+C       3.23017500   -1.88003900    0.34527100
+C      -2.91846400    0.11144600    0.02829400
+C       0.76935400    0.80820200    0.23396500
+C      -1.51123800   -0.09830700    0.09199100
+C       1.28495500   -0.50051800    0.22531700
+C      -0.59550400    0.98573400    0.16444900
+C      -0.94480400   -1.39242500    0.08331900
+C       0.42608700   -1.59172200    0.14650400
+H       2.24536500    1.93452800    1.29979800
+H       1.14735500    2.91082400    0.31665700
+H      -3.24115200    2.03800800    0.95768700
+H      -3.08546100    2.10616100   -0.79369800
+H      -4.56858900    1.48636200   -0.06630800
+H      -4.89652000   -0.73067200   -0.04282300
+H      -3.69325500   -1.65970000   -0.93924100
+H      -3.72742500   -1.73294900    0.81894100
+H       3.02442400   -2.44854700   -0.56812500
+H       4.30341500   -1.72127600    0.43646000
+H       2.87318600   -2.44236600    1.21464900
+H      -0.97434200    2.00182800    0.16800300
+H      -1.58581300   -2.26344700    0.02264400
+H       0.81122400   -2.60336100    0.13267800
+H       3.16280800    1.25020800   -0.70346900"""  # COC1=C(CO)C=C([C](C)C)C=C1
+
+        xyz3 = """N       2.24690600   -0.00006500    0.11597700
+C      -1.05654800    1.29155000   -0.02642500
+C      -1.05661400   -1.29150400   -0.02650600
+C      -0.30514100    0.00000200    0.00533200
+C       1.08358900   -0.00003400    0.06558000
+H      -0.39168300    2.15448600   -0.00132500
+H      -1.67242600    1.35091400   -0.93175000
+H      -1.74185400    1.35367700    0.82742800
+H      -0.39187100   -2.15447800    0.00045500
+H      -1.74341400   -1.35278100    0.82619100
+H      -1.67091600   -1.35164600   -0.93286400"""  # N#C[C](C)(C)
+
+        xyz4 = """C      -0.86594600    0.19886100    2.37159000
+C       0.48486900   -0.16232000    1.75422500
+C       1.58322700    0.83707500    2.14923200
+C       0.88213600   -1.51753600    2.17861400
+N       1.17852900   -2.57013900    2.53313600
+N       0.51051200   -0.21074800    0.26080100
+N      -0.51042000    0.21074000   -0.26079600
+C      -0.48479200    0.16232300   -1.75422300
+C       0.86590400   -0.19926100   -2.37161200
+C      -1.58344900   -0.83674100   -2.14921800
+C      -0.88166600    1.51765700   -2.17859800
+N      -1.17777100    2.57034900   -2.53309500
+H      -1.16019200    1.20098300    2.05838400
+H      -1.64220300   -0.50052400    2.05954500
+H      -0.78054100    0.17214100    3.45935000
+H       1.70120000    0.85267300    3.23368300
+H       2.53492600    0.56708700    1.69019900
+H       1.29214500    1.83331400    1.80886700
+H       1.15987300   -1.20145600   -2.05838100
+H       0.78046800   -0.17257000   -3.45937100
+H       1.64236100    0.49992400   -2.05962300
+H      -2.53504500   -0.56650600   -1.69011500
+H      -1.70149200   -0.85224500   -3.23366300
+H      -1.29263300   -1.83308300   -1.80892900"""  # N#CC(C)(C)N=NC(C)(C)C#N
+
+        _, mol1 = converter.molecules_from_xyz(xyz1)
+        _, mol2 = converter.molecules_from_xyz(xyz2)
+        _, mol3 = converter.molecules_from_xyz(xyz3)
+        _, mol4 = converter.molecules_from_xyz(xyz4)
+
+        self.assertEqual(mol1.toSMILES(), '[NH-][S+](=O)(O)C')
+        self.assertEqual(mol2.toSMILES(), 'COC1C=CC(=CC=1CO)[C](C)C')
+        self.assertEqual(mol3.toSMILES(), '[N]=C=C(C)C')
+        self.assertEqual(mol4.toSMILES(), 'N#CC(N=NC(C#N)(C)C)(C)C')
+
+    def test_rdkit_conf_from_mol(self):
+        """Test rdkit_conf_from_mol"""
+        _, b_mol = converter.molecules_from_xyz(self.xyz2)
+        xyz, _, _, _, _ = converter.get_xyz_matrix(self.xyz2)
+        conf, rd_mol, indx_map = converter.rdkit_conf_from_mol(mol=b_mol, coordinates=xyz)
+        self.assertTrue(conf.Is3D())
+        self.assertEqual(rd_mol.GetNumAtoms(), 5)
+        self.assertEqual(indx_map, {0: 0, 1: 1, 2: 2, 3: 3, 4: 4})
+
+
+################################################################################
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This module contains unit tests of the arc.species module
+This module contains unit tests of the arc.species.species module
 """
 
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -13,9 +13,9 @@ from rmgpy.molecule.molecule import Molecule
 from rmgpy.species import Species
 from rmgpy.reaction import Reaction
 
-from arc.species import ARCSpecies, TSGuess, mol_from_xyz, check_xyz,\
-    determine_rotor_type, determine_rotor_symmetry
-from arc.parser import get_xyz_string, get_xyz_matrix
+from arc.species.species import ARCSpecies, TSGuess,\
+    determine_rotor_type, determine_rotor_symmetry, check_species_xyz
+from arc.species.converter import get_xyz_string, get_xyz_matrix, molecules_from_xyz
 from arc.settings import arc_path
 
 ################################################################################
@@ -72,7 +72,7 @@ class TestARCSpecies(unittest.TestCase):
 
     def test_conformers(self):
         """Test conformer generation"""
-        self.spc1.generate_conformers()  # vinoxy has two res. structures, each is assgined two conformers (rdkit/ob)
+        self.spc1.generate_conformers()  # vinoxy has two res. structures, each is assigned two conformers (RDkit/ob)
         self.assertEqual(len(self.spc1.conformers), 4)
         self.assertEqual(len(self.spc1.conformers), len(self.spc1.conformer_energies))
 
@@ -188,41 +188,51 @@ class TestARCSpecies(unittest.TestCase):
 
     def test_xyz_format_conversion(self):
         """Test conversions from string to list xyz formats"""
-        xyz_str0 = """C       0.66165148    0.40274815   -0.48473823
-N      -0.60397931    0.66372701    0.06716371
-H      -1.42268656   -0.49732107   -0.22387123
-H      -0.49930106    0.65310204    1.08530923
-H      -2.21157969   -0.45292568    0.41445163
-H      -1.81136714   -0.32689007   -1.14689570
+        xyz_str0 = """N       2.24690600   -0.00006500    0.11597700
+C      -1.05654800    1.29155000   -0.02642500
+C      -1.05661400   -1.29150400   -0.02650600
+C      -0.30514100    0.00000200    0.00533200
+C       1.08358900   -0.00003400    0.06558000
+H      -0.39168300    2.15448600   -0.00132500
+H      -1.67242600    1.35091400   -0.93175000
+H      -1.74185400    1.35367700    0.82742800
+H      -0.39187100   -2.15447800    0.00045500
+H      -1.74341400   -1.35278100    0.82619100
+H      -1.67091600   -1.35164600   -0.93286400
 """
 
         xyz_list, atoms, x, y, z = get_xyz_matrix(xyz_str0)
 
-        # test all forms of input into get_xyz_string():
+        # test all forms of input for get_xyz_string():
         xyz_str1 = get_xyz_string(xyz_list, symbol=atoms)
-        xyz_str2 = get_xyz_string(xyz_list, number=[6, 7, 1, 1, 1, 1])
-        mol, _ = mol_from_xyz(xyz_str0)
+        xyz_str2 = get_xyz_string(xyz_list, number=[7, 6, 6, 6, 6, 1, 1, 1, 1, 1, 1])
+        mol, _ = molecules_from_xyz(xyz_str0)
         xyz_str3 = get_xyz_string(xyz_list, mol=mol)
 
         self.assertEqual(xyz_str0, xyz_str1)
         self.assertEqual(xyz_str1, xyz_str2)
         self.assertEqual(xyz_str2, xyz_str3)
-        self.assertEqual(atoms, ['C', 'N', 'H', 'H', 'H', 'H'])
-        self.assertEqual(x, [0.66165148, -0.60397931, -1.42268656, -0.49930106, -2.21157969, -1.81136714])
-        self.assertEqual(y, [0.40274815, 0.66372701, -0.49732107, 0.65310204, -0.45292568, -0.32689007])
-        self.assertEqual(z, [-0.48473823, 0.06716371, -0.22387123, 1.08530923, 0.41445163, -1.1468957])
+        self.assertEqual(atoms, ['N', 'C', 'C', 'C', 'C', 'H', 'H', 'H', 'H', 'H', 'H'])
+        self.assertEqual(x, [2.246906, -1.056548, -1.056614, -0.305141, 1.083589, -0.391683, -1.672426, -1.741854,
+                             -0.391871, -1.743414, -1.670916])
+        self.assertEqual(y[1], 1.29155)
+        self.assertEqual(z[-1], -0.932864)
 
     def test_is_linear(self):
         """Test determination of molecule linearity by xyz"""
         xyz1 = """C  0.000000    0.000000    0.000000
                   O  0.000000    0.000000    1.159076
                   O  0.000000    0.000000   -1.159076"""  # a trivial case
-        xyz2 = """C  0.6616514836    0.4027481525   -0.4847382281
-                  N -0.6039793084    0.6637270105    0.0671637135
-                  H -1.4226865648   -0.4973210697   -0.2238712255
-                  H -0.4993010635    0.6531020442    1.0853092315
-                  H -2.2115796924   -0.4529256762    0.4144516252
-                  H -1.8113671395   -0.3268900681   -1.1468957003"""  # a non linear molecule
+        xyz2 = """S      -0.06618943   -0.12360663   -0.07631983
+                  O      -0.79539707    0.86755487    1.02675668
+                  O      -0.68919931    0.25421823   -1.34830853
+                  N       0.01546439   -1.54297548    0.44580391
+                  C       1.59721519    0.47861334    0.00711000
+                  H       1.94428095    0.40772394    1.03719428
+                  H       2.20318015   -0.14715186   -0.64755729
+                  H       1.59252246    1.51178950   -0.33908352
+                  H      -0.87856890   -2.02453514    0.38494433
+                  H      -1.34135876    1.49608206    0.53295071"""  # a non linear molecule
         xyz3 = """N  0.0000000000     0.0000000000     0.3146069129
                   O -1.0906813653     0.0000000000    -0.1376405244
                   O  1.0906813653     0.0000000000    -0.1376405244"""  # a non linear 3-atom molecule
@@ -246,15 +256,15 @@ H      -1.81136714   -0.32689007   -1.14689570
         xyz9 = """C -1.1998 0.1610 0.0275
                   C -1.4021 0.6223 -0.8489
                   C -1.48302 0.80682 -1.19946"""  # just 3 points in space on a straight line (not a physical molecule)
-        spc1 = ARCSpecies(label=str('test_spc'), xyz=xyz1, multiplicity=1, charge=0, smiles=str('C'))
-        spc2 = ARCSpecies(label=str('test_spc'), xyz=xyz2, multiplicity=1, charge=0, smiles=str('C'))
-        spc3 = ARCSpecies(label=str('test_spc'), xyz=xyz3, multiplicity=1, charge=0, smiles=str('C'))
-        spc4 = ARCSpecies(label=str('test_spc'), xyz=xyz4, multiplicity=1, charge=0, smiles=str('C'))
-        spc5 = ARCSpecies(label=str('test_spc'), xyz=xyz5, multiplicity=1, charge=0, smiles=str('C'))
-        spc6 = ARCSpecies(label=str('test_spc'), xyz=xyz6, multiplicity=1, charge=0, smiles=str('C'))
-        spc7 = ARCSpecies(label=str('test_spc'), xyz=xyz7, multiplicity=1, charge=0, smiles=str('C'))
-        spc8 = ARCSpecies(label=str('test_spc'), xyz=xyz8, multiplicity=1, charge=0, smiles=str('C'))
-        spc9 = ARCSpecies(label=str('test_spc'), xyz=xyz9, multiplicity=1, charge=0, smiles=str('C'))
+        spc1 = ARCSpecies(label=str('test_spc'), xyz=xyz1, multiplicity=1, charge=0, smiles=str('O=C=O'))
+        spc2 = ARCSpecies(label=str('test_spc'), xyz=xyz2, multiplicity=1, charge=0, smiles=str('[NH-][S+](=O)(O)C'))
+        spc3 = ARCSpecies(label=str('test_spc'), xyz=xyz3, multiplicity=1, charge=0, smiles=str('[O]N=O'))
+        spc4 = ARCSpecies(label=str('test_spc'), xyz=xyz4, multiplicity=1, charge=0, smiles=str('[NH2]'))
+        spc5 = ARCSpecies(label=str('test_spc'), xyz=xyz5, multiplicity=1, charge=0, smiles=str('[O]S'))
+        spc6 = ARCSpecies(label=str('test_spc'), xyz=xyz6, multiplicity=1, charge=0, smiles=str('C#N'))
+        spc7 = ARCSpecies(label=str('test_spc'), xyz=xyz7, multiplicity=1, charge=0, smiles=str('C#C'))
+        spc8 = ARCSpecies(label=str('test_spc'), xyz=xyz8, multiplicity=1, charge=0, smiles=str('C#C'))
+        spc9 = ARCSpecies(label=str('test_spc'), xyz=xyz9, multiplicity=1, charge=0, smiles=str('[C+]C#[C-]'))
 
         self.assertTrue(spc1.is_linear())
         self.assertTrue(spc6.is_linear())
@@ -268,10 +278,10 @@ H      -1.81136714   -0.32689007   -1.14689570
 
     def test_charge_and_multiplicity(self):
         """Test determination of molecule charge and multiplicity"""
-        spc1 = ARCSpecies(label='spc1', mol=Molecule(SMILES=str('C[CH]C')), generate_thermo=False)  # 2
-        spc2 = ARCSpecies(label='spc2', mol=Molecule(SMILES=str('CCC')), generate_thermo=False)  # 1
-        spc3 = ARCSpecies(label='spc3', smiles=str('N[NH]'), generate_thermo=False)  # 2
-        spc4 = ARCSpecies(label='spc4', smiles=str('NNN'), generate_thermo=False)  # 1
+        spc1 = ARCSpecies(label='spc1', mol=Molecule(SMILES=str('C[CH]C')), generate_thermo=False)
+        spc2 = ARCSpecies(label='spc2', mol=Molecule(SMILES=str('CCC')), generate_thermo=False)
+        spc3 = ARCSpecies(label='spc3', smiles=str('N[NH]'), generate_thermo=False)
+        spc4 = ARCSpecies(label='spc4', smiles=str('NNN'), generate_thermo=False)
         adj1 = """multiplicity 2
                   1 O u1 p2 c0 {2,S}
                   2 H u0 p0 c0 {1,S}
@@ -285,8 +295,8 @@ H      -1.81136714   -0.32689007   -1.14689570
                   7 H u0 p0 c0 {2,S}
                   8 H u0 p0 c0 {3,S}
                """
-        spc5 = ARCSpecies(label='spc5', adjlist=str(adj1), generate_thermo=False)  # 2
-        spc6 = ARCSpecies(label='spc6', adjlist=str(adj2), generate_thermo=False)  # 1
+        spc5 = ARCSpecies(label='spc5', adjlist=str(adj1), generate_thermo=False)
+        spc6 = ARCSpecies(label='spc6', adjlist=str(adj2), generate_thermo=False)
         xyz1 = """O       0.00000000    0.00000000   -0.10796235
                   H       0.00000000    0.00000000    0.86318839"""
         xyz2 = """N      -0.74678912   -0.11808620    0.00000000
@@ -296,8 +306,8 @@ H      -1.81136714   -0.32689007   -1.14689570
                   H       1.07725194    1.05216961    0.00000000
                   H      -1.15564250    0.32084669    0.81500594
                   H      -1.15564250    0.32084669   -0.81500594"""
-        spc7 = ARCSpecies(label='spc7', xyz=xyz1, generate_thermo=False)  # 2
-        spc8 = ARCSpecies(label='spc8', xyz=xyz2, generate_thermo=False)  # 1
+        spc7 = ARCSpecies(label='spc7', xyz=xyz1, generate_thermo=False)
+        spc8 = ARCSpecies(label='spc8', xyz=xyz2, generate_thermo=False)
 
         self.assertEqual(spc1.charge, 0)
         self.assertEqual(spc2.charge, 0)
@@ -327,13 +337,13 @@ H      -1.81136714   -0.32689007   -1.14689570
                          'multiplicity': 1,
                          'arkane_file': None,
                          'E0': None,
-                         'mol': """1 N u0 p1 c0 {2,S} {6,S} {7,S}
-2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
-3 H u0 p0 c0 {2,S}
-4 H u0 p0 c0 {2,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {1,S}
-7 H u0 p0 c0 {1,S}
+                         'mol': """1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 N u0 p1 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
 """,
                          'generate_thermo': True,
                          't0': None,
@@ -357,41 +367,6 @@ H      -1.81136714   -0.32689007   -1.14689570
         self.assertEqual(spc.label, 'OH')
         self.assertEqual(spc.mol.toSMILES(), '[OH]')
         self.assertFalse(spc.is_ts)
-
-    def test_check_xyz(self):
-        """Test the check_xyz() function"""
-        xyz = """
-        
-        
- C                 -0.67567701    1.18507660    0.04672449
- H                 -0.25592948    1.62415961    0.92757746
- H                 -2.26870864    1.38030564    0.05865317
- O                 -0.36671999   -0.21081064    0.01630374
- H                 -0.73553821   -0.63718986    0.79332805
- C                 -0.08400571    1.86907236   -1.19973252
- 
- H                 -0.50375517    1.42998100   -2.08057962
- H                 -0.31518819    2.91354759   -1.17697025
- H                  0.97802159    1.73893214   -1.20769117
- O                 -3.69788377    1.55609096    0.07050345
- O                 -4.28667752    0.37487691    0.04916102
- H                 -4.01978712   -0.12970163    0.82103635
- 
- """
-        expected_xyz = """ C                 -0.67567701    1.18507660    0.04672449
- H                 -0.25592948    1.62415961    0.92757746
- H                 -2.26870864    1.38030564    0.05865317
- O                 -0.36671999   -0.21081064    0.01630374
- H                 -0.73553821   -0.63718986    0.79332805
- C                 -0.08400571    1.86907236   -1.19973252
- H                 -0.50375517    1.42998100   -2.08057962
- H                 -0.31518819    2.91354759   -1.17697025
- H                  0.97802159    1.73893214   -1.20769117
- O                 -3.69788377    1.55609096    0.07050345
- O                 -4.28667752    0.37487691    0.04916102
- H                 -4.01978712   -0.12970163    0.82103635"""
-        new_xyz = check_xyz(xyz)
-        self.assertEqual(new_xyz, expected_xyz)
 
     def test_determine_rotor_type(self):
         """Test that we correctly determine whether a rotor is FreeRotor or HinderedRotor"""
@@ -420,10 +395,58 @@ H      -1.81136714   -0.32689007   -1.14689570
         self.assertEqual(symmetry4, 3)
         self.assertEqual(symmetry5, 6)
 
-
     def test_xyz_from_file(self):
         """Test parsing xyz from a file and saving it in the .initial_xyz attribute"""
         self.assertTrue(' N                 -2.36276900    2.14528400   -0.76917500' in self.spc7.initial_xyz)
+
+    def test_check_species_xyz(self):
+        """Test the check_xyz() function"""
+        xyz = """
+        
+        
+ C                 -0.67567701    1.18507660    0.04672449
+ H                 -0.25592948    1.62415961    0.92757746
+ H                 -2.26870864    1.38030564    0.05865317
+ O                 -0.36671999   -0.21081064    0.01630374
+ H                 -0.73553821   -0.63718986    0.79332805
+ C                 -0.08400571    1.86907236   -1.19973252
+ 
+ H                 -0.50375517    1.42998100   -2.08057962
+ H                 -0.31518819    2.91354759   -1.17697025
+ H                  0.97802159    1.73893214   -1.20769117
+ O                 -3.69788377    1.55609096    0.07050345
+ O                 -4.28667752    0.37487691    0.04916102
+ H                 -4.01978712   -0.12970163    0.82103635
+ 
+ """
+        expected_xyz1 = """ C                 -0.67567701    1.18507660    0.04672449
+ H                 -0.25592948    1.62415961    0.92757746
+ H                 -2.26870864    1.38030564    0.05865317
+ O                 -0.36671999   -0.21081064    0.01630374
+ H                 -0.73553821   -0.63718986    0.79332805
+ C                 -0.08400571    1.86907236   -1.19973252
+ H                 -0.50375517    1.42998100   -2.08057962
+ H                 -0.31518819    2.91354759   -1.17697025
+ H                  0.97802159    1.73893214   -1.20769117
+ O                 -3.69788377    1.55609096    0.07050345
+ O                 -4.28667752    0.37487691    0.04916102
+ H                 -4.01978712   -0.12970163    0.82103635"""
+        new_xyz1 = check_species_xyz(xyz)
+        self.assertEqual(new_xyz1, expected_xyz1)
+
+        xyz_path = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'CH3C(O)O.xyz')
+        expected_xyz2 = """O      -0.53466300   -1.24850800   -0.02156300
+O      -0.79314200    1.04818800    0.18134200
+C      -0.02397300    0.01171700   -0.37827400
+C       1.40511900    0.21728200    0.07675200
+H      -0.09294500    0.02877800   -1.47163200
+H       2.04132100   -0.57108600   -0.32806800
+H       1.45535600    0.19295200    1.16972300
+H       1.77484100    1.18704300   -0.25986700
+H      -0.43701200   -1.34990600    0.92900600
+H      -1.69944700    0.93441600   -0.11271200"""
+        new_xyz2 = check_species_xyz(xyz_path)
+        self.assertEqual(new_xyz2, expected_xyz2)
 
 
 class TestTSGuess(unittest.TestCase):

--- a/arc/species/xyz_to_2d.py
+++ b/arc/species/xyz_to_2d.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Written by Colin Grambow
+
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+import numpy as np
+
+import pybel
+from rdkit import Chem
+from rdkit.Chem import GetPeriodicTable
+
+from arc.arc_exceptions import SanitizationError
+
+_rdkit_periodic_table = GetPeriodicTable()
+
+
+class Atom(object):
+    """
+    Represents an atopm in a molecular graph.
+    """
+
+    def __init__(self, symbol=None, idx=None, coords=np.array([]), frozen=False):
+        self.symbol = symbol
+        self.idx = idx
+        self.coords = coords
+        self.frozen = frozen
+        self.connections = {}
+
+    def __str__(self):
+        return '{}: {}'.format(self.idx, self.symbol)
+
+    def __repr__(self):
+        return '<Atom "{}">'.format(str(self))
+
+    def copy(self):
+        return Atom(
+            symbol=self.symbol,
+            idx=self.idx,
+            coords=self.coords.copy(),
+            frozen=self.frozen,
+        )
+
+    def get_atomicnum(self):
+        return _rdkit_periodic_table.GetAtomicNumber(self.symbol)
+
+    def get_cov_rad(self):
+        return _rdkit_periodic_table.GetRcovalent(self.symbol)
+
+
+class Connection(object):
+    """
+    Represents a connection in a molecular graph.
+
+    Note: Equality and hash are only based on atom symbols and indices.
+    """
+
+    def __init__(self, atom1, atom2):
+        self._atom1 = atom1
+        self._atom2 = atom2
+        self._make_order_invariant()
+
+    def __str__(self):
+        return '({})--({})'.format(str(self.atom1), str(self.atom2))
+
+    def __repr__(self):
+        return '<Connection "{}">'.format(str(self))
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def _make_order_invariant(self):
+        # Ensure that atom ordering is consistent
+        atoms = [self._atom1, self._atom2]
+        atoms.sort(key=lambda a: a.symbol)
+        if self._atom1.idx is not None or self._atom2.idx is not None:
+            atoms.sort(key=lambda a: a.idx)
+        self._atom1, self._atom2 = atoms
+
+    @property
+    def atom1(self):
+        return self._atom1
+
+    @property
+    def atom2(self):
+        return self._atom2
+
+    @atom1.setter
+    def atom1(self, val):
+        self._atom1 = val
+        self._make_order_invariant()
+
+    @atom2.setter
+    def atom2(self, val):
+        self._atom2 = val
+        self._make_order_invariant()
+
+    def copy(self):
+        return Connection(self.atom1, self.atom2)
+
+
+class MolGraph(object):
+    """
+    Class to convert coordinates to a molecular graph w/o bond order information
+    and to generate driving coordinates.
+
+    Note: Atom indices start at 1.
+    """
+
+    def __init__(self, atoms=None, symbols=None, coords=None, energy=None):
+        self.atoms = atoms or []
+        self.energy = energy
+
+        if not self.atoms and symbols is not None:
+            for idx, symbol in enumerate(symbols):
+                atom = Atom(symbol=symbol, idx=idx+1)
+                self.add_atom(atom)
+
+        if coords is not None:
+            self.set_coords(coords)
+
+    def __iter__(self):
+        for atom in self.atoms:
+            yield atom
+
+    def get_formula(self):
+        """
+        Return the molecular formula corresponding to the graph.
+        """
+        # Count the numbers of each element
+        elements = {}
+        for atom in self:
+            symbol = atom.symbol
+            elements[symbol] = elements.get(symbol, 0) + 1
+
+        # Carbon and hydrogen come first if carbon is present, other
+        # atoms come in alphabetical order (also hydrogen if there is no
+        # carbon)
+        formula = ''
+        if 'C' in elements.keys():
+            count = elements['C']
+            formula += 'C{:d}'.format(count) if count > 1 else 'C'
+            del elements['C']
+            if 'H' in elements.keys():
+                count = elements['H']
+                formula += 'H{:d}'.format(count) if count > 1 else 'H'
+                del elements['H']
+        keys = elements.keys()
+        keys.sort()
+        for key in keys:
+            count = elements[key]
+            formula += '{}{:d}'.format(key, count) if count > 1 else key
+
+        return formula
+
+    def to_rmg_mol(self):
+        import rmgpy.molecule.molecule as rmg_molecule
+
+        rmg_atoms = [rmg_molecule.Atom(element=str(atom.symbol), coords=atom.coords) for atom in self]
+        mapping = {atom: rmg_atom for atom, rmg_atom in zip(self.atoms, rmg_atoms)}
+        rmg_bonds = [rmg_molecule.Bond(mapping[connection.atom1], mapping[connection.atom2])
+                     for connection in self.get_all_connections()]
+        rmg_mol = rmg_molecule.Molecule(atoms=rmg_atoms)
+        for bond in rmg_bonds:
+            rmg_mol.addBond(bond)
+
+        return rmg_mol
+
+    def to_rdkit_mol(self):
+        """
+        Convert the graph to an RDKit molecule with atom map numbers set
+        by the indices of the atoms.
+        """
+        assert all(atom.idx is not None for atom in self)
+
+        rd_mol = Chem.rdchem.EditableMol(Chem.rdchem.Mol())
+        for atom in self:
+            rd_atom = Chem.rdchem.Atom(atom.symbol)
+            rd_atom.SetAtomMapNum(atom.idx)
+            rd_mol.AddAtom(rd_atom)
+
+        for atom1 in self:
+            for atom2 in atom1.connections.keys():
+                idx1 = self.atoms.index(atom1)  # This is the index in the atoms list
+                idx2 = self.atoms.index(atom2)
+                if idx1 < idx2:
+                    rd_mol.AddBond(idx1, idx2, Chem.rdchem.BondType.SINGLE)
+
+        rd_mol = rd_mol.GetMol()
+        return rd_mol
+
+    def to_pybel_mol(self, from_coords=True):
+        """
+        Convert the graph to a Pybel molecule. Currently only supports
+        creating the molecule from 3D coordinates.
+        """
+        if from_coords:
+            xyz = self.to_xyz()
+            mol = pybel.readstring('xyz', xyz)
+            return mol
+        else:
+            raise NotImplementedError('Can only create Pybel molecules from 3D structure')
+
+    def to_xyz(self, comment=''):
+        """
+        Convert the graph to an XYZ-format string. Optionally, add
+        comment on the second line.
+        """
+        for atom in self:
+            assert len(atom.coords) != 0
+        symbols, coords = self.get_geometry()
+        cblock = ['{0}  {1[0]: .10f}  {1[1]: .10f}  {1[2]: .10f}'.format(s, c) for s, c in zip(symbols, coords)]
+        return str(len(symbols)) + '\n' + comment + '\n' + '\n'.join(cblock)
+
+    def perceive_smiles(self, atommap=True):
+        """
+        Using the geometry, perceive the corresponding SMILES with bond
+        orders using Open Babel and RDKit. In order to create a sensible
+        SMILES, first infer the connectivity from the 3D coordinates
+        using Open Babel, then convert to InChI to saturate unphysical
+        multi-radical structures, then convert to RDKit and match the
+        atoms to the ones in self in order to return a SMILES with atom
+        mapping corresponding to the order given by the values of
+        atom.idx for all atoms in self.
+
+        This method requires Open Babel version >=2.4.1
+        """
+
+        # Get dict of atomic numbers for later comparison.
+        atoms_in_mol_true = {}
+        for atom in self:
+            anum = atom.get_atomicnum()
+            atoms_in_mol_true[anum] = atoms_in_mol_true.get(anum, 0) + 1
+
+        # There seems to be no particularly simple way in RDKit to read
+        # in 3D structures, so use Open Babel for this part. RMG doesn't
+        # recognize some single bonds, so we can't use that.
+        # We've probably called to_pybel_mol at some previous time to set
+        # connections, but it shouldn't be too expensive to do it again.
+        pybel_mol = self.to_pybel_mol()
+
+        # Open Babel will often make single bonds and generate Smiles
+        # that have multiple radicals, which would probably correspond
+        # to double bonds. To get around this, convert to InChI (which
+        # does not consider bond orders) and then convert to Smiles.
+        inchi = pybel_mol.write('inchi', opt={'F': None}).strip()  # Add fixed H layer
+
+        # Use RDKit to convert back to Smiles
+        mol_sanitized = Chem.MolFromInchi(inchi)
+
+        # RDKit doesn't like some hypervalent atoms
+        if mol_sanitized is None:
+            raise SanitizationError(
+                'Could not convert \n{}\nto Smiles. Unsanitized Smiles: {}'.format(self.to_xyz(),
+                                                                                   pybel_mol.write('smi').strip()))
+
+        # RDKit adds unnecessary hydrogens in some cases. If
+        # this happens, give up and return an error.
+        mol_sanitized = Chem.AddHs(mol_sanitized)
+        atoms_in_mol_sani = {}
+        for atom in mol_sanitized.GetAtoms():
+            atoms_in_mol_sani[atom.GetAtomicNum()] = atoms_in_mol_sani.get(atom.GetAtomicNum(), 0) + 1
+        if atoms_in_mol_sani != atoms_in_mol_true:
+            raise SanitizationError(
+                'Could not convert \n{}\nto Smiles. Wrong Smiles: {}'.format(self.to_xyz(),
+                                                                             Chem.MolToSmiles(mol_sanitized)))
+
+        if not atommap:
+            return Chem.MolToSmiles(mol_sanitized)
+
+        # Because we went through InChI, we lost atom mapping
+        # information. Restore it by matching the original molecule.
+        # There should only be one unique map.
+        mol_with_map = self.to_rdkit_mol()  # This only has single bonds
+        mol_sani_sb = Chem.Mol(mol_sanitized)  # Make copy with single bonds only
+        for bond in mol_sani_sb.GetBonds():
+            bond.SetBondType(Chem.rdchem.BondType.SINGLE)
+        match = mol_sani_sb.GetSubstructMatch(mol_with_map)  # Isomorphism mapping
+        assert mol_with_map.GetNumAtoms() == len(match)  # Make sure we match all atoms
+        for atom in mol_with_map.GetAtoms():
+            idx = match[atom.GetIdx()]
+            map_num = atom.GetAtomMapNum()
+            mol_sanitized.GetAtomWithIdx(idx).SetAtomMapNum(map_num)
+
+        # If everything succeeded up to here, we hopefully have a
+        # sensible Smiles string with atom mappings for all atoms.
+        return Chem.MolToSmiles(mol_sanitized)
+
+    def add_atom(self, atom):
+        self.atoms.append(atom)
+        atom.connections = {}
+        return atom
+
+    def add_connection(self, connection=None, atom1=None, atom2=None):
+        """
+        Either add a connection directly or first create one from two
+        atoms and then add it.
+        """
+        if connection is None:
+            connection = Connection(atom1, atom2)
+        if connection.atom1 not in self.atoms or connection.atom2 not in self.atoms:
+            raise Exception('Cannot add connection between atoms not in the graph')
+        else:
+            connection.atom1.connections[connection.atom2] = connection
+            connection.atom2.connections[connection.atom1] = connection
+            return connection
+
+    def get_all_connections(self):
+        return {connection for atom in self.atoms for connection in atom.connections.values()}
+
+    def get_connection(self, atom1, atom2):
+        if atom1 not in self.atoms or atom2 not in self.atoms:
+            raise Exception('One or both of the specified atoms are not in this graph')
+
+        try:
+            return atom1.connections[atom2]
+        except KeyError:
+            raise Exception('The specified atoms are not connected in this graph')
+
+    def remove_atom(self, atom):
+        for atom2 in atom.connections:
+            del atom2.connections[atom]
+        atom.connections = {}
+        self.atoms.remove(atom)
+
+    def remove_connection(self, connection):
+        if connection.atom1 not in self.atoms or connection.atom2 not in self.atoms:
+            raise Exception('Cannot remove connection between atoms not in the graph')
+        del connection.atom1.connections[connection.atom2]
+        del connection.atom2.connections[connection.atom1]
+
+    def copy(self, deep=False):
+        other = MolGraph(energy=self.energy)
+        atoms = self.atoms
+        mapping = {}
+        for atom in atoms:
+            if deep:
+                atom2 = other.add_atom(atom.copy())
+                mapping[atom] = atom2
+            else:
+                connections = atom.connections
+                other.add_atom(atom)
+                atom.connections = connections
+        if deep:
+            for atom1 in atoms:
+                for atom2 in atom1.connections:
+                    connection = atom1.connections[atom2]
+                    connection = connection.copy()
+                    connection.atom1 = mapping[atom1]
+                    connection.atom2 = mapping[atom2]
+                    other.add_connection(connection)
+        return other
+
+    def merge(self, other):
+        new = MolGraph()
+        for atom in self.atoms:
+            connections = atom.connections
+            new.add_atom(atom)
+            atom.connections = connections
+        for atom in other.atoms:
+            connections = atom.connections
+            new.add_atom(atom)
+            atom.connections = connections
+        new.energy = self.energy + other.energy
+        return new
+
+    def split(self):
+        new1 = self.copy()
+        new2 = MolGraph()
+
+        if len(self.atoms) == 0:
+            return [new1]
+
+        atoms_to_move = [self.atoms[-1]]
+        idx = 0
+        while idx < len(atoms_to_move):
+            for atom2 in atoms_to_move[idx].connections:
+                if atom2 not in atoms_to_move:
+                    atoms_to_move.append(atom2)
+            idx += 1
+
+        if len(new1.atoms) == len(atoms_to_move):
+            return [new1]
+
+        for atom in atoms_to_move:
+            new2.atoms.append(atom)
+            new1.atoms.remove(atom)
+
+        new = [new2]
+        new.extend(new1.split())
+        new.energy = None
+        return new
+
+    def sort_atoms(self):
+        self.atoms.sort(key=lambda a: a.idx)
+
+    def is_radical(self):
+        """
+        Determine whether or not the molecule is a radical based on the number
+        of valence electrons for each atom. If the total number of valence
+        electrons is odd, then it is a radical. This assumes that molecules
+        with an even number of electrons are singlets. This method also assumes
+        that none of the atoms are charged.
+        """
+        valence_electrons = {'H': 1, 'C': 4, 'N': 5, 'O': 6, 'F': 7, 'P': 5, 'S': 6, 'Cl': 7, 'Br': 7, 'I': 7}
+        symbols = [atom.symbol for atom in self]
+        total_valence_electrons = sum(valence_electrons[s] for s in symbols)
+        return bool(total_valence_electrons % 2)
+
+    def is_isomorphic(self, other):
+        """
+        Test if self is isomorphic with other, ignoring atom indices.
+        Requires RMG to do the isomorphism check.
+        """
+        self_rmg = self.to_rmg_mol()
+        other_rmg = other.to_rmg_mol()
+        return self_rmg.isIsomorphic(other_rmg)
+
+    def set_coords(self, coords):
+        """
+        Set atom coordinates. Assumes coords are in same order as self.atoms.
+        """
+        try:
+            coords = np.reshape(coords, (-1,3))
+        except ValueError:
+            raise Exception('Coordinates cannot be reshaped into matrix of size Nx3')
+        assert len(coords) == len(self.atoms)
+
+        for atom, xyz in zip(self.atoms, coords):
+            atom.coords = xyz
+
+    def get_coords(self):
+        """
+        Get coordinates in the order specified by the atom indices.
+        """
+        assert all(atom.idx is not None for atom in self)
+        atoms = self.atoms[:]
+        atoms.sort(key=lambda a: a.idx)
+        return np.array([atom.coords for atom in atoms])
+
+    def get_symbols(self):
+        """
+        Get symbols in the order specified by the atom indices.
+        """
+        assert all(atom.idx is not None for atom in self)
+        atoms = self.atoms[:]
+        atoms.sort(key=lambda a: a.idx)
+        return [atom.symbol for atom in atoms]
+
+    def get_geometry(self):
+        """
+        Get symbols and coordinates in the order specified by the atom
+        indices.
+        """
+        assert all(atom.idx is not None for atom in self)
+        atoms = self.atoms[:]
+        atoms.sort(key=lambda a: a.idx)
+        return [atom.symbol for atom in atoms], np.array([atom.coords for atom in atoms])
+
+    def infer_connections(self, use_ob=True):
+        """
+        Delete connections and set them again based on coordinates.
+
+        Note: By default this uses Open Babel, which is better than a
+        simple covalent radii check.
+        """
+        atoms = self.atoms
+
+        for atom in atoms:
+            assert len(atom.coords) != 0
+
+        for atom in atoms:
+            for connection in atom.connections:
+                self.remove_connection(connection)
+
+        if use_ob:
+            pybel_mol = self.to_pybel_mol()  # Should be sorted by atom indices
+            assert all(ap.idx == a.idx for ap, a in zip(pybel_mol, self))  # Check to be sure
+            mapping = {ap.idx: a for ap, a in zip(pybel_mol, self)}
+            for bond in pybel.ob.OBMolBondIter(pybel_mol.OBMol):
+                atom1 = mapping[bond.GetBeginAtomIdx()]
+                atom2 = mapping[bond.GetEndAtomIdx()]
+                connection = Connection(atom1, atom2)
+                self.add_connection(connection)
+        else:
+            sorted_atoms = sorted(atoms, key=lambda a: a.coords[2])
+            for i, atom1 in enumerate(sorted_atoms):
+                for atom2 in sorted_atoms[(i+1):]:
+                    crit_dist = (atom1.get_cov_rad() + atom2.get_cov_rad() + 0.45)**2
+                    z_boundary = (atom1.coords[2] - atom2.coords[2])**2
+                    if z_boundary > 16.0:
+                        break
+                    dist_sq = sum((atom1.coords - atom2.coords)**2)
+                    if dist_sq > crit_dist or dist_sq < 0.4:
+                        continue
+                    else:
+                        connection = Connection(atom1, atom2)
+                        self.add_connection(connection)
+
+    def is_atom_in_cycle(self, atom):
+        return self._is_chain_in_cycle([atom])
+
+    def _is_chain_in_cycle(self, chain):
+        atom1 = chain[-1]
+        for atom2 in atom1.connections:
+            if atom2 is chain[0] and len(chain) > 2:
+                return True
+            elif atom2 not in chain:
+                chain.append(atom2)
+                if self._is_chain_in_cycle(chain):
+                    return True
+                else:
+                    chain.remove(atom2)
+        return False
+
+    def label_equivalent_hydrogens(self):
+        """
+        Mark all equivalent hydrogens as frozen. For now, this assumes that the
+        carbons they are attached to have 4 connections, which means this
+        method does not yet work for radicals.
+        """
+        if self.is_radical():
+            raise NotImplementedError('Cannot yet label equivalent hydrogens for radicals')
+        for atom in self:
+            if (atom.symbol.upper() == 'C'
+                    and len(atom.connections) == 4
+                    and not self.is_atom_in_cycle(atom)):
+                first_hydrogen = True
+                for atom2 in atom.connections:
+                    if atom2.symbol.upper() == 'H':
+                        if first_hydrogen:
+                            first_hydrogen = False
+                        else:
+                            atom2.frozen = True

--- a/arc/ts/atst.py
+++ b/arc/ts/atst.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 import os
 
-from arc.exceptions import TSError
+from arc.arc_exceptions import TSError
 from arc.settings import arc_path
 
 

--- a/arc/ts/run_autotst.py
+++ b/arc/ts/run_autotst.py
@@ -19,7 +19,7 @@ import logging
 
 from autotst.reaction import AutoTST_Reaction
 
-from arc.parser import get_xyz_string
+from arc.species.converter import get_xyz_string
 from arc.arc_exceptions import TSError
 from arc.settings import arc_path
 

--- a/arc/ts/run_autotst.py
+++ b/arc/ts/run_autotst.py
@@ -20,7 +20,7 @@ import logging
 from autotst.reaction import AutoTST_Reaction
 
 from arc.parser import get_xyz_string
-from arc.exceptions import TSError
+from arc.arc_exceptions import TSError
 from arc.settings import arc_path
 
 


### PR DESCRIPTION
This is the first stage for achieving correct atom mapping in reactions.

Species was relocated into a species folder. Imports of `ARCSpecies` will not be affected since the `__init__` imports it at the correct level.

 Added species/xyz_to_2d.py with the MolGraph class (Written by Colin Grambow)

Created converter.py for various format conversions (xyz, molecules, etc.)

ARC is now able to infer 2D graph representations including bond orders from xyz coordinates (though not perfectly).

Added tetst

The main feature introduced by this PR is atom order consistency between the `.initial_xyz`, `.mol`, and `.mol_list` attributes of a ARCSpecies.