### PR TITLE
TS rotors

### DIFF
--- a/arc/job/inputs.py
+++ b/arc/job/inputs.py
@@ -42,7 +42,7 @@ name
 
 {charge} {multiplicity}
 {xyz}
-{scan}(scan_trsh}
+{scan}{scan_trsh}
 
 
 """,

--- a/arc/main.py
+++ b/arc/main.py
@@ -518,13 +518,14 @@ class ARC(object):
             for spc in self.arc_species_list:
                 for rotor_num, rotor_dict in spc.rotors_dict.items():
                     if not os.path.isfile(rotor_dict['scan_path']):
-                        dir_path = os.path.dirname(os.path.realpath(__file__))
-                        if os.path.isfile(os.path.join(dir_path, rotor_dict['scan_path'])):
-                            # correct relative paths
-                            spc.rotors_dict[rotor_num]['scan_path'] = os.path.join(dir_path, rotor_dict['scan_path'])
-                        else:
-                            raise SpeciesError('Could not find rotor scan output file for rotor {0} of species {1}:'
-                                               ' {2}'.format(rotor_num, spc.label, rotor_dict['scan_path']))
+                        if rotor_dict['scan_path'] != '':
+                            dir_path = os.path.dirname(os.path.realpath(__file__))
+                            if os.path.isfile(os.path.join(dir_path, rotor_dict['scan_path'])):
+                                # correct relative paths
+                                spc.rotors_dict[rotor_num]['scan_path'] = os.path.join(dir_path, rotor_dict['scan_path'])
+                            else:
+                                raise SpeciesError('Could not find rotor scan output file for rotor {0} of species {1}:'
+                                                   ' {2}'.format(rotor_num, spc.label, rotor_dict['scan_path']))
         else:
             self.arc_species_list = list()
         if 'reactions' in input_dict:

--- a/arc/parser.py
+++ b/arc/parser.py
@@ -117,3 +117,52 @@ def parse_xyz_from_file(path):
     if xyz is None and relevant_lines:
         xyz = ''.join([line for line in relevant_lines if line])
     return xyz
+
+def parse_lines(path,start,stop=None,time=1):
+    """
+    Return the list of lines from the time-th occurance of start
+    to the next occurance of stop
+    """
+    if not os.path.isfile(path):
+        raise InputError('Could not find file {0}'.format(path))
+    f = open(path)
+    line = f.readline()
+    lines = []
+    boo = False
+    c = 1
+    while line != '':
+        if start in line:
+            if time == c:
+                boo = True
+                line = f.readline()
+                continue
+            else:
+                c += 1
+
+        if boo and stop in line:
+            break
+        if boo:
+            lines.append(line)
+        line = f.readline()
+    return lines
+
+def parse_scan_coords(path,point_index,software):
+    """
+    Parse the coordinates of the point_index-th point
+    in a rotor scan
+    """
+    if software == 'gaussian':
+        start = 'Optimization completed'
+        stop = 'Distance matrix (angstroms):'
+        lines = parse_lines(path,start,stop=stop,time=point_index+1)
+        atoms = int(lines[-2].split()[0])
+        lines = lines[-atoms-1:-1]
+        coords = []
+        for line in lines:
+            vals = line.split()
+            coords.append([float(x) for x in vals[3:]])
+        coords = np.array(coords)
+        return coords
+    else:
+        raise ValueError('parse_scan_coords() can currently only parse gaussian files,'
+                         ' got {0}'.format(software))

--- a/arc/parser.py
+++ b/arc/parser.py
@@ -166,3 +166,20 @@ def parse_scan_coords(path,point_index,software):
     else:
         raise ValueError('parse_scan_coords() can currently only parse gaussian files,'
                          ' got {0}'.format(software))
+
+def parse_scan_input_geo(path,software):
+    if software == 'gaussian':
+        start = 'Input orientation:'
+        stop = 'Distance matrix (angstroms):'
+        lines = parse_lines(path,start,stop=stop)
+        atoms = int(lines[-2].split()[0])
+        lines = lines[-atoms-1:-1]
+        coords = []
+        for line in lines:
+            vals = line.split()
+            coords.append([float(x) for x in vals[3:]])
+        coords = np.array(coords)
+        return coords
+    else:
+        raise ValueError('parse_scan_coords() can currently only parse gaussian files,'
+                         ' got {0}'.format(software))

--- a/arc/parserTest.py
+++ b/arc/parserTest.py
@@ -71,6 +71,19 @@ class TestParser(unittest.TestCase):
         t1 = parser.parse_t1(path)
         self.assertEqual(t1, 0.0086766)
 
+    def test_parse_scan(self):
+        """Test parsing of rotor scans"""
+        path = os.path.join(arc_path,'arc','testing','rotor_scans','OOC1CCOCO1.out')
+        log = parser.Log(path='')
+        log.determine_qm_software(fullpath=path)
+        v_list, angle = log.software_log.loadScanEnergies()
+        input_xyzs = parser.parse_scan_input_geo(path,'gaussian')
+        base_xyzs = parser.parse_scan_coords(path,0,'gaussian')
+        self.assertTupleEqual(base_xyzs.shape,input_xyzs.shape)
+        errors = []
+        for i in xrange(len(v_list)):
+            base_xyzs = parser.parse_scan_coords(path,i,'gaussian')
+            self.assertTrue(np.round(base_xyzs-input_xyzs,3).any().any())
 ################################################################################
 
 if __name__ == '__main__':

--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -45,6 +45,7 @@ class ARCReaction(object):
     `index`                 ``int``      An auto-generated index associating the ARCReaction object with the
                                          corresponding TS ARCSpecies object
     `ts_label`              ``str``      The ARCSpecies label of the respective TS. Determined automatically
+    `atom_length_constraints` ``list``   A list of lists of indices coresponding to pairs of atoms in the ts guess that should be close together in the ts
     ====================== ============= ===============================================================================
 
     Either give reactants and products (just list of labels), a reaction label, or an RMG Reaction object.
@@ -54,7 +55,7 @@ class ARCReaction(object):
     as self.reactants, self.products, and self.ts_label, respectively.
     """
     def __init__(self, label='', reactants=None, products=None, ts_label=None, rmg_reaction=None,
-                 ts_methods=None, ts_xyz_guess=None, multiplicity=None, charge=0, reaction_dict=None):
+                 ts_methods=None, ts_xyz_guess=None, multiplicity=None, charge=0, reaction_dict=None, atom_length_constraints=None):
         self.arrow = ' <=> '
         self.plus = ' + '
         self.r_species = list()
