### PR TITLE
 Save conformer jobs in the restart file 

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1040,14 +1040,7 @@ class Scheduler(object):
         if job.job_status[1] == 'done':
             if not os.path.isfile(job.local_path_to_output_file):
                 raise SchedulerError('Called check_freq_job with no output file')
-            ccparser = cclib.io.ccopen(str(job.local_path_to_output_file))
-            try:
-                data = ccparser.parse()
-                vibfreqs = data.vibfreqs
-            except AssertionError:
-                # In cclib/parser/qchemparser.py there's an assertion of `assert 'Beta MOs' in line`
-                # which sometimes fails (CClib issue https://github.com/cclib/cclib/issues/678)
-                vibfreqs = parser.parse_frequencies(path=str(job.local_path_to_output_file), software=job.software)
+            vibfreqs = parser.parse_frequencies(path=str(job.local_path_to_output_file), software=job.software)
             freq_ok = self.check_negative_freq(label=label, job=job, vibfreqs=vibfreqs)
             if not self.species_dict[label].is_ts and not freq_ok:
                 self.troubleshoot_negative_freq(label=label, job=job)

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -111,11 +111,11 @@ output_filename = {'gaussian': 'input.log',
 default_levels_of_theory = {'conformer': 'b3lyp/6-31+g(d,p)',
                             'ts_guesses': 'b3lyp/6-31+g(d,p)',  # used for IRC as well
                             'opt': 'wb97xd/6-311++g(d,p)',
-                            'freq': 'wb97xd/6-311++g(d,p)',  # should be the same level as opt
+                            'freq': 'wb97xd/6-311++g(d,p)',  # should be the same level as opt (to calc freq at min E)
+                            'scan': 'wb97xd/6-311++g(d,p)',  # should be the same level as freq (to project out rotors)
                             'sp': 'ccsd(t)-f12/cc-pvtz-f12',  # This should be a level for which BAC is available
                             # 'sp': 'b3lyp/6-311+g(3df,2p)',
                             'orbitals': 'b3lyp/6-311+g(d,p)',  # save orbitals for visualization
-                            'scan': 'b3lyp/6-311+g(d,p)',
                             'scan_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
                             'freq_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of the CBS-QB3 method
                             }

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -999,7 +999,7 @@ class ARCSpecies(object):
         """
         original_comment = self.transport_data.comment
         comment = 'L-J coefficients calculated by OneDMin using a DF-MP2/aug-cc-pVDZ potential energy surface ' \
-                  'with {0} as the collider'.format(bath_gas)
+                  'with {0} as the bath gas'.format(bath_gas)
         epsilon, sigma = None, None
         with open(lj_path, 'r') as f:
             lines = f.readlines()

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -715,7 +715,7 @@ H       1.32129900    0.71837500    0.38017700
         self.assertEqual(self.spc1.transport_data.rotrelaxcollnum, 2)
         self.assertEqual(self.spc1.transport_data.comment, 'L-J coefficients calculated by OneDMin using a '
                                                            'DF-MP2/aug-cc-pVDZ potential energy surface with N2 as '
-                                                           'the collider; Dipole moment was calculated at the CBS-QB3 '
+                                                           'the bath gas; Dipole moment was calculated at the CBS-QB3 '
                                                            'level of theory; Polarizability was calculated at the '
                                                            'CBS-QB3 level of theory; Rotational Relaxation Collision '
                                                            'Number was not determined, default value is 2')


### PR DESCRIPTION
Why not? For large species they take a while to run, let's spare running
them again.
If conformers are loaded from a restart file, ARC won't generate
additional conformers for the species (since it thinks it already has,
using the Scheduler.dont_gen_confs list)
We are still generating conformers, though, if guesses were given as
Species.xyz