### PR TITLE
YAML file related changes

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -121,8 +121,12 @@ class ARC(object):
             self.scan_rotors = scan_rotors
             self.run_orbitals = run_orbitals
             self.use_bac = use_bac
-            self.model_chemistry = model_chemistry
-            if self.model_chemistry:
+            if model_chemistry.lower() == 'fake':
+                self.model_chemistry = 'cbs-qb3'
+                logging.warning('user specified model_chemistry is fake, ARC is using cbs-qb3 model_chemistry to '
+                                'generate YAML files for species. Warning: Do NOT use YAML for thermo calculation')
+            else:
+                self.model_chemistry = model_chemistry
                 logging.info('Using {0} as model chemistry for energy corrections in Arkane'.format(self.model_chemistry))
             if not self.fine:
                 logging.info('\n')

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -378,5 +378,8 @@ class Processor(object):
         Copy the frequency job output file into the TS geometry folder
         """
         calc_path = os.path.join(self.output[label]['freq'])
-        output_path = os.path.join(self.project_directory, 'output', 'rxns', label, 'geometry', 'frequency.out')
+        out_path = os.path.join(self.project_directory, 'output', 'rxns', label, 'geometry')
+        if not os.path.exists(out_path):
+            os.makedirs(out_path)
+        output_path = os.path.join(out_path, 'frequency.out')
         shutil.copyfile(calc_path, output_path)


### PR DESCRIPTION
1. BugFix: Create geometry directory before copying files 
    ARC will create geometry directory in the local os.path if the directory isn't exist. This resolves a copy error occured when running yml input file

2. Feature: Define fake model_chemistry to force generate YAML species files
    Now user can specify model_chemistry.lower() == 'fake' to force ARC generate YAML species files.
    This feature is useful for rate calculation with model_chemistry not defined in Arkane.