### PR TITLE
Globalize paths in an input file

### DIFF
--- a/ARC.py
+++ b/ARC.py
@@ -50,8 +50,8 @@ def main():
     # Parse the command-line arguments (requires the argparse module)
     args = parse_command_line_arguments()
     input_file = args.file
-    input_dict = read_yaml_file(input_file)
     project_directory = os.path.abspath(os.path.dirname(args.file))
+    input_dict = read_yaml_file(path=input_file, project_directory=project_directory)
     try:
         input_dict['project']
     except KeyError:

--- a/arc/common.py
+++ b/arc/common.py
@@ -357,7 +357,7 @@ def string_representer(dumper, data):
     return dumper.represent_scalar(tag='tag:yaml.org,2002:str', value=data)
 
 
-def get_ordinal_indicator(number):
+def get_ordinal_indicator(number: int) -> str:
     """
     Returns the ordinal indicator for an integer.
 
@@ -375,7 +375,7 @@ def get_ordinal_indicator(number):
     return 'th'
 
 
-def get_atom_radius(symbol):
+def get_atom_radius(symbol: str) -> float:
     """
     Get the atom covalent radius of an atom in Angstroms.
 
@@ -397,7 +397,9 @@ def get_atom_radius(symbol):
     return r
 
 
-def colliding_atoms(xyz, threshold=0.55):
+def colliding_atoms(xyz: dict,
+                    threshold: float = 0.55,
+                    ) -> bool:
     """
     Check whether atoms are too close to each other.
     A default threshold of 55% the covalent radii of two atoms is used.
@@ -446,7 +448,9 @@ SINGLE_BOND_LENGTH = {'Br-Br': 2.29, 'Br-Cr': 1.94, 'Br-H': 1.41,
                       }
 
 
-def get_single_bond_length(symbol1, symbol2):
+def get_single_bond_length(symbol1: str,
+                           symbol2: str,
+                           ) -> float:
     """
     Get the an approximate for a single bond length between two elements.
 
@@ -537,7 +541,9 @@ def determine_top_group_indices(mol, atom1, atom2, index=1):
     return top, not atom2.is_hydrogen()
 
 
-def extermum_list(lst, return_min=True):
+def extermum_list(lst: list,
+                  return_min: bool = True,
+                  ) -> int:
     """
     A helper function for finding the minimum of a list of numbers (int/float) where some of the entries might be None.
 
@@ -717,7 +723,7 @@ def almost_equal_coords_lists(xyz1: dict,
     return True
 
 
-def determine_model_chemistry_type(method):
+def determine_model_chemistry_type(method: str or dict) -> str:
     """
     Determine the type of a model chemistry (e.g., DFT, wavefunction, force field, semi-empirical, composite).
 
@@ -767,7 +773,7 @@ def determine_model_chemistry_type(method):
     return model_chemistry_class
 
 
-def format_level_of_theory_inputs(level_of_theory):
+def format_level_of_theory_inputs(level_of_theory: str or dict):
     """
     A helper function to format level of theory inputs for internal use in ARC.
 
@@ -855,7 +861,7 @@ def format_level_of_theory_inputs(level_of_theory):
     return formatted_model_chemistry_dict, formatted_model_chemistry_str
 
 
-def format_level_of_theory_for_logging(level_of_theory):
+def format_level_of_theory_for_logging(level_of_theory: str or dict) -> str:
     """
     Format level of theory dictionary to string for logging purposes.
 
@@ -892,7 +898,7 @@ def format_level_of_theory_for_logging(level_of_theory):
     return level_of_theory_log_str
 
 
-def is_notebook():
+def is_notebook() -> bool:
     """
     Check whether ARC was called from an IPython notebook.
 
@@ -911,7 +917,7 @@ def is_notebook():
         return False  # Probably standard Python interpreter
 
 
-def is_str_float(value):
+def is_str_float(value: str) -> bool:
     """
     Check whether a string represents a number.
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -224,7 +224,7 @@ class ARC(object):
             self.n_confs = n_confs
             self.e_confs = e_confs
             self.adaptive_levels = adaptive_levels
-            self.project_directory = project_directory if project_directory is not None\
+            self.project_directory = project_directory if project_directory is not None \
                 else os.path.join(arc_path, 'Projects', self.project)
             if not os.path.exists(self.project_directory):
                 os.makedirs(self.project_directory)
