### PR TITLE
BugFix: Make sure Cartesian coordinates are not np arrays

### DIFF
--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -279,9 +279,13 @@ def xyz_from_data(coords, numbers=None, symbols=None, isotopes=None):
         ConverterError: If neither ``numbers`` nor ``symbols`` are specified, if both are specified,
                         or if the input lengths aren't consistent.
     """
-    if isinstance(coords, (list, np.ndarray)):
+    if isinstance(coords, np.ndarray):
+        coords = tuple(tuple(coord.tolist()) for coord in coords)
+    elif isinstance(coords, list):
         coords = tuple(tuple(coord) for coord in coords)
-    if numbers is not None and isinstance(numbers, (list, np.ndarray)):
+    if numbers is not None and isinstance(numbers, np.ndarray):
+        numbers = tuple(numbers.tolist())
+    elif numbers is not None and isinstance(numbers, list):
         numbers = tuple(numbers)
     if symbols is not None and isinstance(symbols, list):
         symbols = tuple(symbols)

--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -5,6 +5,7 @@
 This module contains unit tests of the arc.species.converter module
 """
 
+import numpy as np
 import unittest
 
 from rdkit import Chem
@@ -565,6 +566,18 @@ R1=1.0912"""
                   [0.6300326, -0.6300326, -0.6300326]]
         xyz_dict2 = converter.xyz_from_data(coords=coords, numbers=numbers)
         self.assertEqual(xyz_dict2, self.xyz1['dict'])
+
+        numbers = [6, 1, 1, 1, 1]
+        coords = [[0.0, 0.0, 0.0],
+                  [0.6300326, 0.6300326, 0.6300326],
+                  [-0.6300326, -0.6300326, 0.6300326],
+                  [-0.6300326, 0.6300326, -0.6300326],
+                  [0.6300326, -0.6300326, -0.6300326]]
+        coords = np.array([np.array(coord, np.float64) for coord in coords], np.float64)
+        xyz_dict2 = converter.xyz_from_data(coords=coords, numbers=numbers)
+        self.assertEqual(xyz_dict2, self.xyz1['dict'])
+        self.assertIsInstance(xyz_dict2['coords'], tuple)
+        self.assertIsInstance(xyz_dict2['coords'][0], tuple)
 
     def test_get_most_common_isotope_for_element(self):
         """Test the get_most_common_isotope_for_element function"""


### PR DESCRIPTION
Otherwise, ARC's restart file cannot be read by YAML's FullLoader.
Also added a test