### PR TITLE
Fix broken link to arc.main

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -51,7 +51,7 @@ All the parameters of `arc.main.ARC`__ class are allowed input file keywords.
 Specifying species and reactions lists define :ref:`ARCSpecies <species>` and :ref:`ARCReaction <reaction>`
 object. See ARC's API for a complete and updated list of keywords along with their allowed types.
 
-__ api/main_
+__ api/main.html
 
 
 Additional input file examples are available in the examples folder.


### PR DESCRIPTION
There was a broken link on the running.rst page of the documentation to the arc.main.ARC api. This PR fixes this issue, though perhaps there is a more elegant solution.