### PR TITLE
Select the lowest conformers from the pool of new conformers

### DIFF
--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -798,7 +798,7 @@ def plot_torsion_angles(torsion_angles, torsions_sampling_points=None, wells_dic
         # Hide x labels and tick labels for all but bottom plot.
         # for ax in axs:
         #     ax.label_outer()
-        axs[0].axes.xaxis.set_ticks(ticks=ticks)
+        plt.setp(axs, xticks=ticks)  # set the x ticks of all subplots
         fig.set_size_inches(8, len(torsions) * 1.5)
     plt.show()
     if plot_path is not None:

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -188,9 +188,9 @@ def generate_conformers(mol_list, label, xyzs=None, torsions=None, tops=None, ch
     conformers.extend(new_conformers)
 
     num_confs_to_return = min(num_confs_to_return, hypothetical_num_comb)  # don't return more than we have
-    lowest_confs = get_lowest_confs(label, conformers, n=num_confs_to_return)
+    lowest_confs = get_lowest_confs(label, new_conformers, n=num_confs_to_return)
 
-    lowest_conf = get_lowest_confs(label, conformers, n=1)[0]
+    lowest_conf = get_lowest_confs(label, new_conformers, n=1)[0]
     enantiomeric_xyzs = generate_all_enantiomers(label=label, mol=mol_list[0], xyz=lowest_conf['xyz'])
 
     for enantiomeric_xyz in enantiomeric_xyzs:

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -357,7 +357,8 @@ def generate_conformer_combinations(label, mol, base_xyz, hypothetical_num_comb,
         # just generate all combinations and get their FF energies
         logger.debug('hypothetical_num_comb for {0} is < {1}'.format(label, combination_threshold))
         new_conformers = generate_all_combinations(label, mol, base_xyz, multiple_tors, multiple_sampling_points,
-                                                   len_conformers=len_conformers, force_field=force_field)
+                                                   len_conformers=len_conformers, force_field=force_field,
+                                                   torsions=list(torsion_angles.keys()))
     return new_conformers
 
 
@@ -454,7 +455,7 @@ def conformers_combinations_by_lowest_conformer(label, mol, base_xyz, multiple_t
 
 
 def generate_all_combinations(label, mol, base_xyz, multiple_tors, multiple_sampling_points, len_conformers=-1,
-                              force_field='MMFF94s'):
+                              torsions=None, force_field='MMFF94s'):
     """
     Generate all combinations of torsion wells from a base conformer.
     untested
@@ -468,6 +469,7 @@ def generate_all_combinations(label, mol, base_xyz, multiple_tors, multiple_samp
                                          to torsions in multiple_tors.
         len_conformers (int, optional): The length of the existing conformers list (for consecutive numbering).
         force_field (str, optional): The type of force field to use.
+        torsions (list, optional): A list of all possible torsions in the molecule. Will be determined if not given.
 
     Returns:
         list: New conformer combinations, entries are conformer dictionaries.
@@ -494,6 +496,9 @@ def generate_all_combinations(label, mol, base_xyz, multiple_tors, multiple_samp
                                'xyz': base_xyz,
                                'FF energy': energy,
                                'source': 'Generated all combinations from scan map (trivial case)'})
+    if torsions is None:
+        torsions = determine_rotors([mol])
+    new_conformers = determine_dihedrals(new_conformers, torsions)
     return new_conformers
 
 

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -602,22 +602,23 @@ def change_dihedrals_and_force_field_it(label, mol, xyz, torsions, new_dihedrals
         new_dihedrals = [new_dihedrals]
 
     for dihedrals in new_dihedrals:
+        xyz_dihedrals = xyz
         for torsion, dihedral in zip(torsions, dihedrals):
-            conf, rd_mol, index_map = converter.rdkit_conf_from_mol(mol, xyz)
+            conf, rd_mol, index_map = converter.rdkit_conf_from_mol(mol, xyz_dihedrals)
             rd_torsion = [index_map[i - 1] for i in torsion]  # convert the atom indices in the torsion to RDKit indices
             xyz_dihedrals = converter.set_rdkit_dihedrals(conf, rd_mol, index_map, rd_torsion, deg_abs=dihedral)
-            if force_field != 'gromacs':
-                xyz_, energy = get_force_field_energies(label, mol=mol, xyz=xyz_dihedrals, optimize=True,
-                                                        force_field=force_field)
-                if energy and xyz_:
-                    energies.append(energy[0])
-                    if optimize:
-                        xyzs.append(xyz_[0])
-                    else:
-                        xyzs.append(xyz_dihedrals)
-            else:
-                energies.append(None)
-                xyzs.append(xyz_dihedrals)
+        if force_field != 'gromacs':
+            xyz_, energy = get_force_field_energies(label, mol=mol, xyz=xyz_dihedrals, optimize=True,
+                                                    force_field=force_field)
+            if energy and xyz_:
+                energies.append(energy[0])
+                if optimize:
+                    xyzs.append(xyz_[0])
+                else:
+                    xyzs.append(xyz_dihedrals)
+        else:
+            energies.append(None)
+            xyzs.append(xyz_dihedrals)
     return xyzs, energies
 
 

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -1250,14 +1250,14 @@ C	0.0000000	0.0000000	-1.9736270"""  # no colliding atoms
         self.assertEqual(len(energies), 1)
 
         xyzs, energies = conformers.change_dihedrals_and_force_field_it(label='NCC', mol=ncc_mol, xyz=ncc_xyz,
-                                                                        torsions=[torsion, torsion],
-                                                                        new_dihedrals=[0, 180])
-        self.assertEqual(len(energies), 2)
+                                                                        torsions=[torsion],
+                                                                        new_dihedrals=[0])
+        self.assertEqual(len(energies), 1)
 
         xyzs, energies = conformers.change_dihedrals_and_force_field_it(label='NCC', mol=ncc_mol, xyz=ncc_xyz,
                                                                         torsions=[torsion, torsion],
                                                                         new_dihedrals=[[0, 180], [90, -120]])
-        self.assertEqual(len(energies), 4)
+        self.assertEqual(len(energies), 2)
 
     def test_determine_well_width_tolerance(self):
         """Test determining well width tolerance"""
@@ -1274,15 +1274,20 @@ C	0.0000000	0.0000000	-1.9736270"""  # no colliding atoms
 
     def test_get_lowest_confs(self):
         """Test getting the n lowest conformers"""
+
         # test a case where confs is a list of dicts:
         confs = [{'index': 0,
-                  'FF energy': 20},
+                  'FF energy': 20,
+                  'xyz': converter.str_to_xyz('C 1 0 0')},
                  {'index': 1,
-                  'FF energy': 30},
-                 {'index': 1,
-                  'FF energy': 40},
-                 {'index': 1,
-                  'some other energy': 10}]
+                  'FF energy': 30,
+                  'xyz': converter.str_to_xyz('C 2 0 0')},
+                 {'index': 2,
+                  'FF energy': 40,
+                  'xyz': converter.str_to_xyz('C 3 0 0')},
+                 {'index': 3,
+                  'some other energy': 10,
+                  'xyz': converter.str_to_xyz('C 4 0 0')}]
         lowest_confs = conformers.get_lowest_confs(label='', confs=confs, n=2, energy='FF energy')
         self.assertEqual(len(lowest_confs), 2)
         for conf in lowest_confs:
@@ -1296,14 +1301,16 @@ C	0.0000000	0.0000000	-1.9736270"""  # no colliding atoms
                  ['C 4 0 0', 5]]
         lowest_confs = conformers.get_lowest_confs(label='', confs=confs)
         self.assertEqual(len(lowest_confs), 1)
