### PR TITLE
BugFix: Re-run job if FileNotFoundError

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -721,15 +721,25 @@ class Scheduler(object):
             if job.job_type not in ['orbitals']:
                 logger.warning('Tried to determine status of job {0}, but it seems like the job never ran.'
                                ' Re-running job.'.format(job.job_name))
-                self.run_job(label=label, xyz=job.xyz, level_of_theory=job.level_of_theory, job_type=job.job_type,
-                             fine=job.fine, software=job.software, shift=job.shift, trsh=job.trsh, memory=job.memory_gb,
-                             conformer=job.conformer, ess_trsh_methods=job.ess_trsh_methods, scan=job.scan,
-                             pivots=job.pivots, occ=job.occ, scan_trsh=job.scan_trsh, scan_res=job.scan_res,
-                             max_job_time=job.max_job_time, confs=job.conformers, radius=job.radius,
-                             directed_scan_type=job.directed_scan_type, directed_scans=job.directed_scans,
-                             directed_dihedrals=job.directed_dihedrals, rotor_index=job.rotor_index)
+                self._run_a_job(job=job, label=label)
             if job_name in self.running_jobs[label]:
                 self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
+
+        if not os.path.exists(job.local_path_to_output_file):
+            if 'restart_due_to_file_not_found' in job.ess_trsh_methods:
+                job.job_status[0] = 'errored'
+                job.job_status[1] = 'errored'
+                logger.warning('Job {0} errored because for the second time ARC did not find the output file path {1}.'
+                               .format(job.job_name, job.local_path_to_output_file))
+            elif job.job_type not in ['orbitals']:
+                job.ess_trsh_methods.append('restart_due_to_file_not_found')
+                logger.warning('Did not find the output file of job {0} with path {1}. Maybe the job never ran.'
+                               ' Re-running job.'.format(job.job_name, job.local_path_to_output_file))
+                self._run_a_job(job=job, label=label)
+            if job_name in self.running_jobs[label]:
+                self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
+            return False
+
         if job.job_status[0] != 'running' and job.job_status[1]['status'] != 'running':
             if job_name in self.running_jobs[label]:
                 self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
@@ -747,6 +757,22 @@ class Scheduler(object):
                     if job.job_type != 'conformer':
                         self.species_dict[label].checkfile = check_path
             return True
+
+    def _run_a_job(self, job, label):
+        """
+        A helper function to run ARC job (used internally).
+
+        Args:
+            job (Job): The job object.
+            label (str): The species label.
+        """
+        self.run_job(label=label, xyz=job.xyz, level_of_theory=job.level_of_theory, job_type=job.job_type,
+                     fine=job.fine, software=job.software, shift=job.shift, trsh=job.trsh, memory=job.memory_gb,
+                     conformer=job.conformer, ess_trsh_methods=job.ess_trsh_methods, scan=job.scan,
+                     pivots=job.pivots, occ=job.occ, scan_trsh=job.scan_trsh, scan_res=job.scan_res,
+                     max_job_time=job.max_job_time, confs=job.conformers, radius=job.radius,
+                     directed_scan_type=job.directed_scan_type, directed_scans=job.directed_scans,
+                     directed_dihedrals=job.directed_dihedrals, rotor_index=job.rotor_index)
 
     def run_conformer_jobs(self):
         """


### PR DESCRIPTION
Avoid ARC crash and re-run the job one more time if QM output files do not exist in the path.