### PR TITLE
Allow ARCSpecies to be initialized with a conformer list file

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -234,7 +234,10 @@ class Job(object):
         self.submit = ''
         self.input = ''
         self.server_nodes = list()
-        self._write_initiated_job_to_csv_file()
+        if job_num is None:
+            # this checks jon_num and not self.job_num on purpose
+            # if job_num was given, then don't save as initiated jobs, this is a restarted job
+            self._write_initiated_job_to_csv_file()
 
     def as_dict(self):
         """A helper function for dumping this object as a dictionary in a YAML file for restarting ARC"""

--- a/arc/job/submit.py
+++ b/arc/job/submit.py
@@ -31,12 +31,12 @@ WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
 SubmitDir=`pwd`
 
 GAUSS_SCRDIR=/scratch/users/{un}/g09/$SLURM_JOB_NAME-$SLURM_JOB_ID
-export  GAUSS_SCRDIR
+export GAUSS_SCRDIR
 
 mkdir -p $GAUSS_SCRDIR
 mkdir -p $WorkDir
 
-cd  $WorkDir
+cd $WorkDir
 . $g09root/g09/bsd/g09.profile
 
 cp $SubmitDir/input.gjf .
@@ -79,7 +79,7 @@ WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
 SubmitDir=`pwd`
 
 mkdir -p $WorkDir
-cd  $WorkDir
+cd $WorkDir
 
 cp $SubmitDir/input.inp .
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -3,6 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 import logging
+import warnings
 import sys
 import os
 import time
@@ -776,6 +777,8 @@ class ARC(object):
             logging.log(level, 'The current git HEAD for ARC is:')
             logging.log(level, '    {0}\n    {1}\n'.format(head, date))
         logging.info('Starting project {0}'.format(self.project))
+        # ignore Paramiko warnings:
+        warnings.filterwarnings(action='ignore', module='.*paramiko.*')
 
     def log_footer(self, level=logging.INFO):
         """

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -75,7 +75,6 @@ class TestARC(unittest.TestCase):
                                       'multiplicity': 1,
                                       'neg_freqs_trshed': [],
                                       'number_of_rotors': 0,
-                                      'opt_level': '',
                                       'rotors_dict': {},
                                       't1': None}],
                          }

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -734,7 +734,7 @@ class Scheduler(object):
         if self.species_dict[label].is_ts:
             raise SchedulerError('The determine_most_stable_conformer() method does not deal with transition'
                                  ' state guesses.')
-        if all(e == 0.0 for e in self.species_dict[label].conformer_energies):
+        if 'conformers' in self.job_dict[label] and all(e is None for e in self.species_dict[label].conformer_energies):
             logging.error('No conformer converged for species {0}! Trying to troubleshoot conformer jobs...'.format(
                 label))
             for i, job in self.job_dict[label]['conformers'].items():
@@ -835,7 +835,7 @@ class Scheduler(object):
         if not self.species_dict[label].is_ts:
             raise SchedulerError('The determine_most_likely_ts_conformer() method only deals with transition'
                                  ' state guesses.')
-        if all(e == 0.0 for e in self.species_dict[label].conformer_energies):
+        if all(e is None for e in self.species_dict[label].conformer_energies):
             logging.error('No guess converged for TS {0}!')
             # for i, job in self.job_dict[label]['conformers'].items():
             #     self.troubleshoot_ess(label, job, level_of_theory=job.level_of_theory, job_type='conformer',
@@ -1303,7 +1303,7 @@ class Scheduler(object):
             xyz2 = atomcoords - factor * displacement
             self.species_dict[label].conformers.append(get_xyz_string(xyz=xyz1, number=atomnos))
             self.species_dict[label].conformers.append(get_xyz_string(xyz=xyz2, number=atomnos))
-            self.species_dict[label].conformer_energies.extend([0.0, 0.0])  # a placeholder (lists are synced)
+            self.species_dict[label].conformer_energies.extend([None, None])  # a placeholder (lists are synced)
         self.job_dict[label]['conformers'] = dict()  # initialize the conformer job dictionary
         for i, xyz in enumerate(self.species_dict[label].conformers):
             self.run_job(label=label, xyz=xyz, level_of_theory=self.conformer_level, job_type='conformer', conformer=i)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -442,7 +442,8 @@ class Scheduler(object):
                             folder_name = 'rxns' if self.species_dict[label].is_ts else 'Species'
                             orbitals_path = os.path.join(self.project_directory, 'output', folder_name, label, 'geometry',
                                                          'orbitals.fchk')
-                            shutil.copyfile(job.local_path_to_orbitals_file, orbitals_path)
+                            if os.path.isfile(job.local_path_to_orbitals_file):
+                                shutil.copyfile(job.local_path_to_orbitals_file, orbitals_path)
                         self.timer = False
                         break
 

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -882,6 +882,7 @@ class Scheduler(object):
             self.species_dict[label].final_xyz = get_xyz_string(xyz=coord, number=number)
             self.output[label]['status'] += 'composite converged; '
             self.output[label]['composite'] = os.path.join(job.local_path, 'output.out')
+            self.species_dict[label].opt_level = self.composite_method
             rxn_str = ''
             if self.species_dict[label].is_ts:
                 rxn_str = ' of reaction {0}'.format(self.species_dict[label].rxn_label)
@@ -903,7 +904,6 @@ class Scheduler(object):
                 return True  # run freq / scan jobs on this optimized geometry
             elif not self.species_dict[label].is_ts:
                 self.troubleshoot_negative_freq(label=label, job=job)
-            self.species_dict[label].opt_level = self.composite_method
         if job.job_status[1] != 'done' or not freq_ok:
             self.troubleshoot_ess(label=label, job=job, level_of_theory=job.level_of_theory, job_type='composite')
         return False  # return ``False``, so no freq / scan jobs are initiated for this unoptimized geometry

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -715,13 +715,13 @@ class Scheduler(object):
 
     def parse_conformer_energy(self, job, label, i):
         """
