### PR TITLE
Allow the user to define adaptive levels of theory (by heavy atoms)

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -133,6 +133,7 @@ class ARCSpecies(object):
         self.rmg_thermo = None
         self.rmg_kinetics = None
         self._number_of_atoms = None
+        self._number_of_heavy_atoms = None
         self.mol = mol
         self.mol_list = None
         self.multiplicity = multiplicity
@@ -303,6 +304,27 @@ class ARCSpecies(object):
     def number_of_atoms(self, value):
         """Allow setting number of atoms, e.g. a TS might not have Molecule or xyz when initialized"""
         self._number_of_atoms = value
+
+    @property
+    def number_of_heavy_atoms(self):
+        """The number of heavy (non hydrogen) atoms in the species"""
+        if self._number_of_heavy_atoms is None:
+            if self.mol is not None:
+                self._number_of_heavy_atoms = len([atom for atom in self.mol.atoms if atom.isNonHydrogen()])
+            elif self.final_xyz is not None or self.initial_xyz is not None:
+                xyz = self.final_xyz or self.initial_xyz
+                self._number_of_heavy_atoms = len([line for line in xyz.splitlines() if line.split()[0] != 'H'])
+            elif self.is_ts:
+                for ts_guess in self.ts_guesses:
+                    if ts_guess.xyz is not None:
+                        self._number_of_heavy_atoms =\
+                            len([line for line in ts_guess.xyz.splitlines() if line.split()[0] != 'H'])
+        return self._number_of_heavy_atoms
+
+    @number_of_heavy_atoms.setter
+    def number_of_heavy_atoms(self, value):
+        """Allow setting number of heavy atoms, e.g. a TS might not have Molecule or xyz when initialized"""
+        self._number_of_heavy_atoms = value
 
     def as_dict(self):
         """A helper function for dumping this object as a dictionary in a YAML file for restarting ARC"""

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -603,7 +603,7 @@ H      -1.69944700    0.93441600   -0.11271200"""
                            sp_level=default_levels_of_theory['sp'], scan_level=default_levels_of_theory['scan'],
                            ts_guess_level=default_levels_of_theory['ts_guesses'], rmgdatabase=rmgdb,
                            project_directory=project_directory, testing=True, job_types=job_types1,
-                           orbitals_level=default_levels_of_theory['orbitals'])
+                           orbitals_level=default_levels_of_theory['orbitals'], adaptive_levels=None)
         xyzs = ["""O       1.09068700    0.26516800   -0.16706300
 C       2.92204100   -1.18335700   -0.38884900
 C       2.27655500   -0.00373900    0.08543500
@@ -648,7 +648,7 @@ H      -1.16675800    1.03362600   -0.11273700"""]
         self.assertEqual(spc3.conformers[2], xyzs[2])
         self.assertEqual(spc3.conformer_energies[2], energies[2])
 
-    def test_the_number_of_atoms_property(self):
+    def test_number_of_atoms_property(self):
         """Test that the number_of_atoms property functions correctly"""
         self.assertEqual(self.spc1.number_of_atoms, 6)
         self.assertEqual(self.spc2.number_of_atoms, 2)
@@ -671,6 +671,30 @@ H       1.32129900    0.71837500    0.38017700
 """
         spc10 = ARCSpecies(label='spc10', xyz=xyz10)
         self.assertEqual(spc10.number_of_atoms, 7)
+
+    def test_number_of_heavy_atoms_property(self):
+        """Test that the number_of_heavy_atoms property functions correctly"""
+        self.assertEqual(self.spc1.number_of_heavy_atoms, 3)
+        self.assertEqual(self.spc2.number_of_heavy_atoms, 1)
+        self.assertEqual(self.spc3.number_of_heavy_atoms, 2)
+        self.assertEqual(self.spc4.number_of_heavy_atoms, 3)
+        self.assertEqual(self.spc5.number_of_heavy_atoms, 2)
+        self.assertEqual(self.spc6.number_of_heavy_atoms, 3)
+        self.assertEqual(self.spc7.number_of_heavy_atoms, 12)
+        self.assertEqual(self.spc8.number_of_heavy_atoms, 4)
+        self.assertEqual(self.spc9.number_of_heavy_atoms, 1)
+
+        xyz10 = """N       0.82269400    0.19834500   -0.33588000
+C      -0.57469800   -0.02442800    0.04618900
+H      -1.08412400   -0.56416500   -0.75831900
+H      -0.72300600   -0.58965300    0.98098100
+H      -1.07482500    0.94314300    0.15455500
+H       1.31266200   -0.68161600   -0.46770200
+H       1.32129900    0.71837500    0.38017700
+
+"""
+        spc10 = ARCSpecies(label='spc10', xyz=xyz10)
+        self.assertEqual(spc10.number_of_heavy_atoms, 2)
 
     def test_set_transport_data(self):
         """Test the set_transport_data method"""


### PR DESCRIPTION
A user can now pass a dictionary similar to the following into ARC:
```python
adaptive_levels = {(1, 5):      {'optfreq': 'opt1',
                                 'sp': 'sp1'},
                   (6, 15):     {'optfreq': 'op2',
                                 'sp': 'sp2'},
                   (16, 30):    {'optfreq': 'opt3',
                                 'sp': 'sp3'},
                   (31, 'inf'): {'optfreq': 'opt4',
                                 'sp': 'sp4'}}
```
and ARC will use the corresponding level of theory according to the number of heavy atoms in the molecule.
Jobs which are not opt, freq, optfreq, composite, or sp are unaffected.