### PR TITLE
Minor: Change YAML `FullLoader` to `Loader`

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -264,7 +264,7 @@ def read_yaml_file(path):
     if not os.path.isfile(path):
         raise InputError('Could not find the YAML file {0}'.format(path))
     with open(path, 'r') as f:
-        content = yaml.load(stream=f, Loader=yaml.FullLoader)
+        content = yaml.load(stream=f, Loader=yaml.Loader)
     return content
 
 

--- a/arc/scripts/conformers/mdconf.py
+++ b/arc/scripts/conformers/mdconf.py
@@ -75,7 +75,7 @@ def read_yaml(path):
     if not os.path.isfile(path):
         raise IOError('The file {0} was not found and cannot be read.'.format(path))
     with open(path, 'r') as f:
-        content = yaml.load(stream=f, Loader=yaml.FullLoader)
+        content = yaml.load(stream=f, Loader=yaml.Loader)
     return content
 
 
@@ -232,7 +232,7 @@ def main():
     size = args.size[0]
     mdp_filename = args.mdp[0]
     with open('coords.yml', 'r') as f:
-        coords = yaml.load(stream=f, Loader=yaml.FullLoader)
+        coords = yaml.load(stream=f, Loader=yaml.Loader)
 
     output = list()
     for i, coord in enumerate(coords):


### PR DESCRIPTION
In PyYaml version 5.x above, the `FullLoader` is not backward compatible with previous PyYaml versions. This results in ARC crash in some restart jobs. The `Loader` function, instead, is backward compatible.

-- legacy comments
PyYaml version 3.12 works well with the current ARC codebase. New versions of PyYaml leads to restart issues.

When I restart an ARC job, it crashed because PyYaml complains that 
"yaml.constructor.ConstructorError: while constructing a Python instance
expected a class, but found <class 'builtin_function_or_method'>"

After traceback the code, I find PyYaml crashed because of the following code in ARC 
yaml.load(stream=f, Loader=yaml.FullLoader)

This seems to be a common PyYaml issue, especially for new versions: 
https://github.com/facebookresearch/Detectron/issues/840

Take advice online, I changed the PyYaml version to 3.12. Because in this version, FullLoader is not available, I changed it to Loader. Now we have in ARC 
pyyaml = 3.12
yaml.load(stream=f, Loader=yaml.Loader)

After these changes, my restart job works fine :-) 

