### PR TITLE
Remove rotor info related to re-run after conformer correction

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1522,7 +1522,7 @@ class Scheduler(object):
                                     message += error_message + '; '
                                     invalidate = True
                                     invalidation_reason = 'two consecutive points are inconsistent by more than ' \
-                                                          '{0:.2f} kJ/mol'.format(inconsistency_ab)
+                                                          '{0:.2f} kJ/mol'.format(inconsistency_ab * max(v_list))
                                     if not job.scan_trsh:
                                         logger.info('Trying to troubleshoot rotor {0} of {1}...'.format(
                                             job.pivots, label))

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1563,6 +1563,12 @@ class Scheduler(object):
                                     scan=self.species_dict[label].rotors_dict[i]['scan'],
                                     deg_increment=min_index*rotor_scan_resolution)
                                 self.delete_all_species_jobs(label)
+                                # Remove all completed rotor calculation information
+                                for rotor in self.species_dict[label].rotors_dict.values():
+                                    rotor["scan_path"] = ''
+                                    rotor["invalidation_reason"] = ''
+                                    rotor["success"] = None
+                                    rotor.pop('symmetry', None)
                                 self.run_opt_job(label)  # run opt on new initial_xyz with the desired dihedral
                             else:
                                 self.species_dict[label].rotors_dict[i]['success'] = True


### PR DESCRIPTION
Fix1:
Fix the logging message when detecting inconsistencies between two consecutive points.

Fix2:
Remove all the information (keep pivots, scan, and time_set_dihedrals) when a conformer correction needs to be made. 