### PR TITLE
BugFix: Make sure that np arrays are not saved to a restart file

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -478,7 +478,8 @@ class ARCSpecies(object):
         species_dict['number_of_rotors'] = self.number_of_rotors
         species_dict['external_symmetry'] = self.external_symmetry
         species_dict['optical_isomers'] = self.optical_isomers
-        species_dict['neg_freqs_trshed'] = self.neg_freqs_trshed
+        species_dict['neg_freqs_trshed'] = self.neg_freqs_trshed.tolist() \
+            if isinstance(self.neg_freqs_trshed, np.ndarray) else self.neg_freqs_trshed
         species_dict['arkane_file'] = self.arkane_file
         species_dict['consider_all_diastereomers'] = self.consider_all_diastereomers
         if self.is_ts:


### PR DESCRIPTION
fixes #223
fixes #279

Convert negative frequencies troubleshooted to a list when generated, and double-check when dumping a species as a dictionary. This avoids saving a numpy ndarray into ARC's YAML restart file.

Reviewers, please let me know if you think the two implementations are an over-kill, we can keep only one.
