### PR TITLE
BugFix: Don't lose track of jobs in 'qw' status on SGE

### DIFF
--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -166,7 +166,7 @@ class SSH_Client(object):
         else:
             return 'done'
         status = status_line.split()[4]
-        if status.lower() == 'r':
+        if status.lower() in ['r', 'qw']:
             return 'running'
         else:
             if servers[self.server]['cluster_soft'].lower() == 'oge':


### PR DESCRIPTION
Add qw as a keyword when ARC determines job server status
This aviods losing track of qw jobs on pharos
Previously, if a job has qw status on pharos for extended time
(e.g. server is loaded), ARC has chances of losing track of it