### PR TITLE
BugFix: use copy() instead of copy(deep=True)

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -243,7 +243,7 @@ class Scheduler(object):
                 if family_text:
                     logger.info(f'({family_text})')
                 if rxn.rmg_reaction is not None:
-                    display(rxn.rmg_reaction.copy(deep=True))
+                    display(rxn.rmg_reaction.copy())
                 rxn.determine_rxn_charge()
                 rxn.determine_rxn_multiplicity()
                 rxn.ts_label = rxn.ts_label if rxn.ts_label is not None else f'TS{rxn.index}'


### PR DESCRIPTION
This PR fixed a bug related to deepcopy. The bug was found during the execution of an ARC reaction job. 

The traceback was:
"""
Traceback (most recent call last):
  File "/home/wuh104/workspace/ARC/ARC.py", line 73, in <module>
    main()
  File "/home/wuh104/workspace/ARC/ARC.py", line 67, in main
    arc_object.execute()
  File "/gpfs/workspace/users/wuh104/ARC/arc/main.py", line 531, in execute
    dont_gen_confs=self.dont_gen_confs)
  File "/gpfs/workspace/users/wuh104/ARC/arc/scheduler.py", line 246, in __init__
    display(rxn.rmg_reaction.copy(deep=True))
TypeError: copy() takes no keyword arguments
"""