### PR TITLE
Improved troubleshoot methods for issues related to Orca job memory and cpu allocations

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -985,16 +985,33 @@ def is_notebook() -> bool:
 
 def is_str_float(value: str) -> bool:
     """
-    Check whether a string represents a number.
+    Check whether a string can be converted to a floating number.
 
     Args:
         value (str): The string to check.
 
     Returns:
-        bool: ``True`` if it does, ``False`` otherwise.
+        bool: ``True`` if it can, ``False`` otherwise.
     """
     try:
         float(value)
+        return True
+    except ValueError:
+        return False
+
+
+def is_str_int(value: str) -> bool:
+    """
+    Check whether a string can be converted to an integer.
+
+    Args:
+        value (str): The string to check.
+
+    Returns:
+        bool: ``True`` if it can, ``False`` otherwise.
+    """
+    try:
+        int(value)
         return True
     except ValueError:
         return False

--- a/arc/common.py
+++ b/arc/common.py
@@ -22,7 +22,7 @@ import yaml
 import numpy as np
 import qcelemental as qcel
 
-from typing import List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from arkane.ess import GaussianLog, MolproLog, OrcaLog, QChemLog, TeraChemLog
 from arkane.util import determine_qm_software
@@ -39,7 +39,9 @@ logger = logging.getLogger('arc')
 VERSION = '1.1.0'
 
 
-def initialize_job_types(job_types, specific_job_type=''):
+def initialize_job_types(job_types: dict,
+                         specific_job_type: str = '',
+                         ) -> dict:
     """
     A helper function for initializing job_types.
     Returns the comprehensive (default values for missing job types) job types for ARC.
@@ -99,7 +101,7 @@ def initialize_job_types(job_types, specific_job_type=''):
     return job_types
 
 
-def determine_ess(log_file):
+def determine_ess(log_file: str) -> str:
     """
     Determine the ESS to which the log file belongs.
 
@@ -124,7 +126,7 @@ def determine_ess(log_file):
                      f'Gaussian, Molpro, Orca, QChem, or TeraChem.')
 
 
-def check_ess_settings(ess_settings=None):
+def check_ess_settings(ess_settings: Optional[dict] = None) -> dict:
     """
     A helper function to convert servers in the ess_settings dict to lists
     Assists in troubleshooting job and trying a different server
@@ -163,7 +165,11 @@ def check_ess_settings(ess_settings=None):
     return settings
 
 
-def initialize_log(log_file, project, project_directory=None, verbose=logging.INFO):
+def initialize_log(log_file: str,
+                   project: str,
+                   project_directory: Optional[str] = None,
+                   verbose: int = logging.INFO,
+                   ) -> None:
     """
     Set up a logger for ARC.
 
@@ -226,7 +232,9 @@ def get_logger():
     return logger
 
 
-def log_header(project, level=logging.INFO):
+def log_header(project: str,
+               level: int = logging.INFO,
+               ) -> None:
     """
     Output a header containing identifying information about ARC to the log.
 
@@ -259,7 +267,9 @@ def log_header(project, level=logging.INFO):
     logger.info(f'Starting project {project}')
 
 
-def log_footer(execution_time, level=logging.INFO):
+def log_footer(execution_time: str,
+               level: int = logging.INFO,
+               ) -> None:
     """
     Output a footer for the log.
 
@@ -312,7 +322,7 @@ def get_git_branch():
 
 
 def read_yaml_file(path: str,
-                   project_directory: str = None,
+                   project_directory: Optional[str] = None,
                    ) -> dict or list:
     """
     Read a YAML file (usually an input / restart file, but also conformers file)
@@ -537,7 +547,7 @@ def get_single_bond_length(symbol1: str,
     return 2.5
 
 
-def determine_symmetry(xyz):
+def determine_symmetry(xyz: dict) -> Tuple[int, int]:
     """
     Determine external symmetry and chirality (optical isomers) of the species.
 
@@ -547,7 +557,9 @@ def determine_symmetry(xyz):
     Returns:
         int: The external symmetry number.
     Returns:
-        int: 1 if no chiral centers are present, 2 if chiral centers are present.
+        Tuple[int, int]:
+            - The external symmetry number.
+            - ``1`` if no chiral centers are present, ``2`` if chiral centers are present.
     """
     atom_numbers = list()  # List of atomic numbers
     for symbol in xyz['symbols']:
@@ -635,7 +647,9 @@ def extermum_list(lst: list,
         return max([entry for entry in lst if entry is not None])
 
 
-def sort_two_lists_by_the_first(list1, list2):
+def sort_two_lists_by_the_first(list1: List[Union[float, int, None]],
+                                list2: List[Union[float, int, None]],
+                                ) -> Tuple[List[Union[float, int]], List[Union[float, int]]]:
     """
     Sort two lists in increasing order by the values of the first list.
     Ignoring None entries from list1 and their respective entries in list2.
@@ -681,7 +695,9 @@ def sort_two_lists_by_the_first(list1, list2):
     return sorted_list1, sorted_list2
 
 
-def key_by_val(dictionary, value):
+def key_by_val(dictionary: dict,
+               value: Any,
+               ) -> Any:
     """
     A helper function for getting a key from a dictionary corresponding to a certain value.
     Does not check for value unicity.
@@ -839,7 +855,7 @@ def determine_model_chemistry_type(method: str or dict) -> str:
     return model_chemistry_class
 
 
-def format_level_of_theory_inputs(level_of_theory: str or dict):
+def format_level_of_theory_inputs(level_of_theory: Union[str, dict]) -> Tuple[dict, str]:
     """
     A helper function to format level of theory inputs for internal use in ARC.
 

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -756,6 +756,26 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
         globalized_string = common.globalize_path(string=string, project_directory='')
         self.assertEqual(globalized_string, string)
 
+    def test_estimate_orca_mem_cpu_requirement(self):
+        """Test estimating memory and cpu requirements for an Orca job."""
+        num_heavy_atoms_0 = 0
+        est_cpu_0, est_memory_0 = common.estimate_orca_mem_cpu_requirement(num_heavy_atoms_0)
+        expected_cpu_0, expected_memory_0 = 2, 4000.0
+        self.assertEqual(est_cpu_0, expected_cpu_0)
+        self.assertEqual(est_memory_0, expected_memory_0)
+
+        num_heavy_atoms_1 = 12
+        est_cpu_1, est_memory_1 = common.estimate_orca_mem_cpu_requirement(num_heavy_atoms_1)
+        expected_cpu_1, expected_memory_1 = 50, 100000.0
+        self.assertEqual(est_cpu_1, expected_cpu_1)
+        self.assertEqual(est_memory_1, expected_memory_1)
+
+        num_heavy_atoms_2 = 12
+        est_cpu_2, est_memory_2 = common.estimate_orca_mem_cpu_requirement(num_heavy_atoms_2, 'server2', True)
+        expected_cpu_2, expected_memory_2 = 48, 96000.0
+        self.assertEqual(est_cpu_2, expected_cpu_2)
+        self.assertEqual(est_memory_2, expected_memory_2)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -713,6 +713,25 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
         self.assertFalse(common.is_str_float('R1'))
         self.assertFalse(common.is_str_float('D_3_5_7_4'))
 
+    def test_is_str_int(self):
+        """Test the is_str_int() function"""
+        self.assertTrue(common.is_str_int('0'))
+        self.assertTrue(common.is_str_int('123'))
+        self.assertTrue(common.is_str_int('+123'))
+        self.assertTrue(common.is_str_int('-123'))
+        self.assertFalse(common.is_str_int('6e02'))
+        self.assertFalse(common.is_str_int('+1e1'))
+        self.assertFalse(common.is_str_int('+1e1e'))
+        self.assertFalse(common.is_str_int('text 34'))
+        self.assertFalse(common.is_str_int(' '))
+        self.assertFalse(common.is_str_int('R1'))
+        self.assertFalse(common.is_str_int('D_3_5_7_4'))
+        self.assertFalse(common.is_str_int('.2'))
+        self.assertFalse(common.is_str_int('.0'))
+        self.assertFalse(common.is_str_int('125.84'))
+        self.assertFalse(common.is_str_int('0.0'))
+
+
     def test_get_atom_radius(self):
         """Test determining the covalent radius of an atom"""
         self.assertEqual(common.get_atom_radius('C'), 0.76)

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -1766,9 +1766,13 @@ end
         """
         Set the amount of cpus and memory based on ESS and cluster software.
         """
