### PR TITLE
Miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,11 @@
 # PyCharm project files
 .idea/*
 
-# settings file
-arc/settings.py
-
 # Projects
 Projects/
+
+# Examples
+examples/
 
 # Unit test files
 .coverage

--- a/ARC.py
+++ b/ARC.py
@@ -63,10 +63,7 @@ def main():
         verbose = logging.DEBUG
     elif args.quiet:
         verbose = logging.WARNING
-    try:
-        input_dict['verbose']
-    except KeyError:
-        input_dict['verbose'] = verbose
+    input_dict['verbose'] = input_dict['verbose'] if 'verbose' in input_dict else verbose
     arc_object = ARC(input_dict=input_dict, project_directory=project_directory)
     arc_object.execute()
 

--- a/arc/arc_exceptions.py
+++ b/arc/arc_exceptions.py
@@ -13,9 +13,51 @@ class InputError(Exception):
     pass
 
 
+class JobError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with jobs
+    """
+    pass
+
+
 class OutputError(Exception):
     """
     This exception is raised whenever an error occurs while saving output information
+    """
+    pass
+
+
+class ReactionError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with reactions
+    """
+    pass
+
+
+class RotorError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with rotors
+    """
+    pass
+
+
+class SanitizationError(Exception):
+    """
+    Exception class to handle errors during SMILES perception.
+    """
+    pass
+
+
+class SchedulerError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with the scheduler
+    """
+    pass
+
+
+class ServerError(Exception):
+    """
+    An exception class for exceptional behavior that occurs while working with servers
     """
     pass
 
@@ -37,47 +79,5 @@ class SpeciesError(Exception):
 class TSError(Exception):
     """
     An exception class for exceptional behavior that occurs while working with transition states
-    """
-    pass
-
-
-class ReactionError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with reactions
-    """
-    pass
-
-
-class RotorError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with rotors
-    """
-    pass
-
-
-class SchedulerError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with the scheduler
-    """
-    pass
-
-
-class JobError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with jobs
-    """
-    pass
-
-
-class ServerError(Exception):
-    """
-    An exception class for exceptional behavior that occurs while working with servers
-    """
-    pass
-
-
-class SanitizationError(Exception):
-    """
-    Exception class to handle errors during SMILES perception.
     """
     pass

--- a/arc/job/inputs.py
+++ b/arc/job/inputs.py
@@ -36,7 +36,7 @@ qchem:
 input_files = {
     'gaussian': """%chk=check.chk
 %mem={memory}mb
-%nproc=8
+%nproc={cpus}
 
 #P {job_type_1} {restricted}{method}{slash}{basis} {job_type_2} {fine} {trsh} iop(2/9=2000)
 

--- a/arc/job/inputs.py
+++ b/arc/job/inputs.py
@@ -113,7 +113,7 @@ table,E_mrci,E_mrci_Davidson;
 
 """,
 
-    'arkane_species': """#!/usr/bin/env python
+    'arkane_input_species': """#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 linear = {linear}{bonds}

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -582,9 +582,9 @@ $end
                 try:
                     self.input = input_files['mrci'].format(memory=self.memory, xyz=self.xyz, basis=self.basis_set,
                                                             spin=self.spin, charge=self.charge, trsh=self.trsh)
-                except KeyError as e:
+                except KeyError:
                     logging.error('Could not interpret all input file keys in\n{0}'.format(self.input))
-                    raise e
+                    raise
         else:
             try:
                 cpus = servers[self.server]['cpus'] if 'cpus' in servers[self.server] else 8
@@ -593,9 +593,9 @@ $end
                                                spin=self.spin, xyz=self.xyz, job_type_1=job_type_1, cpus=cpus,
                                                job_type_2=job_type_2, scan=scan_string, restricted=restricted, fine=fine,
                                                shift=self.shift, trsh=self.trsh, scan_trsh=self.scan_trsh)
-            except KeyError as e:
+            except KeyError:
                 logging.error('Could not interpret all input file keys in\n{0}'.format(self.input))
-                raise e
+                raise
         if not os.path.exists(self.local_path):
             os.makedirs(self.local_path)
         with open(os.path.join(self.local_path, input_filename[self.software]), 'wb') as f:

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -130,14 +130,15 @@ class Job(object):
                 # currently we only have a script to print orbitals on QChem,
                 # could/should definately be elaborated to additional ESS
                 if 'qchem' not in self.ess_settings.keys():
-                    logging.debug('Could not find the QChem software to compute molecular orbitals')
+                    logging.debug('Could not find the QChem software to compute molecular orbitals.\n'
+                                  'ess_settings is:\n{0}'.format(self.ess_settings))
                     self.software = None
                 else:
                     self.software = 'qchem'
             elif job_type == 'composite':
                 if 'gaussian' not in self.ess_settings.keys():
-                    raise JobError('Could not find the Gaussian software to run the composite method {0}'.format(
-                        self.method))
+                    raise JobError('Could not find the Gaussian software to run the composite method {0}.\n'
+                                   'ess_settings is:\n{1}'.format(self.ess_settings, self.method))
                 self.software = 'gaussian'
             else:
                 # use the levels_ess dictionary from settings.py:
@@ -355,7 +356,8 @@ class Job(object):
 
     def write_submit_script(self):
         un = servers[self.server]['un']  # user name
-        if self.max_job_time > 9999 or self.max_job_time == 0:
+        if self.max_job_time > 9999 or self.max_job_time <= 0:
+            logging.debug('Setting max_job_time to 120 hours')
             self.max_job_time = 120
         if t_max_format[servers[self.server]['cluster_soft']] == 'days':
             # e.g., 5-0:00:00
@@ -365,7 +367,8 @@ class Job(object):
             # e.g., 120:00:00
             t_max = '{0}:00:00'.format(self.max_job_time)
         else:
-            raise JobError('Could not determine format for maximal job time')
+            raise JobError('Could not determine format for maximal job time.\n Format is determined by {0}, but '
+                           'got {1} for {2}'.format(t_max_format, servers[self.server]['cluster_soft'], self.server))
         cpus = servers[self.server]['cpus'] if 'cpus' in servers[self.server] else 8
         architecture = ''
         if self.server.lower() == 'pharos':

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -779,30 +779,30 @@ $end
                             reason = ''
                             if 'l9999.exe' in line or 'l103.exe' in line:
                                 return 'unconverged'
-                            if 'l502.exe' in line:
+                            elif 'l502.exe' in line:
                                 return 'unconverged SCF'
-                            if 'l103.exe' in line:
+                            elif 'l103.exe' in line:
                                 return 'l103 internal coordinate error'
-                            if 'Erroneous write' in line or 'Write error in NtrExt1' in line:
+                            elif 'Erroneous write' in line or 'Write error in NtrExt1' in line:
                                 reason = 'Ran out of disk space.'
-                            if 'l716.exe' in line:
+                            elif 'l716.exe' in line:
                                 reason = 'Angle in z-matrix outside the allowed range 0 < x < 180.'
-                            if 'l301.exe' in line:
+                            elif 'l301.exe' in line:
                                 reason = 'Input Error. Either charge, multiplicity, or basis set was not specified ' \
                                          'correctly. Or, an atom specified does not match any standard atomic symbol.'
-                            if 'NtrErr Called from FileIO' in line:
+                            elif 'NtrErr Called from FileIO' in line:
                                 reason = 'Operation on .chk file was specified, but .chk was not found.'
-                            if 'l101.exe' in line:
+                            elif 'l101.exe' in line:
                                 reason = 'Input Error. The blank line after the coordinate section is missing, ' \
                                          'or charge/multiplicity was not specified correctly.'
-                            if 'l202.exe' in line:
+                            elif 'l202.exe' in line:
                                 reason = 'During the optimization process, either the standard orientation ' \
                                          'or the point group of the molecule has changed.'
-                            if 'l401.exe' in line:
+                            elif 'l401.exe' in line:
                                 reason = 'The projection from the old to the new basis set has failed.'
-                            if 'malloc failed' in line or 'galloc' in line:
+                            elif 'malloc failed' in line or 'galloc' in line:
                                 reason = 'Memory allocation failed (did you ask for too much?)'
-                            if 'A SYNTAX ERROR WAS DETECTED' in line:
+                            elif 'A SYNTAX ERROR WAS DETECTED' in line:
                                 reason = 'Check .inp carefully for syntax errors in keywords.'
                             return 'errored: {0}; {1}'.format(line, reason)
                     return 'errored: Unknown reason'

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -859,7 +859,7 @@ $end
         if self.settings['ssh']:
             if servers[self.server]['cluster_soft'].lower() == 'oge':
                 # delete present server run
-                logging.error('Job {name} has server status {stat} on {server}. Troubleshooting by changing node.'.format(
+                logging.error('Job {name} has server status "{stat}" on {server}. Troubleshooting by changing node.'.format(
                     name=self.job_name, stat=self.job_status[0], server=self.server))
                 ssh = SSH_Client(self.server)
                 ssh.send_command_to_server(command=delete_command[servers[self.server]['cluster_soft']] +
@@ -893,7 +893,7 @@ $end
             elif servers[self.server]['cluster_soft'].lower() == 'slurm':
                 # TODO: change node on Slurm
                 # delete present server run
-                logging.error('Job {name} has server status {stat} on {server}. Re-running job.'.format(
+                logging.error('Job {name} has server status "{stat}" on {server}. Re-running job.'.format(
                     name=self.job_name, stat=self.job_status[0], server=self.server))
                 ssh = SSH_Client(self.server)
                 ssh.send_command_to_server(command=delete_command[servers[self.server]['cluster_soft']] +

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -903,4 +903,7 @@ $end
 
     def determine_run_time(self):
         """Determine the run time"""
-        self.run_time = self.final_time - self.initial_time
+        if self.initial_time is not None and self.final_time is not None:
+            self.run_time = self.final_time - self.initial_time
+        else:
+            self.run_time = None

--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -27,9 +27,9 @@ class TestJob(unittest.TestCase):
         A method that is run before all unit tests in this class.
         """
         cls.maxDiff = None
-        settings = {'gaussian': 'server1', 'molpro': 'server2', 'qchem': 'server1', 'ssh': False}
-        cls.job1 = Job(project='project_test', settings=settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
-                       job_type='opt', level_of_theory='b3lyp/6-31+g(d)', multiplicity=1,
+        ess_settings = {'gaussian': ['server1','server2'], 'molpro': ['server2'], 'qchem': ['server1'], 'ssh': False}
+        cls.job1 = Job(project='project_test', ess_settings=ess_settings, species_name='tst_spc', xyz='C 0.0 0.0 0.0',
+                       job_type='opt', level_of_theory='b3lyp/6-31+g(d)', multiplicity=1, testing=True,
                        project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
         cls.job1.initial_time = datetime.datetime(2019, 3, 15, 19, 53, 7, 0)
         cls.job1.final_time = datetime.datetime(2019, 3, 15, 19, 53, 8, 0)

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -112,7 +112,11 @@ class SSH_Client(object):
         Download a file from `remote_file_path` to `local_file_path`.
         """
         sftp, ssh = self.connect()
-        sftp.get(remotepath=remote_file_path, localpath=local_file_path)
+        try:
+            sftp.get(remotepath=remote_file_path, localpath=local_file_path)
+        except IOError:
+            logging.warning('Got an IOError when trying to download file {0} from {1}'.format(remote_file_path,
+                                                                                              self.server))
         sftp.close()
         ssh.close()
 
@@ -257,7 +261,10 @@ class SSH_Client(object):
     def get_last_modified_time(self, remote_file_path):
         """returns the last modified time of `remote_file` in a datetime format"""
         sftp, ssh = self.connect()
-        timestamp = sftp.stat(remote_file_path).st_mtime
+        try:
+            timestamp = sftp.stat(remote_file_path).st_mtime
+        except IOError:
+            return None
         sftp.close()
         ssh.close()
         return datetime.datetime.fromtimestamp(timestamp)

--- a/arc/job/submit.py
+++ b/arc/job/submit.py
@@ -12,7 +12,7 @@ submit_scripts = {
 #SBATCH -p defq
 #SBATCH -J {name}
 #SBATCH -N 1
-#SBATCH -n 8
+#SBATCH -n {cpus}
 #SBATCH --time={t_max}
 #SBATCH --mem-per-cpu 4500
 
@@ -49,13 +49,54 @@ rm -rf $GAUSS_SCRDIR
 rm -rf $WorkDir
 
 """,
+        # Gaussian16 on RMG
+        'gaussian16': """#!/bin/bash -l
+#SBATCH -p long
+#SBATCH -J {name}
+#SBATCH -N 1
+#SBATCH -n {cpus}
+#SBATCH --time={t_max}
+#SBATCH --mem-per-cpu={mem_cpu}
+
+which 16
+
+echo "============================================================"
+echo "Job ID : $SLURM_JOB_ID"
+echo "Job Name : $SLURM_JOB_NAME"
+echo "Starting on : $(date)"
+echo "Running on node : $SLURMD_NODENAME"
+echo "Current directory : $(pwd)"
+echo "============================================================"
+
+WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+SubmitDir=`pwd`
+
+GAUSS_SCRDIR=/scratch/users/{un}/g16/$SLURM_JOB_NAME-$SLURM_JOB_ID
+export GAUSS_SCRDIR
+
+mkdir -p $GAUSS_SCRDIR
+mkdir -p $WorkDir
+
+cd $WorkDir
+. $g16root/g16/bsd/g16.profile
+
+cp $SubmitDir/input.gjf .
+
+g16 < input.gjf > input.log
+formchk  check.chk check.fchk
+cp * $SubmitDir/
+
+rm -rf $GAUSS_SCRDIR
+rm -rf $WorkDir
+
+""",
 
         # Orca on C3DDB:
         'orca': """#!/bin/bash -l
 #SBATCH -p defq
 #SBATCH -J {name}
 #SBATCH -N 1
-#SBATCH -n 8
+#SBATCH -n {cpus}
 #SBATCH --time={t_max}
 #SBATCH --mem-per-cpu 4500
 
@@ -95,7 +136,7 @@ rm -rf $WorkDir
 #SBATCH -p long
 #SBATCH -J {name}
 #SBATCH -N 1
-#SBATCH -n 8
+#SBATCH -n {cpus}
 #SBATCH --time={t_max}
 #SBATCH --mem-per-cpu={mem_cpu}
 
@@ -112,7 +153,7 @@ echo "============================================================"
 sdir=/scratch/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
 mkdir -p $sdir
 
-molpro -n 8 -d $sdir input.in
+molpro -n {cpus} -d $sdir input.in
 
 rm -rf $sdir
 
@@ -125,10 +166,9 @@ rm -rf $sdir
         'gaussian': """#!/bin/bash -l
 
 #$ -N {name}
-#$ -l long
-#$ -l harpertown
+#$ -l long{architecture}
 #$ -l h_rt={t_max}
-#$ -pe singlenode 6
+#$ -pe singlenode {cpus}
 #$ -l h=!node60.cluster
 #$ -cwd
 #$ -o out.txt
@@ -152,10 +192,9 @@ rm -r /scratch/{un}/{name}
         'gaussian03_pharos': """#!/bin/bash -l
 
 #$ -N {name}
-#$ -l long
-#$ -l harpertown
+#$ -l long{architecture}
 #$ -l h_rt={t_max}
-#$ -pe singlenode 6
+#$ -pe singlenode {cpus}
 #$ -l h=!node60.cluster
 #$ -cwd
 #$ -o out.txt
@@ -179,10 +218,9 @@ rm -r /scratch/{un}/{name}
         'qchem': """#!/bin/bash -l
 
 #$ -N {name}
-#$ -l long
-#$ -l harpertown
+#$ -l long{architecture}
 #$ -l h_rt={t_max}
-#$ -pe singlenode 6
+#$ -pe singlenode {cpus}
 #$ -l h=!node60.cluster
 #$ -cwd
 #$ -o out.txt
@@ -207,10 +245,9 @@ rm -r /scratch/{un}/{name}
         'molpro': """#! /bin/bash -l
 
 #$ -N {name}
-#$ -l long
-#$ -l harpertown
+#$ -l long{architecture}
 #$ -l h_rt={t_max}
-#$ -pe singlenode 6
+#$ -pe singlenode {cpus}
 #$ -l h=!node60.cluster
 #$ -cwd
 #$ -o out.txt

--- a/arc/main.py
+++ b/arc/main.py
@@ -173,13 +173,6 @@ class ARC(object):
                         self.freq_level = default_levels_of_theory['freq_for_composite'].lower()
                         logging.info('Using default level {0} for frequency calculations after composite jobs'.format(
                             self.freq_level))
-                    if scan_level:
-                        self.scan_level = scan_level.lower()
-                        logging.info('Using {0} for rotor scans'.format(self.scan_level))
-                    else:
-                        self.scan_level = default_levels_of_theory['scan_for_composite'].lower()
-                        logging.info('Using default level {0} for rotor scans after composite jobs'.format(
-                            self.scan_level))
                 elif '//' in level_of_theory:
                     self.composite_method = ''
                     self.opt_level = level_of_theory.lower().split('//')[1]
@@ -263,8 +256,8 @@ class ARC(object):
                 else:
                     # This is a composite method
                     self.scan_level = default_levels_of_theory['scan_for_composite'].lower()
-                    logging.info('Using default level {0} for scan calculations after composite jobs'.format(
-                        self.freq_level))
+                    logging.info('Using default level {0} for rotor scans after composite jobs'.format(
+                        self.scan_level))
             else:
                 self.scan_level = ''
 
@@ -493,13 +486,6 @@ class ARC(object):
                     self.freq_level = default_levels_of_theory['freq_for_composite'].lower()
                     logging.info('Using default level {0} for frequency calculations after composite jobs'.format(
                         self.freq_level))
-                if 'scan_level' in input_dict:
-                    self.scan_level = input_dict['scan_level'].lower()
-                    logging.info('Using {0} for rotor scans'.format(self.scan_level))
-                else:
-                    self.scan_level = default_levels_of_theory['scan_for_composite'].lower()
-                    logging.info('Using default level {0} for rotor scans after composite jobs'.format(
-                        self.scan_level))
             elif '//' in input_dict['level_of_theory']:
                 self.composite_method = ''
                 self.opt_level = input_dict['level_of_theory'].lower().split('//')[1]
@@ -576,9 +562,9 @@ class ARC(object):
                 logging.info('Using default level {0} for rotor scans'.format(self.scan_level))
             else:
                 # This is a composite method
-                self.freq_level = default_levels_of_theory['scan_for_composite'].lower()
-                logging.info('Using default level {0} for scan calculations after composite jobs'.format(
-                    self.freq_level))
+                self.scan_level = default_levels_of_theory['scan_for_composite'].lower()
+                logging.info('Using default level {0} for rotor scans after composite jobs'.format(
+                    self.scan_level))
         else:
             self.scan_level = ''
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -645,7 +645,7 @@ class ARC(object):
             txt += 'NOT using bond additivity corrections for thermo\n'
         if self.initial_trsh:
             txt += 'Using an initial troubleshooting method "{0}"'.format(self.initial_trsh)
-        txt += '\nUsing the following settings: {0}\n'.format(self.ess_settings)
+        txt += '\nUsing the following ESS settings: {0}\n'.format(self.ess_settings)
         txt += '\nConsidered the following species and TSs:\n'
         for species in self.arc_species_list:
             if species.is_ts:

--- a/arc/main.py
+++ b/arc/main.py
@@ -57,7 +57,7 @@ class ARC(object):
     `fine`                 ``bool``   Whether or not to use a fine grid for opt jobs (spawns an additional job)
     `generate_conformers`  ``bool``   Whether or not to generate conformers when an initial geometry is given
     `scan_rotors`          ``bool``   Whether or not to perform rotor scans
-    `visualize_orbitals`   ``bool``   Whether or not to save the molecular orbitals for visualization (default: True)
+    `run_orbitals`         ``bool``   Whether or not to save the molecular orbitals for visualization (default: False)
     `use_bac`              ``bool``   Whether or not to use bond additivity corrections for thermo calculations
     `model_chemistry`      ``list``   The model chemistry in Arkane for energy corrections (AE, BAC).
                                         This can be usually determined automatically.
@@ -86,7 +86,7 @@ class ARC(object):
                  ts_guess_level='', fine=True, generate_conformers=True, scan_rotors=True, use_bac=True,
                  model_chemistry='', ess_settings=None, initial_trsh=None, t_min=None, t_max=None, t_count=None,
                  verbose=logging.INFO, project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False,
-                 job_memory=1500, visualize_orbitals=True):
+                 job_memory=1500, run_orbitals=False):
 
         self.__version__ = '1.0.0'
         self.verbose = verbose
@@ -121,7 +121,7 @@ class ARC(object):
             self.fine = fine
             self.generate_conformers = generate_conformers
             self.scan_rotors = scan_rotors
-            self.visualize_orbitals = visualize_orbitals
+            self.run_orbitals = run_orbitals
             self.use_bac = use_bac
             self.model_chemistry = model_chemistry
             if self.model_chemistry:
@@ -358,7 +358,7 @@ class ARC(object):
         restart_dict['fine'] = self.fine
         restart_dict['generate_conformers'] = self.generate_conformers
         restart_dict['scan_rotors'] = self.scan_rotors
-        restart_dict['visualize_orbitals'] = self.visualize_orbitals
+        restart_dict['run_orbitals'] = self.run_orbitals
         restart_dict['use_bac'] = self.use_bac
         restart_dict['model_chemistry'] = self.model_chemistry
         restart_dict['composite_method'] = self.composite_method
@@ -446,7 +446,7 @@ class ARC(object):
         self.fine = input_dict['fine'] if 'fine' in input_dict else True
         self.generate_conformers = input_dict['generate_conformers'] if 'generate_conformers' in input_dict else True
         self.scan_rotors = input_dict['scan_rotors'] if 'scan_rotors' in input_dict else True
-        self.visualize_orbitals = input_dict['visualize_orbitals'] if 'visualize_orbitals' in input_dict else True
+        self.run_orbitals = input_dict['run_orbitals'] if 'run_orbitals' in input_dict else False
         self.use_bac = input_dict['use_bac'] if 'use_bac' in input_dict else True
         self.model_chemistry = input_dict['model_chemistry'] if 'use_bac' in input_dict\
                                                                 and input_dict['use_bac'] else ''
@@ -628,7 +628,7 @@ class ARC(object):
                                    scan_rotors=self.scan_rotors, initial_trsh=self.initial_trsh, rmgdatabase=self.rmgdb,
                                    restart_dict=self.restart_dict, project_directory=self.project_directory,
                                    max_job_time=self.max_job_time, allow_nonisomorphic_2d=self.allow_nonisomorphic_2d,
-                                   memory=self.memory, visualize_orbitals=self.visualize_orbitals,
+                                   memory=self.memory, run_orbitals=self.run_orbitals,
                                    orbitals_level=self.orbitals_level)
 
         self.save_project_info_file()

--- a/arc/main.py
+++ b/arc/main.py
@@ -373,6 +373,7 @@ class ARC(object):
         restart_dict['max_job_time'] = self.max_job_time
         restart_dict['allow_nonisomorphic_2d'] = self.allow_nonisomorphic_2d
         restart_dict['ess_settings'] = self.ess_settings
+        restart_dict['job_memory'] = self.memory
         return restart_dict
 
     def from_dict(self, input_dict, project=None, project_directory=None):
@@ -394,7 +395,8 @@ class ARC(object):
         self.t0 = time.time()  # init time
         self.execution_time = None
         self.verbose = input_dict['verbose'] if 'verbose' in input_dict else self.verbose
-        self.max_job_time = input_dict['max_job_time'] if 'max_job_time' in input_dict else 5
+        self.max_job_time = input_dict['max_job_time'] if 'max_job_time' in input_dict else self.max_job_time
+        self.memory = input_dict['job_memory'] if 'job_memory' in input_dict else self.memory
         self.allow_nonisomorphic_2d = input_dict['allow_nonisomorphic_2d']\
             if 'allow_nonisomorphic_2d' in input_dict else False
         self.output = input_dict['output'] if 'output' in input_dict else dict()

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -17,7 +17,7 @@ from rmgpy.molecule.molecule import Molecule
 
 from arc.main import ARC
 from arc.species.species import ARCSpecies
-from arc.settings import arc_path
+from arc.settings import arc_path, global_ess_settings
 from arc.arc_exceptions import InputError
 
 ################################################################################
@@ -31,15 +31,13 @@ class TestARC(unittest.TestCase):
     def test_as_dict(self):
         """Test the as_dict() method of ARC"""
         self.maxDiff = None
-        ess_settings = {}
         spc1 = ARCSpecies(label='spc1', smiles=str('CC'), generate_thermo=False)
-        arc0 = ARC(project='arc_test', ess_settings=ess_settings, scan_rotors=False, initial_trsh='scf=(NDump=30)',
+        arc0 = ARC(project='arc_test', scan_rotors=False, initial_trsh='scf=(NDump=30)',
                    arc_species_list=[spc1])
         restart_dict = arc0.as_dict()
         expected_dict = {'composite_method': '',
                          'conformer_level': 'b97-d3/6-311+g(d,p)',
                          'ts_guess_level': 'b3lyp/6-31+g(d,p)',
-                         'ess_settings': {'ssh': True},
                          'fine': True,
                          'opt_level': 'wb97xd/6-311++g(d,p)',
                          'freq_level': 'wb97xd/6-311++g(d,p)',
@@ -60,6 +58,7 @@ class TestARC(unittest.TestCase):
                          'use_bac': True,
                          'visualize_orbitals': True,
                          'allow_nonisomorphic_2d': False,
+                         'ess_settings': global_ess_settings,
                          'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},
                                       'arkane_file': None,
                                       'E0': None,
@@ -118,7 +117,7 @@ class TestARC(unittest.TestCase):
                                       'rotors_dict': {},
                                       'xyzs': []}],
                          'use_bac': True}
-        arc1 = ARC(project='wrong', ess_settings=dict())
+        arc1 = ARC(project='wrong')
         project = 'arc_project_for_testing_delete_after_usage1'
         project_directory = os.path.join(arc_path, 'Projects', project)
         arc1.from_dict(input_dict=restart_dict, project='testing_from_dict', project_directory=project_directory)
@@ -133,15 +132,14 @@ class TestARC(unittest.TestCase):
 
     def test_check_project_name(self):
         """Test project name invalidity"""
-        ess_settings = {}
         with self.assertRaises(InputError):
-            ARC(project='ar c', ess_settings=ess_settings)
+            ARC(project='ar c')
         with self.assertRaises(InputError):
-            ARC(project='ar:c', ess_settings=ess_settings)
+            ARC(project='ar:c')
         with self.assertRaises(InputError):
-            ARC(project='ar<c', ess_settings=ess_settings)
+            ARC(project='ar<c')
         with self.assertRaises(InputError):
-            ARC(project='ar%c', ess_settings=ess_settings)
+            ARC(project='ar%c')
 
     def test_restart(self):
         """
@@ -151,8 +149,7 @@ class TestARC(unittest.TestCase):
         restart_path = os.path.join(arc_path, 'arc', 'testing', 'restart(H,H2O2,N2H3,CH3CO2).yml')
         project = 'arc_project_for_testing_delete_after_usage2'
         project_directory = os.path.join(arc_path, 'Projects', project)
-        arc1 = ARC(project=project, ess_settings=dict(),
-                   input_dict=restart_path, project_directory=project_directory)
+        arc1 = ARC(project=project, input_dict=restart_path, project_directory=project_directory)
         arc1.execute()
 
         with open(os.path.join(project_directory, 'output', 'thermo.info'), 'r') as f:

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -36,7 +36,7 @@ class TestARC(unittest.TestCase):
                    arc_species_list=[spc1])
         restart_dict = arc0.as_dict()
         expected_dict = {'composite_method': '',
-                         'conformer_level': 'b97-d3/6-311+g(d,p)',
+                         'conformer_level': 'b3lyp/6-31+g(d,p)',
                          'ts_guess_level': 'b3lyp/6-31+g(d,p)',
                          'fine': True,
                          'opt_level': 'wb97xd/6-311++g(d,p)',
@@ -56,7 +56,7 @@ class TestARC(unittest.TestCase):
                          't_max': None,
                          't_count': None,
                          'use_bac': True,
-                         'visualize_orbitals': True,
+                         'run_orbitals': False,
                          'allow_nonisomorphic_2d': False,
                          'ess_settings': global_ess_settings,
                          'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -9,16 +9,17 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import unittest
 import os
 import shutil
+import time
 
 from rmgpy import settings
 from rmgpy.data.rmg import RMGDatabase
 from rmgpy.species import Species
 from rmgpy.molecule.molecule import Molecule
 
-from arc.main import ARC
+from arc.main import ARC, read_file, get_git_commit, time_lapse, check_ess_settings
 from arc.species.species import ARCSpecies
-from arc.settings import arc_path, global_ess_settings
-from arc.arc_exceptions import InputError
+from arc.settings import arc_path, servers
+from arc.arc_exceptions import InputError, SettingsError
 
 ################################################################################
 
@@ -28,9 +29,16 @@ class TestARC(unittest.TestCase):
     Contains unit tests for the ARC class
     """
 
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.maxDiff = None
+        cls.servers = [server for server in servers.keys()]
+
     def test_as_dict(self):
         """Test the as_dict() method of ARC"""
-        self.maxDiff = None
         spc1 = ARCSpecies(label='spc1', smiles=str('CC'), generate_thermo=False)
         arc0 = ARC(project='arc_test', scan_rotors=False, initial_trsh='scf=(NDump=30)',
                    arc_species_list=[spc1])
@@ -52,13 +60,15 @@ class TestARC(unittest.TestCase):
                          'scan_level': '',
                          'scan_rotors': False,
                          'sp_level': 'ccsd(t)-f12/cc-pvtz-f12',
+                         'job_memory': 1500,
                          't_min': None,
                          't_max': None,
                          't_count': None,
                          'use_bac': True,
                          'run_orbitals': False,
                          'allow_nonisomorphic_2d': False,
-                         'ess_settings': global_ess_settings,
+                         'ess_settings': {'gaussian': ['server1', 'server2'],
+                                          'molpro': ['server2'], 'qchem': ['server1'], 'ssh': True},
                          'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},
                                       'arkane_file': None,
                                       'E0': None,
@@ -82,41 +92,37 @@ class TestARC(unittest.TestCase):
     def test_from_dict(self):
         """Test the from_dict() method of ARC"""
         restart_dict = {'composite_method': '',
-                         'conformer_level': 'b97-d3/6-311+g(d,p)',
-                         'ess_settings': {'gaussian': 'server1',
-                                          'molpro': 'server1',
-                                          'qchem': u'server1',
-                                          'ssh': True},
-                         'fine': True,
-                         'freq_level': 'wb97x-d3/6-311+g(d,p)',
-                         'generate_conformers': True,
-                         'initial_trsh': 'scf=(NDump=30)',
-                         'model_chemistry': 'ccsd(t)-f12/cc-pvtz-f12',
-                         'opt_level': 'wb97x-d3/6-311+g(d,p)',
-                         'output': {},
-                         'project': 'arc_test',
-                         'rxn_list': [],
-                         'scan_level': '',
-                         'scan_rotors': False,
-                         'sp_level': 'ccsdt-f12/cc-pvqz-f12',
-                         'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},
-                                      'charge': 1,
-                                      'conformer_energies': [],
-                                      'conformers': [],
-                                      'external_symmetry': 1,
-                                      'final_xyz': '',
-                                      'generate_thermo': False,
-                                      'is_ts': False,
-                                      'label': 'testing_spc1',
-                                      'mol': '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}\n2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}\n3 H u0 p0 c0 {1,S}\n4 H u0 p0 c0 {1,S}\n5 H u0 p0 c0 {1,S}\n6 H u0 p0 c0 {2,S}\n7 H u0 p0 c0 {2,S}\n8 H u0 p0 c0 {2,S}\n',
-                                      'multiplicity': 1,
-                                      'neg_freqs_trshed': [],
-                                      'number_of_rotors': 0,
-                                      'opt_level': '',
-                                      'optical_isomers': 1,
-                                      'rotors_dict': {},
-                                      'xyzs': []}],
-                         'use_bac': True}
+                        'conformer_level': 'b97-d3/6-311+g(d,p)',
+                        'fine': True,
+                        'freq_level': 'wb97x-d3/6-311+g(d,p)',
+                        'generate_conformers': True,
+                        'initial_trsh': 'scf=(NDump=30)',
+                        'model_chemistry': 'ccsd(t)-f12/cc-pvtz-f12',
+                        'opt_level': 'wb97x-d3/6-311+g(d,p)',
+                        'output': {},
+                        'project': 'arc_test',
+                        'rxn_list': [],
+                        'scan_level': '',
+                        'scan_rotors': False,
+                        'sp_level': 'ccsdt-f12/cc-pvqz-f12',
+                        'species': [{'bond_corrections': {'C-C': 1, 'C-H': 6},
+                                     'charge': 1,
+                                     'conformer_energies': [],
+                                     'conformers': [],
+                                     'external_symmetry': 1,
+                                     'final_xyz': '',
+                                     'generate_thermo': False,
+                                     'is_ts': False,
+                                     'label': 'testing_spc1',
+                                     'mol': '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}\n2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}\n3 H u0 p0 c0 {1,S}\n4 H u0 p0 c0 {1,S}\n5 H u0 p0 c0 {1,S}\n6 H u0 p0 c0 {2,S}\n7 H u0 p0 c0 {2,S}\n8 H u0 p0 c0 {2,S}\n',
+                                     'multiplicity': 1,
+                                     'neg_freqs_trshed': [],
+                                     'number_of_rotors': 0,
+                                     'opt_level': '',
+                                     'optical_isomers': 1,
+                                     'rotors_dict': {},
+                                     'xyzs': []}],
+                        'use_bac': True}
         arc1 = ARC(project='wrong')
         project = 'arc_project_for_testing_delete_after_usage1'
         project_directory = os.path.join(arc_path, 'Projects', project)
@@ -194,7 +200,7 @@ class TestARC(unittest.TestCase):
                     rtm = True
                 elif 'Loading the RMG database...' in line:
                     ldb = True
-                elif 'Thermodynamics for H2O2:' in line:
+                elif 'Thermodynamics for H2O2' in line:
                     therm = True
                 elif 'Sources of thermoproperties determined by RMG for the parity plots:' in line:
                     src = True
@@ -214,8 +220,13 @@ class TestARC(unittest.TestCase):
 
         with open(os.path.join(project_directory, 'output', 'Species', 'H2O2', 'species_dictionary.txt'), 'r') as f:
             lines = f.readlines()
-        adj_list = str(''.join([line for line in lines if (line and 'H2O2' not in line)]))
-        mol1 = Molecule().fromAdjacencyList(adj_list)
+        adj_list = ''
+        for line in lines:
+            if 'H2O2' not in line:
+                adj_list += line
+            if line == '\n':
+                break
+        mol1 = Molecule().fromAdjacencyList(str(adj_list))
         self.assertEqual(mol1.toSMILES(), str('OO'))
 
         thermo_library_path = os.path.join(project_directory, 'output', 'RMG libraries', 'thermo',
@@ -249,6 +260,62 @@ class TestARC(unittest.TestCase):
 
         # delete the generated library from RMG-database
         os.remove(new_thermo_library_path)
+
+    def test_check_ess_settings(self):
+        """Test the check_ess_settings function"""
+        ess_settings1 = {'gaussian': [self.servers[0]], 'molpro': [self.servers[1], self.servers[0]],
+                         'qchem': [self.servers[0]], 'ssh': False}
+        ess_settings2 = {'gaussian': self.servers[0], 'molpro': self.servers[1], 'qchem': self.servers[0]}
+        ess_settings3 = {'gaussian': self.servers[0], 'molpro': [self.servers[1], self.servers[0]],
+                         'qchem': self.servers[0]}
+        ess_settings4 = {'gaussian': self.servers[0], 'molpro': self.servers[1], 'qchem': self.servers[0], 'ssh': False}
+
+        ess_settings1 = check_ess_settings(ess_settings1)
+        ess_settings2 = check_ess_settings(ess_settings2)
+        ess_settings3 = check_ess_settings(ess_settings3)
+        ess_settings4 = check_ess_settings(ess_settings4)
+
+        ess_list = [ess_settings1, ess_settings2, ess_settings3, ess_settings4]
+
+        for ess in ess_list:
+            for soft, server_list in ess.items():
+                self.assertTrue(soft in ['gaussian', 'molpro', 'qchem', 'ssh'])
+                self.assertIsInstance(server_list, (list, bool))
+
+        with self.assertRaises(SettingsError):
+            ess_settings5 = {'nosoft': ['server1']}
+            check_ess_settings(ess_settings5)
+        with self.assertRaises(SettingsError):
+            ess_settings6 = {'gaussian': ['noserver']}
+            check_ess_settings(ess_settings6)
+
+    def test_time_lapse(self):
+        """Test the time_lapse() function"""
+        t0 = time.time()
+        time.sleep(2)
+        lap = time_lapse(t0)
+        self.assertEqual(lap, '00:00:02')
+
+    def test_get_git_commit(self):
+        """Test the get_git_commit() function"""
+        git_commit = get_git_commit()
+        # output format: ['fafdb957049917ede565cebc58b29899f597fb5a', 'Fri Mar 29 11:09:50 2019 -0400']
+        self.assertEqual(len(git_commit[0]), 40)
+        self.assertEqual(len(git_commit[1].split()), 6)
+
+    def test_read_file(self):
+        """Test the read_file() function"""
+        restart_path = os.path.join(arc_path, 'arc', 'testing', 'restart(H,H2O2,N2H3,CH3CO2).yml')
+        input_dict = read_file(restart_path)
+        self.assertIsInstance(input_dict, dict)
+        self.assertTrue('reactions' in input_dict)
+        self.assertTrue('freq_level' in input_dict)
+        self.assertTrue('use_bac' in input_dict)
+        self.assertTrue('ts_guess_level' in input_dict)
+        self.assertTrue('running_jobs' in input_dict)
+
+        with self.assertRaises(InputError):
+            read_file('nopath')
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -192,7 +192,10 @@ class Processor(object):
                 stat_mech_job.applyBondEnergyCorrections = self.use_bac
                 stat_mech_job.modelChemistry = self.model_chemistry
                 stat_mech_job.frequencyScaleFactor = assign_frequency_scale_factor(self.model_chemistry)
-                stat_mech_job.execute(outputFile=output_file_path, plot=False)
+                try:
+                    stat_mech_job.execute(outputFile=output_file_path, plot=False)
+                except Exception:
+                    continue
                 if species.generate_thermo:
                     thermo_job = ThermoJob(arkane_spc, 'NASA')
                     thermo_job.execute(outputFile=output_file_path, plot=False)

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -7,7 +7,7 @@ import shutil
 import logging
 from random import randint
 
-from arkane.input import species as arkane_species, transitionState as arkane_transition_state,\
+from arkane.input import species as arkane_input_species, transitionState as arkane_transition_state,\
     reaction as arkane_reaction
 from arkane.statmech import StatMechJob, assign_frequency_scale_factor
 from arkane.thermo import ThermoJob
@@ -82,7 +82,8 @@ class Processor(object):
         output_dir = os.path.join(self.project_directory, 'output', folder_name, species.label)
         if not os.path.isdir(output_dir):
             os.makedirs(output_dir)
-        output_file_path = os.path.join(output_dir, species.label + '_arkane_output.py')
+        output_file_path = [os.path.join(output_dir, species.label + '_arkane_output.py'),
+                            os.path.join(output_dir, species.label + '_arkane_output_no_BAC.py')]
         if os.path.isfile(os.path.join(output_dir, 'species_dictionary.txt')):
             os.remove(os.path.join(output_dir, 'species_dictionary.txt'))
 
@@ -153,7 +154,7 @@ class Processor(object):
         # write the Arkane species input file
         input_file_path = os.path.join(self.project_directory, 'output', folder_name, species.label,
                                        '{0}_arkane_input.py'.format(species.label))
-        input_file = input_files['arkane_species']
+        input_file = input_files['arkane_input_species']
         if self.use_bac and not species.is_ts:
             logging.info('Using the following BAC for {0}: {1}'.format(species.label, species.bond_corrections))
             bonds = '\n\nbonds = {0}'.format(species.bond_corrections)
@@ -180,32 +181,37 @@ class Processor(object):
                 unique_arkane_species_label = False
                 while not unique_arkane_species_label:
                     try:
-                        arkane_spc = arkane_species(str(species.label), species.arkane_file)
+                        arkane_spc = arkane_input_species(str(species.label), species.arkane_file)
                     except ValueError:
                         species.label += '_' + str(randint(0, 999))
                     else:
                         unique_arkane_species_label = True
-                if species.mol_list:
-                    arkane_spc.molecule = species.mol_list
-                stat_mech_job = StatMechJob(arkane_spc, species.arkane_file)
-                stat_mech_job.applyBondEnergyCorrections = self.use_bac
-                stat_mech_job.modelChemistry = self.model_chemistry
-                stat_mech_job.frequencyScaleFactor = assign_frequency_scale_factor(self.model_chemistry)
-                try:
-                    stat_mech_job.execute(outputFile=output_file_path, plot=False)
-                except Exception:
-                    continue
-                if species.generate_thermo:
-                    thermo_job = ThermoJob(arkane_spc, 'NASA')
-                    thermo_job.execute(outputFile=output_file_path, plot=False)
-                    species.thermo = arkane_spc.getThermoData()
-                    plotter.log_thermo(species.label, path=output_file_path)
-                    species_for_thermo_lib.append(species)
-
                 species.rmg_species = Species(molecule=[species.mol])
                 species.rmg_species.reactive = True
                 if species.mol_list:
+                    arkane_spc.molecule = species.mol_list
                     species.rmg_species.molecule = species.mol_list  # add resonance structures for thermo determination
+                statmech_success = self._run_statmech(arkane_spc, species.arkane_file, output_file_path[0],
+                                                      use_bac=self.use_bac)
+                if not statmech_success:
+                    continue
+
+                if species.generate_thermo:
+                    thermo_job = ThermoJob(arkane_spc, 'NASA')
+                    thermo_job.execute(outputFile=output_file_path[0], plot=False)
+                    species.thermo = arkane_spc.getThermoData()
+                    plotter.log_thermo(species.label, path=output_file_path[0])
+                    species_for_thermo_lib.append(species)
+                if self.use_bac and self.model_chemistry:
+                    # If BAC was used, save another Arkane YAML file of this species with no BAC, so it can be used
+                    # for further rate calculations if needed (where the conformer.E0 has no BAC)
+                    statmech_success = self._run_statmech(arkane_spc, species.arkane_file, output_file_path[1],
+                                                          use_bac=False)
+                    if statmech_success:
+                        arkane_spc.label += str('_no_BAC')
+                        arkane_spc.thermo = None  # otherwise thermo won't be calculated, although we don't really care
+                        thermo_job = ThermoJob(arkane_spc, 'NASA')
+                        thermo_job.execute(outputFile=output_file_path[1], plot=False)
                 try:
                     species.rmg_thermo = self.rmgdb.thermo.getThermoData(species.rmg_species)
                 except ValueError:
@@ -224,34 +230,16 @@ class Processor(object):
                 self.copy_freq_output_for_ts(species.label)
                 success = True
                 rxn_list_for_kinetics_plots.append(rxn)
-                output_file_path = self._generate_arkane_species_file(species)
+                output_file_path = self._generate_arkane_species_file(species)[0]
                 arkane_ts = arkane_transition_state(str(species.label), species.arkane_file)
                 arkane_spc_dict[species.label] = arkane_ts
-                stat_mech_job = StatMechJob(arkane_ts, species.arkane_file)
-                stat_mech_job.applyBondEnergyCorrections = False
-                if self.model_chemistry:
-                    stat_mech_job.modelChemistry = self.model_chemistry
-                else:
-                    stat_mech_job.applyAtomEnergyCorrections = False
-                stat_mech_job.frequencyScaleFactor = assign_frequency_scale_factor(self.model_chemistry)
-                stat_mech_job.execute(outputFile=None, plot=False)
+                self._run_statmech(arkane_ts, species.arkane_file, kinetics=True)
                 for spc in rxn.r_species + rxn.p_species:
                     if spc.label not in arkane_spc_dict.keys():
                         # add an extra character to the arkane_species label to distinguish between species calculated
                         #  for thermo and species calculated for kinetics (where we don't want to use BAC)
-                        arkane_spc = arkane_species(str(spc.label + '_'), spc.arkane_file)
-                        stat_mech_job = StatMechJob(arkane_spc, spc.arkane_file)
-                        arkane_spc_dict[spc.label] = arkane_spc
-                        stat_mech_job.applyBondEnergyCorrections = False
-                        if self.model_chemistry:
-                            stat_mech_job.modelChemistry = self.model_chemistry
-                        else:
-                            stat_mech_job.applyAtomEnergyCorrections = False
-                        stat_mech_job.frequencyScaleFactor = assign_frequency_scale_factor(self.model_chemistry)
-                        stat_mech_job.execute(outputFile=None, plot=False)
-                        # thermo_job = ThermoJob(arkane_spc, 'NASA')
-                        # thermo_job.execute(outputFile=None, plot=False)
-                        # arkane_spc.thermo = arkane_spc.getThermoData()
+                        arkane_spc = arkane_input_species(str(spc.label + '_'), spc.arkane_file)
+                        self._run_statmech(arkane_spc, spc.arkane_file, kinetics=True)
                 rxn.dh_rxn298 = sum([product.thermo.getEnthalpy(298) for product in arkane_spc_dict.values()
                                      if product.label in rxn.products])\
                                 - sum([reactant.thermo.getEnthalpy(298) for reactant in arkane_spc_dict.values()
@@ -295,9 +283,35 @@ class Processor(object):
             plotter.save_kinetics_lib(rxn_list=rxn_list_for_kinetics_plots, path=libraries_path,
                                       name=self.project, lib_long_desc=self.lib_long_desc)
 
-        self.clean_output_directory()
+        self._clean_output_directory()
 
-    def clean_output_directory(self):
+    def _run_statmech(self, arkane_spc, arkane_file, output_file_path=None, use_bac=False, kinetics=False, plot=False):
+        """
+        A helper function for running an Arkane statmech job
+        `arkane_spc` is the species() function from Arkane's input.py
+        `arkane_file` is the Arkane species file (either .py or YAML form)
+        `output_file_path` is a path to the Arkane output.py file
+        `use_bac` is a bool flag indicating whether or not to use bond additivity corrections
+        `kinetics` is a bool flag indicating whether this specie sis part of a kinetics job, in which case..??
+        `plot` is a bool flag indicating whether or not to plot a PDF of the calculated thermo properties
+        """
+        success = True
+        stat_mech_job = StatMechJob(arkane_spc, arkane_file)
+        stat_mech_job.applyBondEnergyCorrections = use_bac and not kinetics and self.model_chemistry
+        if not kinetics or kinetics and self.model_chemistry:
+            # currently we have to use a model chemistry for thermo
+            stat_mech_job.modelChemistry = self.model_chemistry
+        else:
+            # if this is a klinetics computation and we don't have a valid model chemistry, don't bother about it
+            stat_mech_job.applyAtomEnergyCorrections = False
+        stat_mech_job.frequencyScaleFactor = assign_frequency_scale_factor(self.model_chemistry)
+        try:
+            stat_mech_job.execute(outputFile=output_file_path, plot=plot)
+        except Exception:
+            success = False
+        return success
+
+    def _clean_output_directory(self):
         """
         A helper function to organize the output directory
         - remove redundant rotor.txt files (from kinetics jobs)
@@ -328,9 +342,9 @@ class Processor(object):
                 if os.path.exists(os.path.join(species_path, 'species')):  # This is where Arkane saves the YAML file
                     species_yaml_files = os.listdir(os.path.join(species_path, 'species'))
                     if species_yaml_files:
-                        species_yaml_file = species_yaml_files[0]
-                        shutil.move(src=os.path.join(species_path, 'species', species_yaml_file),
-                                    dst=os.path.join(species_path, species_yaml_file))
+                        for yml_file in species_yaml_files:
+                            shutil.move(src=os.path.join(species_path, 'species', yml_file),
+                                        dst=os.path.join(species_path, yml_file))
                     shutil.rmtree(os.path.join(species_path, 'species'))
 
     def copy_freq_output_for_ts(self, label):

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -183,7 +183,7 @@ class Processor(object):
                     try:
                         arkane_spc = arkane_species(str(species.label), species.arkane_file)
                     except ValueError:
-                        species.label += '_(' + str(randint(0, 999)) + ')'
+                        species.label += '_' + str(randint(0, 999))
                     else:
                         unique_arkane_species_label = True
                 if species.mol_list:

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -176,7 +176,6 @@ class Processor(object):
         species_for_thermo_lib = list()
         for species in self.species_dict.values():
             if not species.is_ts and 'ALL converged' in self.output[species.label]['status']:
-                species_for_thermo_lib.append(species)
                 output_file_path = self._generate_arkane_species_file(species)
                 unique_arkane_species_label = False
                 while not unique_arkane_species_label:
@@ -201,6 +200,7 @@ class Processor(object):
                     thermo_job.execute(outputFile=output_file_path, plot=False)
                     species.thermo = arkane_spc.getThermoData()
                     plotter.log_thermo(species.label, path=output_file_path)
+                    species_for_thermo_lib.append(species)
 
                 species.rmg_species = Species(molecule=[species.mol])
                 species.rmg_species.reactive = True

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -328,10 +328,11 @@ class Scheduler(object):
         for species in self.species_dict.values():
             if not species.initial_xyz and not species.final_xyz and species.conformers and species.conformer_energies:
                 self.determine_most_stable_conformer(species.label)
-                if self.composite_method:
-                    self.run_composite_job(species.label)
-                else:
-                    self.run_opt_job(species.label)
+                if species.initial_xyz is not None:
+                    if self.composite_method:
+                        self.run_composite_job(species.label)
+                    else:
+                        self.run_opt_job(species.label)
         if self.generate_conformers:
             self.run_conformer_jobs()
         while self.running_jobs != {}:  # loop while jobs are still running

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -61,7 +61,7 @@ class Scheduler(object):
     `fine`                  ``bool``  Whether or not to use a fine grid for opt jobs (spawns an additional job)
     `generate_conformers`   ``bool``  Whether or not to generate conformers when an initial geometry is given
     `scan_rotors`           ``bool``  Whether or not to perform rotor scans
-    `visualize_orbitals`    ``bool``  Whether or not to save the molecular orbitals for visualization (default: Tru
+    `run_orbitals`          ``bool``  Whether or not to save the molecular orbitals for visualization (default: Tru
     `output`                ``dict``  Output dictionary with status and final QM file paths for all species
     `settings`              ``dict``  A dictionary of available servers and software
     `initial_trsh`          ``dict``  Troubleshooting methods to try by default. Keys are ESS software, values are trshs
@@ -108,7 +108,7 @@ class Scheduler(object):
     def __init__(self, project, settings, species_list, composite_method, conformer_level, opt_level, freq_level,
                  sp_level, scan_level, ts_guess_level, orbitals_level, project_directory, rmgdatabase, fine=False,
                  scan_rotors=True, generate_conformers=True, initial_trsh=None, rxn_list=None, restart_dict=None,
-                 max_job_time=120, allow_nonisomorphic_2d=False, memory=1500, testing=False, visualize_orbitals=True):
+                 max_job_time=120, allow_nonisomorphic_2d=False, memory=1500, testing=False, run_orbitals=False):
         self.rmgdb = rmgdatabase
         self.restart_dict = restart_dict
         self.species_list = species_list
@@ -143,7 +143,7 @@ class Scheduler(object):
         self.fine = fine
         self.generate_conformers = generate_conformers
         self.scan_rotors = scan_rotors
-        self.visualize_orbitals = visualize_orbitals
+        self.run_orbitals = run_orbitals
         self.unique_species_labels = list()
         self.initial_trsh = initial_trsh if initial_trsh is not None else dict()
         self.save_restart = False
@@ -709,7 +709,7 @@ class Scheduler(object):
         Spawn orbitals job used for molecular orbital visualization
         Currently supporting QChem for printing the orbitals, the output could be visualized using IQMol
         """
-        if self.visualize_orbitals and 'orbitals' not in self.job_dict[label]:
+        if self.run_orbitals and 'orbitals' not in self.job_dict[label]:
             self.run_job(label=label, xyz=self.species_dict[label].final_xyz, level_of_theory=self.orbitals_level,
                          job_type='orbitals')
 

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -22,7 +22,7 @@ import arc.rmgdb as rmgdb
 from arc import plotter
 from arc import parser
 from arc.job.job import Job
-from arc.arc_exceptions import SpeciesError, SchedulerError
+from arc.arc_exceptions import SpeciesError, SchedulerError, TSError
 from arc.job.ssh import SSH_Client
 from arc.species.species import ARCSpecies, TSGuess, determine_rotor_symmetry
 from arc.species.converter import get_xyz_string, molecules_from_xyz, check_isomorphism
@@ -231,7 +231,11 @@ class Scheduler(object):
                         logging.info('Trying to generating a TS guess for {0} reaction {1} using AutoTST{2}...'.format(
                             ts_guess.family, rxn.label, reverse))
                         ts_guess.t0 = datetime.datetime.now()
-                        ts_guess.xyz = autotst(rmg_reaction=ts_guess.rmg_reaction, reaction_family=ts_guess.family)
+                        try:
+                            ts_guess.xyz = autotst(rmg_reaction=ts_guess.rmg_reaction, reaction_family=ts_guess.family)
+                        except TSError as e:
+                            logging.error('Could not generate an AutoTST guess for reaction {0}.\nGot: {1}'.format(
+                                rxn.label, e.message))
                         ts_guess.success = True if ts_guess.xyz is not None else False
                         ts_guess.execution_time = str(datetime.datetime.now() - ts_guess.t0).split('.')[0]
                     else:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -534,7 +534,7 @@ class Scheduler(object):
         try:
             job.determine_job_status()  # also downloads output file
         except IOError:
-            if not job.job_type in ['orbitals']:
+            if job.job_type not in ['orbitals']:
                 logging.warn('Tried to determine status of job {0}, but it seems like the job never ran.'
                              ' Re-running job.'.format(job.job_name))
                 self.run_job(label=label, xyz=job.xyz, level_of_theory=job.level_of_theory, job_type=job.job_type,

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -294,7 +294,8 @@ class Scheduler(object):
                             and 'composite' not in self.job_dict[species.label]:
                         self.run_freq_job(species.label)
                     elif 'opt converged' not in self.output[species.label]['status']\
-                            and 'opt' not in self.job_dict[species.label] and not self.composite_method:
+                            and 'opt' not in self.job_dict[species.label] and not self.composite_method \
+                            and 'geo' not in self.output[species.label]:
                         self.run_opt_job(species.label)
                     elif 'opt converged' in self.output[species.label]['status']:
                         # opt is done
@@ -863,7 +864,7 @@ class Scheduler(object):
                 if tsg.success:
                     # 0.000239006 is the conversion factor from J/mol to kcal/mol
                     tsg.energy = (self.species_dict[label].conformer_energies[tsg.index] - e_min) * 0.000239006
-                    logging.info('{0}. Method: {1}, relative energy: {2} kcal/mol, execution time: {3}'.format(
+                    logging.info('{0}. Method: {1}, relative energy: {2} kcal/mol, guess execution time: {3}'.format(
                         tsg.index, tsg.method, tsg.energy, tsg.execution_time))
                     # for TSs, only use `draw_3d()`, not `show_sticks()` which gets connectivity wrong:
                     plotter.draw_3d(xyz=tsg.xyz)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -855,7 +855,7 @@ class Scheduler(object):
             # currently we take the most stable guess. We'll need to implement additional checks here:
             # - normal displacement mode of the imaginary frequency
             # - IRC
-            e_min = min(energies)
+            e_min = min([e for e in energies if e is not None])
             i_min = energies.index(e_min)
             self.species_dict[label].chosen_ts = None
             logging.info('\n\nShowing geometry *guesses* of successful TS guess methods for {0} of {1}:'.format(

--- a/arc/schedulerTest.py
+++ b/arc/schedulerTest.py
@@ -30,21 +30,21 @@ class TestScheduler(unittest.TestCase):
         A method that is run before all unit tests in this class.
         """
         cls.maxDiff = None
-        settings = {'gaussian': 'server1', 'molpro': 'server2', 'qchem': 'server1', 'ssh': False}
+        ess_settings = {'gaussian': ['server1'], 'molpro': ['server2','server1'], 'qchem': ['server1'], 'ssh': False}
         project_directory = os.path.join(arc_path, 'Projects', 'arc_project_for_testing_delete_after_usage3')
         cls.spc1 = ARCSpecies(label=str('methylamine'), smiles=str('CN'))
         cls.spc2 = ARCSpecies(label=str('C2H6'), smiles=str('CC'))
-        cls.job1 = Job(project='project_test', settings=settings, species_name='methylamine', xyz='C 0.0 0.0 0.0',
-                       job_type='conformer', conformer=0, level_of_theory='b97-d3/6-311+g(d,p)', multiplicity=1,
-                       project_directory=project_directory, job_num=101)
-        cls.job2 = Job(project='project_test', settings=settings, species_name='methylamine', xyz='C 0.0 0.0 0.0',
-                       job_type='conformer', conformer=1, level_of_theory='b97-d3/6-311+g(d,p)', multiplicity=1,
-                       project_directory=project_directory, job_num=102)
-        cls.job3 = Job(project='project_test', settings=settings, species_name='C2H6', xyz='C 0.0 0.0 0.0',
+        cls.job1 = Job(project='project_test', ess_settings=ess_settings, species_name='methylamine',
+                       xyz='C 0.0 0.0 0.0', job_type='conformer', conformer=0, level_of_theory='b97-d3/6-311+g(d,p)',
+                       multiplicity=1, project_directory=project_directory, job_num=101)
+        cls.job2 = Job(project='project_test', ess_settings=ess_settings, species_name='methylamine',
+                       xyz='C 0.0 0.0 0.0', job_type='conformer', conformer=1, level_of_theory='b97-d3/6-311+g(d,p)',
+                       multiplicity=1, project_directory=project_directory, job_num=102)
+        cls.job3 = Job(project='project_test', ess_settings=ess_settings, species_name='C2H6', xyz='C 0.0 0.0 0.0',
                        job_type='freq', level_of_theory='wb97x-d3/6-311+g(d,p)', multiplicity=1,
                        project_directory=project_directory, software='qchem', job_num=103)
         cls.rmgdb = rmgdb.make_rmg_database_object()
-        cls.sched1 = Scheduler(project='project_test', settings=settings, species_list=[cls.spc1, cls.spc2],
+        cls.sched1 = Scheduler(project='project_test', ess_settings=ess_settings, species_list=[cls.spc1, cls.spc2],
                                composite_method='', conformer_level=default_levels_of_theory['conformer'],
                                opt_level=default_levels_of_theory['opt'], freq_level=default_levels_of_theory['freq'],
                                sp_level=default_levels_of_theory['sp'], scan_level=default_levels_of_theory['scan'],

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -41,6 +41,7 @@ servers = {
         'address': 'server2.host.edu',
         'un': '<username>',
         'key': 'path_to_rsa_key',
+        'cpus': 48,  # optional (default: 8)
     }
 }
 

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -34,7 +34,6 @@ servers = {
         'address': 'server1.host.edu',
         'un': '<username>',
         'key': 'path_to_rsa_key',
-        'precedence': 'molpro',
     },
     'server2': {
         'cluster_soft': 'Slurm',  # Simple Linux Utility for Resource Management
@@ -43,6 +42,15 @@ servers = {
         'key': 'path_to_rsa_key',
         'cpus': 48,  # optional (default: 8)
     }
+}
+
+# List here servers you'd like to associate with specific ESS.
+# An ordered list of servers indicates priority
+# Keeping this dictionary empty will cause ARC to scan for software on the servers defined above
+global_ess_settings = {
+    'gaussian': ['server1', 'server2'],
+    'molpro': 'server2',
+    'qchem': 'server1',
 }
 
 # List here (complete or partial) phrases of methods or basis sets you'd like to associate to specific ESS

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -90,13 +90,13 @@ output_filename = {'gaussian': 'input.log',
                    'molpro': 'input.out',
 }
 
-default_levels_of_theory = {'conformer': 'b97-d3/6-311+g(d,p)',
+default_levels_of_theory = {'conformer': 'b3lyp/6-31+g(d,p)',
                             'ts_guesses': 'b3lyp/6-31+g(d,p)',  # used for IRC as well
                             'opt': 'wb97xd/6-311++g(d,p)',
                             'freq': 'wb97xd/6-311++g(d,p)',  # should be the same level as opt
                             'sp': 'ccsd(t)-f12/cc-pvtz-f12',  # This should be a level for which BAC is available
                             # 'sp': 'b3lyp/6-311+g(3df,2p)',
-                            'orbitals': 'b3lyp/6-311++g(3df,3pd)',  # save orbitals for visualization
+                            'orbitals': 'b3lyp/6-311+g(d,p)',  # save orbitals for visualization
                             'scan': 'b3lyp/6-311+g(d,p)',
                             'scan_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
                             'freq_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
@@ -114,8 +114,8 @@ valid_chars = "-_()[]=., %s%s" % (string.ascii_letters, string.digits)
 rotor_scan_resolution = 8.0  # degrees. Default: 8.0
 
 # rotor validation parameters
+maximum_barrier = 40    # a rotor threshold (kJ/mol) above which the rotor is not considered. Default: 40 (~10 kcal/mol)
+minimum_barrier = 0.5   # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 0.5 kJ/mol
 inconsistency_az = 5    # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
 inconsistency_ab = 0.5  # maximum allowed inconsistency between consecutive points in the scan given as a fraction
 #  of the maximum scan energy. Default: 50%
-maximum_barrier = 40    # a rotor threshold (kJ/mol) above which the rotor is not considered. Default: 40 (~10 kcal/mol)
-minimum_barrier = 0.5   # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 0.5 kJ/mol

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -45,6 +45,15 @@ servers = {
     }
 }
 
+# List here (complete or partial) phrases of methods or basis sets you'd like to associate to specific ESS
+# Avoid ascribing the same phrase to more than one server, this may cause undeterministic assignment of software
+# Format is levels_ess = {ess: ['phrase1', 'phrase2'], ess2: ['phrase3', 'phrase3']}
+levels_ess = {
+    'gaussian': ['b3lyp', 'm062x', '3df,3pd'],
+    'molpro': ['ccsd', 'cisd', 'vpz'],
+    'qchem': ['m06-2x', 'def2']
+}
+
 check_status_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qstat',
                         'Slurm': '/usr/bin/squeue'}
 

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -298,7 +298,11 @@ def order_atoms_in_mol_list(ref_mol, mol_list):
     """Order the atoms in all molecules of mol_list by the atom order in ref_mol"""
     if mol_list is not None:
         for mol in mol_list:
-            order_atoms(ref_mol, mol)
+            try:  # TODO: flag as unordered (or solve)
+                order_atoms(ref_mol, mol)
+            except SanitizationError as e:
+                logging.warning('Could not order atoms in\n{0}\nGot the following error:'
+                                '\n{1}'.format(mol.toAdjacencyList, e))
 
 
 def order_atoms(ref_mol, mol):

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -435,9 +435,9 @@ class ARCSpecies(object):
         if arkane_spc.adjacency_list is not None:
             try:
                 self.mol = Molecule().fromAdjacencyList(adjlist=arkane_spc.adjacency_list)
-            except ValueError as e:
+            except ValueError:
                 print('Could not read adjlist:\n{0}'.format(arkane_spc.adjacency_list))  # should *not* be logging
-                raise e
+                raise
         elif arkane_spc.inchi is not None:
             self.mol = Molecule().fromInChI(inchistr=arkane_spc.inchi)
         elif arkane_spc.smiles is not None:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -259,7 +259,8 @@ class ARCSpecies(object):
         if not isinstance(self.charge, int):
             raise SpeciesError('Charge for species {0} is not an integer (got {1}, a {2})'.format(
                 self.label, self.charge, type(self.charge)))
-        if not self.is_ts and self.initial_xyz is None and self.mol is None and not self.conformers:
+        if not self.is_ts and self.initial_xyz is None and not self.final_xyz and self.mol is None\
+                and not self.conformers:
             raise SpeciesError('No structure (xyz, SMILES, adjList, RMG:Species, or RMG:Molecule) was given for'
                                ' species {0}'.format(self.label))
         if self.label is None:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -943,16 +943,16 @@ class TSGuess(object):
                     raise TSError('If no method is specified, an xyz guess must be given')
                 self.success = True
                 self.execution_time = 0
-            if not ('user guess' in self.method or 'autotst' in self.method
-                    or self.method in ['user guess'] + [tsm.lower() for tsm in default_ts_methods]):
-                raise TSError('Unrecognized method. Should be either {0}. Got: {1}'.format(
-                              ['User guess'] + default_ts_methods, self.method))
             self.reactants_xyz = reactants_xyz if reactants_xyz is not None else list()
             self.products_xyz = products_xyz if products_xyz is not None else list()
             self.rmg_reaction = rmg_reaction
             self.family = family
             # if self.family is None and self.method.lower() in ['kinbot', 'autotst']:
             #     raise TSError('No family specified for method {0}'.format(self.method))
+        if not ('user guess' in self.method or 'autotst' in self.method
+                or self.method in ['user guess'] + [tsm.lower() for tsm in default_ts_methods]):
+            raise TSError('Unrecognized method. Should be either {0}. Got: {1}'.format(
+                          ['User guess'] + default_ts_methods, self.method))
 
     def as_dict(self):
         """A helper function for dumping this object as a dictionary in a YAML file for restarting ARC"""
@@ -993,10 +993,6 @@ class TSGuess(object):
                 raise TSError('If no method is specified, an xyz guess must be given')
             self.success = self.success if self.success is not None else True
             self.execution_time = '0'
-        if 'user guess' not in self.method\
-                and self.method not in ['user guess'] + [tsm.lower() for tsm in default_ts_methods]:
-            raise TSError('Unrecognized method. Should be either {0}. Got: {1}'.format(
-                          ['User guess'] + default_ts_methods, self.method))
         self.reactants_xyz = ts_dict['reactants_xyz'] if 'reactants_xyz' in ts_dict else list()
         self.products_xyz = ts_dict['products_xyz'] if 'products_xyz' in ts_dict else list()
         self.family = ts_dict['family'] if 'family' in ts_dict else None

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -434,7 +434,9 @@ class ARCSpecies(object):
                                                                            filter_structures=True)
         if 'conformers_path' in species_dict:
             self.append_conformers(species_dict['conformers_path'])
-        if self.mol is None and self.initial_xyz is None and not self.final_xyz and not self.conformers:
+        if self.mol is None and self.initial_xyz is None and not self.final_xyz and not self.conformers\
+                and not any([tsg.xyz for tsg in self.ts_guesses]):
+            # TS species are allowed to be loaded w/o a structure
             raise SpeciesError('Must have either mol or xyz for species {0}'.format(self.label))
         if self.initial_xyz is not None and not self.final_xyz:
             # consider the initial guess as one of the conformers if generating others.

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -574,6 +574,30 @@ H      -1.16675800    1.03362600   -0.11273700"""]
         self.assertEqual(spc3.conformers[2], xyzs[2])
         self.assertEqual(spc3.conformer_energies[2], energies[2])
 
+    def test_the_number_of_atoms_property(self):
+        """Test that the number_of_atoms property functions correctly"""
+        self.assertEqual(self.spc1.number_of_atoms, 6)
+        self.assertEqual(self.spc2.number_of_atoms, 2)
+        self.assertEqual(self.spc3.number_of_atoms, 7)
+        self.assertEqual(self.spc4.number_of_atoms, 9)
+        self.assertEqual(self.spc5.number_of_atoms, 6)
+        self.assertEqual(self.spc6.number_of_atoms, 8)
+        self.assertEqual(self.spc7.number_of_atoms, 24)
+        self.assertEqual(self.spc8.number_of_atoms, 5)
+        self.assertEqual(self.spc9.number_of_atoms, 2)
+
+        xyz10 = """N       0.82269400    0.19834500   -0.33588000
+C      -0.57469800   -0.02442800    0.04618900
+H      -1.08412400   -0.56416500   -0.75831900
+H      -0.72300600   -0.58965300    0.98098100
+H      -1.07482500    0.94314300    0.15455500
+H       1.31266200   -0.68161600   -0.46770200
+H       1.32129900    0.71837500    0.38017700
+
+"""
+        spc10 = ARCSpecies(label='spc10', xyz=xyz10)
+        self.assertEqual(spc10.number_of_atoms, 7)
+
     @classmethod
     def tearDownClass(cls):
         """

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -516,11 +516,11 @@ H      -1.69944700    0.93441600   -0.11271200"""
 
     def test_append_conformers(self):
         """Test that ARC correctly parses its own conformer files"""
-        settings = {'gaussian': 'server1', 'molpro': 'server2', 'qchem': 'server1', 'ssh': False}
+        ess_settings = {'gaussian': 'server1', 'molpro': 'server2', 'qchem': 'server1', 'ssh': False}
         project_directory = os.path.join(arc_path, 'Projects', 'arc_project_for_testing_delete_after_usage4')
         spc1 = ARCSpecies(label=str('vinoxy'), smiles=str('C=C[O]'))
         rmgdb = make_rmg_database_object()
-        sched1 = Scheduler(project='project_test', settings=settings, species_list=[spc1],
+        sched1 = Scheduler(project='project_test', ess_settings=ess_settings, species_list=[spc1],
                            composite_method='', conformer_level=default_levels_of_theory['conformer'],
                            opt_level=default_levels_of_theory['opt'], freq_level=default_levels_of_theory['freq'],
                            sp_level=default_levels_of_theory['sp'], scan_level=default_levels_of_theory['scan'],


### PR DESCRIPTION
- Added `examples` to .gitignore
- Allow users to specify the number of cpu's to use per server
- Download additional info re failed jobs (out.txt, err.txt, slurm.out)
- Don't run orbitals jobs by default
- Make servers in ess_settings a list
- Allow users to specify a `levels_ess` dictionary associating levels of theory (or partial phrases of methods or basis sets) with an ESS
- Added ess_settings to settings.py instead of the API
- Tests: functions in main
- Additional minor fixes