### PR TITLE
BugFix: Limit the default num of confs to generate

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -442,7 +442,7 @@ class ARC(object):
         self.memory = input_dict['job_memory'] if 'job_memory' in input_dict else self.memory
         self.bath_gas = input_dict['bath_gas'] if 'bath_gas' in input_dict else None
         self.solvent = input_dict['solvent'] if 'solvent' in input_dict else None
-        self.n_confs = input_dict['n_confs'] if 'n_confs' in input_dict else None
+        self.n_confs = input_dict['n_confs'] if 'n_confs' in input_dict else 10
         self.e_confs = input_dict['e_confs'] if 'e_confs' in input_dict else 5  # kJ/mol
         self.adaptive_levels = input_dict['adaptive_levels'] if 'adaptive_levels' in input_dict else None
         self.keep_checks = input_dict['keep_checks'] if 'keep_checks' in input_dict else False

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -214,7 +214,7 @@ class Scheduler(object):
                  memory: float = 14,
                  testing: bool = False,
                  dont_gen_confs: list = None,
-                 n_confs: int = None,
+                 n_confs: int = 10,
                  e_confs: float = 5,
                  ) -> None:
         self.rmg_database = rmg_database

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -108,8 +108,8 @@ def generate_conformers(mol_list,
                         charge=0,
                         multiplicity=None,
                         num_confs_to_generate=None,
-                        n_confs=None,
-                        e_confs=None,
+                        n_confs=10,
+                        e_confs=5.0,
                         de_threshold=None,
                         smeared_scan_res=None,
                         combination_threshold=None,
@@ -934,8 +934,8 @@ def determine_well_width_tolerance(mean_width):
 
 def get_lowest_confs(label: str,
                      confs: dict or list,
-                     n: int = None,
-                     e: float = None,
+                     n: int = 10,
+                     e: float = 5.0,
                      energy: str = 'FF energy',
                      ) -> list:
     """

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -830,7 +830,7 @@ class ARCSpecies(object):
                     mol.atoms = atoms
 
     def generate_conformers(self,
-                            n_confs: int = 15,
+                            n_confs: int = 10,
                             e_confs: float = 5,
                             plot_path: str = None,
                             ) -> None:

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -1185,7 +1185,7 @@ H       1.11582953    0.94384729   -0.10134685"""
         self.assertEqual(cation2.multiplicity, 1)
         self.assertEqual(cation2.charge, 1)
         cation2.generate_conformers()
-        self.assertEqual(len(cation2.conformers), 15)
+        self.assertEqual(len(cation2.conformers), 10)
 
         anion = ARCSpecies(label='CCC(=O)[O-]', smiles='CCC(=O)[O-]', charge=-1)
         anion.determine_multiplicity(smiles='', adjlist='', mol=None)


### PR DESCRIPTION
This is a follow-up fix for 35b68b. all n_confs are set to 10 as default.

The change in the main is the critical one, while other changes don't really have an impact.