### PR TITLE
Preserve atom order when performing isomorphism checks

### DIFF
--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -812,7 +812,7 @@ def determine_torsion_symmetry(label, top1, mol_list, torsion_scan):
                     symmetry *= 2
                 # all other groups:
                 elif not mol.atoms[top[0] - 1].lonePairs > 0 and not mol.atoms[top[0] - 1].radicalElectrons > 0 \
-                        and all([groups[0].isIsomorphic(group) for group in groups[1:]]):
+                        and all([groups[0].isIsomorphic(group, saveOrder=True) for group in groups[1:]]):
                     symmetry *= len(groups)
     return symmetry
 
@@ -1572,8 +1572,8 @@ def identify_chiral_centers(mol):
             for atom2 in atom1.edges.keys():
                 top = determine_top_group_indices(mol, atom1, atom2, index=0)[0]
                 groups.append(to_group(mol, top))
-            if all([not groups[0].isIsomorphic(group) for group in groups[1:]] +
-                   [not groups[-1].isIsomorphic(group) for group in groups[:-1]]):
+            if all([not groups[0].isIsomorphic(group, saveOrder=True) for group in groups[1:]] +
+                   [not groups[-1].isIsomorphic(group, saveOrder=True) for group in groups[:-1]]):
                 # if we can say that TWO groups, each separately considered ins't isomorphic to the other two,
                 # then this nitrogen has all different (three) groups.
                 chiral_centers.append(mol.atoms.index(atom1))

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -151,7 +151,8 @@ def generate_conformers(mol_list, label, xyzs=None, torsions=None, tops=None, ch
     if isinstance(mol_list, Molecule):
         mol_list = [mol for mol in mol_list.generate_resonance_structures() if mol.reactive]
     if not isinstance(mol_list, list):
-        raise ConformerError('The `mol_list` argument must be a list, got {0}'.format(type(mol_list)))
+        logger.error('The `mol_list` argument must be a list, got {0}'.format(type(mol_list)))
+        return None
     for mol in mol_list:
         if not isinstance(mol, Molecule):
             raise ConformerError('Each entry in the `mol_list` argument must be an RMG Molecule object, '

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -587,6 +587,7 @@ def check_isomorphism(mol1, mol2, filter_structures=True):
     mol2_copy = mol2.copy(deep=True)
     spc1 = Species(molecule=[mol1_copy])
     spc2 = Species(molecule=[mol2_copy])
+
     try:
         spc1.generate_resonance_structures(keep_isomorphic=False, filter_structures=filter_structures)
     except AtomTypeError:
@@ -595,7 +596,12 @@ def check_isomorphism(mol1, mol2, filter_structures=True):
         spc2.generate_resonance_structures(keep_isomorphic=False, filter_structures=filter_structures)
     except AtomTypeError:
         pass
-    return spc1.isIsomorphic(spc2)
+
+    for molecule1 in spc1.molecule:
+        for molecule2 in spc2.molecule:
+            if molecule1.isIsomorphic(molecule2, saveOrder=True):
+                return True
+    return False
 
 
 def get_center_of_mass(xyz=None, coords=None, symbols=None):

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -211,7 +211,7 @@ def rmg_mol_from_inchi(inchi):
     """
     try:
         rmg_mol = Molecule().fromInChI(str(inchi))
-    except (AtomTypeError, ValueError) as e:
+    except (AtomTypeError, ValueError, KeyError) as e:
         logger.warning('Got the following Error when trying to create an RMG Molecule object from InChI:'
                        '\n{0}'.format(e.message))
         return None
@@ -419,7 +419,7 @@ def update_molecule(mol, to_single_bonds=False):
             new_mol.addBond(bond)
     try:
         new_mol.updateAtomTypes()
-    except AtomTypeError:
+    except (AtomTypeError, KeyError):
         pass
     new_mol.multiplicity = mol.multiplicity
     return new_mol

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -65,9 +65,9 @@ class ARCSpecies(object):
                                      (If there's only one entry, it could be given directly as a string, not in a list).
                                      The file paths could direct to either a .xyz file, ARC conformers
                                      (w/ or w/o energies), or an ESS log/input files.
-        multiplicity (int, optional): The species' multiplicity. Can be determined from the adjlist/smiles/xyz
-                                      (the algorithm assumes it's either a singlet or a doublet).
-        charge (int, optional): The species' net charge. Assumed to be 0 be default.
+        multiplicity (int, optional): The species' electron spin multiplicity. Can be determined from the
+                                      adjlist/smiles/xyz (If unspecified, assumed to be either a singlet or a doublet).
+        charge (int, optional): The species' net charge. Assumed to be 0 if unspecified.
         smiles (str, optional): A `SMILES <https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system>`_
                                 representation for the species 2D graph.
         adjlist (str, optional): An `RMG adjacency list
@@ -108,16 +108,16 @@ class ARCSpecies(object):
 
     Attributes:
         label (str): The species' label.
-        multiplicity (int): The species' multiplicity. Can be determined from the adjlist/smiles/xyz
-                            (the algorithm assumes it's either a singlet or a doublet).
-        charge (int): The species' net charge. Assumed to be 0 be default.
+        multiplicity (int): The species' electron spin multiplicity. Can be determined from the adjlist/smiles/xyz
+                            (If unspecified, assumed to be either a singlet or a doublet).
+        charge (int): The species' net charge. Assumed to be 0 if unspecified.
         number_of_radicals (int): The number of radicals (inputted by the user, ARC won't attempt to determine it).
                                   Defaults to None. Important, e.g., if a Species is a bi-rad singlet, in which case
                                   the job should be unrestricted, but the multiplicity does not have the required
                                   information to make that decision (r vs. u).
         e_elect (float): The total electronic energy (without ZPE) at the chosen sp level, in kJ/mol.
         e0 (float): The 0 Kelvin energy (total electronic energy plus ZPE) at the chosen sp level, in kJ/mol.
-        is_ts (bool):  Whether or not the species represents a transition state.
+        is_ts (bool):  Whether the species represents a transition state. `True` if it does.
         number_of_rotors (int): The number of potential rotors to scan.
         rotors_dict (dict): A dictionary of rotors. structure given below.
         conformers (list): A list of selected conformers XYZs.

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -685,11 +685,17 @@ class ARCSpecies(object):
                                                           force_field=self.force_field, print_logs=False,
                                                           num_confs_to_return=confs_to_dft, return_all_conformers=False,
                                                           plot_path=plot_path)
-            self.conformers.extend([conf['xyz'] for conf in lowest_confs])
-            self.conformer_energies.extend([None] * len(lowest_confs))
-            lowest_conf = conformers.get_lowest_confs(label=self.label, confs=lowest_confs, n=1)[0]
-            logger.info('Most stable force field conformer for {0}:'.format(self.label))
-            logger.info(lowest_conf['xyz'])
+            if lowest_confs is not None:
+                self.conformers.extend([conf['xyz'] for conf in lowest_confs])
+                self.conformer_energies.extend([None] * len(lowest_confs))
+                lowest_conf = conformers.get_lowest_confs(label=self.label, confs=lowest_confs, n=1)[0]
+                logger.info('Most stable force field conformer for {0}:'.format(self.label))
+                logger.info(lowest_conf['xyz'])
+            else:
+                logger.error('Could not generate conformers for {0}'.format(self.label))
+                if not self.get_xyz(get_cheap=False):
+                    logger.warning('No 3D coordinates available for species {0}!'.format(self.label))
+
 
     def get_cheap_conformer(self):
         """

--- a/arc/species/xyz_to_2d.py
+++ b/arc/species/xyz_to_2d.py
@@ -423,7 +423,7 @@ class MolGraph(object):
         """
         self_rmg = self.to_rmg_mol()
         other_rmg = other.to_rmg_mol()
-        return self_rmg.isIsomorphic(other_rmg)
+        return self_rmg.isIsomorphic(other_rmg, saveOrder=True)
 
     def set_coords(self, coords):
         """


### PR DESCRIPTION
Also added KeyError exceptions when generating RMG Molecule objects to allow elements not supported by RMG's atom types.