### PR TITLE
A large rewriting to the SSHClient

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1593,7 +1593,7 @@ end
                     elif 'terachem' in esss:
                         self.software = 'terachem'
                 elif self.job_type in ['conformer', 'opt', 'freq', 'optfreq', 'sp',
-                                     'directed_scan']:
+                                       'directed_scan']:
                     if self.method == 'hf':
                         if 'gaussian' in esss:
                             self.software = 'gaussian'

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1229,13 +1229,11 @@ end
 
     def _upload_submit_file(self):
         ssh = SSHClient(self.server)
-        ssh.send_command_to_server(command='mkdir -p {0}'.format(self.remote_path))
         remote_file_path = os.path.join(self.remote_path, submit_filename[servers[self.server]['cluster_soft']])
         ssh.upload_file(remote_file_path=remote_file_path, file_string=self.submit)
 
     def _upload_input_file(self):
         ssh = SSHClient(self.server)
-        ssh.send_command_to_server(command='mkdir -p {0}'.format(self.remote_path))
         if self.input is not None:
             remote_file_path = os.path.join(self.remote_path, input_filename[self.software])
             ssh.upload_file(remote_file_path=remote_file_path, file_string=self.input)

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1310,10 +1310,9 @@ end
 
             # download molpro log file (in addition to the output file)
             if self.software.lower() == 'molpro':
-                remote_log_file_path = os.path.join(self.remote_path, 'input.log')
-                local_log_file_path = os.path.join(self.local_path, 'output.log')
-                ssh.download_file(remote_file_path=remote_log_file_path, local_file_path=local_log_file_path)
-                if not os.path.isfile(local_log_file_path):
+                remote_log_file_path = os.path.join(self.remote_path, output_filename[self.software])
+                ssh.download_file(remote_file_path=remote_log_file_path, local_file_path=self.local_path_to_output_file)
+                if not os.path.isfile(self.local_path_to_output_file):
                     logger.warning(f'Could not download Molpro log file for {self.job_name} ' \
                                    f'(this is not the output file)')
 

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1456,7 +1456,7 @@ end
         elif cluster_soft == 'slurm':
             if self.server != 'local':
                 ssh = SSHClient(self.server)
-                response = ssh.send_command_to_server(command='ls -alF', remote_path=self.remote_path)
+                response = ssh.list_dir(remote_path=self.remote_path)
             else:
                 response = execute_command('ls -alF {0}'.format(self.local_path))
             files = list()

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1249,7 +1249,7 @@ end
                                'got: {1}'.format(up_file['name'], up_file['source']))
             ssh.upload_file(remote_file_path=up_file['remote'], local_file_path=local_file_path)
             if up_file['make_x']:
-                ssh.send_command_to_server(command='chmod +x {0}'.format(up_file['name']), remote_path=self.remote_path)
+                ssh.change_mode(mode='+x', path=up_file['name'], remote_path=self.remote_path)
         self.initial_time = ssh.get_last_modified_time(
             remote_file_path=os.path.join(self.remote_path, submit_filename[servers[self.server]['cluster_soft']]))
 

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -123,11 +123,13 @@ class SSHClient(object):
                     f'Cannot execute command at given remote_path({remote_path})')
         try:
             _, stdout, stderr = self._ssh.exec_command(command)
-        except:  # SSHException: Timeout opening channel.
+        except Exception as e:  # SSHException: Timeout opening channel.
+            logger.debug(f'ssh timed-out in the first trial. Got:{e}')
             try:  # try again
                 _, stdout, stderr = self._ssh.exec_command(command)
-            except:
-                return '', 'ssh timed-out after two trials'
+            except Exception as e:
+                logger.debug(f'ssh timed-out after two trials. Got:{e}')
+                return ['',], ['ssh timed-out after two trials',]
         stdout = stdout.readlines()
         stderr = stderr.readlines()
         return stdout, stderr

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -342,6 +342,25 @@ class SSHClient(object):
                      if line.split()[1] in ['mix', 'alloc', 'idle']]
         return nodes
 
