### PR TITLE
Add method for converting xyz coordinates from rmgpy conformer objects

### DIFF
--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -15,7 +15,9 @@ from rdkit.Chem import rdMolTransforms as rdMT
 from arkane.common import symbol_by_number, mass_by_symbol, get_element_mass
 from rmgpy.exceptions import AtomTypeError
 from rmgpy.molecule.molecule import Atom, Bond, Molecule
+from rmgpy.quantity import ArrayQuantity
 from rmgpy.species import Species
+from rmgpy.statmech import Conformer
 
 from arc.common import get_logger, is_str_float, get_atom_radius
 from arc.exceptions import ConverterError, InputError, SanitizationError, SpeciesError
@@ -316,6 +318,61 @@ def xyz_from_data(coords, numbers=None, symbols=None, isotopes=None):
         isotopes = tuple(get_most_common_isotope_for_element(symbol) for symbol in symbols)
     xyz_dict = {'symbols': symbols, 'isotopes': isotopes, 'coords': coords}
     return xyz_dict
+
+
+def rmg_conformer_to_xyz(conformer):
+    """
+    Convert xyz coordinates from an rmgpy.statmech.Conformer object into the ARC dict xyz style.
+
+    Notes:
+        Only the xyz information (symbols and coordinates) will be taken from the Conformer object. Other properties
+        such as electronic energy will not be converted.
+
+        We also assume that we can get the isotope number by rounding the mass
+
+    Args:
+        conformer (Conformer): An rmgpy.statmech.Conformer object containing the desired xyz coordinates
+
+    Raises:
+        TypeError: If conformer is not an rmgpy.statmech.Conformer object
+
+    Returns:
+        dict: The ARC xyz format
+    """
+    if not isinstance(conformer, Conformer):
+        raise TypeError(f'Expected conformer to be an rmgpy.statmech.Conformer object but instead got {conformer}, '
+                        f'which is a {type(conformer)} object.')
+
+    symbols = tuple(symbol_by_number[n] for n in conformer.number.value)
+    isotopes = tuple(int(round(m)) for m in conformer.mass.value)
+    coords = tuple(tuple(coord) for coord in conformer.coordinates.value)
+
+    xyz_dict = {'symbols': symbols, 'isotopes': isotopes, 'coords': coords}
+    return xyz_dict
+
+
+def xyz_to_rmg_conformer(xyz_dict):
+    """
+    Convert the Arc dict xyz style into an rmgpy.statmech.Conformer object containing these coordinates.
+
+    Notes:
+        Only the xyz information will be supplied to the newly created Conformer object
+
+    Args:
+        xyz_dict (dict): The ARC dict xyz style coordinates
+
+    Returns:
+        Conformer: An rmgpy.statmech.Conformer object containing the desired xyz coordinates
+    """
+    xyz_dict = check_xyz_dict(xyz_dict)
+    mass_and_number = (get_element_mass(*args) for args in zip(xyz_dict['symbols'], xyz_dict['isotopes']))
+    mass, number = zip(*mass_and_number)
+    mass = ArrayQuantity(mass, 'amu')
+    number = ArrayQuantity(number, '')
+    coordinates = ArrayQuantity(xyz_dict['coords'], 'angstroms')
+
+    conformer = Conformer(number=number, mass=mass, coordinates=coordinates)
+    return conformer
 
 
 def standardize_xyz_string(xyz_str, isotope_format=None):

--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -18,7 +18,7 @@ from rmgpy.statmech import Conformer
 
 import arc.species.converter as converter
 from arc.common import almost_equal_coords_lists
-from arc.exceptions import ConverterError, ZMatError
+from arc.exceptions import ConverterError
 from arc.species.species import ARCSpecies
 from arc.species.zmat import xyz_to_zmat
 

--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -12,7 +12,9 @@ from rdkit import Chem
 from rdkit.Chem import rdMolTransforms as rdMT, rdchem
 
 from rmgpy.molecule.molecule import Molecule
+from rmgpy.quantity import ArrayQuantity
 from rmgpy.species import Species
+from rmgpy.statmech import Conformer
 
 import arc.species.converter as converter
 from arc.common import almost_equal_coords_lists