@@ -67,6 +68,10 @@ class ARCReaction(object):
         self.ts_label = ts_label
         self.dh_rxn298 = None
         self.rmg_reactions = None
+        if atom_length_constraints is None:
+            self.atom_length_constraints = []
+        else:
+            self.atom_length_constraints = atom_length_constraints
         if reaction_dict is not None:
             # Reading from a dictionary
             self.from_dict(reaction_dict=reaction_dict)
@@ -117,6 +122,7 @@ class ARCReaction(object):
         reaction_dict['ts_methods'] = self.ts_methods
         reaction_dict['ts_xyz_guess'] = self.ts_xyz_guess
         reaction_dict['ts_label'] = self.ts_label
+        reaction_dict['atom_length_constraints'] = self.atom_length_constraints
         return reaction_dict
 
     def from_dict(self, reaction_dict):
@@ -160,6 +166,7 @@ class ARCReaction(object):
         self.ts_methods = reaction_dict['ts_methods'] if 'ts_methods' in reaction_dict else default_ts_methods
         self.ts_methods = [tsm.lower() for tsm in self.ts_methods]
         self.ts_xyz_guess = reaction_dict['ts_xyz_guess'] if 'ts_xyz_guess' in reaction_dict else list()
+        self.atom_length_constraints = reaction_dict['atom_length_constraints'] if 'atom_length_constraints' in reaction_dict else list()
 
     def set_label_reactants_products(self):
         """A helper function for settings the label, reactants, and products attributes for a Reaction"""

