### PR TITLE
Use the Gaussian check file

### DIFF
--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -27,10 +27,12 @@ class TestJob(unittest.TestCase):
         A method that is run before all unit tests in this class.
         """
         cls.maxDiff = None
-        ess_settings = {'gaussian': ['server1','server2'], 'molpro': ['server2'], 'qchem': ['server1'], 'ssh': False}
-        cls.job1 = Job(project='project_test', ess_settings=ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
-                       job_type='opt', level_of_theory='b3lyp/6-31+g(d)', multiplicity=1, testing=True,
-                       project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        cls.ess_settings = {'gaussian': ['server1','server2'], 'molpro': ['server2'],
+                            'qchem': ['server1'], 'ssh': False}
+        cls.job1 = Job(project='project_test', ess_settings=cls.ess_settings, species_name='tst_spc',
+                       xyz='C 0.0 0.0 0.0', job_type='opt', level_of_theory='b3lyp/6-31+g(d)', multiplicity=1,
+                       testing=True, project_directory=os.path.join(arc_path, 'Projects', 'project_test'),
+                       fine=True, job_num=100)
         cls.job1.initial_time = datetime.datetime(2019, 3, 15, 19, 53, 7, 0)
         cls.job1.final_time = datetime.datetime(2019, 3, 15, 19, 53, 8, 0)
         cls.job1.determine_run_time()
@@ -68,6 +70,56 @@ class TestJob(unittest.TestCase):
                          'software': 'gaussian',
                          'xyz': 'C 0.0 0.0 0.0'}
         self.assertEqual(job_dict, expected_dict)
+
+    def test_automatic_ess_assignment(self):
+        """Test that the Job module correctly assigns a software for specific methods and basis sets"""
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='b3lyp/6-311++G(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'gaussian')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='ccsd(t)/avtz', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'molpro')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='wb97xd/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'gaussian')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='wb97x-d3/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'qchem')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='b97/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'gaussian')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='m062x/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'gaussian')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='opt', level_of_theory='m06-2x/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'qchem')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='scan', level_of_theory='m062x/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'gaussian')
+
+        job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                   job_type='scan', level_of_theory='m06-2x/6-311++g(d,p)', multiplicity=1, testing=True,
+                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+        self.assertEqual(job0.software, 'qchem')
+
+        self.assertEqual(job0.memory, 15000)
+        self.assertEqual(job0.max_job_time, 120)
 
 
 ################################################################################

--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -54,7 +54,7 @@ class TestJob(unittest.TestCase):
                          'job_status': ['initializing', 'initializing'],
                          'job_type': 'opt',
                          'level_of_theory': 'b3lyp/6-31+g(d)',
-                         'memory': 1500,
+                         'memory': 15000,
                          'occ': None,
                          'pivots': [],
                          'project_directory': os.path.join(arc_path, 'Projects', 'project_test'),

--- a/arc/job/submit.py
+++ b/arc/job/submit.py
@@ -40,6 +40,7 @@ cd $WorkDir
 . $g09root/g09/bsd/g09.profile
 
 cp $SubmitDir/input.gjf .
+cp $SubmitDir/check.chk .
 
 g09 < input.gjf > input.log
 formchk  check.chk check.fchk

--- a/arc/main.py
+++ b/arc/main.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
+"""
+ARC's main module
+"""
 
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 import logging
@@ -86,8 +89,7 @@ class ARC(object):
                  ts_guess_level='', fine=True, generate_conformers=True, scan_rotors=True, use_bac=True,
                  model_chemistry='', initial_trsh=None, t_min=None, t_max=None, t_count=None, run_orbitals=False,
                  verbose=logging.INFO, project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False,
-                 job_memory=1500, ess_settings=None):
-
+                 job_memory=15000, ess_settings=None):
         self.__version__ = '1.0.0'
         self.verbose = verbose
         self.output = dict()
@@ -123,7 +125,8 @@ class ARC(object):
             self.use_bac = use_bac
             self.model_chemistry = model_chemistry
             if self.model_chemistry:
-                logging.info('Using {0} as model chemistry for energy corrections in Arkane'.format(self.model_chemistry))
+                logging.info('Using {0} as model chemistry for energy corrections in Arkane'.format(
+                    self.model_chemistry))
             if not self.fine:
                 logging.info('\n')
                 logging.warning('Not using a fine grid for geometry optimization jobs')
@@ -475,9 +478,12 @@ class ARC(object):
                 self.opt_level = input_dict['level_of_theory'].lower().split('//')[1]
                 self.freq_level = input_dict['level_of_theory'].lower().split('//')[1]
                 self.sp_level = input_dict['level_of_theory'].lower().split('//')[0]
-                logging.info('Using {0} for geometry optimizations'.format(input_dict['level_of_theory'].split('//')[1]))
-                logging.info('Using {0} for frequency calculations'.format(input_dict['level_of_theory'].split('//')[1]))
-                logging.info('Using {0} for single point calculations'.format(input_dict['level_of_theory'].split('//')[0]))
+                logging.info('Using {0} for geometry optimizations'.format(
+                    input_dict['level_of_theory'].split('//')[1]))
+                logging.info('Using {0} for frequency calculations'.format(
+                    input_dict['level_of_theory'].split('//')[1]))
+                logging.info('Using {0} for single point calculations'.format(
+                    input_dict['level_of_theory'].split('//')[0]))
             elif '/' in input_dict['level_of_theory'] and '//' not in input_dict['level_of_theory']:
                 # assume this is not a composite method, and the user meant to run opt, freq and sp at this level.
                 # running an sp after opt at the same level is meaningless, but doesn't matter much also...
@@ -574,6 +580,7 @@ class ARC(object):
             self.arc_rxn_list = list()
 
     def execute(self):
+        """Execute ARC"""
         logging.info('\n')
         for species in self.arc_species_list:
             if not isinstance(species, ARCSpecies):
@@ -613,6 +620,7 @@ class ARC(object):
         self.log_footer()
 
     def save_project_info_file(self):
+        """Save a project info file"""
         self.execution_time = time_lapse(t0=self.t0)
         path = os.path.join(self.project_directory, '{0}.info'.format(self.project))
         if os.path.exists(path):
@@ -658,7 +666,7 @@ class ARC(object):
         txt += '\n'
 
         with open(path, 'w') as f:
-            f.write(txt)
+            f.write(str(txt))
         self.lib_long_desc = txt
 
     def summary(self):
@@ -754,6 +762,7 @@ class ARC(object):
         logging.log(level, 'ARC execution terminated on {0}'.format(time.asctime()))
 
     def determine_model_chemistry(self):
+        """Determine the model_chemistry used in Arkane"""
         if self.model_chemistry:
             self.model_chemistry = self.model_chemistry.lower()
             if self.model_chemistry not in ['cbs-qb3', 'cbs-qb3-paraskevas', 'ccsd(t)-f12/cc-pvdz-f12',
@@ -834,7 +843,7 @@ class ARC(object):
             # ARC is executed on a server, proceed
             logging.info('\n\nExecuting QM jobs locally.')
             if diagnostics:
-                logging.info('ARC is being excecuted on a server (found "SSH_CONNECTION" in the os.environ dictionary')
+                logging.info('ARC is being executed on a server (found "SSH_CONNECTION" in the os.environ dictionary')
                 logging.info('Using distutils.spawn.find_executable() to find ESS')
             self.ess_settings['ssh'] = False
             g03 = find_executable('g03')
@@ -871,7 +880,7 @@ class ARC(object):
         else:
             # ARC is executed locally, communication with a server needs to be established
             if diagnostics:
-                logging.info('ARC is being excecuted on a PC'
+                logging.info('ARC is being executed on a PC'
                              ' (did not find "SSH_CONNECTION" in the os.environ dictionary')
             self.ess_settings['ssh'] = True
             logging.info('\n\nMapping servers...\n\n')
@@ -896,7 +905,8 @@ class ARC(object):
                     else:
                         self.ess_settings['gaussian'].append(server)
                 elif diagnostics:
-                    logging.info('  Did NOT find Gaussian on {3}: g03={0}, g09={1}, g16={2}'.format(g03, g09, g16, server))
+                    logging.info('  Did NOT find Gaussian on {3}: g03={0}, g09={1}, g16={2}'.format(
+                        g03, g09, g16, server))
                 cmd = '. ~/.bashrc; which qchem'
                 qchem, _ = ssh.send_command_to_server(cmd)
                 if qchem:
@@ -958,6 +968,7 @@ def read_file(path):
 
 
 def get_git_commit():
+    """Get the recent git commit to be logged"""
     if os.path.exists(os.path.join(arc_path, '.git')):
         try:
             return subprocess.check_output(['git', 'log', '--format=%H%n%cd', '-1'], cwd=arc_path).splitlines()

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -60,7 +60,7 @@ class TestARC(unittest.TestCase):
                          'scan_level': '',
                          'scan_rotors': False,
                          'sp_level': 'ccsd(t)-f12/cc-pvtz-f12',
-                         'job_memory': 1500,
+                         'job_memory': 15000,
                          't_min': None,
                          't_max': None,
                          't_count': None,

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -87,6 +87,9 @@ class ARCSpecies(object):
     `rxn_label`             ``str``      The reaction string (relevant for TSs)
     `arkane_file`           ``str``      Path to the Arkane Species file generated in Processor
     `yml_path`              ``str``      Path to an Arkane YAML file representing a species (for loading the object)
+    `checkfile`             ``str``      The local path to the latest checkfile by Gaussian for the species
+    `conformer_checkfiles`  ``dict``     A dictionary of conformer checkfiles. Keys are conformer indices,
+                                           Values are local paths to check files
     `external_symmetry`     ``int``      The external symmetry of the species (not including rotor symmetries)
     `optical_isomers`       ``int``      Whether (=2) or not (=1) the species has chiral center/s
     ====================== ============= ===============================================================================
@@ -108,7 +111,7 @@ class ARCSpecies(object):
     def __init__(self, is_ts=False, rmg_species=None, mol=None, label=None, xyz=None, multiplicity=None, charge=None,
                  smiles='', adjlist='', inchi='', bond_corrections=None, generate_thermo=True, species_dict=None,
                  yml_path=None, ts_methods=None, ts_number=None, rxn_label=None, external_symmetry=None,
-                 optical_isomers=None, run_time=None):
+                 optical_isomers=None, run_time=None, checkfile=None):
         self.t1 = None
         self.ts_number = ts_number
         self.conformers = list()
@@ -126,6 +129,9 @@ class ARCSpecies(object):
         self.optical_isomers = optical_isomers
         self.charge = charge
         self.run_time = run_time
+        self.checkfile = checkfile
+        self.conformer_checkfiles = dict()
+        self.most_stable_conformer = None
 
         if species_dict is not None:
             # Reading from a dictionary
@@ -327,6 +333,12 @@ class ARCSpecies(object):
             species_dict['mol'] = self.mol.toAdjacencyList()
         if self.initial_xyz is not None:
             species_dict['initial_xyz'] = self.initial_xyz
+        if self.checkfile is not None:
+            species_dict['checkfile'] = self.checkfile
+        if self.conformer_checkfiles:
+            species_dict['conformer_checkfiles'] = self.conformer_checkfiles
+        if self.most_stable_conformer is not None:
+            species_dict['most_stable_conformer'] = self.most_stable_conformer
         return species_dict
 
     def from_dict(self, species_dict):
@@ -372,6 +384,11 @@ class ARCSpecies(object):
                 if 'unsuccessful_methods' in species_dict else list()
             self.chosen_ts_method = species_dict['chosen_ts_method'] if 'chosen_ts_method' in species_dict else None
             self.chosen_ts = species_dict['chosen_ts'] if 'chosen_ts' in species_dict else None
+            self.checkfile = species_dict['checkfile'] if 'checkfile' in species_dict else None
+            self.conformer_checkfiles = species_dict['conformer_checkfiles'] if 'conformer_checkfiles' in species_dict\
+                else list()
+            self.most_stable_conformer = species_dict['most_stable_conformer'] if 'most_stable_conformer'\
+                                                                                  in species_dict else None
         else:
             self.ts_methods = None
         for char in self.label:


### PR DESCRIPTION
The Gaussian check file `check.chk` will now be used from previous Gaussian jobs to speed up subsequent jobs and maintain WF consistency.
The most recent path of a check file from a composite / opt / conformer job is saved as a Species attribute, and passed to the next job executed for this species. If the next job uses Gaussian, the check file will be uploaded along with the input file (and will be used).