### PR TITLE
Added an option to run Gaussian calculations using solvent corrections

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1129,7 +1129,7 @@ end
                                   self.software, self.method + '/' + self.basis_set))
 
         if self.software == 'gaussian' and not self.trsh:
-            if self.level_of_theory[:2] == 'ro':
+            if self.job_level_of_theory_dict['method'][:2] == 'ro':
                 self.trsh = 'use=L506'
             else:
                 # xqc will do qc (quadratic convergence) if the job fails w/o it, so use by default

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -105,6 +105,12 @@ class Job(object):
         cpu_cores (int, optional): The total number of cpu cores requested for a job.
         job_additional_options (dict, optional): Additional specifications to control the execution of a job.
         job_shortcut_keywords (dict, optional): Shortcut keyword specifications to control the execution of a job.
+        solvent (dict): This argument, if not None, requests that a calculation be performed in the presence of a
+                        solvent by placing the solute in a cavity within the solvent reaction field.
+                        Keys are:
+                        - 'method' (optional values: 'pcm' (default), 'cpcm', 'dipole', 'ipcm', 'scipcm')
+                        -  'solvent' (values are strings of "known" solvents, see https://gaussian.com/scrf/,
+                                      default is "water")
 
     Attributes:
         project (str): The project's name. Used for naming the directory.
@@ -188,16 +194,16 @@ class Job(object):
         directed_dihedrals (list): The dihedral angles of a directed scan job corresponding to ``directed_scans``.
         directed_scan_type (str): The type of the directed scan.
         rotor_index (int): The 0-indexed rotor number (key) in the species.rotors_dict dictionary.