@@ -313,9 +313,9 @@ class ARC(object):
         else:
             # ARC is run from an input or a restart file.
             # Read the input_dict
-            project_directory = project_directory if project_directory is not None\
+            self.project_directory = project_directory if project_directory is not None \
                 else os.path.abspath(os.path.dirname(input_dict))
-            self.from_dict(input_dict=input_dict, project=project, project_directory=project_directory)
+            self.from_dict(input_dict=input_dict, project=project, project_directory=self.project_directory)
         if self.adaptive_levels is not None:
             logger.info('Using the following adaptive levels of theory:\n{0}'.format(self.adaptive_levels))
         if not self.ess_settings:
@@ -446,7 +446,7 @@ class ARC(object):
         self.e_confs = input_dict['e_confs'] if 'e_confs' in input_dict else 5  # kJ/mol
         self.adaptive_levels = input_dict['adaptive_levels'] if 'adaptive_levels' in input_dict else None
         self.keep_checks = input_dict['keep_checks'] if 'keep_checks' in input_dict else False
-        self.allow_nonisomorphic_2d = input_dict['allow_nonisomorphic_2d']\
+        self.allow_nonisomorphic_2d = input_dict['allow_nonisomorphic_2d'] \
             if 'allow_nonisomorphic_2d' in input_dict else False
         self.output = input_dict['output'] if 'output' in input_dict else dict()
         self.freq_scale_factor = input_dict['freq_scale_factor'] if 'freq_scale_factor' in input_dict else None
@@ -459,21 +459,21 @@ class ARC(object):
                                 # try correcting relative paths
                                 if os.path.isfile(os.path.join(arc_path, val)):
                                     self.output[label]['paths'][key] = os.path.join(arc_path, val)
-                                    logger.debug('corrected path to {0}'.format(os.path.join(arc_path, val)))
+                                    logger.debug(f'corrected path to {os.path.join(arc_path, val)}')
                                 elif os.path.isfile(os.path.join(arc_path, 'Projects', val)):
                                     self.output[label]['paths'][key] = os.path.join(arc_path, 'Projects', val)
-                                    logger.debug('corrected path to {0}'.format(os.path.join(arc_path, val)))
+                                    logger.debug(f'corrected path to {os.path.join(arc_path, val)}')
                                 else:
                                     raise SpeciesError('Could not find {0} output file for species {1}: {2}'.format(
                                         key, label, val))
         self.running_jobs = input_dict['running_jobs'] if 'running_jobs' in input_dict else dict()
-        logger.debug('output dictionary successfully parsed:\n{0}'.format(self.output))
+        logger.debug(f'output dictionary successfully parsed:\n{self.output}')
         self.T_min = input_dict['T_min'] if 'T_min' in input_dict else None
         self.T_max = input_dict['T_max'] if 'T_max' in input_dict else None
         self.T_count = input_dict['T_count'] if 'T_count' in input_dict else None
         self.job_additional_options = input_dict['job_additional_options'] if 'job_additional_options' \
                                                                               in input_dict else dict()
-        self.job_shortcut_keywords = input_dict['job_shortcut_keywords'] if 'job_shortcut_keywords'\
+        self.job_shortcut_keywords = input_dict['job_shortcut_keywords'] if 'job_shortcut_keywords' \
                                                                             in input_dict else dict()
         self.specific_job_type = input_dict['specific_job_type'] if 'specific_job_type' in input_dict else None
         self.job_types = input_dict['job_types'] if 'job_types' in input_dict else default_job_types
@@ -503,9 +503,9 @@ class ARC(object):
             logger.info('\n')
         if not self.job_types['rotors']:
             logger.info('\n')
-            logger.warning("Not running rotor scans."
-                           " This might compromise finding the best conformer, as dihedral angles won't be"
-                           " corrected. Also, entropy won't be accurate.")
+            logger.warning("Not running rotor scans. "
+                           "This might compromise finding the best conformer, as dihedral angles won't be "
+                           "corrected. Also, entropy won't be accurate.")
             logger.info('\n')
 
         if 'species' in input_dict:
@@ -517,7 +517,7 @@ class ARC(object):
                         if os.path.isfile(os.path.join(arc_path, rotor_dict['scan_path'])):
                             spc.rotors_dict[rotor_num]['scan_path'] = os.path.join(arc_path, rotor_dict['scan_path'])
                         elif os.path.isfile(os.path.join(arc_path, 'Projects', rotor_dict['scan_path'])):
