### PR TITLE
Allow dont_gen_confs as an attribute of ARC

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -74,7 +74,7 @@ class Scheduler(object):
                  label_2: {...},
                  }
 
-    Note that rotor scans are located under Species.rotors_dict
+    Note: The rotor scan dicts are located under Species.rotors_dict
 
     Args:
         project (str): The project's name. Used for naming the working directory.
@@ -91,22 +91,22 @@ class Scheduler(object):
         ts_guess_level (str, optional): The level of theory to use for TS guess comparisons.
         orbitals_level (str, optional): The level of theory to use for calculating MOs (for plotting).
         adaptive_levels (dict, optional): A dictionary of levels of theory for ranges of the number of heavy atoms in
-                                            the molecule. Keys are tuples of (min_num_atoms, max_num_atoms), values are
-                                            dictionaries with 'optfreq' and 'sp' as keys and levels of theory as values.
+                                          the molecule. Keys are tuples of (min_num_atoms, max_num_atoms), values are
+                                          dictionaries with 'optfreq' and 'sp' as keys and levels of theory as values.
         rmgdatabase (RMGDatabase, optional): The RMG database object.
         job_types (dict, optional): A dictionary of job types to execute. Keys are job types, values are boolean.
         initial_trsh (dict, optional): Troubleshooting methods to try by default. Keys are ESS software,
-                                         values are trshs.
+                                       values are trshs.
         bath_gas (str, optional): A bath gas. Currently used in OneDMin to calc L-J parameters.
-                                    Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
+                                  Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
         restart_dict (dict, optional): A restart dictionary parsed from a YAML restart file.
         max_job_time (int, optional): The maximal allowed job time on the server in hours.
         allow_nonisomorphic_2d (bool, optional): Whether to optimize species even if they do not have a 3D conformer
-                                                   that is isomorphic to the 2D graph representation.
+                                                 that is isomorphic to the 2D graph representation.
         memory (int, optional): The total allocated job memory in GB (14 by default).
         testing (bool, optional): Used for internal ARC testing (generating the object w/o executing it).
         dont_gen_confs (list, optional): A list of species labels for which conformer jobs were loaded from a restart
-                                           file, and additional conformer generation should be avoided.
+                                         file, or user-requested. Additional conformer generation should be avoided.
         confs_to_dft (int, optional): The number of lowest MD conformers to DFT at the conformers_level.
 
     Attributes:
@@ -117,14 +117,13 @@ class Scheduler(object):
         rxn_list (list): Contains input :ref:`ARCReaction <reaction>` objects.
         unique_species_labels (list): A list of species labels (checked for duplicates).
         adaptive_levels (dict): A dictionary of levels of theory for ranges of the number of heavy atoms in the
-                                            molecule. Keys are tuples of (min_num_atoms, max_num_atoms), values are
-                                            dictionaries with 'optfreq' and 'sp' as keys and levels of theory as values.
+                                molecule. Keys are tuples of (min_num_atoms, max_num_atoms), values are
+                                dictionaries with 'optfreq' and 'sp' as keys and levels of theory as values.
         job_dict (dict): A dictionary of all scheduled jobs. Keys are species / TS labels,
-                                            values are dictionaries where keys are job names (corresponding to
-                                            'running_jobs' if job is running) and values are the Job objects.
+                         values are dictionaries where keys are job names (corresponding to
+                         'running_jobs' if job is running) and values are the Job objects.
         running_jobs (dict): A dictionary of currently running jobs (a subset of `job_dict`).
-                                            Keys are species/TS label, values are lists of job names
-                                            (e.g. 'conformer3', 'opt_a123').
+                             Keys are species/TS label, values are lists of job names (e.g. 'conformer3', 'opt_a123').
         servers_jobs_ids (list): A list of relevant job IDs currently running on the server.
         output (dict): Output dictionary with status and final QM file paths for all species.
         ess_settings (dict): A dictionary of available ESS and a corresponding server list.
@@ -132,20 +131,20 @@ class Scheduler(object):
         restart_dict (dict): A restart dictionary parsed from a YAML restart file.
         project_directory (str): Folder path for the project: the input file path or ARC/Projects/project-name.
         save_restart (bool): Whether to start saving a restart file. ``True`` only after all species are loaded
-                                            (otherwise saves a partial file and may cause loss of information).
+                             (otherwise saves a partial file and may cause loss of information).
         restart_path (str): Path to the `restart.yml` file to be saved.
         max_job_time (int): The maximal allowed job time on the server in hours.
         testing (bool): Used for internal ARC testing (generating the object w/o executing it).
         rmgdb (RMGDatabase): The RMG database object.
         allow_nonisomorphic_2d (bool): Whether to optimize species even if they do not have a 3D conformer that is
-                                         isomorphic to the 2D graph representation.
+                                       isomorphic to the 2D graph representation.
         dont_gen_confs (list): A list of species labels for which conformer jobs were loaded from a restart file,
-                                 and additional conformer generation should be avoided.
+                               or user-requested. Additional conformer generation should be avoided for them.
         confs_to_dft (int): The number of lowest MD conformers to DFT at the conformers_level.
         memory (int): The total allocated job memory in GB (14 by default).
         job_types (dict): A dictionary of job types to execute. Keys are job types, values are boolean.
         bath_gas (str): A bath gas. Currently used in OneDMin to calc L-J parameters.
