### PR TITLE
 Preserve multiplicity throughout Species representations

### DIFF
--- a/arc/processor.py
+++ b/arc/processor.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import os
 import shutil
 import logging
+from random import randint
 
 from arkane.input import species as arkane_species, transitionState as arkane_transition_state,\
     reaction as arkane_reaction
@@ -177,7 +178,14 @@ class Processor(object):
             if not species.is_ts and 'ALL converged' in self.output[species.label]['status']:
                 species_for_thermo_lib.append(species)
                 output_file_path = self._generate_arkane_species_file(species)
-                arkane_spc = arkane_species(str(species.label), species.arkane_file)
+                unique_arkane_species_label = False
+                while not unique_arkane_species_label:
+                    try:
+                        arkane_spc = arkane_species(str(species.label), species.arkane_file)
+                    except ValueError:
+                        species.label += '_(' + str(randint(0, 999)) + ')'
+                    else:
+                        unique_arkane_species_label = True
                 if species.mol_list:
                     arkane_spc.molecule = species.mol_list
                 stat_mech_job = StatMechJob(arkane_spc, species.arkane_file)

--- a/arc/rmgdb.py
+++ b/arc/rmgdb.py
@@ -9,6 +9,7 @@ from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase
 from rmgpy.reaction import isomorphic_species_lists
 from rmgpy.data.kinetics.common import find_degenerate_reactions
+from rmgpy.exceptions import KineticsError
 
 from arc.arc_exceptions import InputError
 
@@ -118,8 +119,12 @@ def load_rmg_database(rmgdb, thermo_libraries=None, reaction_libraries=None, kin
         depository=False,
     )
     for family in rmgdb.kinetics.families.values():
-        family.addKineticsRulesFromTrainingSet(thermoDatabase=rmgdb.thermo)
-        family.fillKineticsRulesByAveragingUp(verbose=False)
+        try:
+            family.addKineticsRulesFromTrainingSet(thermoDatabase=rmgdb.thermo)
+        except KineticsError:
+            logging.info('Could not train family {0}'.format(family))
+        else:
+            family.fillKineticsRulesByAveragingUp(verbose=False)
     logging.info('\n\n')
 
 

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -503,9 +503,11 @@ class Scheduler(object):
                          fine=job.fine, software=job.software, shift=job.shift, trsh=job.trsh, memory=job.memory,
                          conformer=job.conformer, ess_trsh_methods=job.ess_trsh_methods, scan=job.scan,
                          pivots=job.pivots, occ=job.occ, scan_trsh=job.scan_trsh, scan_res=job.scan_res)
-            self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
+            if job_name in self.running_jobs[label]:
+                self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
         if job.job_status[0] != 'running' and job.job_status[1] != 'running':