--- a/arc/reactionTest.py
+++ b/arc/reactionTest.py
@@ -56,7 +56,8 @@ class TestARCReaction(unittest.TestCase):
                          'reactants': [u'CH4', u'OH'],
                          'ts_label': None,
                          'ts_xyz_guess': [],
-                         'ts_methods': [tsm.lower() for tsm in default_ts_methods]}
+                         'ts_methods': [tsm.lower() for tsm in default_ts_methods],
+                         'atom_length_constraints':[]}
         self.assertEqual(rxn_dict, expected_dict)
 
     def test_from_dict(self):

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -192,9 +192,14 @@ class Scheduler(object):
                 if rxn.family_own_reverse and auto_tst and not reverse_auto_tst:
                     rxn.ts_methods.append('reverse_autotst')
                 if not any([spc.label == rxn.ts_label for spc in self.species_list]):
-                    ts_species = ARCSpecies(is_ts=True, label=rxn.ts_label, rxn_label=rxn.label,
+                    if not rxn.ts_xyz_guess:
+                        ts_species = ARCSpecies(is_ts=True, label=rxn.ts_label, rxn_label=rxn.label,
                                             multiplicity=rxn.multiplicity, charge=rxn.charge, generate_thermo=False,
                                             ts_methods=rxn.ts_methods, ts_number=rxn.index)
+                    else:
+                        ts_species = ARCSpecies(is_ts=True, label=rxn.ts_label, rxn_label=rxn.label,
+                                            multiplicity=rxn.multiplicity, charge=rxn.charge, generate_thermo=False,
+                                            ts_methods=rxn.ts_methods, ts_number=rxn.index, xyz=rxn.ts_xyz_guess[0])
                     ts_species.number_of_atoms = sum(reactant.number_of_atoms for reactant in rxn.r_species)
                     self.species_list.append(ts_species)
                 else:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -195,11 +195,12 @@ class Scheduler(object):
                     if not rxn.ts_xyz_guess:
                         ts_species = ARCSpecies(is_ts=True, label=rxn.ts_label, rxn_label=rxn.label,
                                             multiplicity=rxn.multiplicity, charge=rxn.charge, generate_thermo=False,
-                                            ts_methods=rxn.ts_methods, ts_number=rxn.index)
+                                            ts_methods=rxn.ts_methods, ts_number=rxn.index, atom_length_constraints=rxn.atom_length_constraints)
                     else:
                         ts_species = ARCSpecies(is_ts=True, label=rxn.ts_label, rxn_label=rxn.label,
                                             multiplicity=rxn.multiplicity, charge=rxn.charge, generate_thermo=False,
-                                            ts_methods=rxn.ts_methods, ts_number=rxn.index, xyz=rxn.ts_xyz_guess[0])
+                                            ts_methods=rxn.ts_methods, ts_number=rxn.index, atom_length_constraints=rxn.atom_length_constraints,
+                                            xyz=rxn.ts_xyz_guess[0])
                     ts_species.number_of_atoms = sum(reactant.number_of_atoms for reactant in rxn.r_species)
                     self.species_list.append(ts_species)
                 else:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -917,7 +917,7 @@ class Scheduler(object):
             try:
                 data = ccparser.parse()
                 vibfreqs = data.vibfreqs
