### PR TITLE
Minor bug fixes

### DIFF
--- a/arc/processor.py
+++ b/arc/processor.py
@@ -229,7 +229,7 @@ class Processor(object):
                     species_for_thermo_lib.append(species)
                 try:
                     species.rmg_thermo = self.rmgdb.thermo.get_thermo_data(species.rmg_species)
-                except (ValueError, AttributeError) as e:
+                except Exception as e:
                     logger.info(f'Could not retrieve RMG thermo for species {species.label}, possibly due to missing '
                                 f'2D structure (bond orders). Not including this species in the parity plots.'
                                 f'\nGot: {e}')


### PR DESCRIPTION
This PR address a couple of errors that I have encountered recently using ARC

1. **Prevent ARC from crashing when generating parity plots** 

More details:
At the end of the ARC job we try to generate parity plots that show how the thermochemistry of the calculated species differ from what RMG would predict using RMG-database. This can cause problems though if the species can't be estimated by RMG-database (e.g. the species contains Fluorine which has no data). 

Previously there was an except statement to catch some possible errors, but the classes of exceptions allowed were too narrow. While it is in fact good coding practice to use as narrow of a scope as possible for catching exceptions, I would argue that it is better in this case to catch all exceptions and relay them to the user, as generating these parity plots is not critical, and having ARC crash over this prevents more useful output from being generated. 

2. **Do not crash if we try to delete a job that has already stopped**

3. **When an exception is encountered from trying to execute a command, store this exception, as it is needed elsewhere**