### PR TITLE
Modify the check_scan_job module in the scheduler.py

### DIFF
--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -9,7 +9,6 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import numpy as np
 import os
 import shutil
-import math
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.backends.backend_pdf import PdfPages
@@ -174,25 +173,25 @@ def plot_rotor_scan(angle, v_list, path=None, pivots=None, comment=''):
     """
     plots a 1D rotor PES for v_list vs. angle.
     """
-    angle = angle * 180 / math.pi  # convert radians to degree
+    angle = angle * 180 / np.pi  # convert radians to degree
     v_list = np.array(v_list, np.float64)  # in kJ/mol
+    marker_color, line_color = plt.cm.viridis([0.1, 0.9])
     plt.figure(figsize=(4, 3), dpi=120)
     plt.subplot(1, 1, 1)
-    plt.plot(angle, v_list, 'g.')
+    plt.plot(angle, v_list, '.-', markerfacecolor=marker_color,
+             markeredgecolor=marker_color, color=line_color)
     plt.xlabel('dihedral (deg)')
     plt.xlim = (0, 360)
     plt.xticks(np.arange(0, 361, step=60))
     plt.ylabel('V (kJ/mol)')
     plt.tight_layout()
     plt.show()
+
     if path is not None and pivots is not None:
         if not os.path.exists(path):
             os.makedirs(path)
-        fig_path = os.path.join(path, '{0}.png'.format(pivots))
-        plt.savefig(fig_path, dpi=120, facecolor='w', edgecolor='w', orientation='portrait', papertype=None,
-                    format=str('png'), transparent=False, bbox_inches=None, pad_inches=0.1, frameon=False,
-                    metadata=None)
         if comment:
+            fig_name = '{0}-invalid.png'.format(pivots)
             txt_path = os.path.join(path, 'rotor comments.txt')
             if os.path.isfile(txt_path):
                 with open(txt_path, 'a') as f:
@@ -200,6 +199,12 @@ def plot_rotor_scan(angle, v_list, path=None, pivots=None, comment=''):
             else:
                 with open(txt_path, 'w') as f:
                     f.write(str('Pivots: {0}\nComment: {1}'.format(pivots, comment)))
+        else:
+            fig_name = '{0}.png'.format(pivots)
+        fig_path = os.path.join(path, fig_name)
+        plt.savefig(fig_path, dpi=120, facecolor='w', edgecolor='w', orientation='portrait', papertype=None,
+                    format=str('png'), transparent=False, bbox_inches=None, pad_inches=0.1, frameon=False,
+                    metadata=None)
 
 
 def log_thermo(label, path):


### PR DESCRIPTION
Major changes:
(1) Since the `if job.job_status[1] != 'done'` is checked at the beginning, the `invalidation_reason = crash` will never  triggered. So I depreciate the relative codes
(2) The invalidation of a rotor with a barrier larger than 40 kJ should be triggered after the 'lowest-conformer' check.
(3) The previous code/logic structure is complicated. The workflow is simplified:
```
loop: find corresponding rotor
         if found:
             sequential checks (`break` right after any check is failed)
         else not found:
             raise error
assign invalidation_reason, scan_path if not trsh
plot scan curve if available
```
(4) Scan curve plot also for invalid rotors (distinguished by name)
(5) Scan curve is now dot-line curve instead of solely dots
(6) When the conformer with lower energy is found, directly rotate to the lowest conformer instead of the nearest minima.

-----------------------------------------------------------------------------------
Other thoughts:
(1) Tighten the initial-final difference threshold. As long as, there is no change in other dihedrals. The difference ~ 2 kJ (though not large) is usually caused by a change in dihedral R-O-H between initial and final conformers. 
(2) Tighten the lowest conformer threshold. I find some cases failing to find the lowest, especially when the barrier is not high. The current threshold is to avoid false positives in the check, I guess. However, it is usually not that big (from some of my methyl group's example, ~2% difference). To avoid false positives, it can be checked with symmetries.
(3) I am developing a debugging tool now. The problem is how to implement it. Let me give an example, here are three cases (1) ESS failed because of (bond breaking) (2) ESS converged but has a detectable problem (large jump) (3) ESS converged and the curve looks correct by current checking. But the debug tool finds there is an obvious dihedral change, and it is confirmed by GaussView visualization. The workflow will become less clear then. It will be desirable if it can completely replace the whole check_scan_job module, but then the choice of the outlier threshold should be more tailored. I am implementing 1.5 X IQR as the threshold. Generally looks good given some example cases, but need to test its performance on a larger scale. 