### PR TITLE
BugFix: use memory and job time settings from default job settings dict 

### DIFF
--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -249,8 +249,7 @@ class Job(object):
             self.scan_res = scan_res if scan_res is not None else rotor_scan_resolution
             self.scan = scan
             self.pivots = pivots if pivots is not None else list()
-            self.max_job_time = max_job_time if max_job_time is not None \
-                else default_job_settings.get('job_time_limit_hrs', 120)
+            self.max_job_time = max_job_time or default_job_settings.get('job_time_limit_hrs', 120)
             self.bath_gas = bath_gas
             self.solvation = solvation
             self.testing = testing
@@ -269,8 +268,7 @@ class Job(object):
             self.server = server
             self.software = software
             self.cpu_cores = cpu_cores
-            self.total_job_memory_gb = total_job_memory_gb if total_job_memory_gb is not None \
-                else default_job_settings.get('job_total_memory_gb', 14)
+            self.total_job_memory_gb = total_job_memory_gb or default_job_settings.get('job_total_memory_gb', 14)
             self.irc_direction = irc_direction
         # allowed job types:
         job_types = ['conformer', 'opt', 'freq', 'optfreq', 'sp', 'composite', 'bde', 'scan', 'directed_scan',

--- a/arc/main.py
+++ b/arc/main.py
@@ -38,7 +38,7 @@ from arc.species.species import ARCSpecies
 from arc.utils.scale import determine_scaling_factors
 
 try:
-    from arc.settings import global_ess_settings
+    from arc.settings import default_job_settings, global_ess_settings
 except ImportError:
     global_ess_settings = None
 
@@ -188,8 +188,8 @@ class ARC(object):
                  conformer_level='', composite_method='', opt_level='', freq_level='', sp_level='', scan_level='',
                  ts_guess_level='', irc_level='', orbitals_level='', use_bac=True, job_types=None, model_chemistry='',
                  job_additional_options=None, job_shortcut_keywords=None, T_min=None, T_max=None, T_count=50,
-                 verbose=logging.INFO, project_directory=None, max_job_time=120, allow_nonisomorphic_2d=False,
-                 job_memory=14, ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None,
+                 verbose=logging.INFO, project_directory=None, max_job_time=None, allow_nonisomorphic_2d=False,
+                 job_memory=None, ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None,
                  calc_freq_factor=True, n_confs=10, e_confs=5, dont_gen_confs=None, keep_checks=False,
                  solvation=None, compare_to_rmg=True, compute_thermo=True, compute_rates=True, compute_transport=True,
                  specific_job_type='', statmech_adapter='Arkane'):
@@ -200,9 +200,9 @@ class ARC(object):
         self.lib_long_desc = ''
         self.unique_species_labels = list()
         self.rmg_database = rmgdb.make_rmg_database_object()
-        self.max_job_time = max_job_time
+        self.max_job_time = max_job_time or default_job_settings.get('job_time_limit_hrs', 120)
         self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
-        self.memory = job_memory
+        self.memory = job_memory or default_job_settings.get('job_total_memory_gb', 14)
         self.ess_settings = dict()
         self.calc_freq_factor = calc_freq_factor
         self.keep_checks = keep_checks

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -37,7 +37,7 @@ from arc.species.converter import (check_isomorphism,
                                    str_to_xyz,
                                    xyz_to_coords_list,
                                    xyz_to_str)
-from arc.settings import default_job_types, rotor_scan_resolution
+from arc.settings import default_job_settings, default_job_types, rotor_scan_resolution
 import arc.rmgdb as rmgdb
 import arc.species.conformers as conformers  # import after importing plotter to avoid circular import
 from arc.species.vectors import get_angle, calculate_dihedral_angle
@@ -214,9 +214,9 @@ class Scheduler(object):
                  rxn_list: list = None,
                  bath_gas: str = None,
                  restart_dict: dict = None,
-                 max_job_time: float = 120,
+                 max_job_time: float = None,
                  allow_nonisomorphic_2d: bool = False,
