### PR TITLE
Update Arkane ess imports

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -23,9 +23,7 @@ import yaml
 
 import numpy as np
 
-from arkane.logs.gaussian import GaussianLog
-from arkane.logs.molpro import MolproLog
-from arkane.logs.qchem import QChemLog
+from arkane.ess import GaussianLog, MolproLog, QChemLog
 from arkane.util import determine_qm_software
 from rmgpy.molecule.element import get_element
 from rmgpy.qm.qmdata import QMData

--- a/arc/main.py
+++ b/arc/main.py
@@ -701,7 +701,7 @@ class ARC(object):
             else:
                 logger.info('Considering species: {0}'.format(species.label))
                 if species.mol is not None:
-                    display(species.mol)
+                    display(species.mol.copy(deep=True))
         logger.info('\n')
         for rxn in self.arc_rxn_list:
             if not isinstance(rxn, ARCReaction):

--- a/arc/parser.py
+++ b/arc/parser.py
@@ -9,9 +9,7 @@ import numpy as np
 import os
 
 from arkane.exceptions import LogError
-from arkane.logs.gaussian import GaussianLog
-from arkane.logs.molpro import MolproLog
-from arkane.logs.qchem import QChemLog
+from arkane.ess import GaussianLog, MolproLog, QChemLog
 from arkane.util import determine_qm_software
 
 from arc.common import get_logger

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -232,7 +232,7 @@ class Scheduler(object):
                 if family_text:
                     logger.info('({0})'.format(family_text))
                 if rxn.rmg_reaction is not None:
-                    display(rxn.rmg_reaction)
+                    display(rxn.rmg_reaction.copy(deep=True))
                 rxn.determine_rxn_charge()
                 rxn.determine_rxn_multiplicity()
                 rxn.ts_label = rxn.ts_label if rxn.ts_label is not None else 'TS{0}'.format(rxn.index)
@@ -1752,9 +1752,8 @@ class Scheduler(object):
             rxn_str = ''
             if self.species_dict[label].is_ts:
                 rxn_str = ' of reaction {0}'.format(self.species_dict[label].rxn_label)
-            logger.info('\nOptimized geometry for {label}{rxn} at {level}:\n{xyz}'.format(
-                label=label, rxn=rxn_str, level=job.level_of_theory,
-                xyz=xyz_to_str(xyz_dict=self.species_dict[label].final_xyz)))
+            logger.info(f'\nOptimized geometry for {label}{rxn_str} at {job.level_of_theory}:\n'
+                        f'{xyz_to_str(xyz_dict=self.species_dict[label].final_xyz)}')
             if not job.is_ts:
                 plotter.draw_structure(species=self.species_dict[label], project_directory=self.project_directory)
             else:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -970,17 +970,19 @@ class Scheduler(object):
             for i in range(self.species_dict[label].number_of_rotors):
                 scan = self.species_dict[label].rotors_dict[i]['scan']
                 pivots = self.species_dict[label].rotors_dict[i]['pivots']