-        self.assertEqual(lowest_confs[0][0], 'C 4 0 0')
-        self.assertEqual(lowest_confs[0][1], 5)
+        self.assertEqual(lowest_confs[0]['xyz'], 'C 4 0 0')
+        self.assertEqual(lowest_confs[0]['FF energy'], 5)
 
         # test a case where the number of confs is also the number to return:
         confs = [{'index': 0,
-                  'FF energy': 20},
+                  'FF energy': 20,
+                  'xyz': converter.str_to_xyz('C 1 0 0')},
                  {'index': 1,
-                  'FF energy': 10}]
+                  'FF energy': 10,
+                  'xyz': converter.str_to_xyz('C 2 0 0')}]
         lowest_confs = conformers.get_lowest_confs(label='', confs=confs, n=2, energy='FF energy')
         self.assertEqual(len(lowest_confs), 2)
 

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -772,7 +772,7 @@ def s_bonds_mol_from_xyz(xyz):
 
 def to_rdkit_mol(mol, remove_h=False, return_mapping=True, sanitize=True):
     """
-    Convert a molecular structure to a RDKit rdmol object. Uses
+    Convert a molecular structure to an RDKit RDMol object. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
     Perceives aromaticity.
     Adopted from rmgpy/molecule/converter.py

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -109,11 +109,11 @@ class TestARCSpecies(unittest.TestCase):
 
         self.spc5.conformers = list()
         self.spc5.generate_conformers()
-        self.assertEqual(len(self.spc5.conformers), 3)
+        self.assertEqual(len(self.spc5.conformers), 4)
 
         self.spc6.conformers = list()
         self.spc6.generate_conformers()
-        self.assertEqual(len(self.spc6.conformers), 4)
+        self.assertEqual(len(self.spc6.conformers), 5)
 
         self.spc8.conformers = list()
         self.spc8.generate_conformers()
@@ -141,11 +141,11 @@ class TestARCSpecies(unittest.TestCase):
 
         self.spc11.conformers = list()
         self.spc11.generate_conformers(confs_to_dft=2)
-        self.assertEqual(len(self.spc11.conformers), 3)
+        self.assertEqual(len(self.spc11.conformers), 4)
 
         self.spc11.conformers = list()
         self.spc11.generate_conformers(confs_to_dft=3)
-        self.assertIn(len(self.spc11.conformers), [3, 4])
+        self.assertIn(len(self.spc11.conformers), [5, 6])
 
         xyz12 = """C       0.00000000    0.00000000    0.00000000
 H       1.07008000   -0.14173100    0.00385900
@@ -815,7 +815,7 @@ H       2.82319256   -0.46240839   -0.40178723"""
         spc3 = ARCSpecies(label=str('N3'), xyz=n3_xyz, multiplicity=1, smiles=str('NNN'))
         self.assertEqual(spc3.mol.atoms[1].symbol, 'H')
         spc3.generate_conformers()
-        self.assertEqual(len(spc3.conformers), 5)
+        self.assertEqual(len(spc3.conformers), 6)
 
         xyz4 = """O      -1.48027320    0.36597456    0.41386552
         C      -0.49770656   -0.40253648   -0.26500019


### PR DESCRIPTION
This PR fixes several bugs in the conformers module.

Previously the lowest conformers returned from the module to be DFT'ed were selected from the entire pool of conformers generated (random ones + the generated combinations). Since the random conformers contain repetitions, the N lowest conformers also ended up with repetitive structures. Since N conformers will be DFT'ed anyway, they might as well be different, even if that means including less favourable FF ones (which might become favourable at DFT?)

This PR also fixes a bug in plotting the torsion angles, where the first subplot's x axis was scaled differently. Now all subplots' x axes are treated uniformly. (This was perhaps caused by different behaviour in Py3?)

These changes were made following an offline discussion with @oscarwumit and @fhvermei. Thanks!