-                 memory: float = 14,
+                 memory: float = None,
                  testing: bool = False,
                  dont_gen_confs: list = None,
                  n_confs: int = 10,
@@ -228,7 +228,7 @@ class Scheduler(object):
         self.species_list = species_list
         self.rxn_list = rxn_list if rxn_list is not None else list()
         self.project = project
-        self.max_job_time = max_job_time
+        self.max_job_time = max_job_time or default_job_settings.get('job_time_limit_hrs', 120)
         self.ess_settings = ess_settings
         self.project_directory = project_directory
         self.job_dict = dict()
@@ -236,7 +236,7 @@ class Scheduler(object):
         self.running_jobs = dict()
         self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
         self.testing = testing
-        self.memory = memory
+        self.memory = memory or default_job_settings.get('job_total_memory_gb', 14)
         self.bath_gas = bath_gas
         self.solvation = solvation
         self.adaptive_levels = adaptive_levels

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -60,22 +60,32 @@ The first two directives are only required if you'd like ARC to access remote se
   <https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2>`_.
 - Copy the RSA SSH key path/s on your local machine to ARC/arc/settings.py in the servers
   dictionary under keys.
-- Update the `servers` dictionary in `ARC/arc/settings.py
+- Update the ``servers`` dictionary in `ARC/arc/settings.py
   <https://github.com/ReactionMechanismGenerator/ARC/blob/master/arc/settings.py>`_.
 
   * A local server must be named with the reserved keyword ``local``. ``cluster_soft`` and username (``un``) are
     mandatory.
   * A remote server has no limitations for naming. ``cluster_soft``, ``address``, username (``un``), and ``key``
     (the path to the local RSA SSH key) are mandatory.
-  * Optional parameters for both local and remote servers are ``cpus`` and ``memory``. The number of CPU cores ARC
-    will use when spawning ESS jobs defaults to 8 unless otherwise specified under ``cpus``.
-    The ``memory`` parameter stands for the maximum amount of memory available to a node. By default, ARC will use 14 GB
-    of memory for each ESS job. If a job crashes due to insufficient memory, ARC will automatically re-run the job with
-    increased memory. However, ARC will not use more than 90% of the maximum node memory specified under ``memory``.
+  * Optional parameters for both local and remote servers are ``cpus`` and ``memory``. These two parameters stand for
+    the maximum amount of cpu cores and memory in GB available to a node. If a job crashes due to cpu or memory issues,
+    ARC will automatically re-run the job with different cpu and memory allocations within the limitation specified by
+    these two parameters. By default, ``cpus`` is 8 and ``memory`` is 14 GB.
   * Although ARC currently does not allocate computing resources dynamically based on system size or ESS, the user can
     manually control memory specifications for each project. See :ref:`Advanced Features <advanced>` for details.
   * In certain ESS, the maximum number of CPU cores allowed for a calculation depends on system size. If a job crashes
     for this reason, ARC will attempt to re-run the job with fewer CPU cores.
+
+- Update the ``default_job_settings`` dictionary in `ARC/arc/settings.py
+  <https://github.com/ReactionMechanismGenerator/ARC/blob/master/arc/settings.py>`_.
+
+  * This dictionary contains default job memory, cpu, and time settings.
+  * A default ESS job in ARC has 14 GB of memory, 8 cpu cores, and 120 hours of maximum execution time. The default
+    settings can be changed by providing different values to the ``job_total_memory_gb``, ``job_cpu_cores``, and
+    ``job_time_limit_hrs`` keys.
+  * ARC will alter job memory, cpu, and time settings when troubleshoot jobs crashed due to resource allocation issues.
+    The ``job_max_server_node_memory_allocation`` key stands for the maximum percentage of total node memory ARC will
+    use when troubleshoot a job. The default value is 80%.
 
 - Update the submit scripts in `ARC/arc/job/submit.py
   <https://github.com/ReactionMechanismGenerator/ARC/blob/master/arc/job/submit.py>`_


### PR DESCRIPTION
Scheduler and Main should use default job settings in settings.py. Also updated documentation on how to change default job settings.