### PR TITLE
Allow max job time in hours as a float to include minutes and seconds

### DIFF
--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -316,6 +316,13 @@ class TestJob(unittest.TestCase):
         self.assertIn('mdp.mdp', self.job1.additional_files_to_upload[5]['remote'])
         self.assertIn('mdp.mdp', self.job1.additional_files_to_upload[5]['local'])
 
+    def test_format_max_job_time(self):
+        """Test that the maximum job time can be formatted properly, including days, minutes, and seconds"""
+        test_job = Job.__new__(Job)
+        test_job.max_job_time = 59.888
+        self.assertEqual(test_job.format_max_job_time('days'), '2-11:53:16')
+        self.assertEqual(test_job.format_max_job_time('hours'), '59:53:16')
+
     @classmethod
     def tearDownClass(cls):
         """

--- a/arc/main.py
+++ b/arc/main.py
@@ -74,7 +74,7 @@ class ARC(object):
         t_count (int, optional): The number of temperature points between t_min and t_max for kinetics computations.
         verbose (int, optional): The logging level to use.
         project_directory (str, optional): The path to the project directory.
-        max_job_time (int, optional): The maximal allowed job time on the server in hours.
+        max_job_time (float, optional): The maximal allowed job time on the server in hours (can be fractional).
         allow_nonisomorphic_2d (bool, optional): Whether to optimize species even if they do not have a 3D conformer
                                                  that is isomorphic to the 2D graph representation.
         job_memory (int, optional): The total allocated job memory in GB (14 by default to be lower than 90% * 16 GB).
@@ -131,7 +131,7 @@ class ARC(object):
         t_min (tuple): The minimum temperature for kinetics computations, e.g., (500, str('K')).
         t_max (tuple): The maximum temperature for kinetics computations, e.g., (3000, str('K')).
         t_count (int): The number of temperature points between t_min and t_max for kinetics computations.
-        max_job_time (int): The maximal allowed job time on the server in hours.
+        max_job_time (float): The maximal allowed job time on the server in hours (can be fractional).
         rmgdb (RMGDatabase): The RMG database object.
         allow_nonisomorphic_2d (bool): Whether to optimize species even if they do not have a 3D conformer that is
                                        isomorphic to the 2D graph representation.

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -109,7 +109,7 @@ class Scheduler(object):
         bath_gas (str, optional): A bath gas. Currently used in OneDMin to calc L-J parameters.
                                   Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
         restart_dict (dict, optional): A restart dictionary parsed from a YAML restart file.
-        max_job_time (int, optional): The maximal allowed job time on the server in hours.
+        max_job_time (float, optional): The maximal allowed job time on the server in hours (can be fractional).
         allow_nonisomorphic_2d (bool, optional): Whether to optimize species even if they do not have a 3D conformer
                                                  that is isomorphic to the 2D graph representation.
         memory (int, optional): The total allocated job memory in GB (14 by default).
@@ -142,7 +142,7 @@ class Scheduler(object):
         save_restart (bool): Whether to start saving a restart file. ``True`` only after all species are loaded
                              (otherwise saves a partial file and may cause loss of information).
         restart_path (str): Path to the `restart.yml` file to be saved.
-        max_job_time (int): The maximal allowed job time on the server in hours.
+        max_job_time (float): The maximal allowed job time on the server in hours (can be fractional).
         testing (bool): Used for internal ARC testing (generating the object w/o executing it).
         rmgdb (RMGDatabase): The RMG database object.
         allow_nonisomorphic_2d (bool): Whether to optimize species even if they do not have a 3D conformer that is


### PR DESCRIPTION
I was trying to submit a job to a debug queue on a server that allowed for job times of no more than 30 minutes. Since we specify the maximum job time as the number of hours as an integer, there was no way to set this 30 minute time.

I have refactored the code responsible for this so that it can handle hours as a float. 0.5 will convert to 30 minutes, 4.5 will convert to 4 hours and 30 minutes, and so on and so forth.

I have moved the code for this to a new function to reduce code complexity and allow this to be properly unit tested.

Reviewer note: I included type hints in my code, but because this doesn't match the style around it I am happy to convert this so that the type only appears in the doc string, or even get rid of it altogether. 