### PR TITLE
BugFix: Scale job types fix

### DIFF
--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -119,6 +119,31 @@ class TestARC(unittest.TestCase):
         min_lst = common.min_list(lst)
         self.assertEqual(min_lst, -79)
 
+
+    def test_initialize_job_types(self):
+        """Test the initialize_job_types() function"""
+        job_types_0 = {'conformers': False, 'opt': True, 'fine': True, 'freq': True, 'sp': False, '1d_rotors': False}
+        job_types_0_expected = {'1d_rotors': False, 'bde': False, 'conformers': False, 'fine': True,
+                                'freq': True, 'onedmin': False, 'opt': True, 'orbitals': False, 'sp': False}
+        job_types_0_initialized = common.initialize_job_types(job_types_0)
+        self.assertEqual(job_types_0_expected, job_types_0_initialized)
+
+        job_types_1 = {}
+        job_types_1_expected = {'1d_rotors': True, 'bde': False, 'conformers': True, 'fine': True, 'freq': True,
+                                'onedmin': False, 'opt': True, 'orbitals': False, 'sp': True}
+        job_types_1_initialized = common.initialize_job_types(job_types_1)
+        self.assertEqual(job_types_1_expected, job_types_1_initialized)
+
+        job_types_2 = {'bde': True}
+        job_types_2_expected = {'1d_rotors': True, 'bde': True, 'conformers': True, 'fine': True, 'freq': True,
+                                'onedmin': False, 'opt': True, 'orbitals': False, 'sp': True}
+        job_types_2_initialized = common.initialize_job_types(job_types_2)
+        self.assertEqual(job_types_2_expected, job_types_2_initialized)
+        with self.assertRaises(InputError):
+            job_types_3 = {'fake_job': True}
+            common.initialize_job_types(job_types_3)
+
+
 ################################################################################
 
 

--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -18,7 +18,7 @@ from arc.settings import arc_path
 from arc.scheduler import Scheduler
 from arc.arc_exceptions import InputError
 from arc.species.species import ARCSpecies
-from arc.common import get_logger, check_ess_settings, time_lapse, initialize_log
+from arc.common import get_logger, check_ess_settings, time_lapse, initialize_log, initialize_job_types
 
 try:
     from arc.settings import global_ess_settings
@@ -72,8 +72,10 @@ def determine_scaling_factors(levels_of_theory, ess_settings=None, init_log=True
     logger.info(HEADER)
     logger.info('\n\nstarting ARC...\n')
 
-    job_types = {'conformers': False, 'opt': True, 'fine': True, 'freq': True, 'sp': False, '1d_rotors': False,
-                 'orbitals': False, 'onedmin': False}  # only run opt (fine) and freq
+    # only run opt (fine) and freq
+    job_types = initialize_job_types(dict())  # get the defaults, so no job type is missing
+    job_types = {job_type: False for job_type in job_types.keys()}
+    job_types['opt'], job_types['fine'], job_types['freq'] = True, True, True
 
     lambda_zpes, zpe_dicts, times = list(), list(), list()
     for level_of_theory in levels_of_theory:


### PR DESCRIPTION
Initialize job_types in scale.py

Previously scale.py used a hard-coded job_types dictionary, which isn't future compatible once new job types are added.
This was now resolved by relocating `initialize_job_types` from main to common (to avoid circular imports, and initializing job_types in scale. A test was also added.