### PR TITLE
Minor: Limit the default num of confs to generate

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -188,7 +188,7 @@ class ARC(object):
                  job_additional_options=None, job_shortcut_keywords=None, T_min=None, T_max=None, T_count=50,
                  verbose=logging.INFO, project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False,
                  job_memory=14, ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None,
-                 calc_freq_factor=True, n_confs=None, e_confs=5, dont_gen_confs=None, keep_checks=False,
+                 calc_freq_factor=True, n_confs=10, e_confs=5, dont_gen_confs=None, keep_checks=False,
                  solvent=None, compare_to_rmg=True, compute_thermo=True, compute_rates=True, compute_transport=True,
                  specific_job_type='', statmech_adapter='Arkane'):
         self.__version__ = VERSION

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -93,7 +93,7 @@ class TestARC(unittest.TestCase):
                          'T_max': None,
                          'T_count': 50,
                          'use_bac': True,
-                         'n_confs': None,
+                         'n_confs': 10,
                          'e_confs': 5,
                          'allow_nonisomorphic_2d': False,
                          'calc_freq_factor': True,


### PR DESCRIPTION
This commit limits the default number of conformers to generate. The previous default is only limited by energy threshold which can cause hundreds of conformer jobs to run.