### PR TITLE
Use OpenBabel force field to optimize the geoms if RDkit fails

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -781,12 +781,10 @@ def almost_equal_coords_lists(xyz1: dict,
     for xyz1_entry in xyz1:
         for xyz2_entry in xyz2:
             if xyz1_entry['symbols'] != xyz2_entry['symbols']:
-                return False
+                continue
             if almost_equal_coords(xyz1_entry, xyz2_entry, rtol=rtol, atol=atol):
-                break
-        else:
-            return False
-    return True
+                return True  # Anytime find one match, return `True`
+    return False  # If no match is found
 
 
 def determine_model_chemistry_type(method: str or dict) -> str:

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -504,7 +504,7 @@ O       1.40839617    0.14303696    0.00000000"""
     def test_embed_rdkit(self):
         """Test embedding in RDKit"""
         rd_mol = conformers.embed_rdkit(label='CJ', mol=self.cj_spc.mol, num_confs=1)
-        xyzs, energies = conformers.rdkit_force_field(label='CJ', rd_mol=rd_mol, mol=self.cj_spc.mol)
+        xyzs, energies = conformers.rdkit_force_field(label='CJ', rd_mol=rd_mol)
         for atom, symbol in zip(self.cj_spc.mol.atoms, xyzs[0]['symbols']):
             self.assertEqual(atom.symbol, symbol)
 
@@ -540,7 +540,7 @@ O      -1.21746139   -0.72237602    0.00000000
 O       1.40839617    0.14303696    0.00000000"""
         spc = ARCSpecies(label='SO2', smiles='O=S=O', xyz=xyz)
         rd_mol = conformers.embed_rdkit(label='', mol=spc.mol, num_confs=3, xyz=xyz)
-        xyzs, energies = conformers.rdkit_force_field(label='', rd_mol=rd_mol, mol=spc.mol,
+        xyzs, energies = conformers.rdkit_force_field(label='', rd_mol=rd_mol,
                                                       force_field='MMFF94s', optimize=True)
         self.assertEqual(len(energies), 3)
         self.assertAlmostEqual(energies[0], 2.8820960262158292e-11, 5)
@@ -563,7 +563,7 @@ O       1.40839617    0.14303696    0.00000000"""
                            'symbols': ('S', 'O', 'O')}]
 
         self.assertTrue(almost_equal_coords_lists(xyzs, expected_xyzs1))
-        xyzs, energies = conformers.rdkit_force_field(label='', rd_mol=rd_mol, mol=spc.mol,
+        xyzs, energies = conformers.rdkit_force_field(label='', rd_mol=rd_mol,
                                                       force_field='MMFF94s', optimize=False)
         self.assertEqual(len(energies), 0)
         expected_xyzs2 = [{'symbols': ('S', 'O', 'O'),

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -125,6 +125,42 @@ H      -1.22610851    0.40421362    1.35170355"""
         self.assertTrue(found_inf, "The CONFS_VS_TORSIONS dictionary has to have a key that ends with 'inf'. "
                                    "got:\n{0}".format(conformers.CONFS_VS_TORSIONS))
 
+    def test_generate_conformers_with_openbabel(self):
+        """Test the main conformer generation function with a species for which RDKit fails to generate conformers"""
+        xyz = converter.str_to_xyz("""C         -2.18276        2.03598        0.00028
+        C         -0.83696        1.34108       -0.05231
+        H         -2.23808        2.82717       -0.75474
+        H         -2.33219        2.51406        0.97405
+        H         -2.99589        1.32546       -0.17267
+        O          0.18176        2.30786        0.17821
+        H         -0.69161        0.88171       -1.03641
+        H         -0.78712        0.56391        0.71847
+        O          1.39175        1.59510        0.11494""")
+        spc = ARCSpecies(label='CCO[O]', smiles='CCO[O]', xyz=xyz)
+        lowest_confs = conformers.generate_conformers(mol_list=spc.mol_list, label=spc.label,
+                                                        charge=spc.charge, multiplicity=spc.multiplicity,
+                                                        force_field='MMFF94s', print_logs=False, diastereomers=None,
+                                                        n_confs=1, return_all_conformers=False)
+        self.assertEqual(len(lowest_confs), 1)
+        self.assertAlmostEqual(lowest_confs[0]['FF energy'], -0.7460169669694667)
+        expected_xyz = {'symbols': ('C', 'C', 'H', 'H', 'H', 'O', 'H', 'H', 'O'),
+                        'isotopes': (12, 12, 1, 1, 1, 16, 1, 1, 16),
+                        'coords': ((-1.06401, 0.15134, -0.02907),
+                                   (0.39059, -0.26595, -0.11181),
+                                   (-1.38709, 0.21893, 1.01503),
+                                   (-1.21986, 1.1209, -0.51032),
+                                   (-1.70646, -0.59124, -0.51377),
+                                   (0.53686, -1.52925, 0.52713),
+                                   (0.6972, -0.347, -1.16062),
+                                   (1.0214, 0.47542, 0.39124),
+                                   (1.90095, -1.84857, 0.41142))}
+        # Only symbols instead of the coordinate values are compared.
+        # This is due to the unknown behavior of OpenBabel optimization function.
+        # With the same iteration number and same initial xyz, the optimized xyzs can
+        # be different on different machines, while energies are still consistent.
+        # More info can be found from PR #332
+        self.assertEqual(lowest_confs[0]['xyz']['symbols'], expected_xyz['symbols'])
+
     def test_generate_conformers_with_specific_diastereomers(self):
         """Test the main conformer generation function, considering a specific diastereomer"""
         spc1 = ARCSpecies(label='spc1', smiles='IC=CC(Cl)(I)NF')

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -501,6 +501,55 @@ O       1.40839617    0.14303696    0.00000000"""
         self.assertEqual(len(xyzs), 1)
         self.assertAlmostEqual(energies[0], 2.9310163, 3)
 
+    def test_openbabel_force_field_on_rdkit_conformers(self):
+        """Test Open Babel force field on RDKit conformers"""
+        xyz = converter.str_to_xyz("""C         -2.18276        2.03598        0.00028
+        C         -0.83696        1.34108       -0.05231
+        H         -2.23808        2.82717       -0.75474
+        H         -2.33219        2.51406        0.97405
+        H         -2.99589        1.32546       -0.17267
+        O          0.18176        2.30786        0.17821
+        H         -0.69161        0.88171       -1.03641
+        H         -0.78712        0.56391        0.71847
+        O          1.39175        1.59510        0.11494""")
+        spc = ARCSpecies(label='CCO[O]', smiles='CCO[O]', xyz=xyz)
+        rd_mol = conformers.embed_rdkit(
+            label='', mol=spc.mol, num_confs=2, xyz=xyz)
+        xyzs, energies = conformers.openbabel_force_field_on_rdkit_conformers(label='', rd_mol=rd_mol,
+                                                                            force_field='MMFF94s',)
+        expected_xyzs = [{'symbols': ('C', 'C', 'H', 'H', 'H', 'O', 'H', 'H', 'O'),
+                          'isotopes': (12, 12, 1, 1, 1, 16, 1, 1, 16),
+                          'coords': ((-0.92004, 0.17591, -0.00274),
+                                     (0.41052, -0.54976, 0.06772),
+                                     (-1.70176, -0.48351, -0.39026),
+                                     (-0.85205, 1.05583, -0.65051),
+                                     (-1.21725, 0.53214, 0.98907),
+                                     (1.40523, 0.29451, 0.63948),
+                                     (0.7238, -0.90625, -0.92072),
+                                     (0.3145, -1.42616, 0.71666),
+                                     (1.87763, 1.10137, -0.41125))},
+                        {'symbols': ('C', 'C', 'H', 'H', 'H', 'O', 'H', 'H', 'O'),
+                         'isotopes': (12, 12, 1, 1, 1, 16, 1, 1, 16),
+                         'coords': ((-1.06853, -0.10587, 0.01916),
+                                    (0.39395, 0.27799, -0.08402),
+                                    (-1.33109, -0.35023, 1.05379),
+                                    (-1.71119, 0.70925, -0.32507),
+                                    (-1.2765, -0.99769, -0.58128),
+                                    (1.18277, -0.81419, 0.37478),
+                                    (0.64876, 0.50323, -1.12562),
+                                    (0.59336, 1.16044, 0.53412),
+                                    (2.51642, -0.38757, 0.25036))}]  
+        self.assertEqual(len(energies), 2)
+        self.assertAlmostEqual(energies[0], 0.2446742680965306)
+        self.assertAlmostEqual(energies[1], -0.7460169699282158)
+        # Only symbols instead of the coordinate values are compared.
+        # This is due to the unknown behavior of OpenBabel optimization function.
+        # With the same iteration number and same initial xyz, the optimized xyzs can
+        # be different on different machines, while energies are still consistent.
+        # More info can be found from PR #332
+        self.assertEqual(xyzs[0]['symbols'], expected_xyzs[0]['symbols'])
+        self.assertEqual(xyzs[1]['symbols'], expected_xyzs[1]['symbols'])
+
     def test_embed_rdkit(self):
         """Test embedding in RDKit"""
         rd_mol = conformers.embed_rdkit(label='CJ', mol=self.cj_spc.mol, num_confs=1)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -894,7 +894,7 @@ class ARCSpecies(object):
             num_confs = min(500, max(50, len(self.mol.atoms) * 3))
             rd_mol = conformers.embed_rdkit(label=self.label, mol=self.mol, num_confs=num_confs)
             xyzs, energies = conformers.rdkit_force_field(label=self.label, rd_mol=rd_mol,
-                                                          mol=self.mol, force_field='MMFF94s')
+                                                          force_field='MMFF94s')
             if energies:
                 min_energy = min(energies)
                 min_energy_index = energies.index(min_energy)


### PR DESCRIPTION
Related to #306 and #328.

RDKit fails to optimize certain types of molecules (e.g., ROO) using force field. And currently, in ARC, Openbabel force field and conformer search functions are no longer used, due to incompatibility, causes ARC cannot handle these molecules. 

This PR allows force field optimization for molecules like ROOs. It uses randomly generated conformers (by RDKit) and optimizes their geometries using OpenBabel. RDKit is used because I didn't find a random conformer generation function in OpenBabel. Moreover, Openbabel optimizer is slower than RDKit's optimizer makes it a fall back option.

The original OpenBabel methods `openbabel_force_field` and `mix_rdkit_and_openbabel_force_field`, in case, if we want to further investigate on them.

I saw openbabel is prohibited in previous PRs, however since it is a method covering more molecules. Though it is way slower (~10x), it is still worth adding as a fallback method.