-                coords = xyz_to_coords_list(self.species_dict[label].get_xyz())
-                v1 = [c1 - c2 for c1, c2 in zip(coords[scan[0] - 1], coords[scan[1] - 1])]
-                v2 = [c2 - c1 for c1, c2 in zip(coords[scan[1] - 1], coords[scan[2] - 1])]
-                v3 = [c1 - c2 for c1, c2 in zip(coords[scan[2] - 1], coords[scan[3] - 1])]
-                angle1, angle2 = get_angle(v1, v2, units='degs'), get_angle(v2, v3, units='degs')
-                if any([abs(angle - 180.0) < 0.15 for angle in [angle1, angle2]]):
-                    # this is not a torsional mode, invalidate rotor
-                    self.species_dict[label].rotors_dict[i]['success'] = False
-                    self.species_dict[label].rotors_dict[i]['invalidation_reason'] = \
-                        f'not a torsional mode (angles = {angle1:.2f}, {angle2:.2f} degrees)'
-                    return
+                if not isinstance(scan[0], list):
+                    # check that a 1D rotors is not linear
+                    coords = xyz_to_coords_list(self.species_dict[label].get_xyz())
+                    v1 = [c1 - c2 for c1, c2 in zip(coords[scan[0] - 1], coords[scan[1] - 1])]
+                    v2 = [c2 - c1 for c1, c2 in zip(coords[scan[1] - 1], coords[scan[2] - 1])]
+                    v3 = [c1 - c2 for c1, c2 in zip(coords[scan[2] - 1], coords[scan[3] - 1])]
+                    angle1, angle2 = get_angle(v1, v2, units='degs'), get_angle(v2, v3, units='degs')
+                    if any([abs(angle - 180.0) < 0.15 for angle in [angle1, angle2]]):
+                        # this is not a torsional mode, invalidate rotor
+                        self.species_dict[label].rotors_dict[i]['success'] = False
+                        self.species_dict[label].rotors_dict[i]['invalidation_reason'] = \
+                            f'not a torsional mode (angles = {angle1:.2f}, {angle2:.2f} degrees)'
+                        return
                 directed_scan_type = self.species_dict[label].rotors_dict[i]['directed_scan_type'] \
                     if 'directed_scan_type' in self.species_dict[label].rotors_dict[i] else ''
                 if not self.species_dict[label].rotors_dict[i]['scan_path']:

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -2272,6 +2272,19 @@ Cl      2.38846685    0.24054066    0.55443324
         expected_top_element_count = {('C', -1): 3, ('H', -1): 3, ('H', 2): 1, ('H', 3): 1, ('N', -1): 1, ('S', -1): 1}
         self.assertEqual(top_element_count, expected_top_element_count)
 
+    def test_preserve_atom_order(self):
+        """Test that atom order is being preserved when generating conformers"""
+        spc1 = ARCSpecies(label='formic_acid', smiles='O=CO')
+        lowest_confs = conformers.generate_conformers(mol_list=spc1.mol_list, label=spc1.label, charge=spc1.charge,
+                                                      multiplicity=spc1.multiplicity, print_logs=False,
+                                                      num_confs_to_return=1)
+        for mol_atom, conf_atom in zip(spc1.mol.atoms, lowest_confs[0]['xyz']['symbols']):
+            self.assertEqual(mol_atom.element.symbol, conf_atom)
+
+        spc1.generate_conformers(confs_to_dft=1, plot_path=None)
+        for mol_atom, conf_atom in zip(spc1.mol.atoms, spc1.conformers[0]['symbols']):
+            self.assertEqual(mol_atom.element.symbol, conf_atom)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -109,44 +109,44 @@ ARC also supports ND (N dimensional, N >= 1) rotor scans. There are seven differ
 - B. Derive the geometry from the previous point (continuous constrained optimization)
 
 Each of the options above can be either "nested" (considering all ND dihedral combinations) or "diagonal"
-(resulting in a unique 1D rotor scan across several dimensions). THe last option is to allow the ESS to control
-the ND scan, which is similar to option B.
+(resulting in a unique 1D rotor scan across several dimensions). The seventh option is to allow the ESS to control
+the ND scan, which is similar in principal to option B.
 
 The optional primary keys are:
 
-- `brute_force_sp`
-- `brute_force_opt`
-- `cont_opt`
+- ``brute_force_sp``
+- ``brute_force_opt``
+- ``cont_opt``
 
 The brute force methods will generate all the geometries in advance and submit all relevant jobs simultaneously.
 The continuous method will wait for the previous job to terminate, and use its geometry as the initial guess for
 the next job.
 
-Another set of three keys is allowed, adding `_diagonal` to each of the above keys. the secondary keys are therefore:
+Another set of three keys is allowed, adding ``_diagonal`` to each of the above keys. the secondary keys are therefore:
 
-- `brute_force_sp_diagonal`
-- `brute_force_opt_diagonal`
-- `cont_opt_diagonal`
+- ``brute_force_sp_diagonal``
+- ``brute_force_opt_diagonal``
+- ``cont_opt_diagonal``
 