-            self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
+            if job_name in self.running_jobs[label]:
+                self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
             self.timer = False
             job.write_completed_job_to_csv_file()
             logging.info('  Ending job {name} for {label} (run time: {time})'.format(name=job.job_name, label=label,

--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import unittest
 
 from rmgpy.molecule.molecule import Molecule
+from rmgpy.species import Species
 
 import arc.species.converter as converter
 from arc.species.species import ARCSpecies
@@ -96,6 +97,18 @@ H       3.16280800    1.25020800   -0.70346900
         N       1.1997613019    -0.1609980472     0.0274604887
         H       1.1294795781    -0.8708998550     0.7537444446
         H       1.4015274689    -0.6230592706    -0.8487058662"""
+
+        nh_s_adj = str("""1 N u0 p2 c0 {2,S}
+                          2 H u0 p0 c0 {1,S}""")
+        nh_s_xyz = str("""N       0.50949998    0.00000000    0.00000000
+                          H      -0.50949998    0.00000000    0.00000000""")
+        cls.spc1 = ARCSpecies(label=str('NH2(S)'), adjlist=nh_s_adj, xyz=nh_s_xyz, multiplicity=1, charge=0)
+        spc = Species().fromAdjacencyList(nh_s_adj)
+        cls.spc2 = ARCSpecies(label=str('NH2(S)'), rmg_species=spc, xyz=nh_s_xyz)
+
+        cls.spc3 = ARCSpecies(label=str('NCN(S)'), smiles=str('[N]=C=[N]'), multiplicity=1, charge=0)
+
+        cls.spc4 = ARCSpecies(label=str('NCN(T)'), smiles=str('[N]=C=[N]'), multiplicity=3, charge=0)
 
     def test_get_xyz_string(self):
         """Test conversion of xyz array to string format"""
@@ -800,6 +813,17 @@ O       2.17315400   -0.03069900   -0.09349100"""
         self.assertEqual(len(mol3.atoms), 11)
         self.assertEqual(len(mol4.atoms), 24)
         self.assertEqual(len(mol5.atoms), 3)
+
+    def set_radicals_correctly_from_xyz(self):
+        """Test that we determine the number of radicals correctly from given xyz and multiplicity"""
+        self.assertEqual(self.spc1.multiplicity, 1)  # NH(S), a nitrene
+        self.assertTrue(all([atom.radicalElectrons == 0 for atom in self.spc1.mol.atoms]))
+        self.assertEqual(self.spc2.multiplicity, 1)  # NH(S), a nitrene
+        self.assertTrue(all([atom.radicalElectrons == 0 for atom in self.spc2.mol.atoms]))
+        self.assertEqual(self.spc3.multiplicity, 1)  # NCN(S), a singlet birad
+        self.assertTrue(all([atom.radicalElectrons == 1 for atom in self.spc3.mol.atoms if atom.isNitrogen()]))
+        self.assertEqual(self.spc3.multiplicity, 3)  # NCN(T)
+        self.assertTrue(all([atom.radicalElectrons == 1 for atom in self.spc3.mol.atoms if atom.isNitrogen()]))
 
 
 ################################################################################

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -811,7 +811,7 @@ class ARCSpecies(object):
         if self.mol is not None:
             # self.mol should have come from another source, e.g. SMILES or yml
             original_mol = self.mol
-            self.mol = molecules_from_xyz(xyz)[1]
+            self.mol = molecules_from_xyz(xyz, multiplicity=self.multiplicity)[1]
 
             if self.mol is not None and not check_isomorphism(original_mol, self.mol):
                 raise InputError('XYZ and the 2D graph representation of the Molecule are not isomorphic.\n'
@@ -819,14 +819,15 @@ class ARCSpecies(object):
                                    xyz, self.mol.toSMILES(), self.mol.toAdjacencyList(),
                                    original_mol.toSMILES(), original_mol.toAdjacencyList()))
         else:
-            self.mol = molecules_from_xyz(xyz)[1]
+            self.mol = molecules_from_xyz(xyz, multiplicity=self.multiplicity)[1]
 
         if self.mol_list is None:
             # Assign atom ids first, so they carry through to the resonance structures
             self.mol.assignAtomIDs()
             # The generate_resonance_structures method changes atom order
             # Make a copy so we don't disturb the original order from xyz
-            self.mol_list = self.mol.copy(deep=True).generate_resonance_structures(keep_isomorphic=False, filter_structures=True)
+            self.mol_list = self.mol.copy(deep=True).generate_resonance_structures(keep_isomorphic=False,
+                                                                                   filter_structures=True)
         order_atoms_in_mol_list(ref_mol=self.mol, mol_list=self.mol_list)
 
 

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -77,6 +77,12 @@ class TestARCSpecies(unittest.TestCase):
         H       1.84477700   -0.57224200    0.35517700""")
         cls.spc8 = ARCSpecies(label=str('HSO3'), xyz=hso3_xyz, multiplicity=2, charge=0, smiles=str('O[S](=O)=O'))
 
+        nh_s_adj = str("""1 N u0 p2 c0 {2,S}
+                          2 H u0 p0 c0 {1,S}""")
+        nh_s_xyz = str("""N       0.50949998    0.00000000    0.00000000
+                          H      -0.50949998    0.00000000    0.00000000""")
+        cls.spc9 = ARCSpecies(label=str('NH2(S)'), adjlist=nh_s_adj, xyz=nh_s_xyz, multiplicity=1, charge=0)
+
     def test_conformers(self):
         """Test conformer generation"""
         self.spc1.generate_conformers()  # vinoxy has two res. structures, each is assigned two conformers (RDkit/ob)
@@ -260,18 +266,18 @@ H      -1.67091600   -1.35164600   -0.93286400
                   C -0.77966935    0.95278385    0.00000000
                   H -1.23666197    3.17751246    0.00000000
                   H -0.56023545   -0.09447399    0.00000000""" # just 0.5 degree off from linearity, so NOT linear...
-        xyz9 = """C -1.1998 0.1610 0.0275
-                  C -1.4021 0.6223 -0.8489
-                  C -1.48302 0.80682 -1.19946"""  # just 3 points in space on a straight line (not a physical molecule)
+        xyz9 = """O -1.1998 0.1610 0.0275
+                  O -1.4021 0.6223 -0.8489
+                  O -1.48302 0.80682 -1.19946"""  # just 3 points in space on a straight line (not a physical molecule)
         spc1 = ARCSpecies(label=str('test_spc'), xyz=xyz1, multiplicity=1, charge=0, smiles=str('O=C=O'))
         spc2 = ARCSpecies(label=str('test_spc'), xyz=xyz2, multiplicity=1, charge=0, smiles=str('[NH-][S+](=O)(O)C'))
-        spc3 = ARCSpecies(label=str('test_spc'), xyz=xyz3, multiplicity=1, charge=0, smiles=str('[O]N=O'))
-        spc4 = ARCSpecies(label=str('test_spc'), xyz=xyz4, multiplicity=1, charge=0, smiles=str('[NH2]'))
-        spc5 = ARCSpecies(label=str('test_spc'), xyz=xyz5, multiplicity=1, charge=0, smiles=str('[O]S'))
+        spc3 = ARCSpecies(label=str('test_spc'), xyz=xyz3, multiplicity=2, charge=0, smiles=str('[O]N=O'))
+        spc4 = ARCSpecies(label=str('test_spc'), xyz=xyz4, multiplicity=2, charge=0, smiles=str('[NH2]'))
+        spc5 = ARCSpecies(label=str('test_spc'), xyz=xyz5, multiplicity=2, charge=0, smiles=str('[O]S'))
         spc6 = ARCSpecies(label=str('test_spc'), xyz=xyz6, multiplicity=1, charge=0, smiles=str('C#N'))
         spc7 = ARCSpecies(label=str('test_spc'), xyz=xyz7, multiplicity=1, charge=0, smiles=str('C#C'))
         spc8 = ARCSpecies(label=str('test_spc'), xyz=xyz8, multiplicity=1, charge=0, smiles=str('C#C'))
-        spc9 = ARCSpecies(label=str('test_spc'), xyz=xyz9, multiplicity=1, charge=0, smiles=str('[C+]C#[C-]'))
+        spc9 = ARCSpecies(label=str('test_spc'), xyz=xyz9, multiplicity=1, charge=0, smiles=str('[O-][O+]=O'))
 
         self.assertTrue(spc1.is_linear())
         self.assertTrue(spc6.is_linear())
@@ -496,6 +502,15 @@ H      -1.69944700    0.93441600   -0.11271200"""
         res2_ids = [(a.element.symbol, a.id) if a.element.symbol != 'O' else (a.element.symbol,) for a in res2.atoms]
         self.assertEqual(mol_ids, res1_ids)
         self.assertEqual(mol_ids, res2_ids)
+
+    def test_preserving_multiplicity(self):
+        """Test that multiplicity is being preserved, especially when it is guessed differently from xyz"""
+        multiplicity_list = [2, 2, 1, 1, 1, 1, 1, 2, 1]
+        for i, spc in enumerate([self.spc1, self.spc2, self.spc3, self.spc4, self.spc5, self.spc6, self.spc7,
+                                 self.spc8, self.spc9]):
+            self.assertEqual(spc.multiplicity, multiplicity_list[i])
+            self.assertEqual(spc.mol.multiplicity, multiplicity_list[i])
+            self.assertTrue(all([structure.multiplicity == spc.multiplicity for structure in spc.mol_list]))
 
 
 class TestTSGuess(unittest.TestCase):


### PR DESCRIPTION
When an xyz guess is given for a species, the `.mol` and `.mol_list` attributes are updated accordingly to match atom order. However, currently the multiplicity is guessed by openbable, and it might not be the same as the multiplicity given via the 2D graph representation.

A similar issue occurs when testing for isomorphism after generating conformers.

This PR makes sure the species multiplicity is consistent throughout its representations.