### PR TITLE
BugFix: xyz related fix

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -818,7 +818,7 @@ class Scheduler(object):
                     rxn = ' of reaction ' + self.species_dict[label].rxn_label
                 logger.info('Only one TS guess is available for species {0}{1},'
                             ' using it for geometry optimization'.format(label, rxn))
-                self.species_dict[label].initial_xyz = successful_tsgs[0].xyz
+                self.species_dict[label].initial_xyz = successful_tsgs[0].initial_xyz
                 if not self.composite_method:
                     self.run_opt_job(label)
                 else:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1576,6 +1576,7 @@ class TSGuess(object):
         self.index = ts_dict['index'] if 'index' in ts_dict else None
         self.initial_xyz = ts_dict['initial_xyz'] if 'initial_xyz' in ts_dict else None
         self.process_xyz(self.initial_xyz)  # re-populates self.initial_xyz
+        self.opt_xyz = ts_dict['opt_xyz'] if 'opt_xyz' in ts_dict else None
         self.success = ts_dict['success'] if 'success' in ts_dict else None
         self.energy = ts_dict['energy'] if 'energy' in ts_dict else None
         self.execution_time = ts_dict['execution_time'] if 'execution_time' in ts_dict else None

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -821,8 +821,8 @@ class ARCSpecies(object):
         if xyz is None:
             if self.is_ts:
                 for ts_guess in self.ts_guesses:
-                    if ts_guess.xyz is not None:
-                        xyz = ts_guess.xyz
+                    if ts_guess.initial_xyz is not None:
+                        xyz = ts_guess.initial_xyz
                         return xyz
                 return None
             elif generate:


### PR DESCRIPTION
Fixed two bugs in this PR: 

(1) TSGuess object does not have attribute xyz. The initial_xyz attribute should be used instead.
This commit fixed a similar problem as #218. 

(2) ARC crashed during TS job restart, for it did not read opt_xyz from restart file. Now ARC correctly reads this attribute from restart file. 