### PR TITLE
New Feature: Quickly specify a certain job type

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -411,17 +411,29 @@ def min_list(lst):
     return min([entry for entry in lst if entry is not None])
 
 
-def initialize_job_types(job_types):
+def initialize_job_types(job_types, specific_job_type=''):
     """
     A helper function for initializing job_types.
     Returns the comprehensive (default values for missing job types) job types for ARC.
 
     Args:
         job_types (dict): Keys are job types, values are booleans of whether or not to consider this job type.
+        specific_job_type (str): Specific job type to execute. Legal strings are job types (keys of job_types dict).
 
     Returns:
         job_types (dict): An updated (comprehensive) job type dictionary.
     """
+
+    if specific_job_type:
+        if job_types:
+            logger.warning('Both job_types and specific_job_type are given, ARC will only use specific_job_type to '
+                           'populate the job_types dictionary.')
+        job_types = {job_type: False for job_type in default_job_types.keys()}
+        try:
+            job_types[specific_job_type] = True
+        except KeyError:
+            raise InputError('Specified job type "{0}" is not supported'.format(specific_job_type))
+
     defaults_to_true = ['conformers', 'opt', 'fine', 'freq', 'sp', 'rotors']
     defaults_to_false = ['onedmin', 'orbitals', 'bde']
     if job_types is None:

--- a/arc/main.py
+++ b/arc/main.py
@@ -140,6 +140,7 @@ class ARC(object):
                                        isomorphic to the 2D graph representation.
         memory (int): The total allocated job memory in GB (14 by default to be lower than 90% * 16 GB).
         job_types (dict): A dictionary of job types to execute. Keys are job types, values are boolean.
+        specific_job_type (str): Specific job type to execute. Legal strings are job types (keys of job_types dict).
         bath_gas (str): A bath gas. Currently used in OneDMin to calc L-J parameters.
                         Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
         keep_checks (bool): Whether to keep all Gaussian checkfiles when ARC terminates. True to keep, default is False.
@@ -154,7 +155,7 @@ class ARC(object):
                  t_max=None, t_count=None, verbose=logging.INFO, project_directory=None, max_job_time=120,
                  allow_nonisomorphic_2d=False, job_memory=14, ess_settings=None, bath_gas=None,
                  adaptive_levels=None, freq_scale_factor=None, calc_freq_factor=True, confs_to_dft=5,
-                 keep_checks=False, dont_gen_confs=None):
+                 keep_checks=False, dont_gen_confs=None, specific_job_type=''):
         self.__version__ = VERSION
         self.verbose = verbose
         self.output = dict()
@@ -177,7 +178,8 @@ class ARC(object):
             self.t_min = t_min
             self.t_max = t_max
             self.t_count = t_count
-            self.job_types = initialize_job_types(job_types)
+            self.specific_job_type = specific_job_type
+            self.job_types = initialize_job_types(job_types, specific_job_type=self.specific_job_type)
             self.bath_gas = bath_gas
             self.confs_to_dft = confs_to_dft
             self.adaptive_levels = adaptive_levels

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -16,6 +16,15 @@ See :ref:`the examples <examples>`.
 
 __ xyz_format_
 
+Specify a particular job type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run ARC with a particular job type, set ``specific_job_type`` to the job type you want.
+Currently, ARC supports the following job types: ``conformers``, ``opt``, ``fine``, ``freq``,
+``sp``, ``rotors``, ``onedmin``, ``orbitals``, ``bde``.
+
+Notice that ``specific_job_type`` takes higher precedence than ``job_types``. If you specify both attributes, ARC will
+dismiss the given ``job_types`` and will only populate the ``job_types`` dictionary using given ``specific_job_type``.
 
 Using a fine DFT grid for optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Added feature that allows a user to quickly specify a particular job type. This PR is rebuilt from #179 due to files change in #184. 