-            except AssertionError:
+            except (AssertionError, AttributeError):
                 """
                 In cclib/parser/qchemparser.py there's an assertion of `assert 'Beta MOs' in line`
                 which sometimes fails (CClib issue https://github.com/cclib/cclib/issues/678)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -305,7 +305,7 @@ class Scheduler(object):
                             if self.species_dict[species.label].is_ts\
                                     or self.species_dict[species.label].number_of_atoms > 1:
                                 self.run_freq_job(species.label)
-                        if 'sp' not in self.output[species.label] and 'sp' not in self.job_dict[species.label]:
+                        if not self.composite_method and 'sp' not in self.output[species.label] and 'sp' not in self.job_dict[species.label]:
                             self.run_sp_job(species.label)
                         if self.scan_rotors:
                             # restart-related check are performed in run_scan_jobs()

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -100,4 +100,5 @@ inconsistency_ab = 0.5  # maximum allowed inconsistency (kJ/mol) between consecu
 #  of the maximum scan energy. Default: 50%
 maximum_barrier = 40   # a rotor threshold (kJ/mol) above which the rotor is not considered. Default: 40 (~10 kcal/mol)
 minimum_barrier = 0.5  # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 0.5 kJ/mol
-ts_length_change = 0.15 # a threshold for the relative change in the distance between key atoms before invalidating a ts Default:  0.15
+ts_length_change = 0.15 # a threshold for the relative change in the distance between key atoms before invalidating a ts at same level of theory Default:  0.15
+ts_opt_length_change = 0.15 # a threshold for the relative change in the distance between key atoms before invalidating a ts between opt and scan theory levels Default:  0.15

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -95,8 +95,9 @@ valid_chars = "-_()[]=., %s%s" % (string.ascii_letters, string.digits)
 rotor_scan_resolution = 8.0  # degrees. Default: 8.0
 
 # rotor validation parameters
-inconsistency_az = 5    # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
-inconsistency_ab = 0.5  # maximum allowed inconsistency between consecutive points in the scan given as a fraction
+inconsistency_az = 5   # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
+inconsistency_ab = 0.5  # maximum allowed inconsistency (kJ/mol) between consecutive points in the scan. Default: 10
 #  of the maximum scan energy. Default: 50%
-maximum_barrier = 40    # a rotor threshold (kJ/mol) above which the rotor is not considered. Default: 40 (~10 kcal/mol)
-minimum_barrier = 0.5   # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 0.5 kJ/mol
+maximum_barrier = 40   # a rotor threshold (kJ/mol) above which the rotor is not considered. Default: 40 (~10 kcal/mol)
+minimum_barrier = 0.5  # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 0.5 kJ/mol
+ts_length_change = 0.15 # a threshold for the relative change in the distance between key atoms before invalidating a ts Default:  0.15

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -126,7 +126,10 @@ class ARCSpecies(object):
         if atom_length_constraints is None:
             self.atom_length_constraints = []
         else:
-            self.atom_length_constraints = atom_length_constraints
+            if isinstance(atom_length_constraints[0],list):
+                self.atom_length_constraints = atom_length_constraints
+            else:
+                raise TSError("atom_length_constraints should be a list of length 2 lists")
         if species_dict is not None:
             # Reading from a dictionary
             self.from_dict(species_dict=species_dict)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -238,7 +238,7 @@ class ARCSpecies(object):
             elif not self.bond_corrections and self.generate_thermo:
                 logging.warn('Cannot determine bond additivity corrections (BAC) for species {0} based on xyz'
                              ' coordinates only. For better thermoproperties, provide bond corrections.')
-            if self.initial_xyz is not None:
+            if self.initial_xyz is not None and not self.is_ts:
                 # consider the initial guess as one of the conformers if generating others.
                 # otherwise, just consider it as the conformer.
                 self.conformers.append(self.initial_xyz)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -543,22 +543,21 @@ class ARCSpecies(object):
         The resulting rotors are saved in {'pivots': [1, 3], 'top': [3, 7], 'scan': [2, 1, 3, 7]} format
         in self.species_dict[species.label]['rotors_dict']. Also updates 'number_of_rotors'.
         """
