### PR TITLE
Allow nonisomorphic 2d

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -74,6 +74,8 @@ class ARC(object):
     `t_count`              ``int``    The number of temperature points between t_min and t_max for kinetics computations
     `max_job_time`         ``int``    The maximal allowed job time on the server in hours
     `rmgdb`                ``RMGDatabase``  The RMG database object
+    `allow_nonisomorphic_2d` ``bool`` Whether to optimize species even if they do not have a 3D conformer that is
+                                        isomorphic to the 2D graph representation
     ====================== ========== ==================================================================================
 
     `level_of_theory` is a string representing either sp//geometry levels or a composite method, e.g. 'CBS-QB3',
@@ -83,7 +85,7 @@ class ARC(object):
                  conformer_level='', composite_method='', opt_level='', freq_level='', sp_level='', scan_level='',
                  ts_guess_level='', fine=True, generate_conformers=True, scan_rotors=True, use_bac=True,
                  model_chemistry='', ess_settings=None, initial_trsh=None, t_min=None, t_max=None, t_count=None,
-                 verbose=logging.INFO, project_directory=None, max_job_time=120):
+                 verbose=logging.INFO, project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False):
 
         self.__version__ = '1.0.0'
         self.verbose = verbose
@@ -95,6 +97,7 @@ class ARC(object):
         self.unique_species_labels = list()
         self.rmgdb = rmgdb.make_rmg_database_object()
         self.max_job_time = max_job_time
+        self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
 
         if input_dict is None:
             if project is None:
@@ -359,6 +362,7 @@ class ARC(object):
         restart_dict['t_max'] = self.t_max
         restart_dict['t_count'] = self.t_count
         restart_dict['max_job_time'] = self.max_job_time
+        restart_dict['allow_nonisomorphic_2d'] = self.allow_nonisomorphic_2d
         return restart_dict
 
     def from_dict(self, input_dict, project=None, project_directory=None):
@@ -381,6 +385,8 @@ class ARC(object):
         self.execution_time = None
         self.verbose = input_dict['verbose'] if 'verbose' in input_dict else self.verbose
         self.max_job_time = input_dict['max_job_time'] if 'max_job_time' in input_dict else 5
+        self.allow_nonisomorphic_2d = input_dict['allow_nonisomorphic_2d']\
+            if 'allow_nonisomorphic_2d' in input_dict else False
 
         if self.ess_settings is not None:
             self.settings['ssh'] = True
@@ -559,7 +565,7 @@ class ARC(object):
                                    settings=self.settings, generate_conformers=self.generate_conformers,
                                    scan_rotors=self.scan_rotors, initial_trsh=self.initial_trsh, rmgdatabase=self.rmgdb,
                                    restart_dict=self.restart_dict, project_directory=self.project_directory,
-                                   max_job_time=self.max_job_time)
+                                   max_job_time=self.max_job_time, allow_nonisomorphic_2d=self.allow_nonisomorphic_2d)
 
         self.save_project_info_file()
 

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -58,6 +58,7 @@ class TestARC(unittest.TestCase):
                          't_max': None,
                          't_count': None,
                          'use_bac': True,
+                         'allow_nonisomorphic_2d': False,
                          'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},
                                       'arkane_file': None,
                                       'E0': None,

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -75,6 +75,8 @@ class Scheduler(object):
     `max_job_time`          ``int``   The maximal allowed job time on the server in hours
     `testing`               ``bool``  Used for internal ARC testing (generating the object w/o executing it)
     `rmgdb`                 ``RMGDatabase``  The RMG database object
+    `allow_nonisomorphic_2d` ``bool`` Whether to optimize species even if they do not have a 3D conformer that is
+                                        isomorphic to the 2D graph representation
     ======================= ========= ==================================================================================
 
     Dictionary structures:
@@ -107,7 +109,7 @@ class Scheduler(object):
     def __init__(self, project, settings, species_list, composite_method, conformer_level, opt_level, freq_level,
                  sp_level, scan_level, ts_guess_level, project_directory, rmgdatabase, fine=False, scan_rotors=True,
                  generate_conformers=True, initial_trsh=None, rxn_list=None, restart_dict=None, max_job_time=120,
-                 testing=False):
+                 allow_nonisomorphic_2d=False, testing=False):
         self.rmgdb = rmgdatabase
         self.restart_dict = restart_dict
         self.species_list = species_list