-                            spc.rotors_dict[rotor_num]['scan_path'] =\
+                            spc.rotors_dict[rotor_num]['scan_path'] = \
                                 os.path.join(arc_path, 'Projects', rotor_dict['scan_path'])
                         else:
                             raise SpeciesError('Could not find rotor scan output file for rotor {0} of species {1}:'
@@ -881,11 +881,10 @@ class ARC(object):
         """
         for char in self.project:
             if char not in valid_chars:
-                raise InputError('A project name (used to naming folders) must contain only valid characters.'
-                                 ' Got {0} in {1}.'.format(char, self.project))
+                raise InputError(f'A project name (used to naming folders) must contain only valid characters. '
+                                 f'Got {char} in {self.project}.')
             if char == ' ':  # space IS a valid character for other purposes, but isn't valid in project names
-                raise InputError('A project name (used to naming folders) must not contain spaces.'
-                                 ' Got {0}.'.format(self.project))
+                raise InputError(f'A project name (used to naming folders) must not contain spaces. Got {self.project}.')
 
     def check_freq_scaling_factor(self):
         """
@@ -903,8 +902,7 @@ class ARC(object):
                 # Arkane has this harmonic frequencies scaling factor (if not found, the factor is set to exactly 1)
                 self.freq_scale_factor = freq_scale_factor
             else:
-                logger.info('Could not determine the harmonic frequencies scaling factor for {0} from '
-                            'Arkane.'.format(level))
+                logger.info(f'Could not determine the harmonic frequencies scaling factor for {level} from Arkane.')
                 if self.calc_freq_factor:
                     logger.info("Calculating it using Truhlar's method:\n\n")
                     self.freq_scale_factor = determine_scaling_factors(

--- a/arc/main.py
+++ b/arc/main.py
@@ -421,7 +421,7 @@ class ARC(object):
         in the restart dictionary.
         """
         if isinstance(input_dict, str):
-            input_dict = read_yaml_file(input_dict)
+            input_dict = read_yaml_file(path=input_dict, project_directory=self.project_directory)
         if project is None and 'project' not in input_dict:
             raise InputError('A project name must be given')
         self.project = project if project is not None else input_dict['project']

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -155,7 +155,7 @@ orca_default_options_dict = {'opt': {'keyword': {'opt_convergence': 'NormalOpt',
                              }
 
 # default_ts_methods = ['QST2', 'DEGSM', 'NEB', 'Kinbot', 'AutoTST']
-default_ts_methods = ['AutoTST']
+default_ts_methods = []
 
 arc_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))  # absolute path to the ARC folder
 

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -983,7 +983,7 @@ def pybel_to_inchi(pybel_mol, has_h=True):
     return inchi
 
 
-def rmg_mol_from_inchi(inchi):
+def rmg_mol_from_inchi(inchi: str):
     """
     Generate an RMG Molecule object from InChI.
 
@@ -996,8 +996,9 @@ def rmg_mol_from_inchi(inchi):
     try:
         rmg_mol = Molecule().from_inchi(inchi, raise_atomtype_exception=False)
     except (AtomTypeError, ValueError, KeyError, TypeError) as e:
-        logger.warning('Got the following Error when trying to create an RMG Molecule object from InChI:'
-                       '\n{0}'.format(e))
+        logger.warning(f'Got an Error when trying to create an RMG Molecule object from InChI "{inchi}":\n{e}')
+        if 'got an unexpected keyword argument' in str(e):
+            raise ConverterError('Make sure RMG-Py is up to date and compiled!')
         return None
     return rmg_mol
 

--- a/arc/testing/restart/restart_paths.yml
+++ b/arc/testing/restart/restart_paths.yml
@@ -1,0 +1,7 @@
+paths:
+    composite: ''
+    freq: /gpfs/workspace/users/user/runs/ARC/Soup/R_Add_HCN/calcs/Species/HCN/freq_a38229/output.out
+    geo: /gpfs/workspace/users/user/runs/ARC/Soup/R_Add_HCN/calcs/Species/HCN/freq_a38229/output.out
+    sp: /gpfs/workspace/users/user/runs/ARC/Soup/R_Add_HCN/calcs/Species/HCN/sp_a38230/output.out
+restart: 'Restarted ARC at 2020-02-28 12:51:14.446086; '
+warnings: ''


### PR DESCRIPTION
This PR allows transferring the ARC project directories between different machines, as absolute paths are automatically rebased onto the current ARC project path.