-        if not self.is_ts:
-            for mol in self.mol_list:
-                rotors = find_internal_rotors(mol)
-                for new_rotor in rotors:
-                    for existing_rotor in self.rotors_dict.values():
-                        if existing_rotor['pivots'] == new_rotor['pivots']:
-                            break
-                    else:
-                        self.rotors_dict[self.number_of_rotors] = new_rotor
-                        self.number_of_rotors += 1
-            if self.number_of_rotors == 1:
-                logging.info('\nFound 1 rotor for {0}'.format(self.label))
-            elif self.number_of_rotors > 1:
-                logging.info('\nFound {0} rotors for {1}'.format(self.number_of_rotors, self.label))
-            if self.number_of_rotors > 0:
-                logging.info('Pivot list(s) for {0}: {1}\n'.format(self.label,
+        for mol in self.mol_list:
+            rotors = find_internal_rotors(mol)
+            for new_rotor in rotors:
+                for existing_rotor in self.rotors_dict.values():
+                    if existing_rotor['pivots'] == new_rotor['pivots']:
+                        break
+                else:
+                    self.rotors_dict[self.number_of_rotors] = new_rotor
+                    self.number_of_rotors += 1
+        if self.number_of_rotors == 1:
+            logging.info('\nFound 1 rotor for {0}'.format(self.label))
+        elif self.number_of_rotors > 1:
+            logging.info('\nFound {0} rotors for {1}'.format(self.number_of_rotors, self.label))
+        if self.number_of_rotors > 0:
+            logging.info('Pivot list(s) for {0}: {1}\n'.format(self.label,
                                                     [self.rotors_dict[i]['pivots'] for i in range(self.number_of_rotors)]))
 
     def set_dihedral(self, scan, pivots, deg_increment):

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -213,11 +213,16 @@ class ARCSpecies(object):
                 self.multiplicity = multiplicity
                 self.charge = charge
 
-            if self.mol is None and not self.is_ts:
+            if self.mol is None:
                 xyz = self.final_xyz if self.final_xyz else self.initial_xyz
                 _, mol = molecules_from_xyz(xyz)
+                if self.mol_list is None:
+                    self.mol_list = [mol]
+                    if not self.bond_corrections and self.generate_thermo:
+                        logging.warn('Cannot determine bond additivity corrections (BAC) for species {0} based on xyz'
+                                     ' coordinates only. For better thermoproperties, provide bond corrections.')
                 self.number_of_atoms = len(mol.atoms)
-            elif not self.is_ts:
+            else:
                 if self.initial_xyz is not None:
                     self.mol_from_xyz()
                 if not self.bond_corrections:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -104,7 +104,7 @@ class ARCSpecies(object):
                  }
     """
     def __init__(self, is_ts=False, rmg_species=None, mol=None, label=None, xyz=None, multiplicity=None, charge=None,
-                 smiles='', adjlist='', bond_corrections=None, generate_thermo=True, species_dict=None, yml_path=None,
+                 smiles='', adjlist='', inchi='', bond_corrections=None, generate_thermo=True, species_dict=None, yml_path=None,
                  ts_methods=None, ts_number=None, rxn_label=None, external_symmetry=None, optical_isomers=None, atom_length_constraints=None):
 
         self.xyz_mol = None


### PR DESCRIPTION
This PR makes it possible for ARC to do Rotors for TS's.  The user can specify on the reaction object the `atom_length_constraint` that is a list of length 2 lists of 1-indexed atom indices.  Each pair of indices correspond to atoms that need to stay close together in the TS.  

After rotors are calculated normal checks as in thermo are done with two exceptions:  
1) Rotor scan files are parsed and the distances between constrained atom pairs both at the optimized geometry and in the rotor scan are computed.  If the change in distance as a fraction of the distance at the first point in the rotor scan is more than `ts_length_change` or as a fraction of distance in the optimized geometry is more than `ts_opt_length_change` the rotor is considered to break the TS and is invalidated.  
2) If the initial scan point is determined to not be a well instead of launching a new optimization job the rotor is simply invalidated under the assumption that the rotor is moving along the TS.  

Lots of small bug fixes.  

Open to better naming suggestions for user facing parameters.  