+    def change_mode(self,
+                    mode: str,
+                    path: str,
+                    recursive: bool = False,
+                    remote_path: str = ''):
+        """
+        Change the mode to a file or a directory.
+
+        Args:
+            mode (str): The mode change to be applied, can be either octal or symbolic.
+            path (str): The path to the file or the directory to be changed.
+            recursive (bool, optional): Whether to recursively change the mode to all files
+                                        under a directory.``True`` for recursively change.
+            remote_path (str, optional): The directory path at which the command will be executed.
+        """
+        recursive = '-R' if recursive else ''
+        command = f'chmod {recursive} {mode} {path}'
+        self._send_command_to_server(command, remote_path)
+
 
 def write_file(sftp, remote_file_path, local_file_path='', file_string=''):
     """

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -302,6 +302,16 @@ class SSHClient(object):
         command = f'ls -alF'
         return self._send_command_to_server(command, remote_path)[0]
 
+    def find_package(self, package_name: str) -> list:
+        """
+        Find the path to the package.
+
+        Args:
+            package_name (str): The name of the package to search for.
+        """
+        command = f'. ~/.bashrc; which {package_name}'
+        return self._send_command_to_server(command)[0]
+
 
 def write_file(sftp, remote_file_path, local_file_path='', file_string=''):
     """

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -589,19 +589,19 @@ def delete_all_arc_jobs(server_list, jobs=None):
         jobs_message = f'{len(jobs)}' if jobs is not None else 'all'
         print(f'\nDeleting {jobs_message} ARC jobs from {server}...')
         cmd = check_status_command[servers[server]['cluster_soft']] + ' -u $USER'
-        ssh = SSHClient(server)
-        stdout = ssh._send_command_to_server(cmd)[0]
-        for status_line in stdout:
-            s = re.search(r' a\d+', status_line)
-            if s is not None:
-                job_id = s.group()[1:]
-                if job_id in jobs or jobs is None:
-                    if servers[server]['cluster_soft'].lower() == 'slurm':
-                        server_job_id = status_line.split()[0]
-                        ssh.delete_job(server_job_id)
-                        print(f'deleted job {job_id} ({server_job_id} on server)')
-                    elif servers[server]['cluster_soft'].lower() == 'oge':
-                        ssh.delete_job(job_id)
-                        print(f'deleted job {job_id}')
+        with SSHClient(server) as ssh:
+            stdout = ssh._send_command_to_server(cmd)[0]
+            for status_line in stdout:
+                s = re.search(r' a\d+', status_line)
+                if s is not None:
+                    job_id = s.group()[1:]
+                    if job_id in jobs or jobs is None:
+                        if servers[server]['cluster_soft'].lower() == 'slurm':
+                            server_job_id = status_line.split()[0]
+                            ssh.delete_job(server_job_id)
+                            print(f'deleted job {job_id} ({server_job_id} on server)')
+                        elif servers[server]['cluster_soft'].lower() == 'oge':
+                            ssh.delete_job(job_id)
+                            print(f'deleted job {job_id}')
     if server_list:
         print('\ndone.')

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -49,11 +49,19 @@ class SSHClient(object):
         self.key = servers[server]['key']
         logging.getLogger("paramiko").setLevel(logging.WARNING)
 
-    def send_command_to_server(self, command, remote_path=''):
+    def _send_command_to_server(self, command: str, remote_path: str='') -> (list, list):
         """
-        Send commands to server. `command` is either a sting or an array of string commands to send.
-        If remote_path is not an empty string, the command will be executed in the directory path it points to.
-        Returns lists of stdout, stderr corresponding to the commands sent.
+        Send commands to server. 
+
+        Args:
+            command (str or list): A string or an array of string commands to send.
+            remote_path (str, optional): The directory path at which the command will be executed.
+
+        Returns:
+            list: A list of lines of standard output stream.
+
+        Returns:
+            list: A list of lines of standard error stream.
         """
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -291,6 +291,17 @@ class SSHClient(object):
         ssh.close()
         return datetime.datetime.fromtimestamp(timestamp)
 
+    def list_dir(self, remote_path: str = '') -> list:
+        """
+        List directory contents.
+
+        Args:
+            mode (str): The mode change to be applied, can be either octal or symbolic.
+            remote_path (str, optional): The directory path at which the command will be executed.
+        """
+        command = f'ls -alF'
+        return self._send_command_to_server(command, remote_path)[0]
+
 
 def write_file(sftp, remote_file_path, local_file_path='', file_string=''):
     """

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -52,6 +52,13 @@ class SSHClient(object):
         self._ssh = None
         logging.getLogger("paramiko").setLevel(logging.WARNING)
 
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
     def _send_command_to_server(self, command: str, remote_path: str='') -> (list, list):
         """
         A wapper for exec_command in paramiko. SSHClient. Send commands to the server. 