-                          Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
+                        Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
         composite_method (str): A composite method to use.
 
     """

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -694,15 +694,13 @@ class Scheduler(object):
             if not self.species_dict[label].is_ts and 'opt converged' not in self.output[label]['status'] \
                     and 'opt' not in self.job_dict[label] and 'composite' not in self.job_dict[label] \
                     and all([e is None for e in self.species_dict[label].conformer_energies]) \
-                    and self.species_dict[label].number_of_atoms > 1 and label not in self.dont_gen_confs \
-                    and 'geo' not in self.output[label] \
-                    and (self.job_types['conformers'] or (not self.job_types['conformers']
-                                                          and self.species_dict[label].initial_xyz is None
-                                                          and self.species_dict[label].final_xyz is None
-                                                          and not self.species_dict[label].conformers)):
-                # This is not a TS, opt (/composite) did not converged nor running, and conformer energies were not set
-                # (and it's not in self.dont_gen_confs). Also, either 'conformers' are set to True in job_types,
-                # or they are set to False but the species has no 3D information. Generate conformers.
+                    and self.species_dict[label].number_of_atoms > 1 and 'geo' not in self.output[label] \
+                    and (self.job_types['conformers'] and label not in self.dont_gen_confs
+                         or self.species_dict[label].get_xyz(get_cheap=False) is None):
+                # This is not a TS, opt (/composite) did not converged nor running, and conformer energies were not set.
+                # Also, either 'conformers' are set to True in job_types (and it's not in dont_gen_confs),
+                # or they are set to False (or it's in dont_gen_confs), but the species has no 3D information.
+                # Generate conformers.
                 if not log_info_printed:
                     logger.info('\nStarting (non-TS) species conformational analysis...\n')
                     log_info_printed = True
@@ -719,10 +717,9 @@ class Scheduler(object):
                     else:
                         # run the combinatorial method w/o fitting a force field
                         self.species_dict[label].generate_conformers(confs_to_dft=self.confs_to_dft,
-                                                                     plot_path=os.path.join(self.project_directory,
-                                                                                            'output', 'Species',
-                                                                                            label, 'geometry',
-                                                                                            'conformers'))
+                                                                     plot_path=os.path.join(
+                                                                         self.project_directory, 'output', 'Species',
+                                                                         label, 'geometry', 'conformers'))
                     self.process_conformers(label)
             elif not self.job_types['conformers']:
                 # we're not running conformer jobs

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -195,4 +195,61 @@ Open the resulting FCheck file using `IQMol <http://iqmol.org/>`_
 to post process and save images.
 
 
+Don't generate conformers for specific species
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``conformers`` entry in the ``job_types`` dictionary is a global flag,
+affecting conformer generation of all species in the project.
+
+If you'd like to avoid generating conformers just for selected species,
+pass their labels to ARC in the ``dont_gen_confs`` list, e.g.::
+
+    project: arc_demo_selective_confs
+
+    dont_gen_confs:
+    - propanol
+
+    species:
+
+    - label: propane
+      smiles: CCC
+      xyz: |
+        C   0.0000000   0.0000000   0.5863560
+        C   0.0000000   1.2624760  -0.2596090
+        C   0.0000000  -1.2624760  -0.2596090
+        H   0.8743630   0.0000000   1.2380970
+        H  -0.8743630   0.0000000   1.2380970
+        H   0.0000000   2.1562580   0.3624930
+        H   0.0000000  -2.1562580   0.3624930
+        H   0.8805340   1.2981830  -0.9010030
+        H  -0.8805340   1.2981830  -0.9010030
+        H  -0.8805340  -1.2981830  -0.9010030
+        H   0.8805340  -1.2981830  -0.9010030
+
+    - label: propanol
+      smiles: CCCO
+      xyz: |
+        C  -1.4392250   1.2137610   0.0000000
+        C   0.0000000   0.7359250   0.0000000
+        C   0.0958270  -0.7679350   0.0000000
+        O   1.4668240  -1.1155780   0.0000000
+        H  -1.4886150   2.2983600   0.0000000
+        H  -1.9711060   0.8557990   0.8788010
+        H  -1.9711060   0.8557990  -0.8788010
+        H   0.5245130   1.1136730   0.8740840
+        H   0.5245130   1.1136730  -0.8740840
+        H  -0.4095940  -1.1667640   0.8815110
+        H  -0.4095940  -1.1667640  -0.8815110
+        H   1.5267840  -2.0696580   0.0000000
+
+In the above example, ARC will only generate conformers for propane, but not for propanol.
+For propane, it will compare the selected conformers agains the user-given xyz guess using the
+conformer level DFT method, and will take the most stable structure for the rest of the calculations,
+regardless of its source (ARC's conformers or the user guess). For propanol, on the other hand,
+ARC will not attempt to generate conformers, and will simply use the user guess.
+
+Note: If a species label is added to the ``dont_gen_confs`` list, but the species has no 3D
+coordinates, ARC **will** generate conformers for it.
+
+
 .. include:: links.txt

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -7,9 +7,10 @@ Flexible coordinates (xyz) input
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The xyz attribute of an :ref:`ARCSpecies <species>` objects (whether TS or not) is extremely flexible.
-It could be a multiline string containing the coordinates, or a list of several multiline strings (as
-shown in the examples above). It could also contain valid file paths to ESS input files, output files,
-`XYZ format`__ files, or ARC's conformers (before/after optimization) files. See :ref:`the examples <examples>`.
+It could be a multiline string containing the coordinates, or a list of several multiline strings.
+It could also contain valid file paths to ESS input files, output files,
+`XYZ format`__ files, or ARC's conformers (before/after optimization) files.
+See :ref:`the examples <examples>`.
 
 __ xyz_format_
 


### PR DESCRIPTION
- Allow dont_gen_confs as an attribute of ARC 
- Consider dont_gen_confs correctly in Scheduler 
- DON'T Run conformers at conformer_level even if there's only one (reverts commit 0be0273)

Updated documentation

tag @xiaoruiDong 