### PR TITLE
BugFix: Display figure during ARC job in notebook

### DIFF
--- a/ipython/Demo/ARC thermo demo.ipynb
+++ b/ipython/Demo/ARC thermo demo.ipynb
@@ -45,7 +45,7 @@
     "import arc\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib notebook\n",
-    "%matplotlib"
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
A short follow-up change to the ipython notebook. I am really sorry. For some reason, `inline` is not successfully save to the previous PR.