### PR TITLE
Modified delete.py to accept command line arguments 

### DIFF
--- a/ARC.py
+++ b/ARC.py
@@ -15,9 +15,10 @@ from arc.main import ARC
 
 def parse_command_line_arguments(command_line_args=None):
     """
-    Parse the command-line arguments being passed to ARC. This uses the
-    :mod:`argparse` module, which ensures that the command-line arguments are
-    sensible, parses them, and returns them.
+    Parse command-line arguments.
+
+    Args:
+        command_line_args: The command line arguments.
     """
 
     parser = argparse.ArgumentParser(description='Automatic Rate Calculator (ARC)')
@@ -32,22 +33,16 @@ def parse_command_line_arguments(command_line_args=None):
     group.add_argument('-q', '--quiet', action='store_true', help='only print warnings and errors')
 
     args = parser.parse_args(command_line_args)
-
-    # Process args to set correct default values and format
-
-    # For output and scratch directories, if they are empty strings, set them
-    # to match the input file location
     args.file = args.file[0]
-
-    # Set directories
-    # input_directory = os.path.abspath(os.path.dirname(args.file))
 
     return args
 
 
 def main():
-    """The main ARC executable function"""
-    # Parse the command-line arguments (requires the argparse module)
+    """
+    The main ARC executable function
+    """
+
     args = parse_command_line_arguments()
     input_file = args.file
     project_directory = os.path.abspath(os.path.dirname(args.file))
@@ -66,8 +61,6 @@ def main():
     arc_object = ARC(input_dict=input_dict, project_directory=project_directory)
     arc_object.execute()
 
-
-################################################################################
 
 if __name__ == '__main__':
     main()

--- a/arc/job/local.py
+++ b/arc/job/local.py
@@ -206,11 +206,14 @@ def rename_output(local_file_path, software):
         shutil.move(src=os.path.join(os.path.dirname(local_file_path), output_filename[software]), dst=local_file_path)
 
 
-def delete_all_local_arc_jobs():
+def delete_all_local_arc_jobs(jobs=None):
     """
     Delete all ARC-spawned jobs (with job name starting with `a` and a digit) from the local server.
     Make sure you know what you're doing, so unrelated jobs won't be deleted...
     Useful when terminating ARC while some (ghost) jobs are still running.
+
+    Args:
+        jobs (Optional[List[str]]): Specific ARC job IDs to delete.
     """
     server = 'local'
     if server in servers:
@@ -220,13 +223,13 @@ def delete_all_local_arc_jobs():
         for status_line in stdout:
             s = re.search(r' a\d+', status_line)
             if s is not None:
-                if servers[server]['cluster_soft'].lower() == 'slurm':
-                    job_id = s.group()[1:]
-                    server_job_id = status_line.split()[0]
-                    delete_job(server_job_id)
-                    print('deleted job {0} ({1} on server)'.format(job_id, server_job_id))
-                elif servers[server]['cluster_soft'].lower() == 'oge':
-                    job_id = s.group()[1:]
-                    delete_job(job_id)
-                    print('deleted job {0}'.format(job_id))
+                job_id = s.group()[1:]
+                if job_id in jobs or jobs is None:
+                    if servers[server]['cluster_soft'].lower() == 'slurm':
+                        server_job_id = status_line.split()[0]
+                        delete_job(server_job_id)
+                        print(f'deleted job {job_id} ({server_job_id} on server)')
+                    elif servers[server]['cluster_soft'].lower() == 'oge':
+                        delete_job(job_id)
+                        print(f'deleted job {job_id}')
         print('\ndone.')

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -811,4 +811,32 @@ solvation = {'method': 'pcm', 'solvent: 'DiethylEther'}
 See `https://gaussian.com/scrf/ <https://gaussian.com/scrf/>`_ for more details.
 
 
+Batch delete ARC jobs
+^^^^^^^^^^^^^^^^^^^^^
+
+DANGER ZONE: Make sure you understand what you're doing before running this script! Data of running jobs will be lost.
+
+ARC has a feature that deletes all ARC-spawned jobs from selected servers and projects.
+To delete all ARC jobs, type in a terminal in the ARC code folder after activating ``arc_env``::
+
+    python arc/utils/delete.py -a
+
+You can also request to delete jobs from a specific server by specifying its name after the ``-s`` flag::
+
+    python arc/utils/delete.py -s server1 -a
+
+To delete jobs from a specific ARC project, pass the project's name after the ``-p`` flag::
+
+    python arc/utils/delete.py -p project1
+
+Alternatively (since project names might be long and not always shown in full when requesting the server job status),
+one can supply an ARC job ID, and ALL jobs related to the project of the given job ID will be deleted
+(NOT only the given job!)::
+
+    python arc/utils/delete.py -j a_54836
+
+Note that either a ``-a``, a ``-p``, or a ``-j`` flag must be given.
+All flags can be combined with the optional ``-s`` flag.
+
+
 .. include:: links.txt

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -25,7 +25,7 @@ Note: ``specific_job_type`` takes higher precedence than ``job_types``. If you s
 dismiss the given ``job_types`` and will only populate the ``job_types`` dictionary using the given
 ``specific_job_type``.
 
-For bond dissociation energy calculation, the following two ``job_types`` specifications are equivalent::
+For bond dissociation energy calculation, the following two ``job_types`` specifications are equivalent:
 
 Specification 1::
 
@@ -211,7 +211,7 @@ maximal node ``memory``.
 Using a fine DFT grid for optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This option is turned on by default. If you'd like to turn it off,
-set ``fine`` in the ``job_types`` dictionary to `False`.
+set ``fine`` in the ``job_types`` dictionary to ``False``.
 
 If turned on, ARC will spawn another optimization job after the first one converges
 with a fine grid settings, using the already optimized geometry.
@@ -245,7 +245,7 @@ In TeraChem, this will add the following directive::
 Rotor scans
 ^^^^^^^^^^^
 This option is turned on by default. If you'd like to turn it off,
-set ``rotors`` in the ``job_types`` dictionary to `False`.
+set ``rotors`` in the ``job_types`` dictionary to ``False``.
 
 ARC will perform 1D (one dimensional) rotor scans for all possible unique internal rotors in the species,
 
@@ -369,7 +369,7 @@ ARC has fairly good auto-troubleshooting methods.
 
 However, at times a user might know in advance that a particular additional keyword
 is required for the calculation. In such cases, simply pass the relevant keyword
-in the ``initial_trsh`` (`trsh` stands for `troubleshooting`) dictionary passed to ARC::
+in the ``initial_trsh`` (``trsh`` stands for ``troubleshooting``) dictionary passed to ARC::
 
     initial_trsh:
       gaussian:
@@ -409,9 +409,9 @@ Adaptive levels of theory
 Often we'd like to adapt the levels of theory to the size of the molecule.
 To do so, pass the ``adaptive_levels`` attribute, which is a dictionary of
 levels of theory for ranges of the number of heavy (non-hydrogen) atoms in the
-molecule. Keys are tuples of (`min_num_atoms`, `max_num_atoms`), values are
+molecule. Keys are tuples of (``min_num_atoms``, ``max_num_atoms``), values are
 dictionaries with ``optfreq`` and ``sp`` as keys and levels of theory as values.
-Don't forget to bound the entire range between ``1`` and ``inf``, also make sure
+Don't forget to bound the entire range between 1 and ``inf``, also make sure
 there aren't any gaps in the heavy atom ranges. The below is in Python (not YAML) format::
 
     adaptive_levels = {(1, 5):      {'optfreq': 'wb97xd/6-311+g(2d,2p)',
@@ -433,7 +433,7 @@ If the molecule perceived from the 3D coordinate is not isomorphic
 with the input 2D graph, ARC will not spawn any additional jobs for the species, and will not use it further
 (for thermo and/or rates calculations). However, sometimes the perception algorithm doesn't work as expected (e.g.,
 issues with charged species and triplets are known). To continue spawning jobs for all species in an ARC
-project, pass `True` to the ``allow_nonisomorphic_2d`` argument (it is `False` by default).
+project, pass ``True`` to the ``allow_nonisomorphic_2d`` argument (it is ``False`` by default).
 
 
 .. _directory:
@@ -457,11 +457,11 @@ using `GaussView <https://gaussian.com/gaussview6/>`_.
 __ gaussian_
 
 ARC supports an additional way to generate high quality and good looking MOs.
-Simply set the ``orbitals`` entry of the ``job_types`` dictionary to `True` (it is `False` by default`).
+Simply set the ``orbitals`` entry of the ``job_types`` dictionary to ``True`` (it is ``False`` by default`).
 ARC will spawn a `QChem <https://www.q-chem.com/>`_ job with the
 ``PRINT_ORBITALS TRUE`` directive using `NBO <http://nbo.chem.wisc.edu/>`_,
 and will copy the resulting FCheck output file.
-Make sure you set the `orbitals` level of theory to the desired level in ``default_levels_of_theory``
+Make sure you set the ``orbitals`` level of theory to the desired level in ``default_levels_of_theory``
 in ``settings.py``.
 Open the resulting FCheck file using `IQMol <http://iqmol.org/>`_
 to post process and save images.
@@ -701,7 +701,7 @@ The above code generated the following input file::
 
 Calculating BDEs (bond dissociation energies)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To direct ARC to calculate BDEs for a species, set the ``bde`` job type to `True`,
+To direct ARC to calculate BDEs for a species, set the ``bde`` job type to ``True``,
 and set the requested atom indices (1-indexed) in the species ``.bdes`` argument
 as a list of tuples representing indices of bonded atoms (via a single bond)
 between which the BDE will be calculated (a list of lists is also allowed and will be converted),
@@ -709,9 +709,9 @@ E.g., a species can be defined as::
 
     spc1 = ARCSpecies(label='label1', smiles='CC(NO)C', xyz=xyz1, bdes=[(1, 2), (5, 8)])
 
-Note that the `bdes` species argument also accepts the string ``'all_h'`` as one of the entries
+Note that the ``bdes`` species argument also accepts the string ``'all_h'`` as one of the entries
 in the list, directing ARC to calculate BDEs for all hydrogen atoms in the species.
-Below is an example requesting all hydrogen BDEs in ethanol including the `C--O` BDE::
+Below is an example requesting all hydrogen BDEs in ethanol including the ``C--O`` BDE::
 
     project: ethanol_BDEs
 
@@ -767,11 +767,11 @@ but on the optimal geometry determined by ARC. To calculate the same BDEs in eth
       - - 1
         - 2
 
-Note: The BDEs are determined based on `E0`, therefore both ``sp`` and ``freq`` jobs
+Note: The BDEs are determined based on ``E0``, therefore both ``sp`` and ``freq`` jobs
 must be spawned (and successfully terminated for all species and fragments).
 
-The calculated BDEs are reported in the log file as well as in a designated `BDE_report.yml`
-file under the `output` directory in the project's folder. Units are kJ/mol.
+The calculated BDEs are reported in the log file as well as in a designated ``BDE_report.yml``
+file under the ``output`` directory in the project's folder. Units are kJ/mol.
 
 
 Disable comparisons with the RMG database
@@ -796,7 +796,7 @@ With this option specified, ARC will not load the RMG database, and parity plots
 Use solvent corrections
 ^^^^^^^^^^^^^^^^^^^^^^^
 This feature is currently only implemented for jobs spawned using Gaussian.
-The `solvation` argument, if not ``None``, requests that a calculation be performed in the presence of a solvent
+The ``solvation`` argument, if not ``None``, requests that a calculation be performed in the presence of a solvent
 by placing the solute (the species) in a cavity within the solvent reaction field. This argument is a dictionary,
 with the following keys:
 


### PR DESCRIPTION
fixes #354

ARC can now delete all ARC-spawned jobs from selected servers and projects.
To delete all ARC jobs, type in a terminal in the ARC code folder after activating `arc_env`:

    python arc/utils/delete.py -a

You can also request to delete jobs from a specific server by specifying its name after the `-s` flag:

    python arc/utils/delete.py -s server1 -a

To delete jobs from a specific ARC project, pass the project's name after the `-p` flag:

    python arc/utils/delete.py -p project1

Alternatively (since project names might be long and not always shown in full when requesting the server job status),
one can supply an ARC job ID, and ALL jobs related to the project of the given job ID will be deleted
(NOT only the given job!):

    python arc/utils/delete.py -j a_54836

Note that either a `-a`, a `-p`, or a `-j` flag must be given.
All flags can be combined with the optional `-s` flag.