@@ -391,6 +398,16 @@ class SSHClient(object):
             ssh.connect(hostname=self.address, username=self.un)
         sftp = ssh.open_sftp()
         return sftp, ssh
+
+    def close(self):
+        """
+        Close the connection to paramiko SSHClient and SFTPClient
+        """
+        if self._sftp is not None:
+            self._sftp.close()
+        if self._ssh is not None:
+            self._ssh.close()
+
 
     def get_last_modified_time(self, remote_file_path: str):
         """

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -343,11 +343,14 @@ class SSHClient(object):
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.load_system_host_keys(filename=self.key)
         try:
-            ssh.connect(hostname=self.address, username=self.un)
+            # If the server accepts the connection but the SSH daemon doesn't respond in 
+            # 15 seconds (default in paramiko) due to network congestion, faulty switches, 
+            # etc..., common solution is to enlarging the timeout variable.
+            ssh.connect(hostname=self.address, username=self.un, banner_timeout=200)
         except:
             # This sometimes gives "SSHException: Error reading SSH protocol banner[Error 104] Connection reset by peer"
             # Try again:
-            ssh.connect(hostname=self.address, username=self.un)
+            ssh.connect(hostname=self.address, username=self.un, banner_timeout=200)
         sftp = ssh.open_sftp()
         return sftp, ssh
 

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -155,14 +155,18 @@ class SSHClient(object):
         sftp.close()
         ssh.close()
 
-    def read_remote_file(self, remote_path, filename):
+    def read_remote_file(self, remote_file_path: str) -> list:
         """
-        Read a remote file. `remote_path` is the remote path (required), a `filename` is also required.
-        Returns the file's content.
+        Read a remote file.
+
+        Args:
+            remote_file_path (str): The remote path to be read.
+        
+        Returns:
+            list: A list of lines read from the file.
         """
         sftp, ssh = self.connect()
-        full_path = os.path.join(remote_path, filename)
-        with sftp.open(full_path, 'r') as f_remote:
+        with sftp.open(remote_file_path, 'r') as f_remote:
             content = f_remote.readlines()
         sftp.close()
         ssh.close()

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -361,6 +361,36 @@ class SSHClient(object):
         command = f'chmod {recursive} {mode} {path}'
         self._send_command_to_server(command, remote_path)
 
+    def _check_file_exists(self, remote_file_path: str) -> bool:
+        """
+        Check if a file exists on the remote server.
+
+        Args:
+            remote_file_path (str): The path to the file on the remote server.
+
+        Returs:
+            bool: If the file exists on the remote server. ``True`` if exist.
+        """
+        command = f'[ -f "{remote_file_path}" ] && echo "File exists"'
+        stdout, _ = self._send_command_to_server(command, remote_path='')
+        if len(stdout):
+            return True
+
+    def _check_dir_exists(self,
+                          remote_dir_path: str) -> bool:
+        """
+        Check if a directory exists on the remote server.
+
+        Args:
+            remote_dir_path (str): The path to the directory on the remote server.
+
+        Returns:
+            bool: If the directory exists on the remote server. ``True`` if exist.
+        """
+        command = f'[ -d "{remote_dir_path}" ] && echo "Dir exists"'
+        stdout, _ = self._send_command_to_server(command)
+        if len(stdout):
+            return True
 
 def write_file(sftp, remote_file_path, local_file_path='', file_string=''):
     """

--- a/arc/job/submit.py
+++ b/arc/job/submit.py
@@ -41,12 +41,12 @@ mkdir -p $WorkDir
 cd $WorkDir
 . $g09root/g09/bsd/g09.profile
 
-cp $SubmitDir/input.gjf .
-cp $SubmitDir/check.chk .
+cp "$SubmitDir/input.gjf" .
+cp "$SubmitDir/check.chk" .
 
 g09 < input.gjf > input.log
 formchk  check.chk check.fchk
-cp * $SubmitDir/
+cp * "$SubmitDir/"
 
 rm -rf $GAUSS_SCRDIR
 rm -rf $WorkDir