@@ -119,6 +121,7 @@ class Scheduler(object):
         self.job_dict = dict()
         self.servers_jobs_ids = list()
         self.running_jobs = dict()
+        self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
         self.testing = testing
         if self.restart_dict is not None:
             self.output = self.restart_dict['output']
@@ -756,7 +759,8 @@ class Scheduler(object):
                                               label, self.species_dict[label].mol.toSMILES(),
                                               (energies[i] - energies[0]) * 2625.50))
                                 conformer_xyz = xyz
-                                self.output[label]['status'] += 'passed isomorphism check but not for the most stable conformer; '
+                                self.output[label]['status'] += 'passed isomorphism check but not for the most stable' \
+                                                                ' conformer; '
                             break
                         else:
                             if i == 0:
@@ -764,11 +768,18 @@ class Scheduler(object):
                                              'with the 2D graph representation {1}. Searching for a different '
                                              'conformer that is isomorphic'.format(label, b_mol.toSMILES()))
                 else:
-                    logging.error('No conformer for {0} was found to be isomorphic with the 2D graph representation'
-                                  ' {1}. NOT optimizing this species.'.format(
-                                   label, self.species_dict[label].mol.toSMILES()))
-                    self.output[label]['status'] += 'Error: No conformer was found to be isomorphic with the 2D graph' \
-                                                    ' representation! '
+                    if self.allow_nonisomorphic_2d:
+                        # we'll optimize the most stable conformer even if it not isomorphic to the 2D graph
+                        logging.error('No conformer for {0} was found to be isomorphic with the 2D graph representation'
+                                      ' {1}. Optimizing the most stable conformer anyway.'.format(
+                                       label, self.species_dict[label].mol.toSMILES()))
+                        conformer_xyz = xyzs[0]
+                    else:
+                        logging.error('No conformer for {0} was found to be isomorphic with the 2D graph representation'
+                                      ' {1}. NOT optimizing this species.'.format(
+                                       label, self.species_dict[label].mol.toSMILES()))
+                        self.output[label]['status'] += 'Error: No conformer was found to be isomorphic with the 2D' \
+                                                        ' graph representation! '
             else:
                 logging.warn('Could not run isomorphism check for species {0} due to missing 2D graph '
                              'representation. Using the most stable conformer for further geometry'

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -177,6 +177,8 @@ def molecules_from_xyz(xyz):
     This function is based on the MolGraph.perceive_smiles method
     Returns None for b_mol is unsuccessful to infer bond orders
     """
+    if xyz is None:
+        return None, None
     if not isinstance(xyz, (str, unicode)):
         raise SpeciesError('xyz must be a string format, got: {0}'.format(type(xyz)))
     xyz = standardize_xyz_string(xyz)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -546,9 +546,9 @@ class ARCSpecies(object):
                         self.rotors_dict[self.number_of_rotors] = new_rotor
                         self.number_of_rotors += 1
             if self.number_of_rotors == 1:
-                logging.info('\nFound 1 rotor for {0}'.format(self.label))
+                logging.info('\nFound one possible rotor for {0}'.format(self.label))
             elif self.number_of_rotors > 1:
-                logging.info('\nFound {0} rotors for {1}'.format(self.number_of_rotors, self.label))
+                logging.info('\nFound {0} possible rotors for {1}'.format(self.number_of_rotors, self.label))
             if self.number_of_rotors > 0:
                 logging.info('Pivot list(s) for {0}: {1}\n'.format(self.label,
                                                     [self.rotors_dict[i]['pivots'] for i in range(self.number_of_rotors)]))


### PR DESCRIPTION
Sometimes we don't read the 2D graph correctly (e.g., for birads)
This option allows ARC to optimize the most stable conformer even if no
conformer was found to be isomorphic to the 2D graph representation of
the species.