-Specifying `_diagonal` will increment all the respective dihedrals together, resulting in a 1D scan instead of
-an ND scan. Values are nested lists. Each value is a list where the entries are either pivot lists (e.g., [1,5])
-or lists of pivot lists (e.g., [[1,5], [6,8]]), or a mix (e.g., [[4,8], [[6,9], [3, 4]]). The requested directed
-scan type will be executed separately for each list entry in the value. A list entry that contains only two pivots
+Specifying ``_diagonal`` will increment all the respective dihedrals together, resulting in a 1D scan instead of
+an ND scan. Values are nested lists. Each value is a list where the entries are either pivot lists (e.g., ``[1, 5]``)
+or lists of pivot lists (e.g., ``[[1, 5], [6, 8]]``), or a mix (e.g., ``[[4, 8], [[6, 9], [3, 4]]``). The requested
+directed scan type will be executed separately for each list entry. A list entry that contains only two pivots
 will result in a 1D scan, while a list entry with N pivots will consider all of them, and will result in an ND scan
-if '_diagonal' is not specified.
+(if ``_diagonal`` is not specified).
 
-ARC will generate geometries using the ``rotor_scan_resolution`` argument in settings.py
+ARC will generate geometries using the ``rotor_scan_resolution`` argument in ``settings.py``.
 
-Note: An 'all' string entry is also allowed in the value list, triggering a directed internal rotation scan for all
-torsions in the molecule. If 'all' is specified within a second level list, then all the dihedrals will be considered
+Note: An ``'all'`` string entry is also allowed in the value list, triggering a directed internal rotation scan for all
+torsions in the molecule. If ``'all'`` is specified within a second level list, then all the dihedrals will be considered
 together. Currently ARC does not automatically identify torsions to be treated as ND, and this attribute must be
 specified by the user. An additional supported key is 'ess', in which case ARC will allow the ESS to take care of
 spawning the ND continuous constrained optimizations.
 
-To execute ND rotor scans, first set the ```rotors`` job type to ``True``.
+To execute ND rotor scans, first set the ``rotors`` job type to ``True``.
 Next, set the ``directed_rotors`` attribute of the relevant species. Below are several examples.
 
-To run all dihedral scans of a species separately (each as 1D)::
+To run all dihedral scans of a species separately using brute force sp (each as 1D)::
 
     spc1 = ARCSpecies(label='some_label', smiles='species_smiles', directed_rotors={'brute_force_sp': ['all']})
 
@@ -154,18 +154,19 @@ To run all dihedral scans of a species as a conjugated scan (ND, N = the number 
 
     spc1 = ARCSpecies(label='some_label', smiles='species_smiles', directed_rotors={'cont_opt': [['all']]})
 
-Note in the above example the change in list level (``all`` is either within one or two nested lists).
+Note the change in list level (``all`` is either within one or two nested lists) in the above examples.
 
 To run specific dihedrals as ND (here all 2D combinations for a species with 3 torsions)::
 
     spc1 = ARCSpecies(label='C4O2', smiles='[O]CCCC=O', xyz=xyz,
                       directed_rotors={'brute_force_opt': [[[5, 3], [3, 4]], [[3, 4], [4, 6]], [[5, 3], [4, 6]]]})
 
+
 - Note: ND rotors are still **not** incorporated into the molecular partition function,
-so currently will not affect thermo or rates.
+  so currently will not affect thermo or rates.
 - Note: Any torsion defined as part of an ND rotor scan will **not** be spawned for that species as a separate 1D scan.
 - Warning: Job arrays have not been incorporated into ARC yet. Spawning ND rotor scans will result in **many**
-individual jobs being submit to your server queue system.
+  individual jobs being submit to your server queue system.
 
 
 Electronic Structure Software Settings


### PR DESCRIPTION
To comply with recent changes to Arkane (https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1831)

Also added several bug fixes and minor changes:
- Perserve atom order in conformers when generating resonance structures
- Pass a copy of the species/reaction object to display()
- Only check rotor linearity for 1D rotors