+        solvent (dict): The solvent model and solvent to use.
     """
-    def __init__(self, project='', ess_settings=None, species_name='', xyz=None, job_type='',
-                 job_level_of_theory_dict=None,
-                 multiplicity=None, project_directory='', charge=0, conformer=-1, fine=False, shift='', software=None,
-                 is_ts=False, scan=None, pivots=None, total_job_memory_gb=14, comments='', trsh='', scan_trsh='',
-                 job_dict=None, ess_trsh_methods=None, bath_gas=None, job_num=None,
-                 job_server_name=None, job_name=None, job_id=None, server=None, initial_time=None, occ=None,
-                 max_job_time=120, scan_res=None, checkfile=None, number_of_radicals=None, conformers=None, radius=None,
-                 directed_scan_type=None, directed_scans=None, directed_dihedrals=None, rotor_index=None, testing=False,
-                 cpu_cores=None, job_additional_options=None, job_shortcut_keywords=None):
+    def __init__(self, project='', ess_settings=None, species_name='', xyz=None, job_type='', multiplicity=None,
+                 project_directory='', charge=0, conformer=-1, fine=False, shift='', software=None, is_ts=False,
+                 scan=None, pivots=None, total_job_memory_gb=14, comments='', trsh='', scan_trsh='', job_dict=None,
+                 ess_trsh_methods=None, bath_gas=None, solvent=None, job_num=None, job_server_name=None, job_name=None,
+                 job_id=None, server=None, initial_time=None, occ=None, max_job_time=120, scan_res=None, checkfile=None,
+                 number_of_radicals=None, conformers=None, radius=None, directed_scan_type=None, directed_scans=None,
+                 directed_dihedrals=None, rotor_index=None, testing=False, cpu_cores=None, job_additional_options=None,
+                 job_shortcut_keywords=None, job_level_of_theory_dict=None):
         if job_dict is not None:
             self.from_dict(job_dict)
         else:
@@ -243,6 +249,7 @@ class Job(object):
             self.pivots = pivots if pivots is not None else list()
             self.max_job_time = max_job_time
             self.bath_gas = bath_gas
+            self.solvent = solvent
             self.testing = testing
             self.fine = fine
             self.shift = shift
@@ -381,6 +388,8 @@ class Job(object):
             job_dict['rotor_index'] = self.rotor_index
         if self.bath_gas is not None:
             job_dict['bath_gas'] = self.bath_gas
+        if self.solvent is not None:
+            job_dict['solvent'] = self.solvent
         if self.checkfile is not None:
             job_dict['checkfile'] = self.checkfile
         if self.conformers is not None:
@@ -429,6 +438,7 @@ class Job(object):
                                                                           in job_dict else dict()
         self.ess_trsh_methods = job_dict['ess_trsh_methods'] if 'ess_trsh_methods' in job_dict else list()
         self.bath_gas = job_dict['bath_gas'] if 'bath_gas' in job_dict else None
+        self.solvent = job_dict['solvent'] if 'solvent' in job_dict else None
         self.job_num = job_dict['job_num'] if 'job_num' in job_dict else -1
         self.job_server_name = job_dict['job_server_name'] if 'job_server_name' in job_dict else None
         self.job_name = job_dict['job_name'] if 'job_name' in job_dict else None
@@ -1142,6 +1152,13 @@ end
 
         elif self.job_type == 'gsm':  # TODO
             pass
+
+        if self.software == 'gaussian' and self.solvent is not None:
+            if 'method' not in self.solvent:
+                self.solvent['method'] = 'pcm'
+            if 'solvent' not in self.solvent:
+                self.solvent['solvent'] = 'water'
+            job_type_1 += f' SCRF=({self.solvent["method"]},Solvent={self.solvent["solvent"]})'
 
         if 'mrci' in self.method:
             if self.software != 'molpro':

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -759,7 +759,7 @@ def trsh_ess_job(label, level_of_theory_dict, server, job_status, job_type, soft
             add_mem = float(job_status['error'].split()[-2])  # parse Molpro's requirement in MW
             add_mem = int(np.ceil(add_mem / 100.0)) * 100  # round up to the next hundred
             memory = memory_gb + add_mem / 128. + 5  # convert MW to GB, add 5 extra GB (be conservative)
-            logger.info('Troubleshooting {type} job in {software} for {label} using memory: {mem} GB instead of '
+            logger.info('Troubleshooting {type} job in {software} for {label} using memory: {mem:.2f} GB instead of '
                         '{old} GB'.format(type=job_type, software=software, mem=memory, old=memory_gb,
                                           label=label))
         elif 'shift' not in ess_trsh_methods:
@@ -787,7 +787,7 @@ def trsh_ess_job(label, level_of_theory_dict, server, job_status, job_type, soft
             # Increase memory allocation, also run with a shift
             ess_trsh_methods.append('memory')
             memory = servers[server]['memory']  # set memory to the value of an entire node (in GB)
-            logger.info('Troubleshooting {type} job in {software} for {label} using memory: {mem} GB instead of '
+            logger.info('Troubleshooting {type} job in {software} for {label} using memory: {mem:.2f} GB instead of '
                         '{old} GB'.format(type=job_type, software=software, mem=memory, old=memory_gb,
                                           label=label))
             shift = 'shift,-1.0,-0.5;'

--- a/arc/main.py
+++ b/arc/main.py
@@ -105,7 +105,13 @@ class ARC(object):
         dont_gen_confs (list, optional): A list of species labels for which conformer generation should be avoided
                                          if xyz is given.
         compare_to_rmg (bool): If ``True`` data calculated from the RMG-database will be calculated and included on the
-                               parity plot
+                               parity plot.
+        solvent (dict): This argument, if not None, requests that a calculation be performed in the presence of a
+                        solvent by placing the solute in a cavity within the solvent reaction field.
+                        Keys are:
+                        - 'method' (optional values: 'pcm' (default), 'cpcm', 'dipole', 'ipcm', 'scipcm')
+                        -  'solvent' (values are strings of "known" solvents, see https://gaussian.com/scrf/,
+                                      default is "water")
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -158,7 +164,8 @@ class ARC(object):
         dont_gen_confs (list): A list of species labels for which conformer generation should be avoided
                                if xyz is given.
         compare_to_rmg (bool): If ``True`` data calculated from the RMG-database will be calculated and included on the
-                               parity plot
+                               parity plot.
+        solvent (dict): The solvent model and solvent to use.
 
     """
 
