### PR TITLE
Pass on RMG AtomTypeError in Species

### DIFF
--- a/arc/processor.py
+++ b/arc/processor.py
@@ -100,8 +100,14 @@ def process_arc_project(statmech_adapter: str,
     if compute_rates:
         for reaction in reactions:
             species_converged = True
+            considered_labels = list()  # species labels considered in this reaction
             if output_dict[reaction.ts_label]['convergence']:
                 for species in reaction.r_species + reaction.p_species:
+                    if species.label in considered_labels:
+                        # consider cases where the same species appears in a reaction both as a reactant
+                        # and as a product (e.g., H2O that catalyzes a reaction).
+                        continue
+                    considered_labels.append(species.label)
                     if output_dict[species.label]['convergence']:
                         statmech_adapter = statmech_factory(statmech_adapter_label=statmech_adapter_label,
                                                             output_directory=output_directory,

--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -82,8 +82,7 @@ class ARCReaction(object):
         self.ts_label = ts_label
         self.dh_rxn298 = None
         self.rmg_reactions = None
-        if ts_xyz_guess is not None and not isinstance(ts_xyz_guess, list):
-            ts_xyz_guess = [ts_xyz_guess]
+        self.ts_xyz_guess = ts_xyz_guess
         if reaction_dict is not None:
             # Reading from a dictionary
             self.from_dict(reaction_dict=reaction_dict)
@@ -108,9 +107,10 @@ class ARCReaction(object):
             self.ts_methods = [tsm.lower() for tsm in self.ts_methods]
             self.ts_xyz_guess = ts_xyz_guess if ts_xyz_guess is not None else list()
         if len(self.reactants) > 3 or len(self.products) > 3:
-            raise ReactionError('An ARC Reaction can have up to three reactants / products. got {0} reactants'
-                                ' and {1} products for reaction {2}.'.format(len(self.reactants), len(self.products),
-                                                                             self.label))
+            raise ReactionError(f'An ARC Reaction can have up to three reactants / products. got {len(self.reactants)} '
+                                f'reactants and {len(self.products)} products for reaction {self.label}.')
+        if self.ts_xyz_guess is not None and not isinstance(self.ts_xyz_guess, list):
+            self.ts_xyz_guess = [self.ts_xyz_guess]
 
     def __str__(self):
         """Return a string representation of the object"""

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -13,7 +13,7 @@ import os
 import rmgpy.molecule.element as elements
 from arkane.common import ArkaneSpecies, symbol_by_number
 from arkane.statmech import is_linear
-from rmgpy.exceptions import InvalidAdjacencyListError, ILPSolutionError, ResonanceError
+from rmgpy.exceptions import AtomTypeError, InvalidAdjacencyListError, ILPSolutionError, ResonanceError
 from rmgpy.molecule.molecule import Atom, Molecule
 from rmgpy.molecule.resonance import generate_kekule_structure
 from rmgpy.reaction import Reaction
@@ -688,7 +688,7 @@ class ARCSpecies(object):
         try:
             self.mol = Molecule().from_adjacency_list(species_dict['mol'], raise_atomtype_exception=False) \
                 if 'mol' in species_dict else None
-        except (ValueError, InvalidAdjacencyListError) as e:
+        except (ValueError, AtomTypeError, InvalidAdjacencyListError) as e:
             logger.error(f'Could not read RMG adjacency list {species_dict["mol"] if "mol" in species_dict else None}. '
                          f'Got:\n{e}')
             self.mol = None
@@ -1786,9 +1786,8 @@ class TSGuess(object):
         if self.family is None and self.method.lower() in ['kinbot', 'autotst']:
             # raise TSError('No family specified for method {0}'.format(self.method))
             logger.warning('No family specified for method {0}'.format(self.method))
-        if 'rmg_reaction' not in ts_dict:
-            self.rmg_reaction = None
-        else:
+        self.rmg_reaction = None
+        if 'rmg_reaction' in ts_dict:
             rxn_string = ts_dict['rmg_reaction']
             plus = ' + '
             arrow = ' <=> '
@@ -1808,11 +1807,14 @@ class TSGuess(object):
                 prod = [prod]
             reactants = list()
             products = list()
-            for reactant in reac:
-                reactants.append(Species(smiles=reactant))
-            for product in prod:
-                products.append(Species(smiles=product))
-            self.rmg_reaction = Reaction(reactants=reactants, products=products)
+            try:
+                for reactant in reac:
+                    reactants.append(Species(smiles=reactant))
+                for product in prod:
+                    products.append(Species(smiles=product))
+                self.rmg_reaction = Reaction(reactants=reactants, products=products)
+            except AtomTypeError:
+                pass
 
     def execute_ts_guess_method(self):
         """

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -422,7 +422,7 @@ class ARCSpecies(object):
         if self.charge is None:
             logger.debug(f'No charge specified for {self.label}, assuming charge 0.')
             self.charge = 0
-        if self.multiplicity is None:
+        if self.multiplicity is None or self.multiplicity < 1:
             self.determine_multiplicity(smiles, adjlist, self.mol)
             logger.debug(f'No multiplicity specified for {self.label}, assuming {self.multiplicity}.')
         if not isinstance(self.multiplicity, int) and self.multiplicity is not None:
@@ -1177,7 +1177,7 @@ class ARCSpecies(object):
             elif smiles:
                 mol = Molecule(smiles=smiles)
                 self.multiplicity = mol.multiplicity
-            else:
+            if self.multiplicity is None or self.multiplicity < 1:
                 get_mul_from_xyz = True
         if get_mul_from_xyz:
             xyz = self.get_xyz()


### PR DESCRIPTION
might (partially?) solve #348
Also: Allow the same species to be both a reactant and a product in processor
Also: Verify Reaction.ts_xyz_guess is a list after loading from dict