### PR TITLE
Update maxstep settings for Gaussian opt jobs

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -771,7 +771,7 @@ wf,spin={spin},charge={charge};}}
         if self.job_type in ['conformer', 'opt']:
             if self.software == 'gaussian':
                 if self.is_ts:
-                    job_type_1 = 'opt=(ts, calcfc, noeigentest, maxstep=5, maxcycles=100)'
+                    job_type_1 = 'opt=(ts, calcfc, noeigentest, maxcycles=100)'
                 else:
                     job_type_1 = 'opt=(calcfc)'
                 if self.fine:
@@ -780,7 +780,7 @@ wf,spin={spin},charge={charge};}}
                     if self.is_ts:
                         job_type_1 = 'opt=(ts, calcfc, noeigentest, tight, maxstep=5, maxcycles=100)'
                     else:
-                        job_type_1 = 'opt=(tight, calcfc)'
+                        job_type_1 = 'opt=(tight, calcfc, maxstep=5)'
                 if self.checkfile is not None:
                     job_type_1 += ' guess=read'
                 else:


### PR DESCRIPTION
1. Remove maxstep=5 for regular (not fine) TS opt jobs
2. Add maxstep = 5 for non TS fine opt jobs (wells)

'maxstep=5' is too conservative, which makes calculation really expensive. For regular opt TS job, using Gaussian default value maxstep=30 is more efficient. For opt fine job, 'maxstep=5' is kept.

In addition, 'maxstep=5' is also added for opt fine non-ts jobs (wells).