@@ -86,10 +86,10 @@ SubmitDir=`pwd`
 mkdir -p $WorkDir
 cd $WorkDir
 
-cp $SubmitDir/input.inp .
+cp "$SubmitDir/input.inp" .
 
 ${ORCA_DIR}/orca input.inp > input.log
-cp * $SubmitDir/
+cp * "$SubmitDir/"
 
 rm -rf $WorkDir
 
@@ -129,12 +129,12 @@ mkdir -p $WorkDir
 cd $WorkDir
 . $g16root/g16/bsd/g16.profile
 
-cp $SubmitDir/input.gjf .
-cp $SubmitDir/check.chk .
+cp "$SubmitDir/input.gjf" .
+cp "$SubmitDir/check.chk" .
 
 g16 < input.gjf > input.log
 formchk check.chk check.fchk
-cp * $SubmitDir/
+cp * "$SubmitDir/"
 
 rm -rf $GAUSS_SCRDIR
 rm -rf $WorkDir
@@ -165,12 +165,12 @@ SubmitDir=`pwd`
 mkdir -p $sdir
 cd $sdir
 
-cp $SubmitDir/input.in .
+cp "$SubmitDir/input.in" .
 
 molpro -n {cpus} -d $sdir input.in
 
-cp input.* $SubmitDir/
-cp geometry*.* $SubmitDir/
+cp input.* "$SubmitDir/"
+cp geometry*.* "$SubmitDir/"
 
 rm -rf $sdir
 
@@ -225,10 +225,10 @@ SubmitDir=`pwd`
 mkdir -p $WorkDir
 cd $WorkDir
 
-cp $SubmitDir/input.inp .
+cp "$SubmitDir/input.inp" .
 
 ${ORCA_DIR}/orca input.inp > input.log
-cp * $SubmitDir/
+cp * "$SubmitDir/"
 
 rm -rf $WorkDir
 
@@ -409,10 +409,10 @@ SubmitDir=`pwd`
 mkdir -p $WorkDir
 cd $WorkDir
 
-cp $SubmitDir/input.in .
+cp "$SubmitDir/input.in" .
 
 /opt/orca/orca input.in > input.log
