### PR TITLE
BugFix: Check if_str_float before converting a string to float

### DIFF
--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -10,7 +10,7 @@ import os
 
 import numpy as np
 
-from arc.common import get_logger, determine_ess, estimate_orca_mem_cpu_requirement
+from arc.common import get_logger, determine_ess, estimate_orca_mem_cpu_requirement, is_str_float
 from arc.exceptions import SpeciesError, TrshError
 from arc.job.local import execute_command
 from arc.job.ssh import SSHClient
@@ -199,6 +199,8 @@ def determine_ess_status(output_path: str,
                     # not done yet, things can still go wrong (e.g., SCF energy might blow up)
                     for j, info in enumerate(forward_lines):
                         if 'Starting incremental Fock matrix formation' in info:
+                            while not is_str_float(forward_lines[j + 1].split()[1]):
+                                j += 1
                             scf_energy_initial_iteration = float(forward_lines[j + 1].split()[1])
                         if 'TOTAL SCF ENERGY' in info:
                             # this value is very close to the scf energy at last iteration and is easier to parse

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -107,6 +107,19 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, '')
         self.assertEqual(line, '')
 
+        # test detection of a successful job
+        # notice that the log file in this example has a different format under the line
+        # ***  Starting incremental Fock matrix formation  ***
+        # compared to the above example. It is important to make sure that ARC's Orca trsh algorithm parse this
+        # log file successfully
+        path = os.path.join(self.base_path['orca'], 'orca_successful_sp_scf.log')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='test', job_type='sp', software='orca')
+        self.assertEqual(status, 'done')
+        self.assertEqual(keywords, list())
+        self.assertEqual(error, '')
+        self.assertEqual(line, '')
+
         # test detection of SCF energy diverge issue
         path = os.path.join(self.base_path['orca'], 'orca_scf_blow_up_error.log')
         status, keywords, error, line = trsh.determine_ess_status(

--- a/arc/testing/trsh/orca/orca_successful_sp_scf.log
+++ b/arc/testing/trsh/orca/orca_successful_sp_scf.log
@@ -1,0 +1,1994 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.2.0 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel, MM, QM/MM, CI optimization
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 4.2.3
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-TZVP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+----- AuxC basis set information -----
+Your calculation utilizes the auxiliary basis: def2-TZVP/C
+  H-La, Hf-Rn : A. Hellweg, C. Hattig, S. Hofener and W. Klopper, Theor. Chem. Acc. 117, 587 (2007).
+        Ce-Lu : J. Chmela and M. E. Harding, Mol. Phys. (2018).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: MDCI localization with Augmented Hessian Foster-Boys
+  ===> : Switching off randomization!
+
+WARNING: Post HF methods need fully converged wavefunctions
+  ===> : Setting SCFConvForced true
+         You can overwrite this default with %scf ConvForced false 
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> !rHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c  
+|  2> ! NRSCF # using Newton–Raphson SCF algorithm 
+|  3> !sp 
+|  4> 
+|  5> %maxcore 3072
+|  6> %pal # job parallelization settings
+|  7> nprocs 40
+|  8> end
+|  9> %scf # recommended SCF settings 
+| 10> NRMaxIt 400
+| 11> NRStart 0.00005
+| 12> MaxIter 500
+| 13> end
+| 14> 
+| 15> 
+| 16> * xyz 0 1
+| 17> O       1.96373900   -0.82063700   -0.88767100
+| 18> O       1.24899800    0.38018300   -0.65484600
+| 19> C      -0.03603100    0.07534500   -0.12126400
+| 20> C       0.14703700   -0.59194000    1.19065300
+| 21> N       0.31034400   -1.10756500    2.20197900
+| 22> C      -0.84511100   -0.81649600   -1.05511200
+| 23> C      -0.68393600    1.44061200    0.08052400
+| 24> H       2.52581600   -0.87404100   -0.10431300
+| 25> H      -0.34035100   -1.76642700   -1.21432600
+| 26> H      -0.96075200   -0.30741100   -2.01196100
+| 27> H      -1.83043500   -1.00622800   -0.62927100
+| 28> H      -0.77941300    1.93234100   -0.88705900
+| 29> H      -0.07914200    2.06091500    0.74003800
+| 30> H      -1.67406600    1.31819200    0.51743200
+| 31> *
+| 32> 
+| 33>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O      1.963739   -0.820637   -0.887671
+  O      1.248998    0.380183   -0.654846
+  C     -0.036031    0.075345   -0.121264
+  C      0.147037   -0.591940    1.190653
+  N      0.310344   -1.107565    2.201979
+  C     -0.845111   -0.816496   -1.055112
+  C     -0.683936    1.440612    0.080524
+  H      2.525816   -0.874041   -0.104313
+  H     -0.340351   -1.766427   -1.214326
+  H     -0.960752   -0.307411   -2.011961
+  H     -1.830435   -1.006228   -0.629271
+  H     -0.779413    1.932341   -0.887059
+  H     -0.079142    2.060915    0.740038
+  H     -1.674066    1.318192    0.517432
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999    3.710929   -1.550779   -1.677455
+   1 O     8.0000    0    15.999    2.360264    0.718442   -1.237480
+   2 C     6.0000    0    12.011   -0.068089    0.142381   -0.229156
+   3 C     6.0000    0    12.011    0.277860   -1.118604    2.250008
+   4 N     7.0000    0    14.007    0.586465   -2.092995    4.161137
+   5 C     6.0000    0    12.011   -1.597028   -1.542954   -1.993873
+   6 C     6.0000    0    12.011   -1.292452    2.722362    0.152168
+   7 H     1.0000    0     1.008    4.773101   -1.651698   -0.197123
+   8 H     1.0000    0     1.008   -0.643170   -3.338063   -2.294744
+   9 H     1.0000    0     1.008   -1.815558   -0.580923   -3.802055
+  10 H     1.0000    0     1.008   -3.459021   -1.901495   -1.189150
+  11 H     1.0000    0     1.008   -1.472877    3.651595   -1.676299
+  12 H     1.0000    0     1.008   -0.149557    3.894565    1.398469
+  13 H     1.0000    0     1.008   -3.163526    2.491022    0.977805
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     1.416697162454     0.00000000     0.00000000
+ C      2   1   0     1.424407065346   109.59134791     0.00000000
+ C      3   2   1     1.483209148683   108.43749472    63.10506777
+ N      4   3   2     1.146873399792   178.90219617   355.87461189
+ C      3   2   1     1.523831651720   112.00481159   301.35909301
+ C      3   2   1     1.524615776928   103.96428834   179.86906719
+ H      1   2   3     0.965625340030   101.95974595   261.26814794
+ H      6   3   2     1.087428462087   110.76468360    61.06076059
+ H      6   3   2     1.090000177480   108.72042210   301.08230093
+ H      6   3   2     1.090046867837   110.02327812   181.57881963
+ H      7   3   2     1.089555014150   108.89556866    62.19073046
+ H      7   3   2     1.088811420973   110.74934637   302.05381350
+ H      7   3   2     1.089143091501   109.80199082   181.59285970
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ O      1   0   0     2.677169651742     0.00000000     0.00000000
+ C      2   1   0     2.691739256727   109.59134791     0.00000000
+ C      3   2   1     2.802859090338   108.43749472    63.10506777
+ N      4   3   2     2.167276635886   178.90219617   355.87461189
+ C      3   2   1     2.879624495952   112.00481159   301.35909301
+ C      3   2   1     2.881106277850   103.96428834   179.86906719
+ H      1   2   3     1.824767440632   101.95974595   261.26814794
+ H      6   3   2     2.054941983576   110.76468360    61.06076059
+ H      6   3   2     2.059801821363   108.72042210   301.08230093
+ H      6   3   2     2.059890053350   110.02327812   181.57881963
+ H      7   3   2     2.058960584584   108.89556866    62.19073046
+ H      7   3   2     2.057555397124   110.74934637   302.05381350
+ H      7   3   2     2.058182163589   109.80199082   181.59285970
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   2 Type C   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   3 Type N   : 11s6p2d1f contracted to 5s3p2d1f pattern {62111/411/11/1}
+ Group   4 Type H   : 5s1p contracted to 3s1p pattern {311/1}
+
+Atom   0O    basis set group =>   1
+Atom   1O    basis set group =>   1
+Atom   2C    basis set group =>   2
+Atom   3C    basis set group =>   2
+Atom   4N    basis set group =>   3
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+Atom  12H    basis set group =>   4
+Atom  13H    basis set group =>   4
+---------------------------------
+AUXILIARY/C BASIS SET INFORMATION
+---------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   2 Type C   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   3 Type N   : 8s6p5d3f1g contracted to 8s6p4d3f1g pattern {11111111/111111/2111/111/1}
+ Group   4 Type H   : 4s3p2d contracted to 4s2p1d pattern {1111/21/2}
+
+Atom   0O    basis set group =>   1
+Atom   1O    basis set group =>   1
+Atom   2C    basis set group =>   2
+Atom   3C    basis set group =>   2
+Atom   4N    basis set group =>   3
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+Atom  12H    basis set group =>   4
+Atom  13H    basis set group =>   4
+
+Checking for AutoStart:
+The File: input.gbw exists
+Trying to determine its content:
+     ... Fine, the file contains calculation information
+     ... Fine, the calculation information was read
+     ... Fine, the file contains a basis set
+     ... Fine, the basis set was read
+     ... Fine, the file contains a geometry
+     ... Fine, the geometry was read
+     ... Fine, the file contains a set of orbitals
+     ... Fine, the orbitals can be read
+     => possible old guess file was deleted
+     => GBW file was renamed to GES file
+     => GES file is set as startup file
+     => Guess is set to MORead
+     ... now leaving AutoStart
+
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...  182
+ # of primitive gaussian functions       ...  378
+ # of contracted shells                  ...  105
+ # of contracted basis functions         ...  259
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    6
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-10
+ Primitive cut-off              TCut     ...  1.000e-11
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.002 sec)
+
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   54
+ Basis Dimension        Dim             ....  259
+ Nuclear Repulsion      ENuc            ....    305.9732499577 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... on
+   Start iteration      NRMaxIt         ....   400
+   Startup grad/error   NRStart         ....  0.000050
+ SOSCF                  CNVSOSCF        .... off
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   500
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  1.000e-10 Eh
+ Primitive CutOff       TCut            ....  1.000e-11 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 1
+ Energy Change          TolE            ....  1.000e-06 Eh
+ 1-El. energy change                    ....  1.000e-03 Eh
+ Orbital Gradient       TolG            ....  5.000e-05
+ Orbital Rotation angle TolX            ....  5.000e-05
+ DIIS Error             TolErr          ....  1.000e-06
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 8.691e-05
+Time for diagonalization                   ...    0.181 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.243 sec
+Total time needed                          ...    0.424 sec
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: input.ges
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+MOs were renormalized
+MOs were reorthogonalized (Cholesky)
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the Newton-Raphson procedure ***
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0   -359.75006651 -359.7500665143  0.000003  0.000000  0.000007  0.000000
+                   <<< The NR Solver signals convergence >>>
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   1 CYCLES          *
+               *****************************************************
+
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :         -359.75006652 Eh           -9789.29699 eV
+
+Components:
+Nuclear Repulsion  :          305.97324996 Eh            8325.95541 eV
+Electronic Energy  :         -665.72331648 Eh          -18115.25240 eV
+One Electron Energy:        -1097.20582897 Eh          -29856.48848 eV
+Two Electron Energy:          431.48251250 Eh           11741.23608 eV
+
+Virial components:
+Potential Energy   :         -719.11937322 Eh          -19568.23297 eV
+Kinetic Energy     :          359.36930670 Eh            9778.93599 eV
+Virial Ratio       :            2.00105952
+
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.5975e+02  Tolerance :   1.0000e-06
+  Last MAX-Density change    ...    7.1989e-06  Tolerance :   1.0000e-05
+  Last RMS-Density change    ...    9.5182e-08  Tolerance :   1.0000e-06
+  Last Orbital Gradient      ...    7.7238e-06  Tolerance :   5.0000e-05
+  Last Orbital Rotation      ...    0.0000e+00  Tolerance :   5.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (input.gbw) ****
+             **** DENSITY FILE WAS UPDATED (input.scfp) ****
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+             **** THE GBW FILE WAS UPDATED (input.gbw) ****
+             **** DENSITY FILE WAS UPDATED (input.scfp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -20.647813      -561.8555 
+   1   2.0000     -20.640438      -561.6549 
+   2   2.0000     -15.580942      -423.9790 
+   3   2.0000     -11.352371      -308.9137 
+   4   2.0000     -11.277189      -306.8679 
+   5   2.0000     -11.249662      -306.1189 
+   6   2.0000     -11.243037      -305.9386 
+   7   2.0000      -1.514740       -41.2182 
+   8   2.0000      -1.264104       -34.3980 
+   9   2.0000      -1.228934       -33.4410 
+  10   2.0000      -1.080755       -29.4088 
+  11   2.0000      -0.976093       -26.5608 
+  12   2.0000      -0.885702       -24.1012 
+  13   2.0000      -0.748288       -20.3619 
+  14   2.0000      -0.738093       -20.0845 
+  15   2.0000      -0.683258       -18.5924 
+  16   2.0000      -0.642193       -17.4750 
+  17   2.0000      -0.599001       -16.2996 
+  18   2.0000      -0.588367       -16.0103 
+  19   2.0000      -0.575795       -15.6682 
+  20   2.0000      -0.572094       -15.5675 
+  21   2.0000      -0.551006       -14.9936 
+  22   2.0000      -0.531924       -14.4744 
+  23   2.0000      -0.507173       -13.8009 
+  24   2.0000      -0.493583       -13.4311 
+  25   2.0000      -0.480186       -13.0665 
+  26   2.0000      -0.467662       -12.7257 
+  27   0.0000       0.121908         3.3173 
+  28   0.0000       0.145478         3.9587 
+  29   0.0000       0.162278         4.4158 
+  30   0.0000       0.170687         4.6446 
+  31   0.0000       0.186870         5.0850 
+  32   0.0000       0.202199         5.5021 
+  33   0.0000       0.206015         5.6059 
+  34   0.0000       0.211617         5.7584 
+  35   0.0000       0.231856         6.3091 
+  36   0.0000       0.252128         6.8607 
+  37   0.0000       0.260180         7.0799 
+  38   0.0000       0.274170         7.4605 
+  39   0.0000       0.284038         7.7291 
+  40   0.0000       0.302888         8.2420 
+  41   0.0000       0.328806         8.9473 
+  42   0.0000       0.352475         9.5913 
+  43   0.0000       0.384630        10.4663 
+  44   0.0000       0.391693        10.6585 
+  45   0.0000       0.411046        11.1851 
+  46   0.0000       0.429871        11.6974 
+  47   0.0000       0.436730        11.8840 
+  48   0.0000       0.441108        12.0032 
+  49   0.0000       0.485843        13.2205 
+  50   0.0000       0.501733        13.6528 
+  51   0.0000       0.525602        14.3024 
+  52   0.0000       0.529125        14.3982 
+  53   0.0000       0.552940        15.0463 
+  54   0.0000       0.556793        15.1511 
+  55   0.0000       0.572575        15.5805 
+  56   0.0000       0.589638        16.0449 
+  57   0.0000       0.591627        16.0990 
+  58   0.0000       0.603073        16.4104 
+  59   0.0000       0.618514        16.8306 
+  60   0.0000       0.632295        17.2056 
+  61   0.0000       0.636278        17.3140 
+  62   0.0000       0.658756        17.9256 
+  63   0.0000       0.669590        18.2205 
+  64   0.0000       0.692375        18.8405 
+  65   0.0000       0.700240        19.0545 
+  66   0.0000       0.724407        19.7121 
+  67   0.0000       0.743822        20.2404 
+  68   0.0000       0.752837        20.4857 
+  69   0.0000       0.782517        21.2934 
+  70   0.0000       0.824334        22.4313 
+  71   0.0000       0.827397        22.5146 
+  72   0.0000       0.845403        23.0046 
+  73   0.0000       0.854024        23.2392 
+  74   0.0000       0.887282        24.1442 
+  75   0.0000       0.974758        26.5245 
+  76   0.0000       0.986942        26.8561 
+  77   0.0000       0.998171        27.1616 
+  78   0.0000       1.015120        27.6228 
+  79   0.0000       1.025429        27.9034 
+  80   0.0000       1.040550        28.3148 
+  81   0.0000       1.077411        29.3179 
+  82   0.0000       1.109673        30.1957 
+  83   0.0000       1.122147        30.5352 
+  84   0.0000       1.169994        31.8371 
+  85   0.0000       1.183213        32.1969 
+  86   0.0000       1.213411        33.0186 
+  87   0.0000       1.228645        33.4331 
+  88   0.0000       1.305182        35.5158 
+  89   0.0000       1.346380        36.6369 
+  90   0.0000       1.373356        37.3709 
+  91   0.0000       1.382114        37.6092 
+  92   0.0000       1.406130        38.2627 
+  93   0.0000       1.412579        38.4382 
+  94   0.0000       1.465823        39.8871 
+  95   0.0000       1.503291        40.9066 
+  96   0.0000       1.521061        41.3902 
+  97   0.0000       1.553724        42.2790 
+  98   0.0000       1.588826        43.2342 
+  99   0.0000       1.609597        43.7994 
+ 100   0.0000       1.640982        44.6534 
+ 101   0.0000       1.659657        45.1616 
+ 102   0.0000       1.705124        46.3988 
+ 103   0.0000       1.719944        46.8020 
+ 104   0.0000       1.743682        47.4480 
+ 105   0.0000       1.771600        48.2077 
+ 106   0.0000       1.784923        48.5702 
+ 107   0.0000       1.799390        48.9639 
+ 108   0.0000       1.818805        49.4922 
+ 109   0.0000       1.853463        50.4353 
+ 110   0.0000       1.866562        50.7917 
+ 111   0.0000       1.876044        51.0498 
+ 112   0.0000       1.888551        51.3901 
+ 113   0.0000       1.910314        51.9823 
+ 114   0.0000       1.962657        53.4066 
+ 115   0.0000       1.990588        54.1666 
+ 116   0.0000       2.005661        54.5768 
+ 117   0.0000       2.043321        55.6016 
+ 118   0.0000       2.068318        56.2818 
+ 119   0.0000       2.107025        57.3351 
+ 120   0.0000       2.139842        58.2281 
+ 121   0.0000       2.182573        59.3908 
+ 122   0.0000       2.227473        60.6126 
+ 123   0.0000       2.240877        60.9774 
+ 124   0.0000       2.251261        61.2599 
+ 125   0.0000       2.292962        62.3947 
+ 126   0.0000       2.329411        63.3865 
+ 127   0.0000       2.344036        63.7845 
+ 128   0.0000       2.381573        64.8059 
+ 129   0.0000       2.399240        65.2866 
+ 130   0.0000       2.418659        65.8151 
+ 131   0.0000       2.449336        66.6498 
+ 132   0.0000       2.456243        66.8378 
+ 133   0.0000       2.538272        69.0699 
+ 134   0.0000       2.551750        69.4367 
+ 135   0.0000       2.575118        70.0725 
+ 136   0.0000       2.588435        70.4349 
+ 137   0.0000       2.620304        71.3021 
+ 138   0.0000       2.624790        71.4242 
+ 139   0.0000       2.647148        72.0326 
+ 140   0.0000       2.653409        72.2029 
+ 141   0.0000       2.672560        72.7241 
+ 142   0.0000       2.690497        73.2121 
+ 143   0.0000       2.707348        73.6707 
+ 144   0.0000       2.710255        73.7498 
+ 145   0.0000       2.789059        75.8941 
+ 146   0.0000       2.804528        76.3151 
+ 147   0.0000       2.826573        76.9150 
+ 148   0.0000       2.863434        77.9180 
+ 149   0.0000       2.872707        78.1703 
+ 150   0.0000       2.882937        78.4487 
+ 151   0.0000       2.927498        79.6613 
+ 152   0.0000       2.946819        80.1870 
+ 153   0.0000       2.956386        80.4473 
+ 154   0.0000       2.968851        80.7866 
+ 155   0.0000       3.001396        81.6721 
+ 156   0.0000       3.022987        82.2596 
+ 157   0.0000       3.046353        82.8955 
+ 158   0.0000       3.079915        83.8087 
+ 159   0.0000       3.096989        84.2734 
+ 160   0.0000       3.139542        85.4313 
+ 161   0.0000       3.143184        85.5304 
+ 162   0.0000       3.156186        85.8842 
+ 163   0.0000       3.180717        86.5517 
+ 164   0.0000       3.244435        88.2856 
+ 165   0.0000       3.280163        89.2578 
+ 166   0.0000       3.288657        89.4889 
+ 167   0.0000       3.302215        89.8578 
+ 168   0.0000       3.351699        91.2044 
+ 169   0.0000       3.367802        91.6426 
+ 170   0.0000       3.382621        92.0458 
+ 171   0.0000       3.424965        93.1980 
+ 172   0.0000       3.453563        93.9762 
+ 173   0.0000       3.492589        95.0382 
+ 174   0.0000       3.520847        95.8071 
+ 175   0.0000       3.546874        96.5153 
+ 176   0.0000       3.553185        96.6871 
+ 177   0.0000       3.589633        97.6789 
+ 178   0.0000       3.616915        98.4213 
+ 179   0.0000       3.636693        98.9595 
+ 180   0.0000       3.644545        99.1731 
+ 181   0.0000       3.665014        99.7301 
+ 182   0.0000       3.680836       100.1606 
+ 183   0.0000       3.689474       100.3957 
+ 184   0.0000       3.702278       100.7441 
+ 185   0.0000       3.721501       101.2672 
+ 186   0.0000       3.799910       103.4008 
+ 187   0.0000       3.826992       104.1377 
+ 188   0.0000       3.847764       104.7030 
+ 189   0.0000       3.887911       105.7954 
+ 190   0.0000       3.922049       106.7244 
+ 191   0.0000       4.022164       109.4486 
+ 192   0.0000       4.069968       110.7495 
+ 193   0.0000       4.128012       112.3289 
+ 194   0.0000       4.148076       112.8749 
+ 195   0.0000       4.187903       113.9586 
+ 196   0.0000       4.290857       116.7601 
+ 197   0.0000       4.294279       116.8533 
+ 198   0.0000       4.340644       118.1149 
+ 199   0.0000       4.347954       118.3138 
+ 200   0.0000       4.363931       118.7486 
+ 201   0.0000       4.378709       119.1507 
+ 202   0.0000       4.404513       119.8529 
+ 203   0.0000       4.428678       120.5105 
+ 204   0.0000       4.471887       121.6862 
+ 205   0.0000       4.495400       122.3260 
+ 206   0.0000       4.617218       125.6409 
+ 207   0.0000       4.686346       127.5220 
+ 208   0.0000       4.719122       128.4138 
+ 209   0.0000       4.736706       128.8923 
+ 210   0.0000       4.751806       129.3032 
+ 211   0.0000       4.846060       131.8680 
+ 212   0.0000       4.871975       132.5732 
+ 213   0.0000       4.955690       134.8512 
+ 214   0.0000       4.970952       135.2665 
+ 215   0.0000       4.985056       135.6503 
+ 216   0.0000       5.070798       137.9834 
+ 217   0.0000       5.110711       139.0695 
+ 218   0.0000       5.145505       140.0163 
+ 219   0.0000       5.205159       141.6396 
+ 220   0.0000       5.225955       142.2055 
+ 221   0.0000       5.273562       143.5009 
+ 222   0.0000       5.346497       145.4856 
+ 223   0.0000       5.420660       147.5036 
+ 224   0.0000       5.491423       149.4292 
+ 225   0.0000       5.550475       151.0361 
+ 226   0.0000       5.600435       152.3956 
+ 227   0.0000       5.636770       153.3843 
+ 228   0.0000       5.688434       154.7901 
+ 229   0.0000       5.799865       157.8223 
+ 230   0.0000       5.904687       160.6747 
+ 231   0.0000       5.988840       162.9646 
+ 232   0.0000       6.084992       165.5810 
+ 233   0.0000       6.124020       166.6431 
+ 234   0.0000       6.212184       169.0421 
+ 235   0.0000       6.265238       170.4858 
+ 236   0.0000       6.362910       173.1436 
+ 237   0.0000       6.420333       174.7061 
+ 238   0.0000       6.562195       178.5664 
+ 239   0.0000       6.604689       179.7227 
+ 240   0.0000       6.649477       180.9415 
+ 241   0.0000       6.895481       187.6356 
+ 242   0.0000       6.925661       188.4568 
+ 243   0.0000       6.945381       188.9934 
+ 244   0.0000       7.145138       194.4291 
+ 245   0.0000       7.246008       197.1739 
+ 246   0.0000       7.300881       198.6671 
+ 247   0.0000       7.369197       200.5260 
+ 248   0.0000       7.615384       207.2251 
+ 249   0.0000       7.709446       209.7847 
+ 250   0.0000       7.784124       211.8168 
+ 251   0.0000       8.676235       236.0924 
+ 252   0.0000      23.465563       638.5304 
+ 253   0.0000      23.481679       638.9690 
+ 254   0.0000      23.789721       647.3512 
+ 255   0.0000      24.509861       666.9472 
+ 256   0.0000      33.439671       909.9397 
+ 257   0.0000      45.113437      1227.5990 
+ 258   0.0000      45.766232      1245.3625 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.347518
+   1 O :   -0.219183
+   2 C :    0.520047
+   3 C :   -0.285439
+   4 N :   -0.141510
+   5 C :   -0.352493
+   6 C :   -0.317956
+   7 H :    0.361271
+   8 H :    0.149152
+   9 H :    0.127084
+  10 H :    0.118978
+  11 H :    0.132625
+  12 H :    0.134219
+  13 H :    0.120722
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.841780  s :     3.841780
+      pz      :     1.610125  p :     4.458992
+      px      :     1.544236
+      py      :     1.304631
+      dz2     :     0.008671  d :     0.044069
+      dxz     :     0.011011
+      dyz     :     0.007781
+      dx2y2   :     0.007846
+      dxy     :     0.008759
+      f0      :     0.000176  f :     0.002677
+      f+1     :     0.000636
+      f-1     :     0.000225
+      f+2     :     0.000379
+      f-2     :     0.000246
+      f+3     :     0.000706
+      f-3     :     0.000309
+  1 O s       :     3.822065  s :     3.822065
+      pz      :     1.823024  p :     4.341487
+      px      :     1.293482
+      py      :     1.224981
+      dz2     :     0.006138  d :     0.052643
+      dxz     :     0.008303
+      dyz     :     0.005605
+      dx2y2   :     0.017259
+      dxy     :     0.015339
+      f0      :     0.000372  f :     0.002988
+      f+1     :     0.000318
+      f-1     :     0.000361
+      f+2     :     0.000296
+      f-2     :     0.000372
+      f+3     :     0.000685
+      f-3     :     0.000584
+  2 C s       :     2.854068  s :     2.854068
+      pz      :     0.774846  p :     2.377456
+      px      :     0.704615
+      py      :     0.897995
+      dz2     :     0.047013  d :     0.233535
+      dxz     :     0.044704
+      dyz     :     0.046158
+      dx2y2   :     0.048102
+      dxy     :     0.047559
+      f0      :     0.001460  f :     0.014894
+      f+1     :     0.002889
+      f-1     :     0.001778
+      f+2     :     0.002381
+      f-2     :     0.001717
+      f+3     :     0.002173
+      f-3     :     0.002497
+  3 C s       :     3.304556  s :     3.304556
+      pz      :     1.017310  p :     2.865585
+      px      :     0.924508
+      py      :     0.923768
+      dz2     :     0.030080  d :     0.097824
+      dxz     :     0.026542
+      dyz     :     0.025438
+      dx2y2   :     0.007958
+      dxy     :     0.007806
+      f0      :     0.005286  f :     0.017474
+      f+1     :     0.003324
+      f-1     :     0.003147
+      f+2     :     0.002457
+      f-2     :     0.002677
+      f+3     :     0.000278
+      f-3     :     0.000305
+  4 N s       :     3.692163  s :     3.692163
+      pz      :     1.241161  p :     3.390974
+      px      :     1.034949
+      py      :     1.114864
+      dz2     :     0.016290  d :     0.055357
+      dxz     :     0.017094
+      dyz     :     0.012799
+      dx2y2   :     0.004436
+      dxy     :     0.004737
+      f0      :     0.000932  f :     0.003016
+      f+1     :     0.000608
+      f-1     :     0.000455
+      f+2     :     0.000437
+      f-2     :     0.000489
+      f+3     :     0.000046
+      f-3     :     0.000050
+  5 C s       :     3.252394  s :     3.252394
+      pz      :     0.983051  p :     3.026386
+      px      :     1.003999
+      py      :     1.039336
+      dz2     :     0.013288  d :     0.069118
+      dxz     :     0.012159
+      dyz     :     0.015239
+      dx2y2   :     0.014923
+      dxy     :     0.013509
+      f0      :     0.000444  f :     0.004596
+      f+1     :     0.000348
+      f-1     :     0.000979
+      f+2     :     0.000799
+      f-2     :     0.000838
+      f+3     :     0.000853
+      f-3     :     0.000335
+  6 C s       :     3.229560  s :     3.229560
+      pz      :     1.071837  p :     3.016443
+      px      :     1.033117
+      py      :     0.911489
+      dz2     :     0.010938  d :     0.067362
+      dxz     :     0.011603
+      dyz     :     0.017609
+      dx2y2   :     0.014306
+      dxy     :     0.012906
+      f0      :     0.000654  f :     0.004592
+      f+1     :     0.000147
+      f-1     :     0.000882
+      f+2     :     0.000544
+      f-2     :     0.000701
+      f+3     :     0.001023
+      f-3     :     0.000639
+  7 H s       :     0.594866  s :     0.594866
+      pz      :     0.017969  p :     0.043863
+      px      :     0.016162
+      py      :     0.009732
+  8 H s       :     0.828241  s :     0.828241
+      pz      :     0.003911  p :     0.022606
+      px      :     0.006191
+      py      :     0.012505
+  9 H s       :     0.850718  s :     0.850718
+      pz      :     0.012775  p :     0.022198
+      px      :     0.003745
+      py      :     0.005678
+ 10 H s       :     0.858909  s :     0.858909
+      pz      :     0.004896  p :     0.022113
+      px      :     0.013003
+      py      :     0.004214
+ 11 H s       :     0.845070  s :     0.845070
+      pz      :     0.012343  p :     0.022305
+      px      :     0.003740
+      py      :     0.006222
+ 12 H s       :     0.843471  s :     0.843471
+      pz      :     0.007734  p :     0.022310
+      px      :     0.006873
+      py      :     0.007703
+ 13 H s       :     0.857078  s :     0.857078
+      pz      :     0.005513  p :     0.022200
+      px      :     0.013099
+      py      :     0.003588
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.099990
+   1 O :    0.087156
+   2 C :   -0.398806
+   3 C :   -0.136784
+   4 N :    0.040553
+   5 C :   -0.215299
+   6 C :   -0.209189
+   7 H :    0.172065
+   8 H :    0.128060
+   9 H :    0.125558
+  10 H :    0.125840
+  11 H :    0.126534
+  12 H :    0.126977
+  13 H :    0.127327
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.499128  s :     3.499128
+      pz      :     1.617611  p :     4.491173
+      px      :     1.508766
+      py      :     1.364795
+      dz2     :     0.015061  d :     0.101559
+      dxz     :     0.019145
+      dyz     :     0.018525
+      dx2y2   :     0.023292
+      dxy     :     0.025536
+      f0      :     0.000701  f :     0.008131
+      f+1     :     0.001231
+      f-1     :     0.000963
+      f+2     :     0.000911
+      f-2     :     0.000945
+      f+3     :     0.002090
+      f-3     :     0.001290
+  1 O s       :     3.398072  s :     3.398072
+      pz      :     1.740016  p :     4.366404
+      px      :     1.329943
+      py      :     1.296445
+      dz2     :     0.015645  d :     0.138234
+      dxz     :     0.020924
+      dyz     :     0.017466
+      dx2y2   :     0.041002
+      dxy     :     0.043197
+      f0      :     0.000945  f :     0.010134
+      f+1     :     0.000909
+      f-1     :     0.000921
+      f+2     :     0.000823
+      f-2     :     0.001362
+      f+3     :     0.002572
+      f-3     :     0.002601
+  2 C s       :     2.706853  s :     2.706853
+      pz      :     0.934772  p :     2.804620
+      px      :     0.849849
+      py      :     1.019998
+      dz2     :     0.157648  d :     0.784262
+      dxz     :     0.158468
+      dyz     :     0.156230
+      dx2y2   :     0.159387
+      dxy     :     0.152529
+      f0      :     0.012329  f :     0.103071
+      f+1     :     0.019974
+      f-1     :     0.009960
+      f+2     :     0.017318
+      f-2     :     0.011506
+      f+3     :     0.013767
+      f-3     :     0.018217
+  3 C s       :     2.827873  s :     2.827873
+      pz      :     1.097764  p :     2.829678
+      px      :     0.843797
+      py      :     0.888118
+      dz2     :     0.139223  d :     0.419348
+      dxz     :     0.095635
+      dyz     :     0.123451
+      dx2y2   :     0.030764
+      dxy     :     0.030275
+      f0      :     0.016421  f :     0.059886
+      f+1     :     0.009659
+      f-1     :     0.016470
+      f+2     :     0.007934
+      f-2     :     0.007660
+      f+3     :     0.000884
+      f-3     :     0.000857
+  4 N s       :     3.300065  s :     3.300065
+      pz      :     1.397839  p :     3.528198
+      px      :     1.005829
+      py      :     1.124531
+      dz2     :     0.038109  d :     0.115367
+      dxz     :     0.028188
+      dyz     :     0.033755
+      dx2y2   :     0.007506
+      dxy     :     0.007810
+      f0      :     0.004103  f :     0.015817
+      f+1     :     0.002600
+      f-1     :     0.004655
+      f+2     :     0.002020
+      f-2     :     0.002031
+      f+3     :     0.000205
+      f-3     :     0.000203
+  5 C s       :     2.820220  s :     2.820220
+      pz      :     1.024204  p :     3.109490
+      px      :     1.040277
+      py      :     1.045010
+      dz2     :     0.057909  d :     0.261012
+      dxz     :     0.043634
+      dyz     :     0.054609
+      dx2y2   :     0.058395
+      dxy     :     0.046464
+      f0      :     0.002670  f :     0.024577
+      f+1     :     0.002529
+      f-1     :     0.004597
+      f+2     :     0.004656
+      f-2     :     0.003581
+      f+3     :     0.004283
+      f-3     :     0.002261
+  6 C s       :     2.820331  s :     2.820331
+      pz      :     1.060910  p :     3.101336
+      px      :     1.047048
+      py      :     0.993378
+      dz2     :     0.032976  d :     0.262792
+      dxz     :     0.037727
+      dyz     :     0.077596
+      dx2y2   :     0.062478
+      dxy     :     0.052015
+      f0      :     0.003395  f :     0.024730
+      f+1     :     0.001432
+      f-1     :     0.003961
+      f+2     :     0.002739
+      f-2     :     0.003666
+      f+3     :     0.004670
+      f-3     :     0.004866
+  7 H s       :     0.668887  s :     0.668887
+      pz      :     0.075441  p :     0.159048
+      px      :     0.054496
+      py      :     0.029111
+  8 H s       :     0.809062  s :     0.809062
+      pz      :     0.012379  p :     0.062878
+      px      :     0.018511
+      py      :     0.031987
+  9 H s       :     0.813597  s :     0.813597
+      pz      :     0.031114  p :     0.060845
+      px      :     0.012262
+      py      :     0.017469
+ 10 H s       :     0.813211  s :     0.813211
+      pz      :     0.015637  p :     0.060949
+      px      :     0.032089
+      py      :     0.013223
+ 11 H s       :     0.812270  s :     0.812270
+      pz      :     0.032345  p :     0.061196
+      px      :     0.012417
+      py      :     0.016435
+ 12 H s       :     0.811367  s :     0.811367
+      pz      :     0.021721  p :     0.061657
+      px      :     0.020254
+      py      :     0.019681
+ 13 H s       :     0.811519  s :     0.811519
+      pz      :     0.016581  p :     0.061153
+      px      :     0.032724
+      py      :     0.011848
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.3475     8.0000    -0.3475     1.7654     1.7654    -0.0000
+  1 O      8.2192     8.0000    -0.2192     1.7817     1.7817    -0.0000
+  2 C      5.4800     6.0000     0.5200     3.7541     3.7541    -0.0000
+  3 C      6.2854     6.0000    -0.2854     4.0253     4.0253    -0.0000
+  4 N      7.1415     7.0000    -0.1415     3.0477     3.0477    -0.0000
+  5 C      6.3525     6.0000    -0.3525     3.8811     3.8811    -0.0000
+  6 C      6.3180     6.0000    -0.3180     3.8716     3.8716    -0.0000
+  7 H      0.6387     1.0000     0.3613     0.8838     0.8838    -0.0000
+  8 H      0.8508     1.0000     0.1492     0.9780     0.9780     0.0000
+  9 H      0.8729     1.0000     0.1271     0.9750     0.9750    -0.0000
+ 10 H      0.8810     1.0000     0.1190     0.9744     0.9744     0.0000
+ 11 H      0.8674     1.0000     0.1326     0.9770     0.9770    -0.0000
+ 12 H      0.8658     1.0000     0.1342     0.9804     0.9804     0.0000
+ 13 H      0.8793     1.0000     0.1207     0.9767     0.9767    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-O ) :   0.8249 B(  0-O ,  7-H ) :   0.8742 B(  1-O ,  2-C ) :   0.9492 
+B(  2-C ,  3-C ) :   0.8887 B(  2-C ,  5-C ) :   0.9663 B(  2-C ,  6-C ) :   0.9510 
+B(  3-C ,  4-N ) :   3.0520 B(  5-C ,  8-H ) :   0.9744 B(  5-C ,  9-H ) :   0.9839 
+B(  5-C , 10-H ) :   0.9733 B(  6-C , 11-H ) :   0.9849 B(  6-C , 12-H ) :   0.9767 
+B(  6-C , 13-H ) :   0.9731 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 2 sec 
+
+Total time                  ....       2.603 sec
+Sum of individual times     ....       1.243 sec  ( 47.7%)
+
+Fock matrix formation       ....       0.979 sec  ( 37.6%)
+Diagonalization             ....       0.014 sec  (  0.5%)
+Density matrix formation    ....       0.019 sec  (  0.7%)
+Population analysis         ....       0.077 sec  (  3.0%)
+Initial guess               ....       0.150 sec  (  5.8%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.127 sec  (  4.9%)
+DIIS solution               ....       0.003 sec  (  0.1%)
+NR solution                 ....       0.000 sec  (  0.0%)
+
+
+           ************************************************************
+           *        Program running with 40 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+
+------------------------------------------------------------------------------- 
+                              ORCA-MATRIX DRIVEN CI                            
+------------------------------------------------------------------------------- 
+
+
+Wavefunction type
+-----------------
+Correlation treatment                      ...      CCSD     
+Single excitations                         ... ON
+Orbital optimization                       ... OFF
+Calculation of Z vector                    ... OFF
+Calculation of Brueckner orbitals          ... OFF
+Perturbative triple excitations            ... ON
+Calculation of F12 correction              ... OFF
+Frozen core treatment                      ... chemical core (14 el)
+Reference Wavefunction                     ... RHF
+  Internal Orbitals:     7 ...   26 ( 20 MO's/ 40 electrons)
+  Virtual  Orbitals:    27 ...  258 (232 MO's              )
+Number of AO's                             ...    259
+Number of electrons                        ...     54
+Number of correlated electrons             ...     40
+
+Algorithmic settings
+--------------------
+Integral transformation                    ... All integrals via the RI transformation
+K(C) Formation                             ... RI-DLPNO
+   PNO-Integral Storage                    ... ON DISK
+   PNO occupation number cut-off           ... 3.330e-07
+   Singles PNO occupation number cut-off   ... 9.990e-09
+   PNO Mulliken prescreening cut-off       ... 1.000e-03
+   Domain cut-off (Mulliken population)    ... 1.000e-03
+   PNO Normalization                       ...    1
+Maximum number of iterations               ...        50
+Convergence tolerance (max. residuum)      ... 2.500e-05
+Level shift for amplitude update           ... 2.000e-01
+Maximum number of DIIS vectors             ...         7
+DIIS turned on at iteration                ...         0
+Damping before turning on DIIS             ...     0.500
+Damping after turning on DIIS              ...     0.000
+Pair specific amplitude update             ... OFF
+Natural orbital iterations                 ... OFF
+Perturbative natural orbital generation    ... OFF
+Printlevel                                 ... 2
+
+Singles Fock matrix elements calculated using PNOs.
+
+Memory handling:
+----------------
+Maximum memory for working arrays          ...   3072 MB
+Data storage in matrix containers          ... UNCOMPRESSED
+Data type for integral storage             ... DOUBLE
+In-Core Storage of quantities:
+   Amplitudes+Sigma Vector      ... NO
+   J+K operators                ... NO
+   DIIS vectors                 ... NO
+   3-external integrals         ... NO
+   4-external integrals         ... NO
+
+Localization treatment:
+-----------------------
+Localization option                        ...    6
+Localization threshhold                    ... -1.0e+00
+Using relative localization threshhold     ... 1.0e-08
+Neglect threshold for strong pairs         ... 1.000e-04 Eh
+Prescreening threshold for very weak pairs ... 1.000e-06 Eh
+
+Initializing the integral package          ... done
+Localizing the valence orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... input.gbw
+Output orbitals are to                   ... input.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 7 to 26
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :   209.610299
+ITERATION   0 : L=  247.1069036897 DL=  3.75e+01 (AVERGE_DL)=    0.4442415438 
+ITERATION   1 : L=  253.3393143415 DL=  6.23e+00 (AVERGE_DL)=    0.1811136696 
+ITERATION   2 : L=  253.4246082555 DL=  8.53e-02 (AVERGE_DL)=    0.0211876223 
+ITERATION   3 : L=  253.4269927552 DL=  2.38e-03 (AVERGE_DL)=    0.0035425977 
+ITERATION   4 : L=  253.4271915072 DL=  1.99e-04 (AVERGE_DL)=    0.0010227723 
+ITERATION   5 : L=  253.4272499522 DL=  5.84e-05 (AVERGE_DL)=    0.0005546217 
+ITERATION   6 : L=  253.4272967401 DL=  4.68e-05 (AVERGE_DL)=    0.0004962377 
+ITERATION   7 : L=  253.4273420513 DL=  4.53e-05 (AVERGE_DL)=    0.0004883445 
+ITERATION   8 : L=  253.4273866553 DL=  4.46e-05 (AVERGE_DL)=    0.0004845180 
+ITERATION   9 : L=  253.4274305955 DL=  4.39e-05 (AVERGE_DL)=    0.0004808995 
+ITERATION  10 : L=  253.4274738609 DL=  4.33e-05 (AVERGE_DL)=    0.0004771920 
+ITERATION  11 : L=  253.4275164402 DL=  4.26e-05 (AVERGE_DL)=    0.0004733938 
+ITERATION  12 : L=  253.4275583166 DL=  4.19e-05 (AVERGE_DL)=    0.0004694700 
+ITERATION  13 : L=  253.4275994812 DL=  4.12e-05 (AVERGE_DL)=    0.0004654630 
+ITERATION  14 : L=  253.4276399228 DL=  4.04e-05 (AVERGE_DL)=    0.0004613575 
+ITERATION  15 : L=  253.4276796336 DL=  3.97e-05 (AVERGE_DL)=    0.0004571698 
+DETECTED SLOW CONVERGENCE - QUITTING
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          7 to 26
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         190
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 253.4276796336   Grad. norm: 9.554259e-03
+Iter:    1   L: 253.4288011697   Grad. norm: 1.440620e-02
+Iter:    2   L: 253.4290812597   Grad. norm: 8.249536e-03
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  1.32e-06 -2.52e-02 -1.84e+00 -1.92e+00 ... 
+Iter:    3   L: 253.4290819194   Grad. norm: 5.339586e-06
+Iter:    4   L: 253.4290819194   Grad. norm: 4.659816e-11
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -2.513e-02
+  1 -1.838e+00
+  2 -1.920e+00
+  3 -3.723e+00
+  4 -3.772e+00
+  5 -4.907e+00
+  6 -5.193e+00
+  7 -6.941e+00
+  8 -7.483e+00
+  9 -8.548e+00
+    ...
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   5 strongly local MO`s
+       -  15 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO  11:   4N  -   0.966550
+MO  10:   1O  -   1.004063
+MO   9:   1O  -   0.999708
+MO   8:   0O  -   1.012411
+MO   7:   0O  -   1.011502
+Bond-like localized orbitals:
+MO  26:  13H  -   0.453870  and   6C  -   0.561061
+MO  25:  12H  -   0.443221  and   6C  -   0.574919
+MO  24:  11H  -   0.445723  and   6C  -   0.582521
+MO  23:  10H  -   0.456038  and   5C  -   0.561064
+MO  22:   9H  -   0.450044  and   5C  -   0.576415
+MO  21:   8H  -   0.434511  and   5C  -   0.585791
+MO  20:   7H  -   0.329001  and   0O  -   0.682761
+MO  19:   6C  -   0.464607  and   2C  -   0.545871
+MO  18:   5C  -   0.472530  and   2C  -   0.554021
+MO  17:   4N  -   0.527961  and   3C  -   0.476238
+MO  16:   4N  -   0.539792  and   3C  -   0.472095
+MO  15:   4N  -   0.543435  and   3C  -   0.468906
+MO  14:   3C  -   0.688518  and   2C  -   0.339489
+MO  13:   2C  -   0.335590  and   1O  -   0.670520
+MO  12:   1O  -   0.507259  and   0O  -   0.502232
+Localized MO's were stored in: input.loc
+
+Localizing the core orbitals
+------------------------------------------------------------------------------
+                           ORCA ORBITAL LOCALIZATION
+------------------------------------------------------------------------------
+
+Input orbitals are from                  ... input.loc
+Output orbitals are to                   ... input.loc
+Max. number of iterations                ... 128
+Localizations seeded randomly            ... off
+Convergence tolerance                    ... 1.000e-06
+Using relative localization threshhold   ... 1.000e-08
+Treshold for strong local MOs            ... 9.500e-01
+Treshold for bond MOs                    ... 8.500e-01
+Operator                                 ... 0
+Orbital range for localization           ... 0 to 6
+Localization criterion                   ... FOSTER-BOYS (AUGMENTED HESSIAN)
+Doing the dipole integrals     ... o.k.
+Initial value of the localization sum :    73.120163
+ITERATION   0 : L=   73.1201698867 DL=  6.40e-06 (AVERGE_DL)=    0.0005520967 
+ITERATION   1 : L=   73.1201698867 DL=  0.00e+00 (AVERGE_DL)=    0.0000000000 
+LOCALIZATION SUM CONVERGED
+
+------------------------------------------------------
+AUGMENTED HESSIAN OPTIMIZATION OF FOSTER-BOYS ORBITALS
+------------------------------------------------------
+
+Spin operator:           0
+Orbital window:          0 to 6
+Number of iterations:    128
+Gradient tolerance:      1.000e-06
+Number of pairs:         21
+Davidson threshold:      2000
+Diagonalization method:  LAPACK
+Iter:    0   L: 73.1201698867   Grad. norm: 3.064613e-04
+   *** Likely close to a maximum now. ***
+       Augmented Hessian eigenvalues:  6.69e-10 -1.88e+01 -2.87e+01 -2.90e+01 ... 
+Iter:    1   L: 73.1201698870   Grad. norm: 2.007190e-15
+LOCALIZATION HAS CONVERGED.
+
+Eigenvalues of the Hessian:
+  0 -1.878e+01
+  1 -2.866e+01
+  2 -2.898e+01
+  3 -3.142e+01
+  4 -3.317e+01
+  5 -3.320e+01
+  6 -7.697e+01
+  7 -7.716e+01
+  8 -7.949e+01
+  9 -8.538e+01
+    ...
+
+
+------------------------------------------------------------------------------- 
+                    LOCALIZED MOLECULAR ORBITAL COMPOSITIONS                   
+------------------------------------------------------------------------------- 
+
+The Mulliken populations for each LMO on each atom are computed
+The LMO`s will be ordered according to atom index and type
+  (A) Strongly localized MO`s have populations of >=0.950 on one atom
+  (B) Two center bond orbitals have populations of >=0.850 on two atoms
+  (C) Other MO`s are considered to be `delocalized`
+
+FOUND  -   7 strongly local MO`s
+       -   0 two center bond MO`s
+       -   0 significantly delocalized MO`s
+
+Rather strongly localized orbitals:
+MO   6:   6C  -   1.000977
+MO   5:   5C  -   1.000866
+MO   4:   4N  -   0.998980
+MO   3:   3C  -   0.997366
+MO   2:   2C  -   1.002433
+MO   1:   1O  -   0.999740
+MO   0:   0O  -   1.000030
+Localized MO's were stored in: input.loc
+
+Warning: reference  - re-canonicalizations have been set to INT 1 VIRT 1
+Warning: internal orbitals are localized - no re-canonicalization of internal orbitals
+Warning: UsePNO is turned on - no re-canonicalization of internal and virtual orbitals
+
+--------------------------
+CLOSED-SHELL FOCK OPERATOR
+--------------------------
+
+<ss|ss>:      1024596 b       168432 skpd ( 16.4%)    0.008 s ( 0.000 ms/b)
+<ss|sp>:      2106432 b       324775 skpd ( 15.4%)    0.027 s ( 0.000 ms/b)
+<ss|sd>:      1048923 b       193090 skpd ( 18.4%)    0.032 s ( 0.000 ms/b)
+<ss|sf>:       523746 b       106812 skpd ( 20.4%)    0.010 s ( 0.000 ms/b)
+<ss|pp>:       569538 b        76818 skpd ( 13.5%)    0.016 s ( 0.000 ms/b)
+<ss|pd>:       545211 b        82765 skpd ( 15.2%)    0.017 s ( 0.000 ms/b)
+<ss|pf>:       276183 b        48684 skpd ( 17.6%)    0.010 s ( 0.000 ms/b)
+<ss|dd>:       145962 b        22638 skpd ( 15.5%)    0.006 s ( 0.000 ms/b)
+<ss|df>:       137376 b        25719 skpd ( 18.7%)    0.007 s ( 0.000 ms/b)
+<ss|ff>:        40068 b         8031 skpd ( 20.0%)    0.005 s ( 0.000 ms/b)
+<sp|sp>:      1084128 b       152758 skpd ( 14.1%)    0.028 s ( 0.000 ms/b)
+<sp|sd>:      1078976 b       186549 skpd ( 17.3%)    0.024 s ( 0.000 ms/b)
+<sp|sf>:       538752 b       103190 skpd ( 19.2%)    0.020 s ( 0.000 ms/b)
+<sp|pp>:       585856 b        70214 skpd ( 12.0%)    0.031 s ( 0.000 ms/b)
+<sp|pd>:       560832 b        77067 skpd ( 13.7%)    0.031 s ( 0.000 ms/b)
+<sp|pf>:       284096 b        45914 skpd ( 16.2%)    0.022 s ( 0.000 ms/b)
+<sp|dd>:       150144 b        20712 skpd ( 13.8%)    0.011 s ( 0.000 ms/b)
+<sp|df>:       141312 b        24702 skpd ( 17.5%)    0.016 s ( 0.000 ms/b)
+<sp|ff>:        41216 b         7751 skpd ( 18.8%)    0.012 s ( 0.000 ms/b)
+<sd|sd>:       269011 b        55924 skpd ( 20.8%)    0.022 s ( 0.000 ms/b)
+<sd|sf>:       268278 b        62258 skpd ( 23.2%)    0.015 s ( 0.000 ms/b)
+<sd|pp>:       291734 b        43601 skpd ( 14.9%)    0.024 s ( 0.000 ms/b)
+<sd|pd>:       279273 b        47744 skpd ( 17.1%)    0.024 s ( 0.000 ms/b)
+<sd|pf>:       141469 b        28312 skpd ( 20.0%)    0.023 s ( 0.000 ms/b)
+<sd|dd>:        74766 b        13242 skpd ( 17.7%)    0.011 s ( 0.000 ms/b)
+<sd|df>:        70368 b        15015 skpd ( 21.3%)    0.014 s ( 0.000 ms/b)
+<sd|ff>:        20524 b         4937 skpd ( 24.1%)    0.008 s ( 0.001 ms/b)
+<sf|sf>:        67161 b        17584 skpd ( 26.2%)    0.008 s ( 0.000 ms/b)
+<sf|pp>:       145668 b        24163 skpd ( 16.6%)    0.022 s ( 0.000 ms/b)
+<sf|pd>:       139446 b        26761 skpd ( 19.2%)    0.022 s ( 0.000 ms/b)
+<sf|pf>:        70638 b        16182 skpd ( 22.9%)    0.031 s ( 0.001 ms/b)
+<sf|dd>:        37332 b         7641 skpd ( 20.5%)    0.008 s ( 0.000 ms/b)
+<sf|df>:        35136 b         8656 skpd ( 24.6%)    0.012 s ( 0.000 ms/b)
+<sf|ff>:        10248 b         2857 skpd ( 27.9%)    0.008 s ( 0.001 ms/b)
+<pp|pp>:        79401 b         8025 skpd ( 10.1%)    0.013 s ( 0.000 ms/b)
+<pp|pd>:       151638 b        17494 skpd ( 11.5%)    0.023 s ( 0.000 ms/b)
+<pp|pf>:        76814 b        10608 skpd ( 13.8%)    0.017 s ( 0.000 ms/b)
+<pp|dd>:        40596 b         4654 skpd ( 11.5%)    0.009 s ( 0.000 ms/b)
+<pp|df>:        38208 b         5586 skpd ( 14.6%)    0.013 s ( 0.000 ms/b)
+<pp|ff>:        11144 b         1726 skpd ( 15.5%)    0.008 s ( 0.001 ms/b)
+<pd|pd>:        72771 b         9832 skpd ( 13.5%)    0.017 s ( 0.000 ms/b)
+<pd|pf>:        73533 b        11905 skpd ( 16.2%)    0.026 s ( 0.000 ms/b)
+<pd|dd>:        38862 b         5270 skpd ( 13.6%)    0.014 s ( 0.000 ms/b)
+<pd|df>:        36576 b         6424 skpd ( 17.6%)    0.022 s ( 0.001 ms/b)
+<pd|ff>:        10668 b         2135 skpd ( 20.0%)    0.013 s ( 0.001 ms/b)
+<pf|pf>:        18721 b         3708 skpd ( 19.8%)    0.021 s ( 0.001 ms/b)
+<pf|dd>:        19686 b         3335 skpd ( 16.9%)    0.013 s ( 0.001 ms/b)
+<pf|df>:        18528 b         3961 skpd ( 21.4%)    0.018 s ( 0.001 ms/b)
+<pf|ff>:         5404 b         1315 skpd ( 24.3%)    0.011 s ( 0.003 ms/b)
+<dd|dd>:         5253 b          739 skpd ( 14.1%)    0.004 s ( 0.001 ms/b)
+<dd|df>:         9792 b         1841 skpd ( 18.8%)    0.010 s ( 0.001 ms/b)
+<dd|ff>:         2856 b          636 skpd ( 22.3%)    0.006 s ( 0.003 ms/b)
+<df|df>:         4656 b         1038 skpd ( 22.3%)    0.009 s ( 0.002 ms/b)
+<df|ff>:         2688 b          701 skpd ( 26.1%)    0.010 s ( 0.005 ms/b)
+<ff|ff>:          406 b          117 skpd ( 28.8%)    0.006 s ( 0.022 ms/b)
+Time needed for Fock operator              ...            1.191 sec
+Reference energy                           ...   -359.750066515
+
+--------------
+DLPNO SETTINGS (2015 fully linear scaling implementation)
+--------------
+
+TCutMKN:           1.000e-03
+TCutPAO:           1.000e-03
+TCutPNO:           3.330e-07
+TCutPNOSingles:    9.990e-09
+TCutEN:            9.700e-01
+TCutPAOExt:        1.000e-01
+TCutPairs:         1.000e-04
+TCutPre:           1.000e-06
+TCutOSV:           1.000e-06
+TCutDOij:          1.000e-05
+TCutDO:            1.000e-02
+TCutC:             1.000e-04
+TCutCPAO:          1.000e-03
+TCutCMO:           1.000e-03
+TScaleDOMP2PreScr: 2.000e+00
+TScaleMKNMP2PreScr:1.000e+01
+TScalePNOMP2PreScr:1.000e+00
+PAO overlap thresh 1.000e-08
+Using PNOs for Singles Fock computation
+Use new domains
+Use fully linear algorithm
+TCutTNO:           1.000e-09
+TCutMP2Pairs:      1.000e-05
+TCutDOStrong:      2.000e-03
+TCutMKNStrong:     1.000e-02
+TCutMKNWeak:       1.000e-01
+TCutDOWeak:        4.000e-03
+NTCutTNO:          1
+
+--------------------------
+Calculating differential overlap integrals ... ok
+--------------------------
+ELECTRON PAIR PRESCREENING
+--------------------------
+
+Dipole-based pair screening          .... used
+
+   TCutDOij = 1.000000e-05
+   TCutPre  = 1.000000e-06
+   .... Finished loop over pairs
+Total time spent in the prescreening                  ...     0.001 sec
+sum of pair energies estimated for screened out pairs ...       0.000000000000 Eh
+Thresholds for map construction and integral transformation for crude MP2:
+   TCutMKN                    ...     1.0e-02
+   TCutDO                     ...     2.0e-02
+   TCutPairs                  ...     1.0e-04
+   TCutPNO_CrudeMP2           ...     3.3e-07
+   TCutPNOSingles_CrudeMP2    ...     1.0e-08
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:       7 to 26
+Number of PAOs:     259
+Basis functions:    259 (105 shells)
+Aux. functions:     637 (203 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs              20.0
+   Aux shells -> PAOs            259.0
+   MOs        -> AO shells       103.4
+   PAOs       -> AO shells       105.0
+
+Calculating integrals (0.8 sec, 25.182 MB)
+Sorting integrals (0.4 sec, 25.175 MB)
+Total time for the integral transformation: 1.1 sec
+--------------------------------
+INITIAL GUESS AND PNO GENERATION
+--------------------------------
+
+PNO truncation parameters                   .... 
+    PAOOverlapThresh   =        1.000e-08
+
+    TCutPairs          =        1.000e-04
+    TCutPNO            =        3.330e-07
+    TCutPNOSingles     =        9.990e-09
+    TCutMP2Pairs       =        1.000e-05
+    TCutMKN            =        1.000e-02
+    TCutDO             =        2.000e-02
+
+Pair selection                          .... not used
+Type of local MP2 treatment                 .... semi-local MP2
+Strategy for PNO selection                  .... occupation number selection
+Pair density normalization                  .... MP2 norm
+Spin component scaling                      .... not used
+
+   .... Finished loop over pairs
+Making pair pair interaction lists          ... done
+
+                       ===========================
+                        182 OF  210 PAIRS ARE KEPT CCSD PAIRS
+                         28 OF  210 PAIRS ARE KEPT MP2 PAIRS FOR (T)
+                          0 OF  210 PAIRS ARE SKIPPED
+                       ===========================
+
+Total time spent in the initial guess                 ...     0.465 sec
+SL-MP2 correlation energy (all non-screened pairs)    ...      -1.258595650100 Eh
+
+Initial PNO correlation energy                        ...      -1.254345281966 Eh
+sum of pair energies prescreened and skipped MP2 pairs...       0.000000000000 Eh
+sum of pair energies of crude MP2 skipped pairs only  ...       0.000000000000 Eh
+sum of MP2 pair energies for pairs that were not kept ...      -0.001472600714 Eh
+sum of PNO error estimates for the kept pairs         ...      -0.002777767419 Eh
+                                                          --------------------
+sum of all corrections                                         -0.004250368134
+Initial total correlation energy                               -1.258595650100
+Thresholds for map construction and integral transformation for fine MP2 and CCSD(T) calculation:
+   TCutMKN   ...     1.0e-03
+   TCutDO    ...     1.0e-02
+   TCutPairs ...     1.0e-04
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Thresholds for map construction and integral transformation for strong Triples:
+   TCutMKN   ...     1.0e-02
+   TCutDO    ...     2.0e-02
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Thresholds for map construction and integral transformation for weak Triples:
+   TCutMKN   ...     1.0e-01
+   TCutDO    ...     4.0e-02
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+--------------------------------
+LOCAL RI TRANSFORMATION (IAVPAO)
+--------------------------------
+
+Orbital window:       7 to 26
+Number of PAOs:     259
+Basis functions:    259 (105 shells)
+Aux. functions:     637 (203 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs              20.0
+   Aux shells -> PAOs            259.0
+   MOs        -> AO shells       103.4
+   PAOs       -> AO shells       105.0
+
+Calculating integrals (0.3 sec, 25.182 MB)
+Sorting integrals (0.1 sec, 25.175 MB)
+Total time for the integral transformation: 1.0 sec
+--------------------------------
+INITIAL GUESS AND PNO GENERATION
+--------------------------------
+
+PNO truncation parameters                   .... 
+    PAOOverlapThresh   =        1.000e-08
+
+    TCutPairs          =        1.000e-04
+    TCutPNO            =        3.330e-07
+    TCutPNOSingles     =        9.990e-09
+    TCutMP2Pairs       =        1.000e-05
+    TCutMKN            =        1.000e-03
+    TCutDO             =        1.000e-02
+
+Pair selection                          .... not used
+Type of local MP2 treatment                 .... semi-local MP2
+Strategy for PNO selection                  .... occupation number selection
+Pair density normalization                  .... MP2 norm
+Spin component scaling                      .... not used
+
+   .... Finished loop over pairs
+
+ PNO Occupation Number Statistics: 
+  | Av. % of trace(Dij) retained        ...  98.647666443330
+  | sigma^2 in % of trace(Dij) retained ...   1.82e+00
+  | Av. % of trace(Di) retained         ...  99.999376086204
+  | sigma^2 in % of trace(Di) retained  ...   8.49e-08
+ Distributions of % trace(Dij) recovered:
+  |       >= 99.9  ...    57 ( 27.1 % of all pairs)
+  |   [90.0, 99.0) ...   104 ( 49.5 % of all pairs)
+  |   [99.0, 99.9) ...    49 ( 23.3 % of all pairs)
+ Distributions of % trace(Di) recovered :
+  |       >= 99.9  ...    20 (100.0 % of all I-pairs )
+
+Making pair pair interaction lists          ... done
+
+                       ===========================
+                        182 OF  210 PAIRS ARE KEPT
+                       ===========================
+
+Total time spent in the initial guess                 ...     2.316 sec
+SL-MP2 correlation energy (all non-screened pairs)    ...      -1.259093020692 Eh
+
+Initial PNO correlation energy                        ...      -1.254851776451 Eh
+sum of pair energies estimated for screened out pairs ...       0.000000000000 Eh
+sum of MP2 pair energies for pairs that were not kept ...      -0.001472555767 Eh
+sum of PNO error estimates for the kept pairs         ...      -0.002768688475 Eh
+                                                          --------------------
+sum of all corrections                                         -0.004241244242
+Initial total correlation energy                               -1.259093020692
+Thresholds for map construction and integral transformation for fine MP2 and CCSD(T) calculation:
+   TCutMKN   ...     1.0e-03
+   TCutDO    ...     1.0e-02
+   TCutPairs ...     1.0e-04
+   TCutCMO   ...     1.0e-03
+   TCutCPAO  ...     1.0e-03
+
+Time for aux screen maps:            0.001
+Time for maps after fine MP2:            0.007
+-----------------------------
+LOCAL RI TRANSFORMATION (IJV)
+-----------------------------
+
+Orbital window:       7 to 26
+Basis functions:    259 (105 shells)
+Aux. functions:     637 (203 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> MOs(i)           20.0
+   Aux shells -> MOs(j)           20.0
+   MOs        -> AO shells       103.4
+
+Calculating integrals (0.3 sec, 1.951 MB)
+Sorting integrals (0.4 sec, 1.944 MB)
+Total time for the integral transformation: 0.8 sec
+--------------------------------
+LOCAL RI TRANSFORMATION (VABPAO)
+--------------------------------
+
+Number of PAOs:     259
+Basis functions:    259 (105 shells)
+Aux. functions:     637 (203 shells)
+
+Processing maps (0.0 sec)
+Average map sizes:
+   Aux shells -> PAOs            259.0
+   PAOs       -> AO shells       105.0
+
+Calculating integrals (1.3 sec, 639.749 MB)
+Finished
+
+
+-------------------------------------
+Pair Pair Term precalculation with     
+RI-(ij|mn) and (im|jn) transformation  
+ON THE FLY                             
+-------------------------------------
+
+   IBatch   1 (of   1)              ... done (    3.409 sec)
+Total EXT                           ...           3.409 sec
+
+---------------------
+RI-PNO TRANSFORMATION
+---------------------
+
+Total Number of PNOs                   ...  4938
+Average number of PNOs per pair        ...    27
+Maximal number of PNOs per pair        ...    49
+   #pairs with  1 -  5 PNOs   :    0
+   #pairs with  6 - 10 PNOs   :   10
+   #pairs with 11 - 15 PNOs   :   27
+   #pairs with 16 - 20 PNOs   :   34
+   #pairs with 21 - 25 PNOs   :   14
+   #pairs with 26 - 30 PNOs   :   19
+   #pairs with 31 - 35 PNOs   :   30
+   #pairs with 36 - 40 PNOs   :    6
+   #pairs with 41 - 45 PNOs   :   28
+   #pairs with 46 - 50 PNOs   :   14
+
+Generation of (ij|ab)[P] integrals            ... on
+Generation of (ia|bc)[P],(ja|bc)[P] integrals ... on
+Storage of 3 and 4 external integrals         ... on
+Generation of ALL (ka|bc)[P] integrals        ... on
+Keep RI integrals in memory                   ... off
+
+Ibatch:  1 (of  1)
+Starting 2-4 index PNO integral generation ... done
+
+Timings:
+Total PNO integral transformation time     ...          5.366 sec
+Size of the 3-external file                ...        46 MB
+Size of the 4-external file                ...       231 MB
+Size of the IKJL file                      ...         0 MB
+Size of the all 3-external file            ...       460 MB
+Size of the 1-external file                ...         2 MB
+
+Making pair/pair overlap matrices          ... done (    1.084 sec)
+Size of the pair overlap file              ... 145 MB
+Redoing the guess amplitudes               ... done (    0.019 sec)
+
+-------------------------
+FINAL STARTUP INFORMATION
+-------------------------
+
+E(0)                                       ...   -359.750066515
+E(SL-MP2)                                  ...     -1.259093021
+E(SL-MP2) including corrections            ...     -1.259093021
+Initial E(tot)                             ...   -361.009159536
+<T|T>                                      ...      0.341420683
+Number of pairs included                   ... 182
+Total number of pairs                      ... 210
+
+------------------------------------------------
+                  RHF COUPLED CLUSTER ITERATIONS
+------------------------------------------------
+
+Number of PNO amplitudes to be optimized   ...       160768
+Number of non-PNO amplitudes               ...      9795968
+Untruncated number of regular amplitudes   ...     11303040
+
+Iter       E(tot)           E(Corr)          Delta-E          Residual     Time
+  0   -361.009199047     -1.254891287      0.004201733      0.021775502   61.97
+                           *** Turning on DIIS ***
+  1   -361.052030156     -1.297722397     -0.042831109      0.020131752    6.98
+  2   -361.087172544     -1.332864784     -0.035142388      0.006411516    7.15
+  3   -361.094725997     -1.340418238     -0.007553454      0.003446466    7.18
+  4   -361.096884538     -1.342576779     -0.002158541      0.001036712    7.08
+  5   -361.097354554     -1.343046795     -0.000470016      0.000482210    7.37
+  6   -361.097442721     -1.343134962     -0.000088167      0.000119163    7.16
+  7   -361.097445933     -1.343138173     -0.000003212      0.000058122    7.13
+  8   -361.097452112     -1.343144352     -0.000006179      0.000035330    7.09
+  9   -361.097447482     -1.343139722      0.000004630      0.000021439    7.09
+               --- The Coupled-Cluster iterations have converged ---
+
+----------------------
+COUPLED CLUSTER ENERGY
+----------------------
+
+E(0)                                       ...   -359.750066515
+E(CORR)(strong-pairs)                      ...     -1.343139722
+E(CORR)(weak-pairs)                        ...     -0.004241244
+E(CORR)(corrected)                         ...     -1.347380967
+E(TOT)                                     ...   -361.097447482
+Singles Norm <S|S>**1/2                    ...      0.072198337  
+T1 diagnostic                              ...      0.011415559  
+
+------------------
+LARGEST AMPLITUDES
+------------------
+  12-> 27  12-> 27       0.085041
+  17-> 27  17-> 27       0.062974
+  16-> 27  16-> 27       0.062419
+  15-> 27  15-> 27       0.060934
+  14-> 29  14-> 29       0.049646
+  16-> 27  15-> 27       0.039390
+  17-> 27  15-> 27       0.037646
+  17-> 27  16-> 27       0.037539
+  13-> 28  13-> 28       0.036217
+  11-> 27  11-> 27       0.035954
+  24-> 34  24-> 34       0.035622
+  11-> 28  11-> 28       0.034721
+  22-> 34  22-> 34       0.034653
+  19-> 29  19-> 29       0.033206
+   8-> 29   8-> 29       0.033089
+  18-> 28  18-> 28       0.030427
+
+
+-------------------------------------------
+DLPNO BASED TRIPLES CORRECTION
+-------------------------------------------
+
+Singles multiplier          ...  1.000000
+TCutTNO                     ... 1.000e-09
+TCutMP2Pairs                ... 1.000e-05
+TCutDOStrong                ... 2.000e-02
+TCutMKNStrong               ... 1.000e-02
+TCutDOWeak                  ... 4.000e-02
+TCutMKNWeak                 ... 1.000e-01
+
+Fragment selection                          .... not used
+Fock matrix occ-virt block is zero --> Setting DT_in_Triples to false.
+Number of Triples that are to be computed   ...      1345
+
+ . . . . . . . . .
+10% done  
+20% done  
+30% done  
+40% done  
+50% done  
+60% done  
+70% done  
+80% done  
+90% done               (      6.936 sec)
+Triples timings:
+Total time for T0               ...     7.635 sec
+Total time for Iterative (T)    ...     0.000 sec
+Total time of overall (T)       ...     8.160 sec
+
+Triples List generation         ...     0.000 sec
+TNO generation                  ...     0.666 sec
+Pair density generation         ...     0.003 sec
+Look up tables                  ...     0.000 sec
+Generating 3-index integrals    ...     4.209 sec
+  Make 4-ind.int. from 3-ind.int...     0.977 sec
+  Projecting amplitudes (D + S) ...     0.786 sec
+  Downprojecting integrals      ...     0.000 sec
+  Energy contr. (sum over a,b,c)...     0.221 sec
+Fitting ET(->0)                 ...     0.000 sec
+
+Everything after 3-index        ...     2.727 sec
+
+Timing details:
+ TNO integrals                  ...     5.031 sec
+   Reading 3-index integrals    ...     0.227 sec
+   Sorting integrals            ...     0.916 sec
+       Sorting integrals 1      ...     0.000 sec
+       Sorting integrals 2      ...     0.544 sec
+       Sorting integrals 3      ...     0.037 sec
+       Sorting integrals 4      ...     0.003 sec
+       Sorting integrals 5      ...     0.018 sec
+       Sorting integrals 6      ...     0.315 sec
+   Calculating local VM**-1/2   ...     0.038 sec
+   Orthogonal. integrals        ...     0.059 sec
+   Multipl. 3-index integrals   ...     3.791 sec
+   All concerning IRIab (w/TNO) ...     0.523 sec
+
+ Calculate W0/W1                ...     0.741 sec
+ W 3-ext contribution           ...     0.292 sec
+ W 3-int contribution           ...     0.139 sec
+ Sorting W                      ...     0.278 sec
+
+ V exchange contribution        ...     0.076 sec
+
+ Timings for Triples without generation
+     of 3-index integrals       ...     2.726 sec
+       0 weak pairs             ...     2.401 sec
+       1 weak pair              ...     0.325 sec
+       2 weak pairs             ...     0.000 sec
+       3 weak pairs             ...     0.000 sec
+  Extra time for extrapolation  ...     0.000 sec
+
+Number of Triples   (0, 1, 2, 3 weak pairs; overall):   1092     253       0       0  (  1345)
+Number of Atoms     (0, 1, 2, 3 weak pairs; overall):   11.8     9.7     0.0     0.0  (    14)
+Number of PAOs      (0, 1, 2, 3 weak pairs; overall):  238.9   206.9     0.0     0.0  (   259)
+Number of AuxFcns   (0, 1, 2, 3 weak pairs; overall):  338.8   285.7     0.0     0.0  (   637)
+Number of TNOs      (0, 1, 2, 3 weak pairs         ):   70.3    54.6     0.0     0.0
+Aver. Number of NTNO, Atoms, PAOs, AuxFcns / Triples:   1345    67.3    11.4   232.9   328.8
+
+Triples Correction (T)                     ...     -0.055581194
+Final correlation energy                   ...     -1.402962160
+E(CCSD)                                    ...   -361.097447482
+E(CCSD(T))                                 ...   -361.153028676
+
+
+Maximum memory used throughout the entire calculation: 619.3 MB
+
+
+------------------------------------------------------------------------------- 
+                                     TIMINGS                                   
+------------------------------------------------------------------------------- 
+
+
+Total execution time                   ...      157.175 sec
+
+Localization of occupied MO's          ...        1.041 sec (  0.7%)
+Fock Matrix Formation                  ...        1.191 sec (  0.8%)
+Global overlap, Fock, MKN matrices     ...        0.582 sec (  0.4%)
+Differential overlap integrals         ...        0.206 sec (  0.1%)
+Organizing maps                        ...        0.032 sec (  0.0%)
+RI 3-index integral generations        ...        4.193 sec (  2.7%)
+RI-PNO integral transformation         ...       11.984 sec (  7.6%)
+Initial Guess                          ...        2.983 sec (  1.9%)
+DIIS Solver                            ...        1.653 sec (  1.1%)
+State Vector Update                    ...        0.013 sec (  0.0%)
+Sigma-vector construction              ...      124.536 sec ( 79.2%)
+  <D|H|D>(0-ext)                       ...        4.180 sec (  3.4% of sigma)
+  <D|H|D>(2-ext Fock)                  ...        0.002 sec (  0.0% of sigma)
+  <D|H|D>(2-ext)                       ...        1.617 sec (  1.3% of sigma)
+  <D|H|D>(4-ext)                       ...        0.789 sec (  0.6% of sigma)
+  <D|H|D>(4-ext-corr)                  ...        3.603 sec (  2.9% of sigma)
+  CCSD doubles correction              ...        0.358 sec (  0.3% of sigma)
+  <S|H|S>                              ...        4.904 sec (  3.9% of sigma)
+  <S|H|D>(1-ext)                       ...        0.536 sec (  0.4% of sigma)
+  <D|H|S>(1-ext)                       ...        0.002 sec (  0.0% of sigma)
+  <S|H|D>(3-ext)                       ...        0.052 sec (  0.0% of sigma)
+  Fock-dressing                        ...        6.249 sec (  5.0% of sigma)
+  Singles amplitudes                   ...       36.980 sec ( 29.7% of sigma)
+  (ik|jl)-dressing                     ...        3.877 sec (  3.1% of sigma)
+  (ij|ab),(ia|jb)-dressing             ...       58.032 sec ( 46.6% of sigma)
+  Pair energies                        ...        0.004 sec (  0.0% of sigma)
+  Shift terms                          ...        0.002 sec (  0.0% of sigma)
+Total Time for computing (T)           ...        8.203 sec (  5.2% of ALL)
+
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -361.153028675730
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... input.gbw
+Electron density file                           ... input.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.664493, -0.371961  0.068873)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      4.71142      -2.02951       2.93964
+Nuclear contribution   :     -5.21670       2.56037      -3.61886
+                        -----------------------------------------
+Total Dipole Moment    :     -0.50528       0.53086      -0.67922
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.99923
+Magnitude (Debye)      :      2.53984
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.097846     0.088235     0.066637 
+Rotational constants in MHz :  2933.362897  2645.231993  1997.719638 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.474060    -0.877343    -0.063218 
+x,y,z [Debye]:    -1.204966    -2.230028    -0.160687 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...      185.977 sec (=   3.100 min)
+GTO integral calculation        ...        9.851 sec (=   0.164 min)   5.3 %
+SCF iterations                  ...       10.494 sec (=   0.175 min)   5.6 %
+MDCI module                     ...      165.632 sec (=   2.761 min)  89.1 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 3 minutes 14 seconds 799 msec


### PR DESCRIPTION
Orca log files have different formats, the previous implementation failed when the information needed in the Orca log file changed location. This PR fixed this issue by first checking if the string read from log file is a float before trying to convert it to float. Also added a test.

Previously, the troubleshooting method expects the following output from Orca:

               ***  Starting incremental Fock matrix formation  ***
  0   -189.1598341022   0.000000000000 0.01426203  0.00045574  0.3200117 0.7000
  1   -189.1954365019  -0.035602399743 0.01167587  0.00035104  0.2256806 0.7000

It turns out that for some Orca jobs, the output is different:

               ***  Starting incremental Fock matrix formation  ***
                      *** Initiating the Newton-Raphson procedure ***
                      *** Removing any level shift *** 
ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
  0   -359.75006651 -359.7500665143  0.000003  0.000000  0.000007  0.000000

The previous troubleshooting algorithm failed because it did not expect the second case. The updated algorithm will read lines until it finds the energy it needs. 