@@ -443,6 +445,40 @@ H       0.63003260   -0.63003260   -0.63003260
                                                     (-0.6300326, -0.6300326, 0.6300326),
                                                     (-0.6300326, 0.6300326, -0.6300326))}}
 
+        cls.xyz_dict_12 = {'symbols': ('F', 'C', 'C', 'C', 'C', 'C', 'C', 'F', 'H', 'H', 'H', 'H'),
+                           'isotopes': (19, 12, 12, 12, 12, 12, 12, 19, 1, 1, 1, 1),
+                           'coords': ((1.34408, 0, 1.70183),
+                                      (0.692492, 0, 0.530349),
+                                      (1.393, 0, -0.657191),
+                                      (0.693305, 0, -1.85652),
+                                      (-0.693305, -5.15e-08, -1.85652),
+                                      (-1.393, -3.87e-08, -0.657191),
+                                      (-0.692492, 4.63e-08, 0.530349),
+                                      (-1.34408, 4.48e-08, 1.70183),
+                                      (2.47418, 0, -0.625387),
+                                      (1.23765, 0, -2.79083),
+                                      (-1.23765, -1.812e-07, -2.79083),
+                                      (-2.47418, -6.81e-08, -0.625387)
+                                      )
+                           }
+
+        cls.conformer_12 = Conformer(number=ArrayQuantity([9, 6, 6, 6, 6, 6, 6, 9, 1, 1, 1, 1], ''),
+                                     mass=ArrayQuantity([18.9984, 12, 12, 12, 12, 12, 12, 18.9984, 1.00783, 1.00783,
+                                                         1.00783, 1.00783], 'amu'),
+                                     coordinates=ArrayQuantity([[1.34408, 0, 1.70183],
+                                                                [0.692492, 0, 0.530349],
+                                                                [1.393, 0, -0.657191],
+                                                                [0.693305, 0, -1.85652],
+                                                                [-0.693305, -5.15e-08, -1.85652],
+                                                                [-1.393, -3.87e-08, -0.657191],
+                                                                [-0.692492, 4.63e-08, 0.530349],
+                                                                [-1.34408, 4.48e-08, 1.70183],
+                                                                [2.47418, 0, -0.625387],
+                                                                [1.23765, 0, -2.79083],
+                                                                [-1.23765, -1.812e-07, -2.79083],
+                                                                [-2.47418, -6.81e-08, -0.625387]], 'angstroms')
+                                     )
+
         nh_s_adj = """1 N u0 p2 c0 {2,S}
                           2 H u0 p0 c0 {1,S}"""
         nh_s_xyz = """N       0.50949998    0.00000000    0.00000000
@@ -588,6 +624,19 @@ R1=1.0912"""
         self.assertEqual(xyz_dict2, self.xyz1['dict'])
         self.assertIsInstance(xyz_dict2['coords'], tuple)
         self.assertIsInstance(xyz_dict2['coords'][0], tuple)
+
+    def test_conformer_to_xyz_dict(self):
+        """Test the rmg_conformer_to_xyz function"""
+        xyz_dict = converter.rmg_conformer_to_xyz(self.conformer_12)
+        self.assertTrue(almost_equal_coords_lists(xyz_dict, self.xyz_dict_12))
+        self.assertEqual(xyz_dict['isotopes'], self.xyz_dict_12['isotopes'])
+
+    def test_xyz_dict_to_conformer(self):
+        """Test the xyz_to_rmg_conformer function"""
+        conformer = converter.xyz_to_rmg_conformer(self.xyz_dict_12)
+        self.assertTrue(np.array_equal(conformer.number.value, self.conformer_12.number.value))
+        self.assertTrue(np.allclose(conformer.mass.value, self.conformer_12.mass.value))
+        self.assertTrue(np.allclose(conformer.coordinates.value, self.conformer_12.coordinates.value))
 
     def test_get_most_common_isotope_for_element(self):
         """Test the get_most_common_isotope_for_element function"""


### PR DESCRIPTION
Potentially useful when working with ArkaneSpecies objects, which stores xyz coordinates inside of rmgpy.statmech.Conformer objects