### PR TITLE
Allow user to input paths to previous jobs

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -119,6 +119,7 @@ class ARC(object):
         compute_rates (bool, optional): Whether to compute rate coefficients for converged reactions.
         compute_transport (bool, optional): Whether to compute transport properties for converged species.
         statmech_adapter (str, optional): The statmech software to use.
+        previous_job_paths (dict, optional): A dictionary for paths to previously run files needed for this job
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -182,6 +183,7 @@ class ARC(object):
         statmech_adapter (str): The statmech software to use.
         fine_only (bool): If ``self.job_types['fine'] and not self.job_types['opt']`` ARC will not run optimization
                           jobs without fine=True
+        previous_job_paths (dict, optional): A dictionary for paths to previously run files needed for this job
     """
 
     def __init__(self, input_dict=None, project=None, arc_species_list=None, arc_rxn_list=None, level_of_theory='',
@@ -192,7 +194,7 @@ class ARC(object):
                  job_memory=None, ess_settings=None, bath_gas=None, adaptive_levels=None, freq_scale_factor=None,
                  calc_freq_factor=True, n_confs=10, e_confs=5, dont_gen_confs=None, keep_checks=False,
                  solvation=None, compare_to_rmg=True, compute_thermo=True, compute_rates=True, compute_transport=True,
-                 specific_job_type='', statmech_adapter='Arkane'):
+                 specific_job_type='', statmech_adapter='Arkane', previous_job_paths=None):
         self.__version__ = VERSION
         self.verbose = verbose
         self.output = dict()
@@ -207,6 +209,7 @@ class ARC(object):
         self.calc_freq_factor = calc_freq_factor
         self.keep_checks = keep_checks
         self.compare_to_rmg = compare_to_rmg
+        self.previous_job_paths = previous_job_paths
 
         if input_dict is None:
             if project is None:
@@ -618,7 +621,8 @@ class ARC(object):
                             T_count=self.T_count or 50,
                             lib_long_desc=self.lib_long_desc,
                             rmg_database=self.rmg_database,
-                            compare_to_rmg=self.compare_to_rmg)
+                            compare_to_rmg=self.compare_to_rmg,
+                            previous_job_paths=self.previous_job_paths)
 
         status_dict = self.summary()
         log_footer(execution_time=self.execution_time)

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -49,6 +49,7 @@ def process_arc_project(statmech_adapter: str,
                         lib_long_desc: str = '',
                         rmg_database: Type[RMGDatabase] = None,
                         compare_to_rmg: bool = True,
+                        previous_job_paths: dict = None,
                         ) -> None:
     """
     Process an RMG project, generate thermo and rate coefficients using statistical mechanics (statmech).
@@ -75,7 +76,22 @@ def process_arc_project(statmech_adapter: str,
         rmg_database (RMGDatabase, optional): The RMG database object.
         compare_to_rmg (bool, optional): If ``True``, ARC's calculations will be compared against estimations
                                          from RMG's database.
+        previous_job_paths (dict, optional): A dictionary for paths to previously run files needed for this job
     """
+    # First, add previous paths to the output dictionary
+    if previous_job_paths is not None:
+        print('Checking to see if previous job paths need to be appended')
+        for spcs_label in species_dict.keys():
+            if spcs_label in previous_job_paths.keys():
+                if 'geo' in previous_job_paths[spcs_label].keys():
+                    geo_path = previous_job_paths[spcs_label]['geo']
+                    output_dict[spcs_label]['paths']['geo'] = geo_path
+                    print(f'Geometry path {geo_path} added for species {spcs_label}')
+                if 'freq' in previous_job_paths[spcs_label].keys():
+                    freq_path = previous_job_paths[spcs_label]['freq']
+                    output_dict[spcs_label]['paths']['freq'] = freq_path
+                    print(f'Frequency path {freq_path} added for species {spcs_label}')
+
     T_min = T_min or (300, 'K')
     T_max = T_max or (3000, 'K')
     if isinstance(T_min, (int, float)):


### PR DESCRIPTION
fixes #347 

There are many times when a user might want to calculate a species at a higher sp level using a previously calculated geometry (for example, when updating the reference database). When this is the case, it does not make sense for ARC to recalculate the geometry. ARC will submit the new sp job, but cannot submit the Arkane job because it does not know the paths to the old geometry/frequency job.

The additions in this PR allow the user to pass a dictionary with species labels as keys, and `geo` and `freq` paths in a dictionary as values. ARC then adds these species paths if given to the output dictionary before processing the species.