### PR TITLE
Don't run torsion scans if the dihedral has a 180 degrees angle at one of its sides

### DIFF
--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1299,28 +1299,22 @@ def check_atom_collisions(xyz):
 
 def check_special_non_rotor_cases(mol, top1, top2):
     """
-    Check whether one of the tops correspond to a special case which could not be rotated
-    `mol` is the RMG Molecule to diagnose
-    `top1` and `top2` are indices of atoms on each side of the pivots, the first index corresponds to one of the pivots
+    Check whether one of the tops correspond to a special case which does not have a torsional mode.
+    Checking for ``R-[C,N]#[N,[CH],[C]]`` groups, such as: in cyano groups (`R-C#N``),
+    C#C groups (``R-C#CH`` or ``R-C#[C]``), and azide groups: (``R-N#N``).
 
-    Special cases considered are:
+    Args:
+        mol (Molecule): The RMG molecule.
+        top1 (list): Entries are atom indices (1-indexed) on one side of the torsion, inc. one of the pivotal atoms.
+        top2 (list): Entries are atom indices (1-indexed) on the other side of the torsion, inc. the other pivotal atom.
 
-    - cyano groups: ``R-C#N``
-    - azide groups: ``N-N#N``
-
-    These cases have a 180 degree angle and torsion is meaningless, but they are identified by our methods since they
-    have a single bond
-    Returns `True` if this is indeed a special case which should not be treated as a rotor
+    Returns:
+        bool: ``True`` if this is indeed a special case which should **not** be treated as a torsional mode.
     """
     for top in [top1, top2]:
-        # check cyano group
-        if len(top) == 2 and mol.atoms[top[0] - 1].is_carbon() and mol.atoms[top[1] - 1].is_nitrogen() \
-                and mol.atoms[top[1] - 1].atomtype.label == 'N3t':
-            return True
-    for tp1, tp2 in [(top1, top2), (top2, top1)]:
-        # check azide group
-        if len(tp1) == 2 and mol.atoms[tp1[0] - 1].atomtype.label == 'N5tc' \
-                and mol.atoms[tp1[1] - 1].atomtype.label == 'N3t' and mol.atoms[tp2[0] - 1].atomtype.label == 'N1sc':
+        if mol.atoms[top[0] - 1].atomtype.label in ['Ct', 'N3t', 'N5tc'] \
+                and mol.atoms[top[1] - 1].atomtype.label in ['Ct', 'N3t'] and \
+                (len(top) == 2 or (len(top) == 3 and mol.atoms[top[2] - 1].is_hydrogen())):
             return True
     return False
 

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1597,7 +1597,7 @@ def translate_group(mol, xyz, pivot, anchor, vector):
     v1 = vectors.unit_vector(vector)
     v2 = vectors.unit_vector(vectors.get_vector(pivot=pivot, anchor=anchor, xyz=xyz))
     normal = vectors.get_normal(v2, v1)
-    theta = vectors.get_theta(v1, v2)
+    theta = vectors.get_angle(v1, v2)
     # print(theta * 180 / math.pi)  # print theta in degrees when troubleshooting
     # All atoms within the group will be rotated around the same normal vector by theta:
     group = determine_top_group_indices(mol=mol, atom1=mol.atoms[pivot], atom2=mol.atoms[anchor], index=0)[0]

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -726,15 +726,26 @@ O       1.40839617    0.14303696    0.00000000"""
 5 H u0 p0 c0 {1,S}
 6 H u0 p0 c0 {1,S}
 7 H u0 p0 c0 {3,S}"""
+        adj3 = """1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}"""
         mol0 = Molecule().from_adjacency_list(adj0)
         mol1 = Molecule().from_adjacency_list(adj1)
         mol2 = Molecule().from_adjacency_list(adj2)
-        non_rotor0 = conformers.check_special_non_rotor_cases(mol=mol0, top1=[2, 1], top2=[3, 4, 5, 6])
+        mol3 = Molecule().from_adjacency_list(adj3)
+        non_rotor0 = conformers.check_special_non_rotor_cases(mol=mol0, top1=[3, 1], top2=[2, 4, 5, 6])
         non_rotor1 = conformers.check_special_non_rotor_cases(mol=mol1, top1=[2, 1, 5, 6, 7], top2=[3, 4])
         non_rotor2 = conformers.check_special_non_rotor_cases(mol=mol2, top1=[1, 4, 5, 6], top2=[2, 3, 7])
+        rotor3 = conformers.check_special_non_rotor_cases(mol=mol3, top1=[1, 3, 4, 5], top2=[2, 6, 7, 8])
         self.assertTrue(non_rotor0)
         self.assertTrue(non_rotor1)
-        self.assertFalse(non_rotor2)
+        self.assertTrue(non_rotor2)
+        self.assertFalse(rotor3)
 
         spc0 = ARCSpecies(label='spc0', mol=mol0)
         spc1 = ARCSpecies(label='spc1', mol=mol1)
