### PR TITLE
BugFix: Correctly check the number of atoms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
         - cd ..
         - git clone https://github.com/ReactionMechanismGenerator/AutoTST
         - cd AutoTST
-        - git checkout -b py3 origin/py3
         - export PYTHONPATH=$PYTHONPATH:$(pwd)
         - cd ..
         - conda install -y -c conda-forge codecov
@@ -67,7 +66,6 @@ jobs:
         - git clone https://github.com/ReactionMechanismGenerator/RMG-database
         - git clone https://github.com/ReactionMechanismGenerator/AutoTST
         - cd AutoTST
-        - git checkout -b py3 origin/py3
         - export PYTHONPATH=$PYTHONPATH:$(pwd)
         - cd ../ARC/docs
         # Install sphinx for building the documentation

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2524,7 +2524,7 @@ class Scheduler(object):
                 self.species_dict[label].checkfile = job.checkfile
         level_of_theory, _ = format_level_of_theory_inputs(level_of_theory)
         # determine if the species is a hydrogen (or its isotope) atom
-        is_h = len(self.species_dict[label].mol.atoms) == 1 and \
+        is_h = self.species_dict[label].number_of_atoms == 1 and \
             self.species_dict[label].mol.atoms[0].element.symbol in ['H', 'D', 'T']
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
         memory, shift, cpu_cores, dont_rerun = \


### PR DESCRIPTION
Species representing TSs do not have a .mol attribute, use the `number_of_atoms` property instead