+        max_cpu = servers[self.server].get('cpus', None)  # max cpus per node on server
+        # set to 8 if user did not specify cpu in settings and in ARC input file
+        job_cpu_cores = default_job_settings.get('job_cpu_cores', 8)
+        if max_cpu is not None and job_cpu_cores > max_cpu:
+            job_cpu_cores = max_cpu
         if self.cpu_cores is None:
-            # set to 8 if user did not specify cpu in settings and in ARC input file
-            self.cpu_cores = servers[self.server].get('cpus', 8)
+            self.cpu_cores = job_cpu_cores
 
         max_mem = servers[self.server].get('memory', None)  # max memory per node in GB
         job_max_server_node_memory_allocation = default_job_settings.get('job_max_server_node_memory_allocation', 0.8)

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -21,8 +21,8 @@ from arc.job.submit import submit_scripts
 from arc.job.ssh import SSHClient
 from arc.job.trsh import determine_ess_status, trsh_job_on_server
 from arc.plotter import save_geo
-from arc.settings import arc_path, servers, submit_filename, t_max_format, input_filename, output_filename, \
-    rotor_scan_resolution, levels_ess, orca_default_options_dict
+from arc.settings import arc_path, default_job_settings, servers, submit_filename, t_max_format, input_filename, \
+    output_filename, rotor_scan_resolution, levels_ess, orca_default_options_dict
 from arc.species.converter import xyz_to_str, str_to_xyz, check_xyz_dict
 from arc.species.vectors import calculate_dihedral_angle
 
