### PR TITLE
Add option for disabling comparisons to RMG-database

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -104,6 +104,8 @@ class ARC(object):
                                       default is False.
         dont_gen_confs (list, optional): A list of species labels for which conformer generation should be avoided
                                          if xyz is given.
+        compare_to_rmg (bool): If ``True`` data calculated from the RMG-database will be calculated and included on the
+                               parity plot
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -155,6 +157,8 @@ class ARC(object):
         keep_checks (bool): Whether to keep all Gaussian checkfiles when ARC terminates. True to keep, default is False.
         dont_gen_confs (list): A list of species labels for which conformer generation should be avoided
                                if xyz is given.
+        compare_to_rmg (bool): If ``True`` data calculated from the RMG-database will be calculated and included on the
+                               parity plot
 
     """
 
@@ -164,7 +168,8 @@ class ARC(object):
                  job_shortcut_keywords=None, t_min=None, t_max=None, t_count=None, verbose=logging.INFO,
                  project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False, job_memory=14,
                  ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None, calc_freq_factor=True,
-                 confs_to_dft=5, keep_checks=False, dont_gen_confs=None, specific_job_type='', orbitals_level=''):
+                 confs_to_dft=5, keep_checks=False, dont_gen_confs=None, specific_job_type='', orbitals_level='',
+                 compare_to_rmg=True):
         self.__version__ = VERSION
         self.verbose = verbose
         self.output = dict()
@@ -178,6 +183,7 @@ class ARC(object):
         self.ess_settings = dict()
         self.calc_freq_factor = calc_freq_factor
         self.keep_checks = keep_checks
+        self.compare_to_rmg = compare_to_rmg
 
         if input_dict is None:
             if project is None:
@@ -541,7 +547,8 @@ class ARC(object):
                         species_dict=self.scheduler.species_dict, rxn_list=self.scheduler.rxn_list,
                         output=self.scheduler.output, use_bac=self.use_bac, model_chemistry=self.model_chemistry,
                         lib_long_desc=self.lib_long_desc, rmgdatabase=self.rmgdb, t_min=self.t_min, t_max=self.t_max,
-                        t_count=self.t_count, freq_scale_factor=self.freq_scale_factor)
+                        t_count=self.t_count, freq_scale_factor=self.freq_scale_factor,
+                        compare_to_rmg=self.compare_to_rmg)
         prc.process()
         self.summary()
         log_footer(execution_time=self.execution_time)

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -791,4 +791,23 @@ The calculated BDEs are reported in the log file as well as in a designated `BDE
 file under the `output` directory in the project's folder. Units are kJ/mol.
 
 
+Disable comparisons with the RMG database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By default, at the end of an ARC job, ARC will try to compare the calculated thermochemistry and kinetics to estimates
+from the RMG database. The comparison is saved as a parity plot in the output directory.
+
+Sometimes though, it is desirable to disable these comparisons with the RMG database. For example, although ARC will
+not crash due to any exceptions encountered while making the parity plots, it makes sense to disable these comparisons
+when dealing with species that cannot be estimated by the RMG database (e.g. because of the presence of atom types that
+are currently not supported). In other circumstances it may make sense to disable this comparison simply to save time
+by not having to load the RMG database if the comparison is not needed.
+
+To disable ARC from generating these parity plots, simply supply the following in the ARC input file (or as a keyword
+argument to the main ARC object if using the API)::
+
+    compare_to_rmg: False
+
+With this option specified, ARC will not load the RMG database, and parity plots will not be generated.
+
+
 .. include:: links.txt

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -480,14 +480,14 @@ Open the resulting FCheck file using `IQMol <http://iqmol.org/>`_
 to post process and save images.
 
 
-Consider a specific diaestereomer
+Consider a specific diastereomer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ARC's conformer generation module will consider by default all non-enantiomeric (non-mirror) diaestereomers,
+ARC's conformer generation module will consider by default all non-enantiomeric (non-mirror) diastereomers,
 using chiral (tetrahedral) carbon atoms, chiral inversion modes in nitrogen atoms, and cis/trans double bonds.
-To consider a specific diaestereomer, pass the 3D xyz coordinates when defining the species, and set the
+To consider a specific diastereomer, pass the 3D xyz coordinates when defining the species, and set the
 ``consider_all_diastereomers`` species flag to ``False`` (it is ``True`` by default). For example, the following code
-will cause ARC to only consider the R-Z diaestereomer of the following hypothetical species::
+will cause ARC to only consider the R-Z diastereomer of the following hypothetical species::
 
     spc1_xyz = """Cl      1.47566594   -2.36900082   -0.86260264
                   O      -1.34833561    1.76407680    0.29252133


### PR DESCRIPTION
fixes #267 

When doing large scale calculations or when dealing with species that we don't have data for in the RMG-database, it can be useful to turn of the feature to compare the calculation with the RMG-database and not load the database. This PR addresses this feature.