### PR TITLE
BugFix: Read specific_job_type from yaml file

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -415,6 +415,7 @@ def initialize_job_types(job_types, specific_job_type=''):
     """
 
     if specific_job_type:
+        logger.info(f'Specific_job_type {specific_job_type} is given by user.')
         if job_types:
             logger.warning('Both job_types and specific_job_type are given, ARC will only use specific_job_type to '
                            'populate the job_types dictionary.')
@@ -422,7 +423,7 @@ def initialize_job_types(job_types, specific_job_type=''):
         try:
             job_types[specific_job_type] = True
         except KeyError:
-            raise InputError('Specified job type "{0}" is not supported'.format(specific_job_type))
+            raise InputError(f'Specified job type {specific_job_type} is not supported.')
 
     if specific_job_type == 'bde':
         bde_default = {'opt': True, 'fine_grid': True, 'freq': True, 'sp': True}
@@ -432,6 +433,9 @@ def initialize_job_types(job_types, specific_job_type=''):
     defaults_to_false = ['onedmin', 'orbitals', 'bde']
     if job_types is None:
         job_types = default_job_types
+        logger.info('Job types were not specified, using default values from ARC settings')
+    else:
+        logger.info(f'the following job types were specified: {job_types}.')
     if 'lennard_jones' in job_types:
         # rename lennard_jones to OneDMin
         job_types['onedmin'] = job_types['lennard_jones']
@@ -453,10 +457,10 @@ def initialize_job_types(job_types, specific_job_type=''):
             if job_type == '1d_rotors':
                 logging.error("Note: The `1d_rotors` job type was renamed to simply `rotors`. "
                               "Please modify your input accordingly (see ARC's documentation for examples).")
-            raise InputError("Job type '{0}' is not supported. Check the job types dictionary "
-                             "(either in ARC's input or in default_job_types under settings).".format(job_type))
+            raise InputError(f"Job type '{job_type}' is not supported. Check the job types dictionary "
+                             "(either in ARC's input or in default_job_types under settings).")
     job_types_report = [job_type for job_type, val in job_types.items() if val]
-    logger.info('\nConsidering the following job types: {0}\n'.format(job_types_report))
+    logger.info(f'\nConsidering the following job types: {job_types_report}\n')
     return job_types
 
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -453,6 +453,7 @@ class ARC(object):
         restart_dict['ess_settings'] = self.ess_settings
         restart_dict['job_memory'] = self.memory
         restart_dict['confs_to_dft'] = self.confs_to_dft
+        restart_dict['specific_job_type'] = self.specific_job_type
         if self.keep_checks:
             restart_dict['keep_checks'] = self.keep_checks
         return restart_dict
@@ -510,8 +511,9 @@ class ARC(object):
         self.t_count = input_dict['t_count'] if 't_count' in input_dict else None
 
         self.initial_trsh = input_dict['initial_trsh'] if 'initial_trsh' in input_dict else dict()
+        self.specific_job_type = input_dict['specific_job_type'] if 'specific_job_type' in input_dict else None
         self.job_types = input_dict['job_types'] if 'job_types' in input_dict else default_job_types
-        self.job_types = initialize_job_types(self.job_types)
+        self.job_types = initialize_job_types(self.job_types, specific_job_type=self.specific_job_type)
         self.use_bac = input_dict['use_bac'] if 'use_bac' in input_dict else True
         self.calc_freq_factor = input_dict['calc_freq_factor'] if 'calc_freq_factor' in input_dict else True
         self.model_chemistry = input_dict['model_chemistry'] if 'model_chemistry' in input_dict else ''

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -107,6 +107,7 @@ class TestARC(unittest.TestCase):
                                       'number_of_rotors': 0,
                                       'force_field': 'MMFF94s',
                                       't1': None}],
+                         'specific_job_type': '',
                          }
         self.assertEqual(restart_dict, expected_dict)
 
@@ -161,6 +162,17 @@ class TestARC(unittest.TestCase):
         self.assertFalse(arc1.arc_species_list[0].is_ts)
         self.assertEqual(arc1.arc_species_list[0].charge, 1)
 
+    def test_from_dict_specific_job(self):
+        """Test the from_dict() method of ARC"""
+        restart_dict = {'specific_job_type': 'bde'}
+        project = 'unit_test_specific_job'
+        project_directory = os.path.join(arc_path, 'Projects', project)
+        arc1 = ARC(project=project)
+        arc1.from_dict(input_dict=restart_dict, project=project, project_directory=project_directory)
+        job_type_expected = {'conformers': False, 'opt': True, 'freq': True, 'sp': True, 'rotors': False,
+                             'orbitals': False, 'bde': True, 'onedmin': False, 'fine': True}
+        self.assertEqual(arc1.job_types, job_type_expected)
+        
     def test_check_project_name(self):
         """Test project name invalidity"""
         with self.assertRaises(InputError):


### PR DESCRIPTION
Fixed a bug that ARC did not read specific_job_type attribute from input file. 

Added a test to maintest.py to check if specific_job_type is given in the yaml file, whether ARC process this attribute to initialize job correctly.

Improved logging to indicate if user specified job_type, specific_job_type, or did not specify any.

Lesson learned: when adding new attribute to arc object, do not forget to update from_dict and as
_dict.
