### PR TITLE
Mark a single conformer that could not be checked for isomorphism

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,8 @@
+exclude:
+- /docs/.*:
+- /examples/.*:
+- /ipython/.*:
+- /logo/.*
+languages:
+- python
+component_depth: 3

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -379,7 +379,7 @@ class Job(object):
                          '{{{{PARAM}}}} instead of {{PARAM}}.\nIdentified the following submit scripts:\n{2}'.format(
                           self.server, self.software.lower(), submit_scripts_for_printing))
             raise
-        if not os.path.exists(self.local_path):
+        if not os.path.isdir(self.local_path):
             os.makedirs(self.local_path)
         with open(os.path.join(self.local_path, submit_filename[servers[self.server]['cluster_soft']]), 'wb') as f:
             f.write(self.submit)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1142,6 +1142,22 @@ class Scheduler(object):
                                                charge=self.species_dict[label].charge)[1]
                 except SanitizationError:
                     b_mol = None
+                    if self.allow_nonisomorphic_2d or self.species_dict[label].charge:
+                        # we'll optimize the single conformer even if it is not isomorphic to the 2D graph
+                        logger.error('The single conformer {0} could not be checked for isomorphism with the 2D graph '
+                                     'representation {1}. Optimizing this conformer anyway.'.format(
+                                      label, self.species_dict[label].mol.toSMILES()))
+                        if self.species_dict[label].charge:
+                            logger.warning('Isomorphism check cannot be done for charged species {0}'.format(label))
+                        self.output[label]['conformers'] += 'Single conformer could not be checked for isomorphism; '
+                        self.output[label]['job_types']['conformers'] = True
+                        self.species_dict[label].conf_is_isomorphic, spawn_jobs = False, True
+                    else:
+                        logger.error('The only conformer for species {0} could not be checked for isomorphism with the '
+                                     '2D graph representation {1}. NOT calculating this species. To change this '
+                                     'behaviour, pass `allow_nonisomorphic_2d = True` to ARC.'.format(
+                                      label, b_mol.toSMILES()))
+                        self.species_dict[label].conf_is_isomorphic, spawn_jobs = False, False
                 if b_mol is not None:
                     try:
                         is_isomorphic = check_isomorphism(self.species_dict[label].mol, b_mol)

--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -11,21 +11,21 @@ Adapted by Duminda Ranasinghe and Alon Grinberg Dana
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 import os
 import time
+import shutil
 
 from arkane.statmech import determine_qm_software
 
-from arc.settings import arc_path
-from arc.scheduler import Scheduler
 from arc.arc_exceptions import InputError
-from arc.species.species import ARCSpecies
 from arc.common import get_logger, check_ess_settings, time_lapse, initialize_log, initialize_job_types
+from arc.scheduler import Scheduler
+from arc.settings import arc_path
+from arc.species.species import ARCSpecies
 
 try:
     from arc.settings import global_ess_settings
 except ImportError:
     global_ess_settings = None
 
-##################################################################
 
 logger = get_logger()
 
@@ -84,6 +84,8 @@ def determine_scaling_factors(levels_of_theory, ess_settings=None, init_log=True
         renamed_level = rename_level(level_of_theory)
         project = 'scaling_' + renamed_level
         project_directory = os.path.join(arc_path, 'Projects', 'scaling_factors', project)
+        if os.path.isdir(project_directory):
+            shutil.rmtree(project_directory)
 
         species_list = get_species_list()
 


### PR DESCRIPTION
as correct (so the species won't fail), if `allow_nonisomorphic_2d` was set to True.