### PR TITLE
Relax isomorphism check, just checking the connectivity should be enough

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -335,6 +335,35 @@ def get_atom_radius(symbol):
     return r
 
 
+def colliding_atoms(xyz):
+    """
+    Check whether atoms are too close to each other.
+
+    Args:
+        xyz (dict): The Cartesian coordinates.
+
+    Returns:
+         bool: ``True`` if they are colliding, ``False`` otherwise.
+    """
+    if len(xyz['symbols']) == 1:
+        # monoatomic
+        return False
+    coords = xyz['coords']
+    symbols = xyz['symbols']
+    atom_radaii = [get_atom_radius(symbol) for symbol in symbols]
+    for i, coord1 in enumerate(coords):
+        if i < len(coords) - 1:
+            for j, coord2 in enumerate(coords[i+1:]):
+                if sum((coord1[k] - coord2[k]) ** 2 for k in range(3)) ** 0.5 < \
+                        0.9 * (atom_radaii[i] + atom_radaii[j + i + 1]):  # take a 10% confidence value
+                    logger.debug(f'atom {symbols[i]} with coords {coord1} is distant '
+                                 f'{sum((coord1[k] - coord2[k]) ** 2 for k in range(3)) ** 0.5} '
+                                 f'from atom {symbols[i + j + 1]} with coords {coord2}, '
+                                 f'should be more than {atom_radaii[i] + atom_radaii[j + i + 1]}')
+                    return True
+    return False
+
+
 def determine_symmetry(xyz):
     """
     Determine external symmetry and chirality (optical isomers) of the species.

--- a/arc/common.py
+++ b/arc/common.py
@@ -872,3 +872,41 @@ def is_str_float(value):
         return True
     except ValueError:
         return False
+
+
+# a bond length dictionary of single bonds, Angstrom
+# https://sites.google.com/site/chempendix/bond-lengths
+# https://courses.lumenlearning.com/suny-potsdam-organicchemistry/chapter/1-3-basics-of-bonding/
+SINGLE_BOND_LENGTH = {'Br-Br': 2.29, 'Br-Cr': 1.94, 'Br-H': 1.41,
+                      'C-C': 1.54, 'C-Cl': 1.77, 'C-F': 1.35, 'C-H': 1.09, 'C-I': 2.13,
+                      'C-N': 1.47, 'C-O': 1.43, 'C-P': 1.87, 'C-S': 1.81, 'C-Si': 1.86,
+                      'Cl-Cl': 1.99, 'Cl-H': 1.27, 'Cl-N': 1.75, 'Cl-Si': 2.03, 'Cl-P': 2.03, 'Cl-S': 2.07,
+                      'F-F': 1.42, 'F-H': 0.92, 'F-P': 1.57, 'F-S': 1.56, 'F-Si': 1.56, 'F-Xe': 1.90,
+                      'H-H': 0.74, 'H-I': 1.61, 'H-N': 1.04, 'H-O': 0.96, 'H-P': 1.42, 'H-S': 1.34, 'H-Si': 1.48,
+                      'I-I': 2.66,
+                      'N-N': 1.45,
+                      'O-O': 1.48, 'O-P': 1.63, 'O-S': 1.58, 'O-Si': 1.66,
+                      'P-P': 2.21,
+                      'S-S': 2.05,
+                      'Si-Si': 2.35,
+                      }
+
+
+def get_single_bond_length(symbol1, symbol2):
+    """
+    Get the an approximate for a single bond length between two elements.
+
+    Args:
+        symbol1 (str): Symbol 1.
+        symbol2 (str): Symbol 2.
+
+    Returns:
+        float: The estimated single bond length in Angstrom.
+    """
+    bond1, bond2 = '-'.join([symbol1, symbol2]), '-'.join([symbol2, symbol1])
+    if bond1 in SINGLE_BOND_LENGTH.keys():
+        return SINGLE_BOND_LENGTH[bond1]
+    if bond2 in SINGLE_BOND_LENGTH.keys():
+        return SINGLE_BOND_LENGTH[bond2]
+    return 2.5
+

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -637,6 +637,12 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
         self.assertEqual(common.get_atom_radius('N'), 0.71)
         self.assertIsNone(common.get_atom_radius('wrong'))
 
+    def test_get_single_bond_length(self):
+        """Test getting an approximation for a single bond length"""
+        self.assertEqual(common.get_single_bond_length('C', 'C'), 1.54)
+        self.assertEqual(common.get_single_bond_length('C', 'O'), 1.43)
+        self.assertEqual(common.get_single_bond_length('O', 'C'), 1.43)
+        self.assertEqual(common.get_single_bond_length('P', 'Si'), 2.5)
 
 
 if __name__ == '__main__':

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -628,6 +628,16 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
         self.assertFalse(common.is_str_float('R1'))
         self.assertFalse(common.is_str_float('D_3_5_7_4'))
 
+    def test_get_atom_radius(self):
+        """Test determining the covalent radius of an atom"""
+        self.assertEqual(common.get_atom_radius('C'), 0.76)
+        self.assertEqual(common.get_atom_radius('S'), 1.05)
+        self.assertEqual(common.get_atom_radius('O'), 0.66)
+        self.assertEqual(common.get_atom_radius('H'), 0.31)
+        self.assertEqual(common.get_atom_radius('N'), 0.71)
+        self.assertIsNone(common.get_atom_radius('wrong'))
+
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -15,6 +15,7 @@ from rmgpy.molecule.molecule import Molecule
 import arc.common as common
 from arc.exceptions import InputError, SettingsError
 from arc.settings import arc_path, servers
+import arc.species.converter as converter
 
 
 class TestCommon(unittest.TestCase):
@@ -72,6 +73,29 @@ class TestCommon(unittest.TestCase):
         time.sleep(2)
         lap = common.time_lapse(t0)
         self.assertEqual(lap, '00:00:02')
+
+    def test_colliding_atoms(self):
+        """Check that we correctly determine when atoms collide in xyz"""
+        xyz0 = """C	0.0000000	0.0000000	0.6505570"""  # monoatomic
+        xyz1 = """C      -0.84339557   -0.03079260   -0.13110478
+N       0.53015060    0.44534713   -0.25006000
+O       1.33245258   -0.55134720    0.44204567
+H      -1.12632103   -0.17824612    0.91628291
+H      -1.52529493    0.70480833   -0.56787044
+H      -0.97406455   -0.97317212   -0.67214713
+H       0.64789210    1.26863944    0.34677470
+H       1.98414750   -0.79355889   -0.24492049"""  # no colliding atoms
+        xyz2 = """C      -0.84339557   -0.03079260   -0.13110478
+N       0.53015060    0.44534713   -0.25006000
+O       1.33245258   -0.55134720    0.44204567
+H      -1.12632103   -0.17824612    0.91628291
+H      -1.52529493    0.70480833   -0.56787044
+H      -0.97406455   -0.97317212   -0.67214713
+H       1.33245258   -0.55134720    0.48204567
+H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
+        self.assertFalse(common.colliding_atoms(converter.str_to_xyz(xyz0)))
+        self.assertFalse(common.colliding_atoms(converter.str_to_xyz(xyz1)))
+        self.assertTrue(common.colliding_atoms(converter.str_to_xyz(xyz2)))
 
     def test_check_ess_settings(self):
         """Test the check_ess_settings function"""

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -62,7 +62,7 @@ def draw_structure(xyz=None, species=None, project_directory=None, method='show_
     if method == 'show_sticks' and notebook:
         try:
             success = show_sticks(xyz=xyz, species=species, project_directory=project_directory)
-        except (IndexError, InputError):
+        except (AttributeError, IndexError, InputError):
             pass
     if method == 'draw_3d' or (method == 'show_sticks' and (not success or not notebook)):
         draw_3d(xyz=xyz, species=species, project_directory=project_directory, save_only=not notebook)

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -504,7 +504,7 @@ def conformers_combinations_by_lowest_conformer(label, mol, base_xyz, multiple_t
                 base_energy = lowest_conf_i['FF energy']
     if plot_path is not None:
         logger.info(converter.xyz_to_str(lowest_conf_i['xyz']))
-        arc.plotter.show_sticks(lowest_conf_i['xyz'])
+        arc.plotter.draw_structure(xyz=lowest_conf_i['xyz'])
         num_comb = arc.plotter.plot_torsion_angles(torsion_angles, multiple_sampling_points_dict,
                                                    wells_dict=wells_dict, e_conformers=newest_conformers_dict,
                                                    de_threshold=de_threshold, plot_path=plot_path)
@@ -1378,33 +1378,6 @@ def get_wells(label, angles, blank=20):
         wells[-1]['end_angle'] = new_angles[-1]
         wells[-1]['angles'].append(new_angles[-1])
     return wells
-
-
-def check_atom_collisions(xyz):
-    """
-    Check whether atoms are too close to each other.
-
-    Args:
-        xyz (dict): The 3D geometry.
-
-    Returns:
-         bool: True if they are colliding, False otherwise.
-
-    Todo:
-        - Consider atomic radius for the different elements
-    """
-    coords = xyz['coords']
-    symbols = xyz['symbols']
-    if symbols == ('H', 'H'):
-        # hard-code for H2:
-        if sum((coords[0][k] - coords[1][k]) ** 2 for k in range(3)) ** 0.5 < 0.5:
-            return True
-    for i, coord1 in enumerate(coords):
-        if i < len(coords) - 1:
-            for coord2 in coords[i+1:]:
-                if sum((coord1[k] - coord2[k]) ** 2 for k in range(3)) ** 0.5 < 0.9:
-                    return True
-    return False
 
 
 def check_special_non_rotor_cases(mol, top1, top2):

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -1220,22 +1220,6 @@ O       1.40839617    0.14303696    0.00000000"""
         self.assertTrue(all([int(round(angle / 5.0) * 5.0) in [60, 300]
                              for angle in torsion_angles[tuple(torsions[1])]]))  # batch check almost equal
 
-    def test_check_atom_collisions(self):
-        """Check that we correctly determine when atoms collide in xyz"""
-        xyz0 = """C	0.0000000	0.0000000	0.6505570
-C	0.0000000	0.0000000	-0.6505570
-C	0.0000000	0.0000000	1.9736270
-C	0.0000000	0.0000000	-1.9736270"""  # no colliding atoms
-        xyz1 = """ C                 -2.09159210   -1.05731582   -0.12426100
- H                 -2.49607181   -1.61463460   -0.94322229
- H                 -1.03488175   -1.21696026   -0.07152162
- H                 -2.54731584   -1.38200055    0.78777873
- N                 -2.36156239    0.37373413   -0.32458326
- N                 -2.10618543   -0.96914562   -0.62731730
- N                 -1.23618386   -0.31836000   -0.51825841"""  # colliding atoms
-        self.assertFalse(conformers.check_atom_collisions(converter.str_to_xyz(xyz0)))
-        self.assertTrue(conformers.check_atom_collisions(converter.str_to_xyz(xyz1)))
-
     def test_determine_torsion_symmetry(self):
         """Test that we correctly determine the torsion symmetry"""
         adj0 = """1 O u0 p2 c0 {2,S} {9,S}

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -220,8 +220,8 @@ class ARCSpecies(object):
                            heteroatoms). Another option is specifying 'cheap', and the "old" RDKit embedding method
                            will be used.
         conf_is_isomorphic (bool): Whether the lowest conformer is isomorphic with the 2D graph representation
-                                   of the species. `True` if it is. Defaults to `None`. If `True`, an isomorphism check
-                                   will be strictly enforced for the final optimized coordinates.
+                                   of the species. ``True`` if it is. Defaults to ``None``. If ``True``, an isomorphism
+                                   check will be strictly enforced for the final optimized coordinates.
         conformers_before_opt (tuple): Conformers XYZs of a species before optimization.
         bdes (list): Specifying for which bonds should bond dissociation energies be calculated.
                      Entries are bonded atom indices tuples (1-indexed). An 'all_h' string entry is also allowed,
@@ -1147,16 +1147,12 @@ class ARCSpecies(object):
             original_mol = self.mol.copy(deep=True)
             self.mol = molecules_from_xyz(xyz, multiplicity=self.multiplicity, charge=self.charge)[1]
             if self.mol is not None and not check_isomorphism(original_mol, self.mol):
-                if original_mol.multiplicity in [1, 2]:
-                    raise SpeciesError('XYZ and the 2D graph representation for {0} are not isomorphic.\n'
-                                       'Got xyz:\n{1}\n\nwhich corresponds to {2}\n{3}\n\nand: {4}\n{5}'.format(
-                                        self.label, xyz, self.mol.to_smiles(), self.mol.to_adjacency_list(),
-                                        original_mol.to_smiles(), original_mol.to_adjacency_list()))
-                else:
-                    logger.warning('XYZ and the 2D graph representation for {0} are not isomorphic.\n'
-                                   'Got xyz:\n{1}\n\nwhich corresponds to {2}\n{3}\n\nand: {4}\n{5}'.format(
-                                    self.label, xyz, self.mol.to_smiles(), self.mol.to_adjacency_list(),
-                                    original_mol.to_smiles(), original_mol.to_adjacency_list()))
+                logger.warning('XYZ and the 2D graph representation for {0} are not isomorphic.\n'
+                               'Got xyz:\n{1}\n\nwhich corresponds to {2}\n{3}\n\nand: {4}\n{5}'.format(
+                                self.label, xyz, self.mol.to_smiles(), self.mol.to_adjacency_list(),
+                                original_mol.to_smiles(), original_mol.to_adjacency_list()))
+                if not are_coords_compliant_with_graph(xyz=xyz, mol=self.mol):
+                    raise SpeciesError(f'XYZ and the 2D graph representation for {self.label} are not compliant')
             elif self.mol is None:
                 # molecules_from_xyz() returned None for b_mol
                 self.mol = original_mol  # todo: Atom order will not be correct, need fix
@@ -1284,6 +1280,8 @@ class ARCSpecies(object):
     def check_xyz_isomorphism(self, allow_nonisomorphic_2d=False, xyz=None, verbose=True):
         """
         Check whether the perception of self.final_xyz or ``xyz`` is isomorphic with self.mol.
+        If it is not isomorphic, compliant coordinates will be checked (equivalent to checking isomorphism without
+        bond order information, only does not necessitates a molecule object, directly checks bond lengths)
 
         Args:
             allow_nonisomorphic_2d (bool, optional): Whether to continue spawning jobs for the species even if this
@@ -1295,45 +1293,46 @@ class ARCSpecies(object):
             bool: Whether the perception of self.final_xyz is isomorphic with self.mol, ``True`` if it is.
         """
         xyz = xyz or self.final_xyz
-        passed_test, return_value = False, False
+        result = False
         if self.mol is not None:
             try:
                 b_mol = molecules_from_xyz(xyz, multiplicity=self.multiplicity, charge=self.charge)[1]
             except SanitizationError:
                 b_mol = None
+                if verbose:
+                    logger.error(f'Could not perceive the Cartesian coordinates of species {self.label}')
             if b_mol is not None:
-                is_isomorphic = check_isomorphism(self.mol, b_mol)
-            else:
-                is_isomorphic = False
-            if is_isomorphic:
-                passed_test, return_value = True, True
-            else:
-                # isomorphism test failed
-                passed_test = False
-                if self.conf_is_isomorphic:
-                    if allow_nonisomorphic_2d:
-                        # conformer was isomorphic, we **do** allow nonisomorphism, and the optimized structure isn't
-                        return_value = True
-                    else:
-                        # conformer was isomorphic, we don't allow nonisomorphism, but the optimized structure isn't
-                        return_value = False
+                result = check_isomorphism(self.mol, b_mol)
+                if not result and verbose:
+                    logger.error(f'The Cartesian coordinates of species {self.label} are not isomorphic with the 2D '
+                                 f'structure {self.mol.to_smiles()}')
+            if b_mol is None or not result:
+                result = are_coords_compliant_with_graph(xyz=xyz, mol=self.mol)
+                if not result and verbose:
+                    logger.error(f'The Cartesian coordinates of species {self.label} are not compliant with the 2D '
+                                 f'structure {self.mol.to_smiles()}')
+            if not result and self.conf_is_isomorphic:
+                if allow_nonisomorphic_2d:
+                    # conformer was isomorphic, we **do** allow nonisomorphism, and the optimized structure isn't
+                    result = True
+                    if verbose:
+                        logger.warning('allowing nonisomorphic 2D')
                 else:
-                    # conformer was not isomorphic, don't strictly enforce isomorphism here
-                    return_value = True
-            if not passed_test and verbose:
-                logger.error('The optimized geometry of species {0} is not isomorphic with the 2D structure {1}'.format(
-                    self.label, self.mol.to_smiles()))
-                if not return_value:
-                    logger.error('Not spawning additional jobs for this species!')
-            elif verbose:
-                logger.info('Species {0} was found to be isomorphic with the perception '
-                            'of its optimized coordinates.'.format(self.label))
+                    # conformer was isomorphic, we don't allow nonisomorphism, but the optimized structure isn't
+                    result = False
+                    if verbose:
+                        logger.warning('not allowing nonisomorphic 2D')
+            elif not result and verbose:
+                logger.warning('not allowing nonisomorphic 2D')
         else:
             if verbose:
-                logger.error('Cannot check isomorphism for species {0}'.format(self.label))
+                logger.error(f'Cannot check isomorphism for species {self.label} '
+                             f'without the 2D graph connectivity information.')
             if allow_nonisomorphic_2d:
-                return_value = True
-        return return_value
+                result = True
+                if verbose:
+                    logger.warning('allowing nonisomorphic 2D')
+        return result
 
     def scissors(self):
         """
@@ -1945,6 +1944,10 @@ def are_coords_compliant_with_graph(xyz, mol):
     """
     checked_atoms = list()
     for atom_index_1, atom1 in enumerate(mol.atoms):
+        if atom1.element.symbol != xyz['symbols'][atom_index_1]:
+            logger.warning(f'Element order in xyz ({xyz["symbols"]}) differs from mol '
+                           f'({[atom.element.symbol for atom in mol.atoms]})')
+            return False
         for atom2 in atom1.edges.keys():
             atom_index_2 = mol.atoms.index(atom2)
             if atom_index_2 not in checked_atoms:

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -18,7 +18,8 @@ from arc.common import almost_equal_coords_lists
 from arc.plotter import save_conformers_file
 from arc.settings import arc_path
 from arc.species.converter import molecules_from_xyz, check_isomorphism, str_to_xyz, xyz_to_str, xyz_to_x_y_z
-from arc.species.species import ARCSpecies, TSGuess, determine_rotor_type, determine_rotor_symmetry, check_xyz
+from arc.species.species import ARCSpecies, TSGuess, are_coords_compliant_with_graph, check_xyz, \
+    determine_rotor_symmetry, determine_rotor_type
 
 
 class TestARCSpecies(unittest.TestCase):
@@ -1080,6 +1081,60 @@ H       1.11582953    0.94384729   -0.10134685"""
         self.assertEqual(cation_rad.charge, 1)
         cation_rad.generate_conformers()
         self.assertTrue(len(cation_rad.conformers))
+
+    def test_are_coords_compliant_with_graph(self):
+        """Test coordinates compliant with 2D graph connectivity"""
+        self.assertTrue(are_coords_compliant_with_graph(xyz=self.spc6.get_xyz(), mol=self.spc6.mol))
+
+        xyz_non_split = str_to_xyz(""" O                 -1.77782500    0.16383000   -1.00470900
+ O                  2.82634100   -0.49758800   -0.22053900
+ O                 -3.00549000    0.30995600   -0.63994200
+ O                  3.40372500    0.73816600   -0.00411700
+ N                  1.58283100   -0.44410100   -0.22685100
+ C                 -0.87680000   -0.04688100    0.15263000
+ C                 -0.91300400    1.19079300    1.04397100
+ C                 -1.28190800   -1.33133800    0.86726200
+ C                  0.45671000   -0.17198800   -0.46072100
+ H                 -0.57829200    2.08105700    0.49410300
+ H                 -1.94993600    1.34102100    1.37594600
+ H                 -0.26515400    1.04703000    1.91910800
+ H                 -0.63490800   -1.49884100    1.73900500
+ H                 -2.32291100   -1.22406700    1.20286200
+ H                 -1.21261900   -2.19592900    0.19252600""")
+        xyz_split = str_to_xyz(""" O                  0.07716500   -0.35216600   -0.85343400
+ O                  2.62355500    1.10632700    0.00977500
+ O                  0.76150400   -1.46024200   -0.66136400
+ O                  3.11333100   -0.00414700    0.06703600
+ N                 -2.16062200    2.08015200   -0.47197200
+ C                 -1.01293500   -0.20025800    0.17009400
+ C                 -1.99168200   -1.36471200    0.01039700
+ C                 -0.37657800   -0.11697600    1.55811500
+ C                 -1.64082800    1.07802900   -0.20550900
+ H                 -2.40531700   -1.38599900   -1.00008100
+ H                 -1.45900400   -2.29793500    0.20302000
+ H                 -2.81142200   -1.26290200    0.72553300
+ H                 -1.15306500    0.01609000    2.31512700
+ H                  0.16104500   -1.04691100    1.75262900
+ H                  0.31981100    0.72190400    1.61289000""")
+        adj_list = """multiplicity 2
+    1  O u0 p2 c0 {3,S} {6,S}
+    2  O u0 p2 c0 {4,S} {5,S}
+    3  O u1 p2 c0 {1,S}
+    4  O u0 p3 c-1 {2,S}
+    5  N u0 p0 c+1 {2,S} {9,T}
+    6  C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+    7  C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+    8  C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+    9  C u0 p0 c0 {5,T} {6,S}
+    10 H u0 p0 c0 {7,S}
+    11 H u0 p0 c0 {7,S}
+    12 H u0 p0 c0 {7,S}
+    13 H u0 p0 c0 {8,S}
+    14 H u0 p0 c0 {8,S}
+    15 H u0 p0 c0 {8,S}"""
+        mol = Molecule().from_adjacency_list(adj_list)
+        self.assertTrue(are_coords_compliant_with_graph(xyz=xyz_non_split, mol=mol))
+        self.assertFalse(are_coords_compliant_with_graph(xyz=xyz_split, mol=mol))
 
 
     @classmethod

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -951,10 +951,6 @@ H       1.11582953    0.94384729   -0.10134685"""
         is_isomorphic3 = spc2.check_xyz_isomorphism(allow_nonisomorphic_2d=True)
         self.assertTrue(is_isomorphic3)
 
-        spc2.conf_is_isomorphic = False  # set to False so that isomorphism is not strictly enforced
-        is_isomorphic4 = spc2.check_xyz_isomorphism()
-        self.assertTrue(is_isomorphic4)
-
     def test_scissors(self):
         """Test the scissors method in Species"""
         ch3oc2h5_xyz = """C  1.3324310  1.2375310  0.0000000

--- a/environment.yml
+++ b/environment.yml
@@ -54,3 +54,4 @@ dependencies:
   - ase >=3.15.0
   - ipython
   - sphinx
+  - qcelemental


### PR DESCRIPTION
fixes #93
fixes #130

The isomorphism check doesn't function correctly for cases of non-trivial multiplicity (e.g., triplets), for charged species, and for species RMG cannot represent (e.g., not implemented elements or heteroatoms in aromatic species).
Here, a function that checks whether the coordinates are "compliant" with the 2D graph molecule was implemented. This function checks whether all bond lengths are reasonable, and makes sure the optimization did not break into several non-connected fragments.