-        Parse E0 (Hartree) from the conformer opt output file, and save it in the 'conformer_energies' attribute.
+        Parse E0 (J/mol) from the conformer opt output file, and save it in the 'conformer_energies' attribute.
         """
         if job.job_status[1] == 'done':
             log = Log(path='')
             log.determine_qm_software(fullpath=job.local_path_to_output_file)
-            e0 = log.software_log.loadEnergy()
-            self.species_dict[label].conformer_energies[i] = e0  # in J/mol
+            self.species_dict[label].conformer_energies[i] = log.software_log.loadEnergy()  # in J/mol
+            logging.debug('energy for {0} is {1}'.format(i, self.species_dict[label].conformer_energies[i]))
         else:
             logging.warn('Conformer {i} for {label} did not converge!'.format(i=i, label=label))
 

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -308,7 +308,7 @@ class Scheduler(object):
                             # restart-related check are performed in run_scan_jobs()
                             self.run_scan_jobs(species.label)
                 elif not self.species_dict[species.label].is_ts and self.generate_conformers\
-                        and 'geo' not in self.output[species.label]:
+                        and 'geo' not in self.output[species.label] and not species.conformers:
                     self.species_dict[species.label].generate_conformers()
             else:
                 # Species is loaded from a YAML file
@@ -557,7 +557,7 @@ class Scheduler(object):
         """
         for label in self.unique_species_labels:
             if not self.species_dict[label].is_ts and 'opt converged' not in self.output[label]['status']\
-                        and 'opt' not in self.job_dict[label]:
+                        and 'opt' not in self.job_dict[label] and not self.species_dict[label].conformer_energies:
                 self.save_conformers_file(label)
                 if not self.testing:
                     if len(self.species_dict[label].conformers) > 1:

--- a/arc/schedulerTest.py
+++ b/arc/schedulerTest.py
@@ -63,10 +63,14 @@ class TestScheduler(unittest.TestCase):
         self.sched1.job_dict[label]['conformers'] = dict()
         self.sched1.job_dict[label]['conformers'][0] = self.job1
         self.sched1.job_dict[label]['conformers'][1] = self.job2
+        self.sched1.species_dict[label].conformer_energies = [None, None]
+        self.sched1.species_dict[label].conformers = [None, None]
         self.sched1.parse_conformer_energy(job=self.job1, label=label, i=0)
         self.sched1.parse_conformer_energy(job=self.job2, label=label, i=1)
         expecting = [-251596443.5088726, -254221943.3698632]
         self.assertEqual(self.sched1.species_dict[label].conformer_energies, expecting)