@@ -169,7 +176,7 @@ class ARC(object):
                  project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False, job_memory=14,
                  ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None, calc_freq_factor=True,
                  confs_to_dft=5, keep_checks=False, dont_gen_confs=None, specific_job_type='', orbitals_level='',
-                 compare_to_rmg=True):
+                 compare_to_rmg=True, solvent=None):
         self.__version__ = VERSION
         self.verbose = verbose
         self.output = dict()
@@ -195,6 +202,7 @@ class ARC(object):
             self.specific_job_type = specific_job_type
             self.job_types = initialize_job_types(job_types, specific_job_type=self.specific_job_type)
             self.bath_gas = bath_gas
+            self.solvent = solvent
             self.confs_to_dft = confs_to_dft
             self.adaptive_levels = adaptive_levels
             self.project_directory = project_directory if project_directory is not None\
@@ -326,6 +334,8 @@ class ARC(object):
         restart_dict['project'] = self.project
         if self.bath_gas is not None:
             restart_dict['bath_gas'] = self.bath_gas
+        if self.solvent is not None:
+            restart_dict['solvent'] = self.solvent
         if self.adaptive_levels is not None:
             restart_dict['adaptive_levels'] = self.adaptive_levels
         restart_dict['job_types'] = self.job_types
@@ -398,6 +408,7 @@ class ARC(object):
         self.max_job_time = input_dict['max_job_time'] if 'max_job_time' in input_dict else self.max_job_time
         self.memory = input_dict['job_memory'] if 'job_memory' in input_dict else self.memory
         self.bath_gas = input_dict['bath_gas'] if 'bath_gas' in input_dict else None
+        self.solvent = input_dict['solvent'] if 'solvent' in input_dict else None
         self.confs_to_dft = input_dict['confs_to_dft'] if 'confs_to_dft' in input_dict else 5
         self.adaptive_levels = input_dict['adaptive_levels'] if 'adaptive_levels' in input_dict else None
         self.keep_checks = input_dict['keep_checks'] if 'keep_checks' in input_dict else False
@@ -534,7 +545,7 @@ class ARC(object):
                                    max_job_time=self.max_job_time, allow_nonisomorphic_2d=self.allow_nonisomorphic_2d,
                                    memory=self.memory, orbitals_level=self.orbitals_level,
                                    adaptive_levels=self.adaptive_levels, confs_to_dft=self.confs_to_dft,