-cp * $SubmitDir/
+cp * "$SubmitDir/"
 
 rm -rf $WorkDir
 

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -25,7 +25,6 @@ from arc.job.ssh import SSHClient
 from arc.settings import (delete_command,
                           inconsistency_ab,
                           inconsistency_az,
-                          list_available_nodes_command,
                           maximum_barrier,
                           preserve_param_in_scan_stable,
                           rotor_scan_resolution,
@@ -1120,54 +1119,59 @@ def trsh_job_on_server(server: str,
         bool: Whether to re-run the job, `True` to rerun.
     """
     server_nodes = server_nodes if server_nodes is not None else list()
+    cluster_soft = servers[server]['cluster_soft']
     if job_server_status != 'done':
         logger.error(f'Job {job_name} has server status "{job_server_status}" on {server}.')
 
     # delete current server run
-    command = delete_command[servers[server]['cluster_soft']] + ' ' + str(job_id)
     if server == 'local':
-        execute_command(command)
+        cmd = delete_command[cluster_soft] + ' ' + str(job_id)
+        execute_command(cmd)
         return None, True
     else:
         ssh = SSHClient(server)
-        ssh.send_command_to_server(command)
+        ssh.delete_job(job_id)
 
-    if servers[server]['cluster_soft'].lower() == 'oge':
-        logger.error('Troubleshooting by changing node.')
-        ssh = SSHClient(server)
-        # find available nodes
-        stdout = ssh.send_command_to_server(command=list_available_nodes_command[servers[server]['cluster_soft']])[0]
-        for line in stdout:
-            node = line.split()[0].split('.')[0].split('node')[1]
-            if servers[server]['cluster_soft'] == 'OGE' and '0/0/8' in line and node not in server_nodes:
-                server_nodes.append(node)
-                break
-        else:
-            logger.error(f'Could not find an available node on the server {server}')
-            # TODO: continue troubleshooting; if all else fails, put the job to sleep,
-            #       and try again searching for a node
-            return None, False
+    # find available node
+    logger.error('Troubleshooting by changing node.')
+    ssh = SSHClient(server)
+    nodes = ssh.list_available_nodes()
+    for node in nodes:
+        if node not in server_nodes:
+            server_nodes.append(node)
+            break
+    else:
+        logger.error(f'Could not find an available node on the server {server}')
+        # TODO: continue troubleshooting; if all else fails, put the job to sleep,
+        #       and try again searching for a node
+        return None, False
 
-        # modify the submit file
-        content = ssh.read_remote_file(remote_path=remote_path,
-                                       filename=submit_filename[servers[server]['cluster_soft']])
-        for i, line in enumerate(content):
-            if '#$ -l h=node' in line:
-                content[i] = '#$ -l h=node{0}.cluster'.format(node)
-                break
-        else:
-            content.insert(7, '#$ -l h=node{0}.cluster'.format(node))
-        content = ''.join(content)  # convert list into a single string, not to upset paramiko
-        # resubmit
-        ssh.upload_file(remote_file_path=os.path.join(remote_path,
-                        submit_filename[servers[server]['cluster_soft']]), file_string=content)
-        return node, True
+    # modify the submit file
+    remote_submit_file = os.path.join(remote_path, submit_filename[cluster_soft])
+    content = ssh.read_remote_file(remote_file_path=remote_submit_file)
+    if cluster_soft.lower() == 'oge':
+        node_assign = '#$ -l h='
+        insert_line_num = 7
+    elif cluster_soft.lower() == 'slurm':
+        node_assign = '#$BATCH -w, --nodelist='
+        insert_line_num = 5
+    else:
+        # Other software?
+        logger.denug(f'Unknown cluster software {cluster_soft} is encountered when '
+                     f'troubleshooting by changing node.')
+        return None, False
+    for i, line in enumerate(content):
+        if node_assign in line:
+            content[i] = node_assign + node
+        break
+    else:
+        content.insert(insert_line_num, node_assign + node)
+    content = ''.join(content)  # convert list into a single string, not to upset paramiko
 
-    elif servers[server]['cluster_soft'].lower() == 'slurm':
-        # TODO: change node on Slurm
-        return None, True
-
-    return None, False
+    # resubmit
+    ssh.upload_file(remote_file_path=os.path.join(remote_path,
+                    submit_filename[cluster_soft]), file_string=content)
+    return node, True
 
 
 def scan_quality_check(label: str,

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -1129,8 +1129,8 @@ def trsh_job_on_server(server: str,
         execute_command(cmd)
         return None, True
     else:
-        ssh = SSHClient(server)
-        ssh.delete_job(job_id)
+        with SSHClient(server) as ssh:
+            ssh.delete_job(job_id)
 
     # find available node
     logger.error('Troubleshooting by changing node.')
@@ -1148,7 +1148,8 @@ def trsh_job_on_server(server: str,
 
     # modify the submit file
     remote_submit_file = os.path.join(remote_path, submit_filename[cluster_soft])
-    content = ssh.read_remote_file(remote_file_path=remote_submit_file)
+    with SSHClient(server) as ssh:
+        content = ssh.read_remote_file(remote_file_path=remote_submit_file)
     if cluster_soft.lower() == 'oge':
         node_assign = '#$ -l h='
         insert_line_num = 7
@@ -1169,8 +1170,9 @@ def trsh_job_on_server(server: str,
     content = ''.join(content)  # convert list into a single string, not to upset paramiko
 
     # resubmit
-    ssh.upload_file(remote_file_path=os.path.join(remote_path,
-                    submit_filename[cluster_soft]), file_string=content)
+    with SSHClient(server) as ssh:
+        ssh.upload_file(remote_file_path=os.path.join(remote_path,
+                        submit_filename[cluster_soft]), file_string=content)
     return node, True
 
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -827,12 +827,9 @@ class ARC(object):
                 logger.info('\nTrying {0}'.format(server))
             ssh = SSHClient(server)
 
-            cmd = '. ~/.bashrc; which g03'
-            g03 = ssh.send_command_to_server(cmd)[0]
-            cmd = '. ~/.bashrc; which g09'
-            g09 = ssh.send_command_to_server(cmd)[0]
-            cmd = '. ~/.bashrc; which g16'
-            g16 = ssh.send_command_to_server(cmd)[0]
+            g03 = ssh.find_package('g03')
+            g09 = ssh.find_package('g09')
+            g16 = ssh.find_package('g16')
             if g03 or g09 or g16:
                 if diagnostics:
                     logger.info(f'  Found Gaussian on {server}: g03={g03}, g09={g09}, g16={g16}')
@@ -840,8 +837,7 @@ class ARC(object):
             elif diagnostics:
                 logger.info(f'  Did NOT find Gaussian on {server}')
 
-            cmd = '. ~/.bashrc; which qchem'
-            qchem = ssh.send_command_to_server(cmd)[0]
+            qchem = ssh.find_package('qchem')
             if qchem:
                 if diagnostics:
                     logger.info(f'  Found QChem on {server}')
@@ -849,8 +845,7 @@ class ARC(object):
             elif diagnostics:
                 logger.info(f'  Did NOT find QChem on {server}')
 
-            cmd = '. ~/.bashrc; which orca'
-            orca = ssh.send_command_to_server(cmd)[0]
+            orca = ssh.find_package('orca')
             if orca:
                 if diagnostics:
                     logger.info(f'  Found Orca on {server}')
@@ -858,8 +853,7 @@ class ARC(object):
             elif diagnostics:
                 logger.info(f'  Did NOT find Orca on {server}')
 
-            cmd = '. ~/.bashrc; which terachem'
-            terachem = ssh.send_command_to_server(cmd)[0]
+            terachem = ssh.find_package('terachem')
             if terachem:
                 if diagnostics:
                     logging.info(f'  Found TeraChem on {server}')
@@ -867,8 +861,7 @@ class ARC(object):
             elif diagnostics:
                 logging.info(f'  Did NOT find TeraChem on {server}')
 
-            cmd = '. .bashrc; which molpro'
-            molpro = ssh.send_command_to_server(cmd)[0]
+            molpro = ssh.find_package('molpro')
             if molpro:
                 if diagnostics:
                     logger.info(f'  Found Molpro on {server}')

--- a/arc/main.py
+++ b/arc/main.py
@@ -825,49 +825,49 @@ class ARC(object):
                 continue
             if diagnostics:
                 logger.info('\nTrying {0}'.format(server))
-            ssh = SSHClient(server)
+            with SSHClient(server) as ssh:
 
-            g03 = ssh.find_package('g03')
-            g09 = ssh.find_package('g09')
-            g16 = ssh.find_package('g16')
-            if g03 or g09 or g16:
-                if diagnostics:
-                    logger.info(f'  Found Gaussian on {server}: g03={g03}, g09={g09}, g16={g16}')
-                self.ess_settings['gaussian'].append(server)
-            elif diagnostics:
-                logger.info(f'  Did NOT find Gaussian on {server}')
+                g03 = ssh.find_package('g03')
+                g09 = ssh.find_package('g09')
+                g16 = ssh.find_package('g16')
+                if g03 or g09 or g16:
+                    if diagnostics:
+                        logger.info(f'  Found Gaussian on {server}: g03={g03}, g09={g09}, g16={g16}')
+                    self.ess_settings['gaussian'].append(server)
+                elif diagnostics:
+                    logger.info(f'  Did NOT find Gaussian on {server}')
 
-            qchem = ssh.find_package('qchem')
-            if qchem:
-                if diagnostics:
-                    logger.info(f'  Found QChem on {server}')
-                self.ess_settings['qchem'].append(server)
-            elif diagnostics:
-                logger.info(f'  Did NOT find QChem on {server}')
+                qchem = ssh.find_package('qchem')
+                if qchem:
+                    if diagnostics:
+                        logger.info(f'  Found QChem on {server}')
+                    self.ess_settings['qchem'].append(server)
+                elif diagnostics:
+                    logger.info(f'  Did NOT find QChem on {server}')
 
-            orca = ssh.find_package('orca')
-            if orca:
-                if diagnostics:
-                    logger.info(f'  Found Orca on {server}')
-                self.ess_settings['orca'].append(server)
-            elif diagnostics:
-                logger.info(f'  Did NOT find Orca on {server}')
+                orca = ssh.find_package('orca')
+                if orca:
+                    if diagnostics:
+                        logger.info(f'  Found Orca on {server}')
+                    self.ess_settings['orca'].append(server)
+                elif diagnostics:
+                    logger.info(f'  Did NOT find Orca on {server}')
 
-            terachem = ssh.find_package('terachem')
-            if terachem:
-                if diagnostics:
-                    logging.info(f'  Found TeraChem on {server}')
-                self.ess_settings['terachem'].append(server)
-            elif diagnostics:
-                logging.info(f'  Did NOT find TeraChem on {server}')
+                terachem = ssh.find_package('terachem')
+                if terachem:
+                    if diagnostics:
+                        logging.info(f'  Found TeraChem on {server}')
+                    self.ess_settings['terachem'].append(server)
+                elif diagnostics:
+                    logging.info(f'  Did NOT find TeraChem on {server}')
 
-            molpro = ssh.find_package('molpro')
-            if molpro:
-                if diagnostics:
-                    logger.info(f'  Found Molpro on {server}')
-                self.ess_settings['molpro'].append(server)
-            elif diagnostics:
-                logger.info(f'  Did NOT find Molpro on {server}')
+                molpro = ssh.find_package('molpro')
+                if molpro:
+                    if diagnostics:
+                        logger.info(f'  Found Molpro on {server}')
+                    self.ess_settings['molpro'].append(server)
+                elif diagnostics:
+                    logger.info(f'  Did NOT find Molpro on {server}')
         if diagnostics:
             logger.info('\n\n')
         if 'gaussian' in self.ess_settings.keys():

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2511,8 +2511,8 @@ class Scheduler(object):
         self.servers_jobs_ids = list()
         for server in self.servers:
             if server != 'local':
-                ssh = SSHClient(server)
-                self.servers_jobs_ids.extend(ssh.check_running_jobs_ids())
+                with SSHClient(server) as ssh:
+                    self.servers_jobs_ids.extend(ssh.check_running_jobs_ids())
             else:
                 self.servers_jobs_ids.extend(check_running_jobs_ids())
 

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -102,7 +102,7 @@ delete_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qdel
                   'Slurm': '/usr/bin/scancel'}
 
 list_available_nodes_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qstat -f | grep "/8 " | grep "long" | grep -v "8/8"| grep -v "aAu"',
-                                'Slurm': 'sinfo'}
+                                'Slurm': 'sinfo -o "%n %t %O %E"'}
 
 submit_filename = {'OGE': 'submit.sh',
                    'Slurm': 'submit.sl'}


### PR DESCRIPTION
This change is originally to solve #346, but soon becoming a rewriting to the whole class. 

What this PR solves and how it solves:
1. In the original issue #346, ARC cannot deal with path has '[]' in it and identifies this kind of problem as connection failure (which is not). 
Solution: make sure remote dir exists (otherwise create it); make sure `""` used when calling `mkdir` or `cd`; Rewrite upload and download file function (actually twice, no need to carefully review the first time change). Add a connection check before calling upload and download function (more details later).

2. Slightly better security. Personally, I don't think directly calling this `send_command_to_server` in other modules is a good idea. It is not readable enough. And it also provides large flexibility to other modules. I don't know much about hacking, but it is not a bad idea to somehow constraint what we can do with this module.
Solution: make this function private and create functions like `create_dir`, `list_available_nodes`, etc.

3. Better handling ssh and sftp. Previously, we will create multiple paramiko SSH and SFTP Client during using this module. Potential problems: (1) increasing connection load and more sensitive to the stability of the connection. (2) different sessions, for some reason, are not synchronized immediately. (3) repetition of creating and closing SSH and SFTP blocks in most of the methods. 
Solution: (1) add these two private attributes _ssh and _sftp. We will only deal with them. (2) convert SSHClient to a Context Manager like class, so people can use `with ... as ...` to use it. Using this syntax not only results in a shorter code but also has better error handling, making sure the clients are closed, even errors are raised.

4. Connection check. Since we are using a single ssh and sftp client. It is better to check their connectivity before using related functions. And some modules have their own connection check, which sometimes will see other issues as connection problems.
Solution: Add a stand-alone connection check decorator to check the connection before each call. If not well connected, then simply reconnect. If still unsuccess, follow the original approach "sleep and try again".

How to review, some of the early changes are less important. More focus can be put on commits since `Add two private attribute _ssh and _sftp`. Once go through by commits, better have a overview directly look at the files changed.

This module has been tested by running the demo thermo job in the ipython folder. I didn't find any abnormalities. Since it heavily related to server communication and we don't have a test server, unit tests are not included.