+        self.sched1.species_dict[label].conformers[0] = parser.parse_xyz_from_file(self.job1.local_path_to_output_file)
+        self.sched1.species_dict[label].conformers[1] = parser.parse_xyz_from_file(self.job2.local_path_to_output_file)
 
         self.sched1.determine_most_stable_conformer(label=label)
         expecting = """N      -0.75555952   -0.12937106    0.00000000
@@ -83,20 +87,21 @@ H      -1.16566701    0.32023496   -0.81630508
         self.assertTrue(os.path.isfile(methylamine_conf_path))
         with open(methylamine_conf_path, 'r') as f:
             lines = f.readlines()
-        self.assertEqual(lines[0], 'conformer 0:\n')
-        self.assertEqual(lines[9], 'SMILES: CN\n')
-        self.assertTrue('Relative Energy:' in lines[10])
-        self.assertEqual(lines[14][0], 'N')
+        self.assertTrue('conformers optimized at' in lines[0])
+        self.assertEqual(lines[11], 'SMILES: CN\n')
+        self.assertTrue('Relative Energy:' in lines[12])
+        self.assertEqual(lines[16][0], 'N')
 
         self.sched1.run_conformer_jobs()
+        self.sched1.save_conformers_file(label='C2H6')
         c2h6_conf_path = os.path.join(self.sched1.project_directory, 'output', 'Species', 'C2H6', 'geometry',
                                       'conformers_before_optimization.txt')
         self.assertTrue(os.path.isfile(c2h6_conf_path))
         with open(c2h6_conf_path, 'r') as f:
             lines = f.readlines()
-        self.assertEqual(lines[0][0], 'C')
+        self.assertEqual(lines[1][0], 'C')
         self.assertEqual(lines[9], '\n')
-        self.assertEqual(lines[12][0], 'H')
+        self.assertEqual(lines[17][0], 'H')
 
     def test_check_negative_freq(self):
         """Test the check_negative_freq() method"""

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -303,7 +303,7 @@ def order_atoms_in_mol_list(ref_mol, mol_list):
 
 def order_atoms(ref_mol, mol):
     """Order the atoms in `mol` by the atom order in ref_mol"""
-    if mol is not None:
+    if ref_mol is not None and mol is not None:
         ref_mol_is_iso_copy = ref_mol.copy(deep=True)
         mol_is_iso_copy = mol.copy(deep=True)
         ref_mol_find_iso_copy = ref_mol.copy(deep=True)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -154,7 +154,7 @@ class ARCSpecies(object):
             self.chosen_ts = None
             self.generate_thermo = generate_thermo if not self.is_ts else False
             self.long_thermo_description = ''
-            self.opt_level = ''
+            self.opt_level = None
             self.ts_report = ''
             self.yml_path = yml_path
             self.final_xyz = ''
@@ -242,7 +242,7 @@ class ARCSpecies(object):
                 # consider the initial guess as one of the conformers if generating others.
                 # otherwise, just consider it as the conformer.
                 self.conformers.append(self.initial_xyz)
-                self.conformer_energies.append(0.0)  # dummy
+                self.conformer_energies.append(None)  # dummy
 
             self.neg_freqs_trshed = list()
 
@@ -298,7 +298,8 @@ class ARCSpecies(object):
         species_dict['multiplicity'] = self.multiplicity
         species_dict['charge'] = self.charge
         species_dict['generate_thermo'] = self.generate_thermo
-        species_dict['opt_level'] = self.opt_level
+        if self.opt_level is not None:
+            species_dict['opt_level'] = self.opt_level
         species_dict['final_xyz'] = self.final_xyz
         species_dict['number_of_rotors'] = self.number_of_rotors
         species_dict['rotors_dict'] = self.rotors_dict
@@ -373,7 +374,7 @@ class ARCSpecies(object):
             self.generate_thermo = False
         else:
             self.generate_thermo = species_dict['generate_thermo'] if 'generate_thermo' in species_dict else True
-        self.opt_level = species_dict['opt_level'] if 'opt_level' in species_dict else ''
+        self.opt_level = species_dict['opt_level'] if 'opt_level' in species_dict else None
         self.number_of_rotors = species_dict['number_of_rotors'] if 'number_of_rotors' in species_dict else 0
         self.rotors_dict = species_dict['rotors_dict'] if 'rotors_dict' in species_dict else dict()
         self.external_symmetry = species_dict['external_symmetry'] if 'external_symmetry' in species_dict else None
@@ -417,7 +418,7 @@ class ARCSpecies(object):
             # consider the initial guess as one of the conformers if generating others.
             # otherwise, just consider it as the conformer.
             self.conformers.append(self.initial_xyz)
-            self.conformer_energies.append(0.0)  # dummy
+            self.conformer_energies.append(None)  # dummy
 
     def from_yml_file(self, label=None):
         """
@@ -474,7 +475,7 @@ class ARCSpecies(object):
                 self.find_conformers(self.mol)
             for xyz in self.xyzs:
                 self.conformers.append(xyz)
-                self.conformer_energies.append(0.0)  # a placeholder (lists are synced)
+                self.conformer_energies.append(None)  # a placeholder (lists are synced)
         else:
             # generate "conformers" from the results of the different TS guess methods, if successful
             tsg_index = 0
@@ -483,7 +484,7 @@ class ARCSpecies(object):
             for tsg in self.ts_guesses:
                 if tsg.success:
                     self.conformers.append(tsg.xyz)
-                    self.conformer_energies.append(0.0)  # a placeholder (lists are synced)
+                    self.conformer_energies.append(None)  # a placeholder (lists are synced)
                     tsg.index = tsg_index
                     tsg_index += 1
                     self.successful_methods.append(tsg.method)


### PR DESCRIPTION
Users can now initialize an ARCSpecies object with either of the `conformers_before_optimization.txt` or `conformers_after_optimization.txt` files. These files are automatically generated by ARC and saved in the Species 'geometry' folder. The latter also reports the conformer energies.