@@ -748,10 +759,18 @@ O       1.40839617    0.14303696    0.00000000"""
         self.assertFalse(torsions0)
 
         torsions1 = [rotor_dict['scan'] for rotor_dict in spc1.rotors_dict.values()]
-        self.assertTrue(len(torsions1) == 1)  # expecting only the CH3 rotor
+        self.assertEqual(len(torsions1), 1)  # expecting only the CH3 rotor
 
         torsions2 = [rotor_dict['scan'] for rotor_dict in spc2.rotors_dict.values()]
-        self.assertTrue(len(torsions2) == 1)  # expecting only the CH3 rotor
+        self.assertFalse(len(torsions2))
+
+        mol4 = Molecule(smiles='c1ccccc1C#C')
+        rotors = conformers.find_internal_rotors(mol4)
+        self.assertFalse(len(rotors))
+
+        mol5 = Molecule(smiles='N#CCC')
+        rotors = conformers.find_internal_rotors(mol5)
+        self.assertEqual(len(rotors), 1)
 
     def test_determine_top_group_indices(self):
         """Test determining the top group in a molecule"""

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -42,7 +42,7 @@ class ARCSpecies(object):
 
     Structures (rotors_dict is initialized in conformers.find_internal_rotors; pivots/scan/top values are 1-indexed)::
 
-            rotors_dict: {1: {'pivots': ``list``,
+            rotors_dict: {0: {'pivots': ``list``,
                               'top': ``list``,
                               'scan': ``list``,
                               'number_of_running_jobs': ``int``,
@@ -59,7 +59,7 @@ class ARCSpecies(object):
                               'directed_scan': ``dict``,  # keys: tuples of dihedrals as strings,
                                                           # values: dicts of energy, xyz, is_isomorphic, trsh
                              }
-                          2: {}, ...
+                          1: {}, ...
                          }
 
     Args:

--- a/arc/species/vectors.py
+++ b/arc/species/vectors.py
@@ -30,18 +30,26 @@ def get_normal(v1, v2):
     return unit_vector(normal)
 
 
-def get_theta(v1, v2):
+def get_angle(v1, v2, units='rads'):
     """
     Calculate the angle in radians between two vectors.
 
     Args:
          v1 (list): Vector 1.
          v2 (list): Vector 2.
+         units (str): The desired units, either 'rads' for radians, or 'degs' for degrees.
 
     Returns:
-        float: The angle in radians between v1 and v2.
+        float: The angle in radians between ``v1`` and ``v2`` in the desired units.
+
+    Raises:
+        VectorsError: If ``v1`` and ``v2`` are of different lengths.
     """
-    return np.arccos(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+    if len(v1) != len(v2):
+        raise VectorsError(f'v1 and v2 must be the same length, got {len(v1)} and {len(v2)}.')
+    v1_u, v2_u = unit_vector(v1), unit_vector(v2)
+    conversion = 180 / math.pi if 'degs' in units else 1
+    return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0)) * conversion
 
 
 def unit_vector(vector):
@@ -54,7 +62,7 @@ def unit_vector(vector):
     Returns:
         list: The unit vector.
     """
-    length = sum([vi ** 2 for vi in vector]) ** 0.5
+    length = get_vector_length(vector)
     return [vi / length for vi in vector]
 
 
@@ -168,4 +176,4 @@ def get_vector_length(v):
     Returns:
         float: The vector's length.
     """
-    return sum([vi ** 2 for vi in v]) ** 0.5
+    return np.dot(v, v) ** 0.5

--- a/arc/species/vectorsTest.py
+++ b/arc/species/vectorsTest.py
@@ -41,13 +41,27 @@ class TestVectors(unittest.TestCase):
         for ni, expected_ni in zip(n, expected_n):
             self.assertEqual(ni, expected_ni)
 
-    def test_get_theta(self):
+    def test_get_angle(self):
         """Test calculating the angle between two vectors"""
         v1 = [-1.45707856 + 0.02416711, -0.94104506 - 0.17703194, -0.20275830 - 0.08644641]
         v2 = [-0.03480906 + 0.02416711, 1.11948179 - 0.17703194, -0.82988874 - 0.08644641]
-        theta = vectors.get_theta(v1, v2)
+        theta = vectors.get_angle(v1, v2)
         self.assertAlmostEqual(theta, 1.8962295, 5)
         self.assertAlmostEqual(theta * 180 / math.pi, 108.6459, 3)
+
+        v1, v2 = [1, 0, 0], [0, 1, 0]
+        theta_rads = vectors.get_angle(v1, v2)
+        theta_degs = vectors.get_angle(v1, v2, units='degs')
+        self.assertEqual(theta_degs / theta_rads, 180 / math.pi)
+        self.assertAlmostEqual(theta_rads, 1.5707963)
+
+        v1, v2 = [1, 0, 0], [1, 0, 0]
+        theta = vectors.get_angle(v1, v2)
+        self.assertAlmostEqual(theta, 0)
+
+        v1, v2 = [1, 0, 0], [-1, 0, 0]
+        theta = vectors.get_angle(v1, v2)
+        self.assertAlmostEqual(theta, math.pi)
 
     def test_unit_vector(self):
         """Test calculating a unit vector"""


### PR DESCRIPTION
Improved (generalized) the `check_special_non_rotor_cases` function for screening torsions.
Also, if after optimization the dihedral is (very close to) 180 degrees, don't run this scan (as suggested by @xiaoruiDong). From my experience, non-rotors like this have dihedrals of 180.0 degrees in DFT opt, here we're using a tolerance of 0.1 degrees.

fixes https://github.com/ReactionMechanismGenerator/ARC/issues/171