@@ -200,9 +200,9 @@ class Job(object):
     """
     def __init__(self, project='', ess_settings=None, species_name='', xyz=None, job_type='', multiplicity=None,
                  project_directory='', charge=0, conformer=-1, fine=False, shift='', software=None, is_ts=False,
-                 scan=None, pivots=None, total_job_memory_gb=14, comments='', trsh='', scan_trsh='', job_dict=None,
+                 scan=None, pivots=None, total_job_memory_gb=None, comments='', trsh='', scan_trsh='', job_dict=None,
                  ess_trsh_methods=None, bath_gas=None, solvation=None, job_num=None, job_server_name=None, job_name=None,
-                 job_id=None, server=None, initial_time=None, occ=None, max_job_time=120, scan_res=None, checkfile=None,
+                 job_id=None, server=None, initial_time=None, occ=None, max_job_time=None, scan_res=None, checkfile=None,
                  number_of_radicals=None, conformers=None, radius=None, directed_scan_type=None, directed_scans=None,
                  directed_dihedrals=None, rotor_index=None, testing=False, cpu_cores=None, job_additional_options=None,
                  job_shortcut_keywords=None, job_level_of_theory_dict=None, irc_direction=None):
@@ -249,7 +249,8 @@ class Job(object):
             self.scan_res = scan_res if scan_res is not None else rotor_scan_resolution
             self.scan = scan
             self.pivots = pivots if pivots is not None else list()
-            self.max_job_time = max_job_time
+            self.max_job_time = max_job_time if max_job_time is not None \
+                else default_job_settings.get('job_time_limit_hrs', 120)
             self.bath_gas = bath_gas
             self.solvation = solvation
             self.testing = testing
@@ -268,7 +269,8 @@ class Job(object):
             self.server = server
             self.software = software
             self.cpu_cores = cpu_cores
-            self.total_job_memory_gb = total_job_memory_gb
+            self.total_job_memory_gb = total_job_memory_gb if total_job_memory_gb is not None \
+                else default_job_settings.get('job_total_memory_gb', 14)
             self.irc_direction = irc_direction
         # allowed job types:
         job_types = ['conformer', 'opt', 'freq', 'optfreq', 'sp', 'composite', 'bde', 'scan', 'directed_scan',
@@ -431,7 +433,8 @@ class Job(object):
         self.is_ts = job_dict['is_ts'] if 'is_ts' in job_dict else False
         self.scan = job_dict['scan'] if 'scan' in job_dict else None
         self.pivots = job_dict['pivots'] if 'pivots' in job_dict else list()
-        self.total_job_memory_gb = job_dict['total_job_memory_gb'] if 'total_job_memory_gb' in job_dict else 14
+        self.total_job_memory_gb = job_dict['total_job_memory_gb'] if 'total_job_memory_gb' in job_dict \
+            else default_job_settings.get('job_total_memory_gb', 14)
         self.cpu_cores = job_dict['cpu_cores'] if 'cpu_cores' in job_dict else None
         self.comments = job_dict['comments'] if 'comments' in job_dict else ''
         self.trsh = job_dict['trsh'] if 'trsh' in job_dict else ''
@@ -449,7 +452,8 @@ class Job(object):
         self.job_id = job_dict['job_id'] if 'job_id' in job_dict else 0
         self.server = job_dict['server'] if 'server' in job_dict else None
         self.occ = job_dict['occ'] if 'occ' in job_dict else None
-        self.max_job_time = job_dict['max_job_time'] if 'max_job_time' in job_dict else 120
+        self.max_job_time = job_dict['max_job_time'] if 'max_job_time' in job_dict \
+            else default_job_settings.get('job_time_limit_hrs', 120)
         self.scan_res = job_dict['scan_res'] if 'scan_res' in job_dict else rotor_scan_resolution
         self.checkfile = job_dict['checkfile'] if 'checkfile' in job_dict else None
         self.number_of_radicals = job_dict['number_of_radicals'] if 'number_of_radicals' in job_dict else None
@@ -1767,11 +1771,12 @@ end
             self.cpu_cores = servers[self.server].get('cpus', 8)
 
         max_mem = servers[self.server].get('memory', None)  # max memory per node in GB
-        if max_mem is not None and self.total_job_memory_gb > max_mem * 0.8:
+        job_max_server_node_memory_allocation = default_job_settings.get('job_max_server_node_memory_allocation', 0.8)
+        if max_mem is not None and self.total_job_memory_gb > max_mem * job_max_server_node_memory_allocation:
             logger.warning(f'The memory for job {self.job_name} using {self.software} ({self.total_job_memory_gb} GB) '
-                           f'exceeds 80% of the the maximum node memory on {self.server}. '
-                           f'Setting it to 80% * {max_mem} GB.')
-            self.total_job_memory_gb = 0.8 * max_mem
+                           f'exceeds {100 * job_max_server_node_memory_allocation}% of the the maximum node memory on '
+                           f'{self.server}. Setting it to {job_max_server_node_memory_allocation * max_mem} GB.')
+            self.total_job_memory_gb = job_max_server_node_memory_allocation * max_mem
             total_submit_script_memory = self.total_job_memory_gb * 1024 * 1.05  # MB
             self.job_status[1]['keywords'].append('max_total_job_memory')  # useful info when trouble shoot
         else:

--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -248,8 +248,8 @@ class TestJob(unittest.TestCase):
         self.job1.server = 'server2'
         self.job1.software = 'terachem'
         self.job1.set_cpu_and_mem()
-        self.assertEqual(self.job1.cpu_cores, 48)
-        expected_memory = math.ceil(14 * 128 / 48)
+        self.assertEqual(self.job1.cpu_cores, 8)
+        expected_memory = math.ceil(14 * 128 / 8)
         self.assertEqual(self.job1.input_file_memory, expected_memory)
 
         self.job1.cpu_cores = 8
@@ -262,7 +262,7 @@ class TestJob(unittest.TestCase):
         expected_memory = math.ceil(14 * 1024)
         self.assertEqual(self.job1.input_file_memory, expected_memory)
 
-        self.job1.cpu_cores = None
+        self.job1.cpu_cores = 48
         self.job1.input_file_memory = None
         self.job1.submit_script_memory = None
         self.job1.server = 'server2'
@@ -272,7 +272,7 @@ class TestJob(unittest.TestCase):
         expected_memory = math.ceil(14 * 1024 / 48)
         self.assertEqual(self.job1.input_file_memory, expected_memory)
 
-        self.job1.cpu_cores = None
+        self.job1.cpu_cores = 48
         self.job1.input_file_memory = None
         self.job1.submit_script_memory = None
         self.job1.server = 'server2'

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -10,7 +10,7 @@ import os
 
 import numpy as np
 
-from arc.common import get_logger, determine_ess
+from arc.common import get_logger, determine_ess, estimate_orca_mem_cpu_requirement
 from arc.exceptions import SpeciesError, TrshError
 from arc.job.local import execute_command
 from arc.job.ssh import SSHClient
@@ -223,9 +223,17 @@ def determine_ess_status(output_path: str,
                     keywords = ['SCF']
                     for j, info in enumerate(reverse_lines):
                         if 'Please increase MaxCore' in info:
-                            estimated_mem = info.split()[-2]  # e.g., Please increase MaxCore to more than: 289 MB
+                            try:
+                                # e.g., Please increase MaxCore to more than: 289 MB
+                                estimated_mem = float(info.split()[-2]) + 500
+                            except ValueError:
+                                error = f'Insufficient Orca job memory. ARC will estimate the amount of memory ' \
+                                        f'required.'
+                                keywords.append('Memory')
+                                break
                             keywords.append('Memory')
-                            line = reverse_lines[j + 3].rstrip()  # e.g., Error (ORCA_SCF): Not enough memory available!
+                            # e.g., Error (ORCA_SCF): Not enough memory available!
+                            line = reverse_lines[j + 3].rstrip()
                             error = f'Orca suggests to increase per cpu core memory to {estimated_mem} MB.'
                             break
                     else:
@@ -235,30 +243,47 @@ def determine_ess_status(output_path: str,
                     keywords = ['MDCI']
                     for j, info in enumerate(reverse_lines):
                         if 'Please increase MaxCore' in info:
-                            # e.g., Please increase MaxCore - by at least ( 9717.9 MB)
-                            # This message appears multiple times, and suggest different memory at each appearance
-                            # Need to store all suggested memory values, and then pick the largest one
                             estimated_mem_list = []
                             for message in reverse_lines:
                                 if 'Please increase MaxCore' in message:
-                                    estimated_mem = math.ceil(float(message.split()[-2]))
+                                    try:
+                                        # e.g., Please increase MaxCore - by at least ( 9717.9 MB)
+                                        # This message appears multiple times, and suggest different memory at each
+                                        # appearance. Need to store all suggested memory values, and then pick the
+                                        # largest one. This error msg appears in Orca version 4.2.x
+                                        estimated_mem = math.ceil(float(message.split()[-2]))
+                                    except ValueError:
+                                        # e.g., Please increase MaxCore
+                                        # In old Orca versions, there is no indication on the minimum memory requirement
+                                        error = f'Insufficient Orca job memory. ARC will estimate the amount of ' \
+                                                f'memory required.'
+                                        break
                                     estimated_mem_list.append(estimated_mem)
+                            if estimated_mem_list:
+                                estimated_max_mem = np.max(estimated_mem_list) + 500
+                                error = f'Orca suggests to increase per cpu core memory to {estimated_max_mem} MB.'
                             keywords.append('Memory')
-                            estimated_max_mem = np.max(estimated_mem_list)
-                            error = f'Orca suggests to increase per cpu core memory to {estimated_max_mem} MB.'
                             line = info
                             break
                         elif 'parallel calculation exceeds number of pairs' in info:
-                            # e.g., Error (ORCA_MDCI): Number of processes (16) in parallel calculation exceeds
-                            # number of pairs (10)
-                            max_core = int(info.split()[-1].strip('()'))
+                            try:
+                                # e.g., Error (ORCA_MDCI): Number of processes (16) in parallel calculation exceeds
+                                # number of pairs (10) - error msg in Orca version 4.2.x
+                                max_core = int(info.split()[-1].strip('()'))
+                                error = f'Orca cannot utilize cpu cores more than electron pairs in a molecule. The ' \
+                                        f'maximum number of cpu cores can be used for this job is {max_core}.'
+                            except ValueError:
+                                # e.g., Error (ORCA_MDCI): Number of processes in parallel calculation exceeds
+                                # number of pairs - error msg in Orca version 4.1.x
+                                error = f'Orca cannot utilize cpu cores more than electron pairs in a molecule. ARC ' \
+                                        f'will estimate the number of cpu cores needed based on the number of heavy ' \
+                                        f'atoms in the molecule.'
                             keywords.append('cpu')
-                            error = f'Orca cannot utilize cpu cores more than electron pairs in a molecule. The ' \
-                                    f'maximum number of cpu cores can be used for this job is {max_core}.'
                             line = info
                             break
                     else:
-                        error = f'MDCI error in Orca.'
+                        error = f'MDCI error in Orca. Assuming memory allocation error.'
+                        keywords.append('Memory')
                     break
                 elif 'Error : multiplicity' in line:
                     keywords = ['Input']
@@ -723,8 +748,15 @@ def trsh_ess_job(label: str,
             # `Error  (ORCA_SCF): Not enough memory available! Please increase MaxCore to more than: 289 MB`.
             if 'memory' not in ess_trsh_methods:
                 ess_trsh_methods.append('memory')
-            estimated_mem_per_core = float(job_status['error'].split()[-2])  # parse Orca's memory requirement in MB
-            estimated_mem_per_core = int(np.ceil(estimated_mem_per_core / 100.0)) * 100  # round up to the next hundred
+            try:
+                # parse Orca's memory requirement in MB
+                estimated_mem_per_core = float(job_status['error'].split()[-2])
+            except ValueError:
+                estimated_mem_per_core = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms,
+                                                                           server=server,
+                                                                           consider_server_limits=True)[1]/cpu_cores
+            # round up to the next hundred
+            estimated_mem_per_core = int(np.ceil(estimated_mem_per_core / 100.0)) * 100
             if 'max_total_job_memory' in job_status['keywords']:
                 per_cpu_core_memory = np.ceil(memory_gb / cpu_cores * 1024)
                 logger.info(f'The crashed Orca job {label} was ran with {cpu_cores} cpu cores and '
@@ -751,11 +783,14 @@ def trsh_ess_job(label: str,
                             f'and {cpu_cores} cpu cores.')
         elif 'cpu' in job_status['keywords']:
             # Reduce cpu allocation.
-            # job_status will be for example
-            # Error (ORCA_MDCI): Number of processes (16) in parallel calculation exceeds number of pairs (10)
-            cpu_cores = int(job_status['error'].split()[-1].strip('.'))  # max_cpu_cores_allowed
-            logger.info(f'Troubleshooting {job_type} job in {software} for {label} using {cpu_cores} cpu cores '
-                        f'(reduced).')
+            try:
+                # job_status will be for example (Orca varsion 4.2.x)
+                # Error (ORCA_MDCI): Number of processes (16) in parallel calculation exceeds number of pairs (10)
+                cpu_cores = int(job_status['error'].split()[-1].strip('.'))  # max_cpu_cores_allowed
+            except ValueError:
+                cpu_cores = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms, server=server,
+                                                              consider_server_limits=True)[0]
+            logger.info(f'Troubleshooting {job_type} job in {software} for {label} using {cpu_cores} cpu cores.')
             if 'cpu' not in ess_trsh_methods:
                 ess_trsh_methods.append('cpu')
         elif 'dlpno' in level_of_theory_dict['method'] and is_h:

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -311,6 +311,11 @@ def determine_ess_status(output_path: str,
                     error = f'Specified wavefunction method is not converged. Please restart calculation with larger ' \
                             f'max iterations or with different convergence flags.'
                     break
+                elif 'ORCA finished by error termination in GTOInt' in line:
+                    error = f'GTOInt error in Orca. Assuming memory allocation error.'
+                    keywords.append('GTOInt')
+                    keywords.append('Memory')
+                    break
             if done:
                 return 'done', keywords, '', ''
             error = error if error else 'Orca job terminated for an unknown reason.'

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -153,6 +153,16 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, expected_error_msg)
         self.assertIn('parallel calculation exceeds', line)
 
+        # test detection of generic GTOInt failure
+        path = os.path.join(self.base_path['orca'], 'orca_GTOInt_error.log')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='test', job_type='sp', software='orca')
+        self.assertEqual(status, 'errored')
+        self.assertEqual(keywords, ['GTOInt', 'Memory'])
+        expected_error_msg = 'GTOInt error in Orca. Assuming memory allocation error.'
+        self.assertEqual(error, expected_error_msg)
+        self.assertIn('ORCA finished by error termination in GTOInt', line)
+
         # test detection of generic MDCI failure
         path = os.path.join(self.base_path['orca'], 'orca_mdci_error.log')
         status, keywords, error, line = trsh.determine_ess_status(

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -128,7 +128,7 @@ class TestTrsh(unittest.TestCase):
             output_path=path, species_label='test', job_type='sp', software='orca')
         self.assertEqual(status, 'errored')
         self.assertEqual(keywords, ['SCF', 'Memory'])
-        expected_error_msg = 'Orca suggests to increase per cpu core memory to 289 MB.'
+        expected_error_msg = 'Orca suggests to increase per cpu core memory to 789.0 MB.'
         self.assertEqual(error, expected_error_msg)
         self.assertEqual(' Error  (ORCA_SCF): Not enough memory available!', line)
 
@@ -138,7 +138,7 @@ class TestTrsh(unittest.TestCase):
             output_path=path, species_label='test', job_type='sp', software='orca')
         self.assertEqual(status, 'errored')
         self.assertEqual(keywords, ['MDCI', 'Memory'])
-        expected_error_msg = 'Orca suggests to increase per cpu core memory to 9718 MB.'
+        expected_error_msg = 'Orca suggests to increase per cpu core memory to 10218 MB.'
         self.assertEqual(error, expected_error_msg)
         self.assertIn('Please increase MaxCore', line)
 
@@ -158,10 +158,32 @@ class TestTrsh(unittest.TestCase):
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label='test', job_type='sp', software='orca')
         self.assertEqual(status, 'errored')
-        self.assertEqual(keywords, ['MDCI'])
-        expected_error_msg = 'MDCI error in Orca.'
+        self.assertEqual(keywords, ['MDCI', 'Memory'])
+        expected_error_msg = 'MDCI error in Orca. Assuming memory allocation error.'
         self.assertEqual(error, expected_error_msg)
         self.assertIn('ORCA finished by error termination in MDCI', line)
+
+        # test detection of generic MDCI failure in Orca version 4.2.x log files
+        path = os.path.join(self.base_path['orca'], 'orca_mdci_error_2.log')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='test', job_type='sp', software='orca')
+        self.assertEqual(status, 'errored')
+        self.assertEqual(keywords, ['MDCI', 'Memory'])
+        expected_error_msg = 'MDCI error in Orca. Assuming memory allocation error.'
+        self.assertEqual(error, expected_error_msg)
+        self.assertIn('ORCA finished by error termination in MDCI', line)
+
+        # test detection of MDCI failure in Orca version 4.1.x log files (no memory/cpu suggestions compared to 4.2.x)
+        path = os.path.join(self.base_path['orca'], 'orca_mdci_error_3.log')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='test', job_type='sp', software='orca')
+        self.assertEqual(status, 'errored')
+        self.assertEqual(keywords, ['MDCI', 'cpu'])
+        expected_error_msg = 'Orca cannot utilize cpu cores more than electron pairs in a molecule. ARC will ' \
+                             'estimate the number of cpu cores needed based on the number of heavy atoms in the ' \
+                             'molecule.'
+        self.assertEqual(error, expected_error_msg)
+        self.assertIn('Number of processes in parallel calculation exceeds number of pairs', line)
 
         # test detection of multiplicty and charge combination error
         path = os.path.join(self.base_path['orca'], 'orca_multiplicity_error.log')
@@ -327,7 +349,7 @@ class TestTrsh(unittest.TestCase):
                                                                    cpu_cores, ess_trsh_methods)
         self.assertIn('memory', ess_trsh_methods)
         self.assertEqual(cpu_cores, 32)
-        self.assertAlmostEqual(memory, 312)
+        self.assertAlmostEqual(memory, 327)
 
         # orca: test 2
         # Test troubleshooting insufficient memory issue
@@ -353,8 +375,8 @@ class TestTrsh(unittest.TestCase):
                                                                    software, fine, memory_gb, num_heavy_atoms,
                                                                    cpu_cores, ess_trsh_methods)
         self.assertIn('memory', ess_trsh_methods)
-        self.assertEqual(cpu_cores, 24)
-        self.assertAlmostEqual(memory, 235)
+        self.assertEqual(cpu_cores, 22)
+        self.assertAlmostEqual(memory, 227)
 
         # orca: test 3
         # Test troubleshooting insufficient memory issue

--- a/arc/settings.py
+++ b/arc/settings.py
@@ -172,3 +172,10 @@ minimum_barrier = 1.0   # a rotor threshold (kJ/mol) below which it is considere
 inconsistency_az = 5    # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
 inconsistency_ab = 0.3  # maximum allowed inconsistency between consecutive points in the scan given as a fraction
 #  of the maximum scan energy. Default: 30%
+
+# Default job memory, cpu, time settings
+default_job_settings = {'job_total_memory_gb': 14,
+                        'job_cpu_cores': 8,
+                        'job_time_limit_hrs': 120,
+                        'job_max_server_node_memory_allocation': 0.8,  # e.g., at most 80% node memory will be used
+                        }

--- a/arc/testing/trsh/orca/orca_GTOInt_error.log
+++ b/arc/testing/trsh/orca/orca_GTOInt_error.log
@@ -1,0 +1,352 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.1.2  - RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Alexander A. Auer      : GIAO ZORA
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, Open-shell LED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-TZVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+----- AuxC basis set information -----
+Your calculation utilizes the auxiliary basis: def2-TZVP/C
+  H-La, Hf-Rn : A. Hellweg, C. Hattig, S. Hofener and W. Klopper, Theor. Chem. Acc. 117, 587 (2007).
+        Ce-Lu : J. Chmela and M. E. Harding, Mol. Phys. (2018).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: MDCI localization with Augmented Hessian Foster-Boys
+  ===> : Switching off randomization!
+
+WARNING: Post HF methods need fully converged wavefunctions
+  ===> : Setting SCFConvForced true
+         You can overwrite this default with %scf ConvForced false 
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> !rHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c  
+|  2> ! NRSCF # using Newton–Raphson SCF algorithm 
+|  3> !sp 
+|  4> 
+|  5> %maxcore 359
+|  6> %pal # job parallelization settings
+|  7> nprocs 40
+|  8> end
+|  9> %scf # recommended SCF settings 
+| 10> NRMaxIt 400
+| 11> NRStart 0.00005
+| 12> MaxIter 500
+| 13> end
+| 14> 
+| 15> 
+| 16> * xyz 0 1
+| 17> C      -2.30304800    0.61044700   -0.65744600
+| 18> O      -2.19505400    2.01965900   -0.65490300
+| 19> O      -2.65557700    2.52428700    0.59247400
+| 20> N      -1.30349000   -0.03696700    0.15453700
+| 21> C      -1.69069600   -1.42278100    0.38734700
+| 22> C       0.00879700    0.05487400   -0.48854200
+| 23> C       1.17327100   -0.31033100    0.41583900
+| 24> C       2.50315000   -0.13374500   -0.29445100
+| 25> N       3.61909000   -0.48380500    0.58485600
+| 26> H      -3.29696300    0.32027300   -0.31336200
+| 27> H      -2.20539800    0.36892500   -1.72676700
+| 28> H      -1.85518700    2.52570700    1.13340400
+| 29> H      -1.72975700   -2.00679900   -0.54488700
+| 30> H      -0.98221400   -1.90571400    1.05798800
+| 31> H      -2.67362600   -1.46003600    0.85769700
+| 32> H       0.02962100   -0.58110400   -1.38941900
+| 33> H       0.13908800    1.08530100   -0.82397300
+| 34> H       1.09173500   -1.34550200    0.75513700
+| 35> H       1.15365100    0.32597100    1.30637800
+| 36> H       2.53868400   -0.79065300   -1.16663100
+| 37> H       2.57198800    0.89487100   -0.67119400
+| 38> H       3.63402400    0.16698300    1.36238900
+| 39> H       4.48971300   -0.34007100    0.08760600
+| 40> *
+| 41> 
+| 42>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -2.303048    0.610447   -0.657446
+  O     -2.195054    2.019659   -0.654903
+  O     -2.655577    2.524287    0.592474
+  N     -1.303490   -0.036967    0.154537
+  C     -1.690696   -1.422781    0.387347
+  C      0.008797    0.054874   -0.488542
+  C      1.173271   -0.310331    0.415839
+  C      2.503150   -0.133745   -0.294451
+  N      3.619090   -0.483805    0.584856
+  H     -3.296963    0.320273   -0.313362
+  H     -2.205398    0.368925   -1.726767
+  H     -1.855187    2.525707    1.133404
+  H     -1.729757   -2.006799   -0.544887
+  H     -0.982214   -1.905714    1.057988
+  H     -2.673626   -1.460036    0.857697
+  H      0.029621   -0.581104   -1.389419
+  H      0.139088    1.085301   -0.823973
+  H      1.091735   -1.345502    0.755137
+  H      1.153651    0.325971    1.306378
+  H      2.538684   -0.790653   -1.166631
+  H      2.571988    0.894871   -0.671194
+  H      3.634024    0.166983    1.362389
+  H      4.489713   -0.340071    0.087606
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     6.0000    0    12.011   -4.352130    1.153578   -1.242393
+   1 O     8.0000    0    15.999   -4.148051    3.816602   -1.237587
+   2 O     8.0000    0    15.999   -5.018313    4.770211    1.119614
+   3 N     7.0000    0    14.007   -2.463239   -0.069858    0.292033
+   4 C     6.0000    0    12.011   -3.194952   -2.688666    0.731980
+   5 C     6.0000    0    12.011    0.016624    0.103697   -0.923211
+   6 C     6.0000    0    12.011    2.217161   -0.586441    0.785822
+   7 C     6.0000    0    12.011    4.730268   -0.252741   -0.556432
+   8 N     7.0000    0    14.007    6.839089   -0.914259    1.105218
+   9 H     1.0000    0     1.008   -6.230357    0.605228   -0.592168
+  10 H     1.0000    0     1.008   -4.167598    0.697167   -3.263117
+  11 H     1.0000    0     1.008   -3.505795    4.772895    2.141823
+  12 H     1.0000    0     1.008   -3.268767   -3.792301   -1.029687
+  13 H     1.0000    0     1.008   -1.856115   -3.601278    1.999308
+  14 H     1.0000    0     1.008   -5.052421   -2.759068    1.620812
+  15 H     1.0000    0     1.008    0.055976   -1.098127   -2.625621
+  16 H     1.0000    0     1.008    0.262838    2.050922   -1.557083
+  17 H     1.0000    0     1.008    2.063080   -2.542630    1.427002
+  18 H     1.0000    0     1.008    2.180084    0.615996    2.468697
+  19 H     1.0000    0     1.008    4.797418   -1.494118   -2.204613
+  20 H     1.0000    0     1.008    4.860353    1.691061   -1.268373
+  21 H     1.0000    0     1.008    6.867310    0.315552    2.574542
+  22 H     1.0000    0     1.008    8.484328   -0.642641    0.165551
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     1.413346253340     0.00000000     0.00000000
+ O      2   1   0     1.422209630133   109.30626964     0.00000000
+ N      1   2   3     1.441380406086   113.19406250   286.08681196
+ C      4   1   2     1.457604001481   109.43876012   164.91327455
+ C      4   1   2     1.464268602372   110.23770271   287.99712185
+ C      6   4   1     1.518973134016   114.23531745   166.81892639
+ C      7   6   4     1.517983087566   111.41128149   182.54572381
+ N      8   7   6     1.463230975427   111.04681359   179.83251740
+ H      1   2   3     1.091082845872   109.52453301    48.64632746
+ H      1   2   3     1.100597928412   102.34354882   164.41746804
+ H      3   2   1     0.966039043414   102.90584564    89.49784936
+ H      5   4   1     1.100755657174   112.24624981    63.50424682
+ H      5   4   1     1.088545073800   110.32260957   184.03860451
+ H      5   4   1     1.090306581850   109.93005916   302.80131027
+ H      6   4   1     1.102941986049   109.84489287   290.25047959
+ H      6   4   1     1.091452932000   107.52786383    46.26111489
+ H      7   6   4     1.092405717369   110.82646187    61.34670684
+ H      7   6   4     1.094680268446   109.32128271   303.32081442
+ H      8   7   6     1.092469101632   109.39694547   299.09969048
+ H      8   7   6     1.097599578056   108.93966745    55.39548836
+ H      9   8   7     1.014054047568   108.57028056   295.83920087
+ H      9   8   7     1.012867924946   109.06136873   180.97654307
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     2.670837351215     0.00000000     0.00000000
+ O      2   1   0     2.687586705976   109.30626964     0.00000000
+ N      1   2   3     2.723814222303   113.19406250   286.08681196
+ C      4   1   2     2.754472374506   109.43876012   164.91327455
+ C      4   1   2     2.767066644982   110.23770271   287.99712185
+ C      6   4   1     2.870443228074   114.23531745   166.81892639
+ C      7   6   4     2.868572311424   111.41128149   182.54572381
+ N      8   7   6     2.765105814227   111.04681359   179.83251740
+ H      1   2   3     2.061847768118   109.52453301    48.64632746
+ H      1   2   3     2.079828668260   102.34354882   164.41746804
+ H      3   2   1     1.825549226727   102.90584564    89.49784936
+ H      5   4   1     2.080126732424   112.24624981    63.50424682
+ H      5   4   1     2.057052073911   110.32260957   184.03860451
+ H      5   4   1     2.060380841708   109.93005916   302.80131027
+ H      6   4   1     2.084258295235   109.84489287   290.25047959
+ H      6   4   1     2.062547129545   107.52786383    46.26111489
+ H      7   6   4     2.064347632958   110.82646187    61.34670684
+ H      7   6   4     2.068645911570   109.32128271   303.32081442
+ H      8   7   6     2.064467411855   109.39694547   299.09969048
+ H      8   7   6     2.074162607234   108.93966745    55.39548836
+ H      9   8   7     1.916284434898   108.57028056   295.83920087
+ H      9   8   7     1.914042987982   109.06136873   180.97654307
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type C   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   2 Type O   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   3 Type N   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   4 Type H   : 5s1p contracted to 3s1p pattern {311/1}
+
+Atom   0C    basis set group =>   1
+Atom   1O    basis set group =>   2
+Atom   2O    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4C    basis set group =>   1
+Atom   5C    basis set group =>   1
+Atom   6C    basis set group =>   1
+Atom   7C    basis set group =>   1
+Atom   8N    basis set group =>   3
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+Atom  12H    basis set group =>   4
+Atom  13H    basis set group =>   4
+Atom  14H    basis set group =>   4
+Atom  15H    basis set group =>   4
+Atom  16H    basis set group =>   4
+Atom  17H    basis set group =>   4
+Atom  18H    basis set group =>   4
+Atom  19H    basis set group =>   4
+Atom  20H    basis set group =>   4
+Atom  21H    basis set group =>   4
+Atom  22H    basis set group =>   4
+-------------------------------
+AUXILIARY BASIS SET INFORMATION
+-------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type C   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   2 Type O   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   3 Type N   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   4 Type H   : 4s3p2d contracted to 4s2p1d pattern {1111/21/2}
+
+Atom   0C    basis set group =>   1
+Atom   1O    basis set group =>   2
+Atom   2O    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4C    basis set group =>   1
+Atom   5C    basis set group =>   1
+Atom   6C    basis set group =>   1
+Atom   7C    basis set group =>   1
+Atom   8N    basis set group =>   3
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+Atom  12H    basis set group =>   4
+Atom  13H    basis set group =>   4
+Atom  14H    basis set group =>   4
+Atom  15H    basis set group =>   4
+Atom  16H    basis set group =>   4
+Atom  17H    basis set group =>   4
+Atom  18H    basis set group =>   4
+Atom  19H    basis set group =>   4
+Atom  20H    basis set group =>   4
+Atom  21H    basis set group =>   4
+Atom  22H    basis set group =>   4
+
+ORCA finished by error termination in GTOInt
+Calling Command: mpirun -np 40  /gpfs/workspace/projects/mit_chemical_stability/orca/orca_4_1_2_linux_x86-64_openmpi313//orca_gtoint_mpi input.int.tmp input 
+[file orca_tools/qcmsg.cpp, line 458]: 
+  .... aborting the run
+

--- a/arc/testing/trsh/orca/orca_mdci_error_3.log
+++ b/arc/testing/trsh/orca/orca_mdci_error_3.log
@@ -1,0 +1,975 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.1.2  - RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Alexander A. Auer      : GIAO ZORA
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, Open-shell LED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-SVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+----- AuxC basis set information -----
+Your calculation utilizes the auxiliary basis: def2-SVP/C
+  H-La, Hf-Rn : A. Hellweg, C. Hattig, S. Hofener and W. Klopper, Theor. Chem. Acc. 117, 587 (2007).
+        Ce-Lu : J. Chmela and M. E. Harding, Mol. Phys. (2018).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: MDCI localization with Augmented Hessian Foster-Boys
+  ===> : Switching off randomization!
+
+WARNING: Post HF methods need fully converged wavefunctions
+  ===> : Setting SCFConvForced true
+         You can overwrite this default with %scf ConvForced false 
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> !rHF dlpno-ccsd(t) def2-svp def2-svp/c  
+|  2> ! NRSCF # using Newton–Raphson SCF algorithm 
+|  3> !sp 
+|  4> 
+|  5> %maxcore 3687
+|  6> %pal # job parallelization settings
+|  7> nprocs 40
+|  8> end
+|  9> %scf # recommended SCF settings 
+| 10> NRMaxIt 400
+| 11> NRStart 0.00005
+| 12> MaxIter 500
+| 13> end
+| 14> 
+| 15> 
+| 16> * xyz 0 1
+| 17> C      -0.36862686   -0.00871354    0.04292587
+| 18> O       0.98182901   -0.04902010    0.46594709
+| 19> H      -0.57257378    0.95163086   -0.43693396
+| 20> H      -0.55632373   -0.82564527   -0.65815446
+| 21> H      -1.01755588   -0.12311763    0.91437513
+| 22> H       1.10435907    0.67758465    1.10037299
+| 23> *
+| 24> 
+| 25>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -0.368627   -0.008714    0.042926
+  O      0.981829   -0.049020    0.465947
+  H     -0.572574    0.951631   -0.436934
+  H     -0.556324   -0.825645   -0.658154
+  H     -1.017556   -0.123118    0.914375
+  H      1.104359    0.677585    1.100373
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     6.0000    0    12.011   -0.696604   -0.016466    0.081118
+   1 O     8.0000    0    15.999    1.855388   -0.092635    0.880512
+   2 H     1.0000    0     1.008   -1.082008    1.798322   -0.825686
+   3 H     1.0000    0     1.008   -1.051299   -1.560243   -1.243732
+   4 H     1.0000    0     1.008   -1.922902   -0.232659    1.727919
+   5 H     1.0000    0     1.008    2.086936    1.280449    2.079404
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     1.415733953879     0.00000000     0.00000000
+ H      1   2   0     1.092758513687   109.52761085     0.00000000
+ H      1   2   3     1.092758525751   109.52761469   120.80820503
+ H      1   2   3     1.092529625027   108.98161849   240.40410079
+ H      2   1   3     0.972349886058   107.09074725    60.40405757
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     2.675349451325     0.00000000     0.00000000
+ H      1   2   0     2.065014321380   109.52761085     0.00000000
+ H      1   2   3     2.065014344177   109.52761469   120.80820503
+ H      1   2   3     2.064581784497   108.98161849   240.40410079
+ H      2   1   3     1.837474990999   107.09074725    60.40405757
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 3 groups of distinct atoms
+
+ Group   1 Type C   : 7s4p1d contracted to 3s2p1d pattern {511/31/1}
+ Group   2 Type O   : 7s4p1d contracted to 3s2p1d pattern {511/31/1}
+ Group   3 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0C    basis set group =>   1
+Atom   1O    basis set group =>   2
+Atom   2H    basis set group =>   3
+Atom   3H    basis set group =>   3
+Atom   4H    basis set group =>   3
+Atom   5H    basis set group =>   3
+-------------------------------
+AUXILIARY BASIS SET INFORMATION
+-------------------------------
+There are 3 groups of distinct atoms
+
+ Group   1 Type C   : 8s6p5d3f contracted to 6s5p4d1f pattern {311111/21111/2111/3}
+ Group   2 Type O   : 8s6p5d3f contracted to 6s5p4d1f pattern {311111/21111/2111/3}
+ Group   3 Type H   : 4s3p2d contracted to 3s2p1d pattern {211/21/2}
+
+Atom   0C    basis set group =>   1
+Atom   1O    basis set group =>   2
+Atom   2H    basis set group =>   3
+Atom   3H    basis set group =>   3
+Atom   4H    basis set group =>   3
+Atom   5H    basis set group =>   3
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   44
+ # of primitive gaussian functions       ...   76
+ # of contracted shells                  ...   24
+ # of contracted basis functions         ...   48
+ Highest angular momentum                ...    2
+ Maximum contraction depth               ...    5
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-10
+ Primitive cut-off              TCut     ...  1.000e-11
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   18
+ Basis Dimension        Dim             ....   48
+ Nuclear Repulsion      ENuc            ....     40.3687355128 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... on
+   Start iteration      NRMaxIt         ....   400
+   Startup grad/error   NRStart         ....  0.000050
+ SOSCF                  CNVSOSCF        .... off
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   500
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  1.000e-10 Eh
+ Primitive CutOff       TCut            ....  1.000e-11 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 1
+ Energy Change          TolE            ....  1.000e-06 Eh
+ 1-El. energy change                    ....  1.000e-03 Eh
+ Orbital Gradient       TolG            ....  5.000e-05
+ Orbital Rotation angle TolX            ....  5.000e-05
+ DIIS Error             TolErr          ....  1.000e-06
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.137e-02
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.030 sec
+Total time needed                          ...    0.032 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-10
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   6548 (   0.0 sec)
+# of grid points (after weights+screening)   ...   6390 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     6390
+Total number of batches                      ...      103
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1065
+Average number of shells per batch           ...    17.75 (73.96%)
+Average number of basis functions per batch  ...    35.75 (74.48%)
+Average number of large shells per batch     ...    17.25 (97.18%)
+Average number of large basis fcns per batch ...    35.25 (98.60%)
+Maximum spatial batch extension              ...   1.79,  2.09,  1.99 au
+Average spatial batch extension              ...   0.05,  0.05,  0.06 au
+
+Time for grid setup =    0.085 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.2 sec)
+                      ------------------
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+  0   -114.8497071784   0.000000000000 0.05468047  0.00338003  0.2402919 0.7000
+  1   -114.8870097574  -0.037302578988 0.03808979  0.00243091  0.1448962 0.7000
+                               ***Turning on DIIS***
+  2   -114.9087715648  -0.021761807365 0.07330627  0.00492944  0.0793498 0.0000
+  3   -114.7693577091   0.139413855658 0.03029894  0.00168191  0.0429324 0.0000
+  4   -114.9557000495  -0.186342340392 0.00623032  0.00035882  0.0054209 0.0000
+  5   -114.9512548952   0.004445154267 0.00169159  0.00014188  0.0017019 0.0000
+  6   -114.9536464353  -0.002391540055 0.00082150  0.00007390  0.0007767 0.0000
+  7   -114.9529052839   0.000741151407 0.00018377  0.00001307  0.0001188 0.0000
+                      *** Initiating the Newton-Raphson procedure ***
+                           *** Shutting down DIIS ***
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  8   -114.95269994   0.0002053389  0.000023  0.000000  0.000062  0.000003
+                   <<< The NR Solver signals convergence >>>
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   9 CYCLES          *
+               *****************************************************
+
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :         -114.95264774 Eh           -3128.02057 eV
+
+Components:
+Nuclear Repulsion  :           40.36873551 Eh            1098.48914 eV
+Electronic Energy  :         -155.32138325 Eh           -4226.50971 eV
+One Electron Energy:         -236.85229747 Eh           -6445.07868 eV
+Two Electron Energy:           81.53091422 Eh            2218.56897 eV
+
+Virial components:
+Potential Energy   :         -229.46308495 Eh           -6244.00798 eV
+Kinetic Energy     :          114.51043721 Eh            3115.98741 eV
+Virial Ratio       :            2.00386175
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    2.0534e-04  Tolerance :   1.0000e-06
+  Last MAX-Density change    ...    6.1758e-05  Tolerance :   1.0000e-05
+  Last RMS-Density change    ...    3.4040e-06  Tolerance :   1.0000e-06
+  Last Orbital Gradient      ...    1.1260e-05  Tolerance :   5.0000e-05
+  Last Orbital Rotation      ...    0.0000e+00  Tolerance :   5.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (input.gbw) ****
+             **** DENSITY FILE WAS UPDATED (input.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -20.541596      -558.9652 
+   1   2.0000     -11.276217      -306.8415 
+   2   2.0000      -1.330387       -36.2017 
+   3   2.0000      -0.910055       -24.7639 
+   4   2.0000      -0.681872       -18.5547 
+   5   2.0000      -0.620670       -16.8893 
+   6   2.0000      -0.593197       -16.1417 
+   7   2.0000      -0.497345       -13.5335 
+   8   2.0000      -0.443895       -12.0790 
+   9   0.0000       0.175907         4.7867 
+  10   0.0000       0.221702         6.0328 
+  11   0.0000       0.264114         7.1869 
+  12   0.0000       0.268766         7.3135 
+  13   0.0000       0.358763         9.7624 
+  14   0.0000       0.640961        17.4414 
+  15   0.0000       0.645049        17.5527 
+  16   0.0000       0.711958        19.3734 
+  17   0.0000       0.823956        22.4210 
+  18   0.0000       0.860974        23.4283 
+  19   0.0000       0.898311        24.4443 
+  20   0.0000       0.925601        25.1869 
+  21   0.0000       0.942722        25.6528 
+  22   0.0000       1.209575        32.9142 
+  23   0.0000       1.224188        33.3118 
+  24   0.0000       1.283141        34.9160 
+  25   0.0000       1.487910        40.4881 
+  26   0.0000       1.564253        42.5655 
+  27   0.0000       1.720485        46.8168 
+  28   0.0000       1.733308        47.1657 
+  29   0.0000       1.790882        48.7324 
+  30   0.0000       1.833549        49.8934 
+  31   0.0000       1.989950        54.1493 
+  32   0.0000       2.048992        55.7559 
+  33   0.0000       2.099449        57.1289 
+  34   0.0000       2.197301        59.7916 
+  35   0.0000       2.290211        62.3198 
+  36   0.0000       2.490110        67.7593 
+  37   0.0000       2.537362        69.0451 
+  38   0.0000       2.645622        71.9910 
+  39   0.0000       2.715671        73.8972 
+  40   0.0000       3.024696        82.3062 
+  41   0.0000       3.178297        86.4858 
+  42   0.0000       3.187288        86.7305 
+  43   0.0000       3.316256        90.2399 
+  44   0.0000       3.434189        93.4490 
+  45   0.0000       3.540363        96.3382 
+  46   0.0000       3.703877       100.7876 
+  47   0.0000       4.158419       113.1563 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 C :    0.218443
+   1 O :   -0.472591
+   2 H :    0.012662
+   3 H :    0.037435
+   4 H :    0.011274
+   5 H :    0.192777
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 C s       :     3.015699  s :     3.015699
+      pz      :     0.984683  p :     2.699248
+      px      :     0.696282
+      py      :     1.018284
+      dz2     :     0.006543  d :     0.066610
+      dxz     :     0.019431
+      dyz     :     0.010849
+      dx2y2   :     0.020740
+      dxy     :     0.009046
+  1 O s       :     3.763621  s :     3.763621
+      pz      :     1.633032  p :     4.694411
+      px      :     1.452257
+      py      :     1.609122
+      dz2     :     0.001587  d :     0.014559
+      dxz     :     0.001760
+      dyz     :     0.003741
+      dx2y2   :     0.005773
+      dxy     :     0.001698
+  2 H s       :     0.962900  s :     0.962900
+      pz      :     0.006849  p :     0.024438
+      px      :     0.002592
+      py      :     0.014996
+  3 H s       :     0.937841  s :     0.937841
+      pz      :     0.010131  p :     0.024724
+      px      :     0.002183
+      py      :     0.012410
+  4 H s       :     0.964285  s :     0.964285
+      pz      :     0.012860  p :     0.024441
+      px      :     0.007192
+      py      :     0.004390
+  5 H s       :     0.737497  s :     0.737497
+      pz      :     0.027192  p :     0.069726
+      px      :     0.013405
+      py      :     0.029129
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 C :    0.118468
+   1 O :   -0.213578
+   2 H :   -0.001892
+   3 H :    0.015218
+   4 H :   -0.002114
+   5 H :    0.083898
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 C s       :     2.834542  s :     2.834542
+      pz      :     1.036181  p :     2.908123
+      px      :     0.809454
+      py      :     1.062488
+      dz2     :     0.012774  d :     0.138866
+      dxz     :     0.040510
+      dyz     :     0.024583
+      dx2y2   :     0.042972
+      dxy     :     0.018026
+  1 O s       :     3.458033  s :     3.458033
+      pz      :     1.634964  p :     4.730830
+      px      :     1.464672
+      py      :     1.631194
+      dz2     :     0.002159  d :     0.024715
+      dxz     :     0.003143
+      dyz     :     0.007553
+      dx2y2   :     0.009399
+      dxy     :     0.002461
+  2 H s       :     0.938386  s :     0.938386
+      pz      :     0.018283  p :     0.063505
+      px      :     0.009549
+      py      :     0.035673
+  3 H s       :     0.922074  s :     0.922074
+      pz      :     0.024709  p :     0.062708
+      px      :     0.008113
+      py      :     0.029885
+  4 H s       :     0.938630  s :     0.938630
+      pz      :     0.030753  p :     0.063484
+      px      :     0.020485
+      py      :     0.012247
+  5 H s       :     0.736820  s :     0.736820
+      pz      :     0.068507  p :     0.179283
+      px      :     0.035108
+      py      :     0.075668
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 C      5.7816     6.0000     0.2184     3.8932     3.8932     0.0000
+  1 O      8.4726     8.0000    -0.4726     1.8993     1.8993     0.0000
+  2 H      0.9873     1.0000     0.0127     0.9757     0.9757     0.0000
+  3 H      0.9626     1.0000     0.0374     0.9832     0.9832     0.0000
+  4 H      0.9887     1.0000     0.0113     0.9760     0.9760     0.0000
+  5 H      0.8072     1.0000     0.1928     0.9896     0.9896     0.0000
+
+  Mayer bond orders larger than 0.1
+B(  0-C ,  1-O ) :   0.9164 B(  0-C ,  2-H ) :   0.9895 B(  0-C ,  3-H ) :   0.9906 
+B(  0-C ,  4-H ) :   0.9903 B(  1-O ,  5-H ) :   0.9776 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 3 sec 
+
+Total time                  ....       3.364 sec
+Sum of individual times     ....       2.837 sec  ( 84.3%)
+
+Fock matrix formation       ....       2.420 sec  ( 71.9%)
+Diagonalization             ....       0.022 sec  (  0.6%)
+Density matrix formation    ....       0.002 sec  (  0.0%)
+Population analysis         ....       0.038 sec  (  1.1%)
+Initial guess               ....       0.150 sec  (  4.5%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.121 sec  (  3.6%)
+NR solution                 ....       0.000 sec  (  0.0%)
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+
+------------------------------------------------------------------------------- 
+                              ORCA-MATRIX DRIVEN CI                            
+------------------------------------------------------------------------------- 
+
+
+Wavefunction type
+-----------------
+Correlation treatment                      ...      CCSD     
+Single excitations                         ... ON
+Orbital optimization                       ... OFF
+Calculation of Z vector                    ... OFF
+Calculation of Brueckner orbitals          ... OFF
+Perturbative triple excitations            ... ON
+Calculation of F12 correction              ... OFF
+Frozen core treatment                      ... chemical core (4 el)
+Reference Wavefunction                     ... RHF
+  Internal Orbitals:     2 ...    8 (  7 MO's/ 14 electrons)
+  Virtual  Orbitals:     9 ...   47 ( 39 MO's              )
+Number of AO's                             ...     48
+Number of electrons                        ...     18
+Number of correlated electrons             ...     14
+
+Algorithmic settings
+--------------------
+Integral transformation                    ... All integrals via the RI transformation
+K(C) Formation                             ... RI-DLPNO
+   PNO-Integral Storage                    ... ON DISK
+   PNO occupation number cut-off           ... 3.330e-07
+   Singles PNO occupation number cut-off   ... 9.990e-09
+   PNO Mulliken prescreening cut-off       ... 1.000e-03
+   Domain cut-off (Mulliken population)    ... 1.000e-03
+   PNO Normalization                       ...    1
+Maximum number of iterations               ...        50
+Convergence tolerance (max. residuum)      ... 2.500e-05
+Level shift for amplitude update           ... 2.000e-01
+Maximum number of DIIS vectors             ...         7
+DIIS turned on at iteration                ...         0
+Damping before turning on DIIS             ...     0.500
+Damping after turning on DIIS              ...     0.000
+Pair specific amplitude update             ... OFF
+Natural orbital iterations                 ... OFF
+Perturbative natural orbital generation    ... OFF
+Printlevel                                 ... 2
+
+Singles Fock matrix elements calculated using PNOs.
+
+Memory handling:
+----------------
+Maximum memory for working arrays          ...   3687 MB
+Data storage in matrix containers          ... UNCOMPRESSED
+Data type for integral storage             ... DOUBLE
+In-Core Storage of quantities:
+   Amplitudes+Sigma Vector      ... NO
+   J+K operators                ... NO
+   DIIS vectors                 ... NO
+   3-external integrals         ... NO
+   4-external integrals         ... NO
+
+Localization treatment:
+-----------------------
+Localization option                        ...    6
+Localization threshhold                    ... -1.0e+00
+Using relative localization threshhold     ... 1.0e-08
+Neglect threshold for strong pairs         ... 1.000e-04 Eh
+Prescreening threshold for very weak pairs ... 1.000e-06 Eh
+
+Initializing the integral package          ... done
+Localizing the valence orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... input.proc0.gbw
+Output orbitals are to                   ... input.proc0.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 2 to 8
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :    19.960728
+ITERATION   0 : L=   27.2572825726 DL=  7.30e+00 (AVERGE_DL)=    0.5894531212 
+ITERATION   1 : L=   27.4871167263 DL=  2.30e-01 (AVERGE_DL)=    0.1046158856 
+ITERATION   2 : L=   27.4973930104 DL=  1.03e-02 (AVERGE_DL)=    0.0221211858 
+ITERATION   3 : L=   27.4981491680 DL=  7.56e-04 (AVERGE_DL)=    0.0060006253 
+ITERATION   4 : L=   27.4982227388 DL=  7.36e-05 (AVERGE_DL)=    0.0018717299 
+ITERATION   5 : L=   27.4982291462 DL=  6.41e-06 (AVERGE_DL)=    0.0005523702 
+ITERATION   6 : L=   27.4982296760 DL=  5.30e-07 (AVERGE_DL)=    0.0001588355 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          2 to 8
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         21
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 27.4982296760   Grad. norm: 4.307385e-04
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  9.06e-08 -1.44e+00 -3.77e+00 -5.44e+00 ... 
+Iter:    1   L: 27.4982297213   Grad. norm: 4.677677e-08
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -1.439e+00
+  1 -3.773e+00
+  2 -5.436e+00
+  3 -5.723e+00
+  4 -7.787e+00
+  5 -1.066e+01
+  6 -1.802e+01
+  7 -2.139e+01
+  8 -2.161e+01
+  9 -2.446e+01
+    ...
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   2 strongly local MO`s
+       -   5 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   3:   1O  -   0.998306
+MO   2:   1O  -   0.998508
+Bond-like localized orbitals:
+MO   8:   5H  -   0.411545  and   1O  -   0.592593
+MO   7:   4H  -   0.512500  and   0C  -   0.511940
+MO   6:   3H  -   0.494091  and   0C  -   0.522719
+MO   5:   2H  -   0.511753  and   0C  -   0.512254
+MO   4:   1O  -   0.672731  and   0C  -   0.337339
+Localized MO's were stored in: input.proc0.loc
+
+Localizing the core orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... input.proc0.loc
+Output orbitals are to                   ... input.proc0.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 0 to 1
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :     4.717698
+ITERATION   0 : L=    4.7176981682 DL=  6.51e-09 (AVERGE_DL)=    0.0000806546 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          0 to 1
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         1
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 4.7176981682   Grad. norm: 3.422013e-18
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  4.09e-37 -2.86e+01
+Iter:    1   L: 4.7176981682   Grad. norm: 1.694066e-21
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -2.862e+01
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   2 strongly local MO`s
+       -   0 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   1:   1O  -   0.999542
+MO   0:   0C  -   0.999449
+Localized MO's were stored in: input.proc0.loc
+
+Warning: internal orbitals are localized - no re-canonicalization of internal orbitals
+
+--------------------------
+CLOSED-SHELL FOCK OPERATOR
+--------------------------
+
+<ss|ss>:         5565 b           21 skpd (  0.4%)    0.000 s ( 0.000 ms/b)
+<ss|sp>:        11760 b           43 skpd (  0.4%)    0.001 s ( 0.000 ms/b)
+<ss|sd>:         2940 b           12 skpd (  0.4%)    0.006 s ( 0.002 ms/b)
+<ss|pp>:         3780 b           16 skpd (  0.4%)    0.000 s ( 0.000 ms/b)
+<ss|pd>:         1680 b           10 skpd (  0.6%)    0.008 s ( 0.005 ms/b)
+<ss|dd>:          315 b            1 skpd (  0.3%)    0.000 s ( 0.001 ms/b)
+<sp|sp>:         6328 b            0 skpd (  0.0%)    0.001 s ( 0.000 ms/b)
+<sp|sd>:         3136 b            0 skpd (  0.0%)    0.000 s ( 0.000 ms/b)
+<sp|pp>:         4032 b            3 skpd (  0.1%)    0.001 s ( 0.000 ms/b)
+<sp|pd>:         1792 b            0 skpd (  0.0%)    0.000 s ( 0.000 ms/b)
+<sp|dd>:          336 b            0 skpd (  0.0%)    0.000 s ( 0.001 ms/b)
+<sd|sd>:          406 b            0 skpd (  0.0%)    0.000 s ( 0.001 ms/b)
+<sd|pp>:         1008 b            0 skpd (  0.0%)    0.008 s ( 0.008 ms/b)
+<sd|pd>:          448 b            0 skpd (  0.0%)    0.000 s ( 0.000 ms/b)
+<sd|dd>:           84 b            0 skpd (  0.0%)    0.000 s ( 0.002 ms/b)
+<pp|pp>:          666 b            1 skpd (  0.2%)    0.000 s ( 0.000 ms/b)
+<pp|pd>:          576 b            0 skpd (  0.0%)    0.000 s ( 0.000 ms/b)
+<pp|dd>:          108 b            0 skpd (  0.0%)    0.000 s ( 0.003 ms/b)
+<pd|pd>:          136 b            0 skpd (  0.0%)    0.001 s ( 0.010 ms/b)
+<pd|dd>:           48 b            0 skpd (  0.0%)    0.000 s ( 0.006 ms/b)
+<dd|dd>:            6 b            0 skpd (  0.0%)    0.000 s ( 0.016 ms/b)
+[file orca_mdci/mdci_def.cpp, line 3426, Process 16]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 22]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 32]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 2]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 3]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 4]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 5]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 6]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 7]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 8]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 9]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 10]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 11]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 12]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 13]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 14]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 15]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 17]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 18]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 19]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 20]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 21]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 23]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 24]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 25]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 26]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 27]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 28]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 29]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 30]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 31]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 33]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 34]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 35]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 36]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 37]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 38]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 39]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+[file orca_mdci/mdci_def.cpp, line 3426, Process 1]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+Time needed for Fock operator              ...            0.060 sec
+Reference energy                           ...   -114.952647741
+[file orca_mdci/mdci_def.cpp, line 3426, Process 0]: Error (ORCA_MDCI): Number of processes in parallel calculation exceeds number of pairs
+
+
+ORCA finished by error termination in MDCI
+Calling Command: mpirun -np 40  /gpfs/workspace/projects/mit_chemical_stability/orca/orca_4_1_2_linux_x86-64_openmpi313//orca_mdci_mpi input.mdciinp.tmp input 
+[file orca_tools/qcmsg.cpp, line 458]: 
+  .... aborting the run
+


### PR DESCRIPTION
1. ARC now estimates memory and cpu cores needed for an Orca job using heuristics based on the number of heavy atoms in a species.
2. ARC now parse Orca version 4.1.x log files for troubleshooting correctly.
   - original code was written for Orca version 4.2.x. The format of the error message in the log files is different from Orca version 4.1.x. Specifically, in 4.2.x, Orca gives estimations of memory and cpu in the log files while in 4.1.x it does not. 
   - ARC now does not crash if it cannot find estimated memory and cpu information from log files.
3. ARC now attempts to troubleshoot GTOInt error.
   - Based on our experience, GTOInt error seems to mostly related to memory allocation. 
4. Tests are updated with new example failed Orca log files.
   