-                                   dont_gen_confs=self.dont_gen_confs)
+                                   dont_gen_confs=self.dont_gen_confs, solvent=self.solvent)
 
         save_yaml_file(path=os.path.join(self.project_directory, 'output', 'status.yml'), content=self.scheduler.output)
 

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -926,7 +926,7 @@ def plot_1d_rotor_scan(angles=None, energies=None, results=None, path=None, scan
     plt.xticks(np.arange(min_angle, min_angle + 361, step=60))
     plt.ylabel('Electronic energy (kJ/mol)')
     if label is not None:
-        original_dihedral_str = f' from {original_dihedral} deg' if original_dihedral is not None else ''
+        original_dihedral_str = f' from {original_dihedral:.1f}$^o$' if original_dihedral is not None else ''
         plt.title(f'{label} 1D scan of {scan}{original_dihedral_str}')
     plt.tight_layout()
     if is_notebook():

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -279,8 +279,16 @@ class Processor(object):
                 for spc in rxn.r_species + rxn.p_species:
                     if spc.label not in arkane_spc_dict.keys():
                         # add an extra character to the arkane_species label to distinguish between species calculated
-                        #  for thermo and species calculated for kinetics (where we don't want to use BAC)
-                        arkane_spc = arkane_input_species(str(spc.label + '_'), spc.arkane_file)
+                        # for thermo and species calculated for kinetics (where we don't want to use BAC)
+                        counter = 1
+                        rename_success = False
+                        while not rename_success:
+                            try:
+                                arkane_spc = arkane_input_species(str(spc.label + '_' * counter), spc.arkane_file)
+                            except ValueError:
+                                counter += 1
+                            else:
+                                break
                         self._run_statmech(arkane_spc, spc.arkane_file, kinetics=True)
                 rxn.dh_rxn298 = sum([product.thermo.get_enthalpy(298) for product in arkane_spc_dict.values()
                                      if product.label in rxn.products])\

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -116,6 +116,12 @@ class Scheduler(object):
         dont_gen_confs (list, optional): A list of species labels for which conformer jobs were loaded from a restart
                                          file, or user-requested. Additional conformer generation should be avoided.
         confs_to_dft (int, optional): The number of lowest MD conformers to DFT at the conformers_level.
+        solvent (dict): This argument, if not None, requests that a calculation be performed in the presence of a
+                        solvent by placing the solute in a cavity within the solvent reaction field.
+                        Keys are:
+                        - 'method' (optional values: 'pcm' (default), 'cpcm', 'dipole', 'ipcm', 'scipcm')
+                        -  'solvent' (values are strings of "known" solvents, see https://gaussian.com/scrf/,
+                                      default is "water")
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -165,11 +171,12 @@ class Scheduler(object):
         adaptive_levels (dict): A dictionary of levels of theory for ranges of the number of heavy atoms in
                                   the molecule. Keys are tuples of (min_num_atoms, max_num_atoms), values are
                                   dictionaries with 'optfreq' and 'sp' as keys and levels of theory as values.
+        solvent (dict): The solvent model and solvent to use.
     """
 
     def __init__(self, project, ess_settings, species_list, project_directory, composite_method='', conformer_level='',
                  opt_level='', freq_level='', sp_level='', scan_level='', ts_guess_level='', orbitals_level='',
-                 adaptive_levels=None, rmgdatabase=None, job_types=None, job_additional_options=None,
+                 adaptive_levels=None, rmgdatabase=None, job_types=None, job_additional_options=None, solvent=None,
                  job_shortcut_keywords=None, rxn_list=None, bath_gas=None, restart_dict=None, max_job_time=120,
                  allow_nonisomorphic_2d=False, memory=14, testing=False, dont_gen_confs=None, confs_to_dft=5):
         self.rmgdb = rmgdatabase
@@ -187,6 +194,7 @@ class Scheduler(object):
         self.testing = testing
         self.memory = memory
         self.bath_gas = bath_gas
+        self.solvent = solvent
         self.adaptive_levels = adaptive_levels
         self.confs_to_dft = confs_to_dft
         self.dont_gen_confs = dont_gen_confs or list()
@@ -705,7 +713,7 @@ class Scheduler(object):
                   scan_res=scan_res, conformer=conformer, checkfile=checkfile, bath_gas=self.bath_gas,
                   number_of_radicals=species.number_of_radicals, conformers=confs, radius=radius,
                   directed_scan_type=directed_scan_type, directed_scans=directed_scans, rotor_index=rotor_index,
-                  directed_dihedrals=directed_dihedrals, cpu_cores=cpu_cores)
+                  directed_dihedrals=directed_dihedrals, cpu_cores=cpu_cores, solvent=self.solvent)
         if job.software is not None:
             if conformer < 0:
                 # this is NOT a conformer DFT job

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -55,7 +55,7 @@ def str_to_xyz(xyz_str):
         xyz_str (str): The string xyz format to be converted.
 
     Returns:
-        xyz_dict (dict): The ARC xyz format.
+        dict: The ARC xyz format.
 
     Raises:
         ConverterError: If xyz_str is not a string or does not have four space-separated entries per non empty line.
@@ -178,11 +178,11 @@ def xyz_to_x_y_z(xyz_dict):
         xyz_dict (dict): The ARC xyz format.
 
     Returns:
-        x (tuple): The X coordinates.
+        tuple: The X coordinates.
     Returns:
-        y (tuple): The Y coordinates.
+        tuple: The Y coordinates.
     Returns:
-        z (tuple): The Z coordinates.
+        tuple: The Z coordinates.
     """
     xyz_dict = check_xyz_dict(xyz_dict)
     x, y, z = tuple(), tuple(), tuple()
@@ -330,7 +330,7 @@ def standardize_xyz_string(xyz_str, isotope_format=None):
                                         option is 'gaussian'.
 
     Returns:
-        xyz (str): The string xyz format in standardized format.
+        str: The string xyz format in standardized format.
 
     Raises:
         ConverterError: If ``xyz_str`` is of wrong type.
@@ -623,7 +623,7 @@ def str_to_zmat(zmat_str):
         zmat_str (str): The string zmat format to be converted.
 
     Returns:
-        zmat_dict (dict): The ARC zmat format.
+        dict: The ARC zmat format.
 
     Raises:
         ConverterError: If zmat_str is not a string or does not have enough values per line.
@@ -875,7 +875,7 @@ def xyz_to_pybel_mol(xyz):
         xyz (dict): ARC's xyz dictionary format.
 
     Returns:
-        pybel_mol (OBmol): An Open Babel molecule.
+        OBmol: An Open Babel molecule.
     """
     xyz = check_xyz_dict(xyz)
     try:
@@ -894,7 +894,7 @@ def pybel_to_inchi(pybel_mol, has_h=True):
         has_h (bool): Whether the molecule has hydrogen atoms. ``True`` if it does.
 
     Returns:
-        inchi (str): The respective InChI representation of the molecule.
+        str: The respective InChI representation of the molecule.
     """
     if has_h:
         inchi = pybel_mol.write('inchi', opt={'F': None}).strip()  # Add fixed H layer
@@ -1232,7 +1232,7 @@ def update_molecule(mol, to_single_bonds=False):
         to_single_bonds (bool, optional): Whether to convert all bonds to single bonds. ``True`` to convert.
 
     Returns:
-        new_mol (Molecule): The updated molecule.
+        Molecule: The updated molecule.
     """
     new_mol = Molecule()
     try:
@@ -1377,7 +1377,7 @@ def set_rdkit_dihedrals(conf, rd_mol, torsion, deg_increment=None, deg_abs=None)
         deg_abs (float, optional): The required dihedral in degrees.
 
     Returns:
-        new_xyz (dict): The xyz with the new dihedral, ordered according to the map.
+        dict: The xyz with the new dihedral, ordered according to the map.
 
     Raises:
         ConverterError: If the dihedral cannot be set.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -7,7 +7,6 @@ Advanced Features
 
 Flexible coordinates (xyz) input
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 The xyz attribute of an :ref:`ARCSpecies <species>` object (whether a TS or not) is extremely flexible.
 It could be a multiline string containing the coordinates, or a list of several such multiline strings.
 It could also contain valid file paths to ESS input files, output files,
@@ -18,7 +17,6 @@ __ xyz_format_
 
 Specify a specific job type to execute
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 To run ARC with a particular job type, set ``specific_job_type`` to the job type you want.
 Currently, ARC supports the following job types: ``conformers``, ``opt``, ``fine``, ``freq``,
 ``sp``, ``rotors``, ``onedmin``, ``orbitals``, ``bde``.
@@ -46,7 +44,6 @@ Specification 2::
 
 Specify job level of theory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 It is possible to specify a level of theory to be used in specific job types (e.g., optimization, single point, etc.).
 If not specified, ARC will use the defaults in the ``default_levels_of_theory`` dictionary in settings.py.
 
@@ -152,7 +149,6 @@ are specified. Also, it is not good practice to specify ``level_of_theory`` alon
 
 Additional job options
 ^^^^^^^^^^^^^^^^^^^^^^
-
 Note: this feature currently has limited support for ESS other than ``Orca``.
 
 ARC allows specification of job options (e.g., SCF convergence) at ease. By default, ARC uses default job options for
@@ -202,7 +198,6 @@ is a shortcut of the previous example.
 
 Control job memory allocation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 To specify the amount of memory for all jobs in an ARC project, set ``job_memory`` with positive integer values in GB.
 
 Notice that user can change the total memory per node by setting the value of ``memory`` key in the servers dictionary
@@ -215,7 +210,6 @@ maximal node ``memory``.
 
 Using a fine DFT grid for optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 This option is turned on by default. If you'd like to turn it off,
 set ``fine`` in the ``job_types`` dictionary to `False`.
 
@@ -247,7 +241,6 @@ In TeraChem, this will add the following directive::
 
 Rotor scans
 ^^^^^^^^^^^
-
 This option is turned on by default. If you'd like to turn it off,
 set ``rotors`` in the ``job_types`` dictionary to `False`.
 
@@ -264,7 +257,6 @@ All of the above settings can be modified in the settings.py file.
 
 ND Rotor scans
 ^^^^^^^^^^^^^^
-
 ARC also supports ND (N dimensional, N >= 1) rotor scans. There are seven different ND types to execute:
 
 - A1. Generate all geometries in advance (brute force), and calculate single point energies (nested or diagonalized).
@@ -336,7 +328,6 @@ To run specific dihedrals as ND (here all 2D combinations for a species with 3 t
 
 Electronic Structure Software Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 ARC currently supports the following electronic structure software (ESS):
 
     - `Gaussian`__
@@ -371,7 +362,6 @@ You may pass an ESS settings dictionary to direct ARC where to find each softwar
 
 Troubleshooting
 ^^^^^^^^^^^^^^^
-
 ARC has fairly good auto-troubleshooting methods.
 
 However, at times a user might know in advance that a particular additional keyword
@@ -390,7 +380,6 @@ in the ``initial_trsh`` (`trsh` stands for `troubleshooting`) dictionary passed 
 
 ESS check files
 ^^^^^^^^^^^^^^^
-
 ARC copies check files from previous `Gaussian`__ and `TeraChem <http://www.petachem.com/products.html>`_ jobs,
 and uses them when spawning additional jobs for the same species.
 When ARC terminates, it will attempt to delete all downloaded checkfiles (remote copies remain).
@@ -402,7 +391,6 @@ __ gaussian_
 
 Frequency scaling factors
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
 ARC will look for appropriate available frequency scaling factors in `Arkane`_
 for the respective ``freq_level``. If a frequency scaling factor isn't available, ARC will attempt
 to determine it using `Truhlar's method`__. This involves spawning fine optimizations anf frequency
@@ -415,7 +403,6 @@ __ Truhlar_
 
 Adaptive levels of theory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Often we'd like to adapt the levels of theory to the size of the molecule.
 To do so, pass the ``adaptive_levels`` attribute, which is a dictionary of
 levels of theory for ranges of the number of heavy (non-hydrogen) atoms in the
@@ -437,7 +424,6 @@ there aren't any gaps in the heavy atom ranges. The below is in Python (not YAML
 
 Isomorphism checks
 ^^^^^^^^^^^^^^^^^^
-
 When a species is defined using a 2D graph (i.e., SMILES, AdjList, or InChI), an isomorphism check
 is performed on the optimized geometry (all conformers and final optimization).
 If the molecule perceived from the 3D coordinate is not isomorphic
@@ -451,7 +437,6 @@ project, pass `True` to the ``allow_nonisomorphic_2d`` argument (it is `False` b
 
 Using a non-default project directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 If ARC is run from the terminal with an input/restart file
 then the folder in which that file is located becomes the Project's folder.
 If ARC is run using the API, a folder with the Project's name is created under ``ARC/Projects/``.
@@ -462,7 +447,6 @@ folder path using the ``project_directory`` argument. If the folder does not exi
 
 Visualizing molecular orbitals (MOs)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 There are various ways to visualize MOs.
 One way is to open a `Gaussian`__ output file
 using `GaussView <https://gaussian.com/gaussview6/>`_.
@@ -482,7 +466,6 @@ to post process and save images.
 
 Consider a specific diastereomer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 ARC's conformer generation module will consider by default all non-enantiomeric (non-mirror) diastereomers,
 using chiral (tetrahedral) carbon atoms, chiral inversion modes in nitrogen atoms, and cis/trans double bonds.
 To consider a specific diastereomer, pass the 3D xyz coordinates when defining the species, and set the
@@ -516,7 +499,6 @@ but just be an arbitrary conformer with the required chiralities to be preserved
 
 Don't generate conformers for specific species
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 The ``conformers`` entry in the ``job_types`` dictionary is a global flag,
 affecting conformer generation of all species in the project.
 
@@ -573,7 +555,6 @@ coordinates, ARC **will** generate conformers for it.
 
 Writing an ARC input file using the API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Writing in YAML isn't very intuitive for many, especially without a good editor.
 You could use ARC's API to define your objects, and then dump it all in a YAML file
 which could be read as an input in ARC::
@@ -717,7 +698,6 @@ The above code generated the following input file::
 
 Calculating BDEs (bond dissociation energies)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 To direct ARC to calculate BDEs for a species, set the ``bde`` job type to `True`,
 and set the requested atom indices (1-indexed) in the species ``.bdes`` argument
 as a list of tuples representing indices of bonded atoms (via a single bond)
@@ -808,6 +788,24 @@ argument to the main ARC object if using the API)::
     compare_to_rmg: False
 
 With this option specified, ARC will not load the RMG database, and parity plots will not be generated.
+
+
+Use solvent corrections
+^^^^^^^^^^^^^^^^^^^^^^^
+This feature is currently only implemented for jobs spawned using Gaussian.
+The `solvent` argument, if not None, requests that a calculation be performed in the presence of a solvent
+by placing the solute (the species) in a cavity within the solvent reaction field. This argument is a dictionary,
+with the following keys:
+
+    - 'method' (optional values: 'pcm' (default), 'cpcm', 'dipole', 'ipcm', 'scipcm')
+    - 'solvent' (values are strings of "known" solvents, default is "water")
+
+Example::
+
+solvent = {'method': 'pcm', 'solvent: 'DiethylEther'}
+
+
+See `https://gaussian.com/scrf/ <https://gaussian.com/scrf/>`_ for more details.
 
 
 .. include:: links.txt

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -9,7 +9,7 @@ __ greengp_
 
 ARC's contributors are:
 
-- `Dr. Alon Grinberg Dana <http://greengroup.mit.edu/alon-grinberg-dana>`_ (leading developer)
+- `Dr. Alon Grinberg Dana <https://dana.net.technion.ac.il/alon-grinberg-dana/>`_ (leading developer)
 - `Dr. Duminda Ranasinghe <http://greengroup.mit.edu/duminda-ranasinghe>`_
 - `Oscar Haoyang Wu <http://greengroup.mit.edu/oscar-haoyang-wu>`_
 - `Colin Grambow <http://greengroup.mit.edu/colin-grambow>`_


### PR DESCRIPTION
This feature is currently only implemented for jobs spawned using Gaussian.
The `solvent` argument, if not None, requests that a calculation be performed in the presence of a solvent by placing the solute (the species) in a cavity within the solvent reaction field. This argument is a dictionary, with the following keys:

    - 'method' (optional values: 'pcm' (default), 'cpcm', 'dipole', 'ipcm', 'scipcm')
    - 'solvent' (values are strings of "known" solvents, default is "water")

Example::
```pyhton
solvent = {'method': 'pcm',
           'solvent: 'DiethylEther'}
```


See https://gaussian.com/scrf/ for more details.