### PR TITLE
BugFix: Remove extra parentheses in gaussian input file

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -525,7 +525,7 @@ wf,spin={spin},charge={charge};}}
         if self.job_type in ['conformer', 'opt']:
             if self.software == 'gaussian':
                 if self.is_ts:
-                    job_type_1 = 'opt=(ts, calcfc, noeigentest, maxstep=5))'
+                    job_type_1 = 'opt=(ts, calcfc, noeigentest, maxstep=5)'
                 else:
                     job_type_1 = 'opt=(calcfc, noeigentest)'
                 if self.checkfile is not None:


### PR DESCRIPTION
Removed an extra parentheses in Gaussian input file that leads to syntax
error and crashes Gaussian jobs.