### PR TITLE
BugFix: Return Angles = None if ZeroDivisionError when parsing scan log

### DIFF
--- a/arc/parser.py
+++ b/arc/parser.py
@@ -291,7 +291,7 @@ def parse_1d_scan_energies(path: str) -> Tuple[Optional[List[float]], Optional[L
         energies, angles = log.load_scan_energies()
         energies *= 0.001  # convert to kJ/mol
         angles *= 180 / np.pi  # convert to degrees
-    except (LogError, NotImplementedError):
+    except (LogError, NotImplementedError, ZeroDivisionError):
         logger.warning(f'Could not read energies from {path}')
         energies, angles = None, None
     return energies, angles

--- a/arc/parserTest.py
+++ b/arc/parserTest.py
@@ -273,6 +273,11 @@ H      -0.59436200   -0.94730400    0.00000000"""
         np.testing.assert_almost_equal(energies, expected_energies)
         np.testing.assert_almost_equal(angles, expected_angles)
 
+        path2 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'scan_1d_curvilinear_error.out')
+        energies_2, angles_2 = parser.parse_1d_scan_energies(path=path2)
+        self.assertEqual(energies_2, None)
+        self.assertEqual(angles_2, None)
+
     def test_parse_nd_scan_energies(self):
         """Test parsing an ND scan output file"""
         path1 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'scan_2D_relaxed_OCdOO.log')

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2400,7 +2400,7 @@ class Scheduler(object):
         self.species_dict[label].rotors_dict[i]['invalidation_reason'] = invalidation_reason
 
         # If energies were obtained, draw the scan curve
-        if len(energies):
+        if energies is not None and len(energies):
             folder_name = 'rxns' if job.is_ts else 'Species'
             rotor_path = os.path.join(self.project_directory, 'output', folder_name, job.species_name, 'rotors')
             plotter.plot_1d_rotor_scan(angles=angles,

--- a/arc/testing/rotor_scans/scan_1d_curvilinear_error.out
+++ b/arc/testing/rotor_scans/scan_1d_curvilinear_error.out
@@ -1,0 +1,1627 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/gridsan/oscarwu/GRPAPI/Software/g16/l1.exe "/home/gridsan/oscarwu/scratch/a3055-610600/Gau-40487.inp" -scrdir="/home/gridsan/oscarwu/scratch/a3055-610600/"
+ Entering Link 1 = /home/gridsan/oscarwu/GRPAPI/Software/g16/l1.exe PID=     40489.
+  
+ Copyright (c) 1988-2017, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision B.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevB.01 20-Dec-2017
+                15-Jun-2020 
+ ******************************************
+ %chk=check.chk
+ %mem=143360mb
+ %NProcShared=40
+ Will use up to   40 processors via shared memory.
+ ----------------------------------------------------------------------
+ #P opt=(modredundant, calcfc, noeigentest, maxStep=5) scf=(tight, dire
+ ct) integral=(grid=ultrafine, Acc2E=12) guess=read uwb97xd/def2svp iop
+ (2/9=2000) scf=xqc
+ ----------------------------------------------------------------------
+ 1/8=5,10=4,11=1,18=120,19=15,26=4,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=43,7=101,11=2,25=1,27=12,30=1,71=2,74=-58,75=-5,116=2,140=1/1,2,3;
+ 4/5=1/1;
+ 5/5=2,8=3,13=1,32=2,38=6,87=12/2,8;
+ 8/6=4,10=90,11=11,87=12/1;
+ 11/6=1,8=1,9=11,15=111,16=1,87=12/1,2,10;
+ 10/6=1,13=1,87=12/2;
+ 6/7=2,8=2,9=2,10=2,28=1,87=12/1;
+ 7/10=1,18=20,25=1,87=12/1,2,3,16;
+ 1/8=5,10=4,11=1,18=20,19=15,26=4/3(2);
+ 2/9=2000/2;
+ 99//99;
+ 2/9=2000/2;
+ 3/5=43,7=101,11=2,25=1,27=12,30=1,71=1,74=-58,75=-5,116=2/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,8=3,13=1,32=2,38=5,87=12/2,8;
+ 7/87=12/1,2,3,16;
+ 1/8=5,11=1,18=20,19=15,26=4/3(-5);
+ 2/9=2000/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1,87=12/1;
+ 99/9=1/99;
+ Leave Link    1 at Mon Jun 15 23:45:29 2020, MaxMem= 18790481920 cpu:              21.5 elap:               0.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l101.exe)
+ ----
+ name
+ ----
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 2
+ C                     2.23253  -1.13076  -0.60352 
+ N                     1.54596  -0.35408   0.40897 
+ C                     2.3487    0.71972   0.95825 
+ C                     0.19181  -0.0317    0.20612 
+ O                     0.08356   0.97804  -0.89599 
+ O                    -0.80525   1.88678  -0.66391 
+ C                    -0.72878  -1.1927   -0.13076 
+ C                    -2.20329  -0.79659  -0.23648 
+ N                    -2.65533  -0.06848   0.93886 
+ H                     3.20808  -1.45114  -0.2086 
+ H                     1.66939  -2.04008  -0.8501 
+ H                     2.4135   -0.56651  -1.53949 
+ H                     2.60764   1.49654   0.21209 
+ H                     3.28581   0.31198   1.36686 
+ H                     1.80571   1.20741   1.78087 
+ H                    -0.19388   0.4998    1.08861 
+ H                    -0.60035  -1.92965   0.67734 
+ H                    -0.41982  -1.6653   -1.07569 
+ H                    -2.35949  -0.24531  -1.18458 
+ H                    -2.78652  -1.72661  -0.32388 
+ H                    -2.40748   0.91531   0.8373 
+ H                    -3.66884  -0.10249   1.00855 
+ 
+ The following ModRedundant input section has been read:
+ D       1       2       3       4 S  45 8.0000                                
+ A       3       2       4 F                                                   
+ D       4       1       2       3 F                                           
+ D       2       3       4      13 F                                           
+ D       4       1       2       3 F                                           
+ D       2       3       4      15 F                                           
+ D       4       1       2       3 F                                           
+ D       2       3       4      14 F                                           
+ D      11       1       2       4 F                                           
+ D      16       4       7       8 F                                           
+ 
+ ITRead=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ ITRead=  0  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ MicOpt= -1 -1
+ NAtoms=     22 NQM=       22 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          12          14          12          12          16          16          12          12          14           1
+ AtmWgt=  12.0000000  14.0030740  12.0000000  12.0000000  15.9949146  15.9949146  12.0000000  12.0000000  14.0030740   1.0078250
+ NucSpn=           0           2           0           0           0           0           0           0           2           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   2.0440000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   2.0440000   0.0000000
+ NMagM=    0.0000000   0.4037610   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.4037610   2.7928460
+ AtZNuc=   6.0000000   7.0000000   6.0000000   6.0000000   8.0000000   8.0000000   6.0000000   6.0000000   7.0000000   1.0000000
+
+  Atom        11          12          13          14          15          16          17          18          19          20
+ IAtWgt=           1           1           1           1           1           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1           1           1           1           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        21          22
+ IAtWgt=           1           1
+ AtmWgt=   1.0078250   1.0078250
+ NucSpn=           1           1
+ AtZEff=  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000
+ Leave Link  101 at Mon Jun 15 23:45:30 2020, MaxMem= 18790481920 cpu:              17.1 elap:               0.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.4491         calculate D2E/DX2 analytically  !
+ ! R2    R(1,10)                 1.1001         calculate D2E/DX2 analytically  !
+ ! R3    R(1,11)                 1.0976         calculate D2E/DX2 analytically  !
+ ! R4    R(1,12)                 1.1078         calculate D2E/DX2 analytically  !
+ ! R5    R(2,3)                  1.4488         calculate D2E/DX2 analytically  !
+ ! R6    R(2,4)                  1.4067         calculate D2E/DX2 analytically  !
+ ! R7    R(3,13)                 1.1078         calculate D2E/DX2 analytically  !
+ ! R8    R(3,14)                 1.1006         calculate D2E/DX2 analytically  !
+ ! R9    R(3,15)                 1.0997         calculate D2E/DX2 analytically  !
+ ! R10   R(4,5)                  1.4986         calculate D2E/DX2 analytically  !
+ ! R11   R(4,7)                  1.5195         calculate D2E/DX2 analytically  !
+ ! R12   R(4,16)                 1.1            calculate D2E/DX2 analytically  !
+ ! R13   R(5,6)                  1.2922         calculate D2E/DX2 analytically  !
+ ! R14   R(7,8)                  1.5304         calculate D2E/DX2 analytically  !
+ ! R15   R(7,17)                 1.1012         calculate D2E/DX2 analytically  !
+ ! R16   R(7,18)                 1.1008         calculate D2E/DX2 analytically  !
+ ! R17   R(8,9)                  1.4546         calculate D2E/DX2 analytically  !
+ ! R18   R(8,19)                 1.1078         calculate D2E/DX2 analytically  !
+ ! R19   R(8,20)                 1.1012         calculate D2E/DX2 analytically  !
+ ! R20   R(9,21)                 1.0196         calculate D2E/DX2 analytically  !
+ ! R21   R(9,22)                 1.0165         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,10)             108.9904         calculate D2E/DX2 analytically  !
+ ! A2    A(2,1,11)             110.9721         calculate D2E/DX2 analytically  !
+ ! A3    A(2,1,12)             113.2501         calculate D2E/DX2 analytically  !
+ ! A4    A(10,1,11)            107.1181         calculate D2E/DX2 analytically  !
+ ! A5    A(10,1,12)            107.865          calculate D2E/DX2 analytically  !
+ ! A6    A(11,1,12)            108.4202         calculate D2E/DX2 analytically  !
+ ! A7    A(1,2,3)              113.5549         calculate D2E/DX2 analytically  !
+ ! A8    A(1,2,4)              118.5668         calculate D2E/DX2 analytically  !
+ ! A9    A(3,2,4)              114.7196         frozen, calculate D2E/DX2 analyt!
+ ! A10   A(2,3,13)             113.195          calculate D2E/DX2 analytically  !
+ ! A11   A(2,3,14)             109.7504         calculate D2E/DX2 analytically  !
+ ! A12   A(2,3,15)             109.7974         calculate D2E/DX2 analytically  !
+ ! A13   A(13,3,14)            108.1082         calculate D2E/DX2 analytically  !
+ ! A14   A(13,3,15)            107.9551         calculate D2E/DX2 analytically  !
+ ! A15   A(14,3,15)            107.8769         calculate D2E/DX2 analytically  !
+ ! A16   A(2,4,5)              109.2685         calculate D2E/DX2 analytically  !
+ ! A17   A(2,4,7)              116.1089         calculate D2E/DX2 analytically  !
+ ! A18   A(2,4,16)             109.4241         calculate D2E/DX2 analytically  !
+ ! A19   A(5,4,7)              107.939          calculate D2E/DX2 analytically  !
+ ! A20   A(5,4,16)             103.8339         calculate D2E/DX2 analytically  !
+ ! A21   A(7,4,16)             109.5493         calculate D2E/DX2 analytically  !
+ ! A22   A(4,5,6)              113.0449         calculate D2E/DX2 analytically  !
+ ! A23   A(4,7,8)              113.6571         calculate D2E/DX2 analytically  !
+ ! A24   A(4,7,17)             106.14           calculate D2E/DX2 analytically  !
+ ! A25   A(4,7,18)             110.3839         calculate D2E/DX2 analytically  !
+ ! A26   A(8,7,17)             109.6493         calculate D2E/DX2 analytically  !
+ ! A27   A(8,7,18)             108.7985         calculate D2E/DX2 analytically  !
+ ! A28   A(17,7,18)            108.053          calculate D2E/DX2 analytically  !
+ ! A29   A(7,8,9)              111.9098         calculate D2E/DX2 analytically  !
+ ! A30   A(7,8,19)             108.8907         calculate D2E/DX2 analytically  !
+ ! A31   A(7,8,20)             107.2873         calculate D2E/DX2 analytically  !
+ ! A32   A(9,8,19)             113.4917         calculate D2E/DX2 analytically  !
+ ! A33   A(9,8,20)             108.8002         calculate D2E/DX2 analytically  !
+ ! A34   A(19,8,20)            106.1209         calculate D2E/DX2 analytically  !
+ ! A35   A(8,9,21)             109.0836         calculate D2E/DX2 analytically  !
+ ! A36   A(8,9,22)             110.3965         calculate D2E/DX2 analytically  !
+ ! A37   A(21,9,22)            106.3487         calculate D2E/DX2 analytically  !
+ ! D1    D(4,1,2,3)           -139.1815         frozen, calculate D2E/DX2 analyt!
+ ! D2    D(10,1,2,3)            51.3284         calculate D2E/DX2 analytically  !
+ ! D3    D(10,1,2,4)          -169.4901         calculate D2E/DX2 analytically  !
+ ! D4    D(11,1,2,3)           169.0567         calculate D2E/DX2 analytically  !
+ ! D5    D(11,1,2,4)           -51.7618         frozen, calculate D2E/DX2 analyt!
+ ! D6    D(12,1,2,3)           -68.7355         calculate D2E/DX2 analytically  !
+ ! D7    D(12,1,2,4)            70.446          calculate D2E/DX2 analytically  !
+ ! D8    D(1,2,3,4)            140.8021         Scan                            !
+ ! D9    D(1,2,3,13)            64.4864         calculate D2E/DX2 analytically  !
+ ! D10   D(1,2,3,14)           -56.386          calculate D2E/DX2 analytically  !
+ ! D11   D(1,2,3,15)          -174.8035         calculate D2E/DX2 analytically  !
+ ! D12   D(4,2,3,13)           -76.3157         calculate D2E/DX2 analytically  !
+ ! D13   D(4,2,3,14)           162.8119         calculate D2E/DX2 analytically  !
+ ! D14   D(4,2,3,15)            44.3944         calculate D2E/DX2 analytically  !
+ ! D15   D(1,2,4,5)            -70.5339         calculate D2E/DX2 analytically  !
+ ! D16   D(1,2,4,7)             51.7885         calculate D2E/DX2 analytically  !
+ ! D17   D(1,2,4,16)           176.3961         calculate D2E/DX2 analytically  !
+ ! D18   D(3,2,4,5)             68.1931         calculate D2E/DX2 analytically  !
+ ! D19   D(3,2,4,7)           -169.4844         calculate D2E/DX2 analytically  !
+ ! D20   D(3,2,4,16)           -44.8769         calculate D2E/DX2 analytically  !
+ ! D21   D(2,3,4,13)          -113.7788         frozen, calculate D2E/DX2 analyt!
+ ! D22   D(2,3,4,14)            25.5373         frozen, calculate D2E/DX2 analyt!
+ ! D23   D(2,3,4,15)           138.7093         frozen, calculate D2E/DX2 analyt!
+ ! D24   D(2,4,5,6)           -140.2912         calculate D2E/DX2 analytically  !
+ ! D25   D(7,4,5,6)             92.6101         calculate D2E/DX2 analytically  !
+ ! D26   D(16,4,5,6)           -23.618          calculate D2E/DX2 analytically  !
+ ! D27   D(2,4,7,8)            175.6708         calculate D2E/DX2 analytically  !
+ ! D28   D(2,4,7,17)            55.0767         calculate D2E/DX2 analytically  !
+ ! D29   D(2,4,7,18)           -61.7757         calculate D2E/DX2 analytically  !
+ ! D30   D(5,4,7,8)            -61.3089         calculate D2E/DX2 analytically  !
+ ! D31   D(5,4,7,17)           178.0971         calculate D2E/DX2 analytically  !
+ ! D32   D(5,4,7,18)            61.2446         calculate D2E/DX2 analytically  !
+ ! D33   D(16,4,7,8)            51.1275         frozen, calculate D2E/DX2 analyt!
+ ! D34   D(16,4,7,17)          -69.4665         calculate D2E/DX2 analytically  !
+ ! D35   D(16,4,7,18)          173.681          calculate D2E/DX2 analytically  !
+ ! D36   D(4,7,8,9)            -52.0125         calculate D2E/DX2 analytically  !
+ ! D37   D(4,7,8,19)            74.2679         calculate D2E/DX2 analytically  !
+ ! D38   D(4,7,8,20)          -171.2849         calculate D2E/DX2 analytically  !
+ ! D39   D(17,7,8,9)            66.5862         calculate D2E/DX2 analytically  !
+ ! D40   D(17,7,8,19)         -167.1334         calculate D2E/DX2 analytically  !
+ ! D41   D(17,7,8,20)          -52.6862         calculate D2E/DX2 analytically  !
+ ! D42   D(18,7,8,9)          -175.4353         calculate D2E/DX2 analytically  !
+ ! D43   D(18,7,8,19)          -49.1549         calculate D2E/DX2 analytically  !
+ ! D44   D(18,7,8,20)           65.2923         calculate D2E/DX2 analytically  !
+ ! D45   D(7,8,9,21)            83.4782         calculate D2E/DX2 analytically  !
+ ! D46   D(7,8,9,22)          -160.0081         calculate D2E/DX2 analytically  !
+ ! D47   D(19,8,9,21)          -40.2543         calculate D2E/DX2 analytically  !
+ ! D48   D(19,8,9,22)           76.2593         calculate D2E/DX2 analytically  !
+ ! D49   D(20,8,9,21)         -158.145          calculate D2E/DX2 analytically  !
+ ! D50   D(20,8,9,22)          -41.6313         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=5.00D-02 FncErr=1.00D-07 GrdErr=1.00D-06 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of optimizations in scan=  46
+ Number of steps in this run=    118 maximum allowed number of steps=    132.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Jun 15 23:45:31 2020, MaxMem= 18790481920 cpu:               3.1 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        2.232532   -1.130762   -0.603523
+      2          7           0        1.545956   -0.354077    0.408972
+      3          6           0        2.348695    0.719723    0.958247
+      4          6           0        0.191808   -0.031696    0.206115
+      5          8           0        0.083559    0.978041   -0.895987
+      6          8           0       -0.805253    1.886784   -0.663914
+      7          6           0       -0.728777   -1.192701   -0.130762
+      8          6           0       -2.203288   -0.796592   -0.236477
+      9          7           0       -2.655329   -0.068483    0.938858
+     10          1           0        3.208078   -1.451136   -0.208597
+     11          1           0        1.669386   -2.040084   -0.850101
+     12          1           0        2.413499   -0.566506   -1.539487
+     13          1           0        2.607639    1.496539    0.212091
+     14          1           0        3.285805    0.311983    1.366862
+     15          1           0        1.805706    1.207413    1.780868
+     16          1           0       -0.193875    0.499800    1.088606
+     17          1           0       -0.600352   -1.929647    0.677338
+     18          1           0       -0.419821   -1.665295   -1.075685
+     19          1           0       -2.359488   -0.245310   -1.184576
+     20          1           0       -2.786518   -1.726605   -0.323878
+     21          1           0       -2.407483    0.915309    0.837297
+     22          1           0       -3.668842   -0.102489    1.008554
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  N    1.449059   0.000000
+     3  C    2.424235   1.448841   0.000000
+     4  C    2.455201   1.406697   2.404682   0.000000
+     5  O    3.025007   2.369823   2.938665   1.498638   0.000000
+     6  O    4.282215   3.420632   3.733742   2.330589   1.292153
+     7  C    2.999448   2.483750   3.783403   1.519505   2.440815
+     8  C    4.463507   3.830046   4.944403   2.552927   2.968829
+     9  N    5.234363   4.244189   5.065758   2.940145   3.458811
+    10  H    1.100135   2.085085   2.610114   3.359268   4.016967
+    11  H    1.097634   2.107871   3.368697   2.707850   3.409697
+    12  H    1.107774   2.143420   2.810206   2.875597   2.868508
+    13  H    2.776444   2.142595   1.107810   2.858632   2.804934
+    14  H    2.659570   2.094818   1.100633   3.322389   3.977248
+    15  H    3.366684   2.094712   1.099720   2.572918   3.191231
+    16  H    3.377793   2.053782   2.555391   1.100014   2.060168
+    17  H    3.209993   2.676019   3.974286   2.109926   3.376053
+    18  H    2.746569   2.790659   4.182089   2.164659   2.696833
+    19  H    4.712568   4.219445   5.262126   2.913548   2.747426
+    20  H    5.062025   4.603394   5.830847   3.467569   3.984942
+    21  H    5.271822   4.174264   4.761734   2.837521   3.035375
+    22  H    6.203415   5.255180   6.073657   3.943797   4.344575
+                    6          7          8          9         10
+     6  O    0.000000
+     7  C    3.126232   0.000000
+     8  C    3.055767   1.530445   0.000000
+     9  N    3.132847   2.473774   1.454612   0.000000
+    10  H    5.239833   3.946096   5.450879   6.132530   0.000000
+    11  H    4.645298   2.643235   4.113443   5.078459   1.768039
+    12  H    4.140728   3.500075   4.802655   5.664207   1.784711
+    13  H    3.545068   4.298980   5.348334   5.538620   3.037481
+    14  H    4.831232   4.541346   5.824927   5.968669   2.365735
+    15  H    3.640826   3.979759   4.915053   4.715689   3.604511
+    16  H    2.317074   2.153494   2.733902   2.530637   4.130638
+    17  H    4.050443   1.101185   2.165243   2.784826   3.939288
+    18  H    3.596579   1.100763   2.153989   3.406712   3.736222
+    19  H    2.689342   2.160392   1.107791   2.151223   5.779649
+    20  H    4.134926   2.134630   1.101236   2.088320   6.002029
+    21  H    2.400945   2.863372   2.031081   1.019602   6.182919
+    22  H    3.867105   3.336253   2.044439   1.016476   7.112829
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    1.788963   0.000000
+    13  H    3.810023   2.713277   0.000000
+    14  H    3.613856   3.159039   1.787898   0.000000
+    15  H    4.181724   3.813261   1.785428   1.778732   0.000000
+    16  H    3.698829   3.852568   3.100040   3.495837   2.231203
+    17  H    2.738061   3.981930   4.716610   4.539005   4.104636
+    18  H    2.134512   3.074110   4.563012   4.858737   4.622263
+    19  H    4.423224   4.796930   5.445830   6.220108   5.315365
+    20  H    4.497806   5.464770   6.306572   6.624768   5.841827
+    21  H    5.310605   5.575549   5.087255   5.749606   4.327426
+    22  H    5.975412   6.610802   6.525753   6.976194   5.681812
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.497314   0.000000
+    18  H    3.069665   1.782011   0.000000
+    19  H    3.226829   3.065661   2.406350   0.000000
+    20  H    3.697809   2.413085   2.483994   1.765613   0.000000
+    21  H    2.266245   3.374179   3.777541   2.331804   2.910619
+    22  H    3.527684   3.586620   4.164439   2.558246   2.278513
+                   21         22
+    21  H    0.000000
+    22  H    1.629806   0.000000
+ Stoichiometry    C5H13N2O2(2)
+ Framework group  C1[X(C5H13N2O2)]
+ Deg. of freedom    60
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        2.233367   -1.128398   -0.602378
+      2          7           0        1.546483   -0.350562    0.409023
+      3          6           0        2.347604    0.726462    0.954336
+      4          6           0        0.191342   -0.031718    0.207214
+      5          8           0        0.079316    0.974860   -0.897398
+      6          8           0       -0.811185    1.882243   -0.666480
+      7          6           0       -0.727135   -1.195645   -0.125306
+      8          6           0       -2.202667   -0.803083   -0.230000
+      9          7           0       -2.654681   -0.072872    0.944040
+     10          1           0        3.210171   -1.445566   -0.207975
+     11          1           0        1.671896   -2.039614   -0.845765
+     12          1           0        2.411776   -0.566220   -1.540082
+     13          1           0        2.603783    1.501874    0.205769
+     14          1           0        3.286186    0.321879    1.362712
+     15          1           0        1.804684    1.215121    1.776426
+     16          1           0       -0.194287    0.501254    1.088838
+     17          1           0       -0.595948   -1.930166    0.684556
+     18          1           0       -0.418450   -1.670050   -1.069410
+     19          1           0       -2.361412   -0.254656   -1.179332
+     20          1           0       -2.783954   -1.734613   -0.314128
+     21          1           0       -2.409160    0.911195    0.839535
+     22          1           0       -3.668018   -0.108938    1.015246
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.4423867           1.0704735           0.9199991
+ Leave Link  202 at Mon Jun 15 23:45:31 2020, MaxMem= 18790481920 cpu:               2.6 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   200 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   191 symmetry adapted basis functions of A   symmetry.
+   191 basis functions,   316 primitive gaussians,   200 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       509.1475628325 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+ HFx  wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+ DFx  wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   22 NActive=   22 NUniq=   22 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0142576669 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      509.1333051656 Hartrees.
+ Leave Link  301 at Mon Jun 15 23:45:32 2020, MaxMem= 18790481920 cpu:              11.5 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    4371 NPrTT=   15207 LenC2=    4320 LenP2D=   11947.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   191 RedAO= T EigKep=  1.45D-03  NBF=   191
+ NBsUse=   191 1.00D-06 EigRej= -1.00D+00 NBFU=   191
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 1.00D-12.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   200   200   200   200   200 MxSgAt=    22 MxSgA2=    22.
+ Leave Link  302 at Mon Jun 15 23:45:33 2020, MaxMem= 18790481920 cpu:              17.0 elap:               0.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Jun 15 23:45:34 2020, MaxMem= 18790481920 cpu:               2.9 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000    0.000000 Ang=  -0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7536 S= 0.5018
+ Leave Link  401 at Mon Jun 15 23:45:35 2020, MaxMem= 18790481920 cpu:              13.1 elap:               0.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 18790481920 LenX= 18790391588 LenY= 18790351147
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+
+ Cycle   1  Pass 1  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=T KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         1 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -457.688510598698    
+ DIIS: error= 4.51D-08 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -457.688510598698     IErMin= 1 ErrMin= 4.51D-08
+ ErrMax= 4.51D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.55D-12 BMatP= 4.55D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.440 Goal=   None    Shift=    0.000
+ Gap=     0.289 Goal=   None    Shift=    0.000
+ RMSDP=9.44D-09 MaxDP=1.54D-07              OVMax= 2.15D-07
+
+ SCF Done:  E(UwB97XD) =  -457.688510599     A.U. after    1 cycles
+            NFock=  1  Conv=0.94D-08     -V/T= 2.0095
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7536 S= 0.5018
+ <L.S>=  0.00000000000    
+ KE= 4.533928070485D+02 PE=-2.085636039613D+03 EE= 6.654214168001D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7536,   after     0.7500
+ Leave Link  502 at Mon Jun 15 23:45:37 2020, MaxMem= 18790481920 cpu:              57.2 elap:               1.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Mon Jun 15 23:45:38 2020, MaxMem= 18790481920 cpu:               0.2 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   191
+ NBasis=   191 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    191 NOA=    37 NOB=    36 NVA=   154 NVB=   155
+ Leave Link  801 at Mon Jun 15 23:45:39 2020, MaxMem= 18790481920 cpu:               1.6 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    22.
+ Will process     23 centers per pass.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    4371 NPrTT=   15207 LenC2=    4320 LenP2D=   11947.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+ Leave Link 1101 at Mon Jun 15 23:45:40 2020, MaxMem= 18790481920 cpu:              23.3 elap:               0.7
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Mon Jun 15 23:45:41 2020, MaxMem= 18790481920 cpu:               3.5 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    22.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   18790480024.
+ G2DrvN: will do    23 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 1.00D-12.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=T KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         1 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3507 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Mon Jun 15 23:45:53 2020, MaxMem= 18790481920 cpu:             449.1 elap:              11.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=1111111111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         6641 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=713565723.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18336 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   18790481920 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    69 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     0.
+     63 vectors produced by pass  0 Test12= 1.63D-14 1.45D-09 XBig12= 1.30D-01 6.46D-02.
+ AX will form    63 AO Fock derivatives at one time.
+     63 vectors produced by pass  1 Test12= 1.63D-14 1.45D-09 XBig12= 1.02D-02 3.44D-02.
+     63 vectors produced by pass  2 Test12= 1.63D-14 1.45D-09 XBig12= 3.27D-04 3.83D-03.
+     63 vectors produced by pass  3 Test12= 1.63D-14 1.45D-09 XBig12= 5.08D-06 2.95D-04.
+     63 vectors produced by pass  4 Test12= 1.63D-14 1.45D-09 XBig12= 6.24D-08 3.43D-05.
+     63 vectors produced by pass  5 Test12= 1.63D-14 1.45D-09 XBig12= 6.60D-10 2.84D-06.
+     62 vectors produced by pass  6 Test12= 1.63D-14 1.45D-09 XBig12= 6.69D-12 2.12D-07.
+     27 vectors produced by pass  7 Test12= 1.63D-14 1.45D-09 XBig12= 4.89D-14 1.51D-08.
+ InvSVY:  IOpt=1 It=  1 EMax= 3.33D-16
+ Solved reduced A of dimension   467 with    69 vectors.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Mon Jun 15 23:46:11 2020, MaxMem= 18790481920 cpu:             699.1 elap:              17.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 1 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+ Beta  Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+ The electronic state is 2-A.
+ Alpha  occ. eigenvalues --  -19.35474 -19.31075 -14.45237 -14.41668 -10.37865
+ Alpha  occ. eigenvalues --  -10.32681 -10.32531 -10.32051 -10.30155  -1.28669
+ Alpha  occ. eigenvalues --   -1.04825  -0.97166  -0.93341  -0.84848  -0.81013
+ Alpha  occ. eigenvalues --   -0.77913  -0.70452  -0.66842  -0.61854  -0.61007
+ Alpha  occ. eigenvalues --   -0.58907  -0.56593  -0.55621  -0.54761  -0.53516
+ Alpha  occ. eigenvalues --   -0.51992  -0.49216  -0.48022  -0.47519  -0.46186
+ Alpha  occ. eigenvalues --   -0.45746  -0.43630  -0.42681  -0.36609  -0.34848
+ Alpha  occ. eigenvalues --   -0.31750  -0.30787
+ Alpha virt. eigenvalues --    0.13237   0.14721   0.15964   0.17446   0.18113
+ Alpha virt. eigenvalues --    0.19016   0.19509   0.20074   0.21170   0.22308
+ Alpha virt. eigenvalues --    0.23203   0.23915   0.24822   0.26340   0.27910
+ Alpha virt. eigenvalues --    0.29084   0.29760   0.32212   0.33968   0.35243
+ Alpha virt. eigenvalues --    0.38848   0.49016   0.50902   0.51728   0.51878
+ Alpha virt. eigenvalues --    0.55481   0.57184   0.58955   0.60005   0.61159
+ Alpha virt. eigenvalues --    0.64553   0.67738   0.68951   0.70525   0.71137
+ Alpha virt. eigenvalues --    0.72459   0.73410   0.73970   0.74440   0.74641
+ Alpha virt. eigenvalues --    0.75139   0.75449   0.76674   0.77221   0.77605
+ Alpha virt. eigenvalues --    0.78413   0.80522   0.81167   0.82285   0.84054
+ Alpha virt. eigenvalues --    0.90749   0.93551   0.93870   0.95074   0.97424
+ Alpha virt. eigenvalues --    1.01721   1.02827   1.05251   1.07110   1.11648
+ Alpha virt. eigenvalues --    1.13932   1.14537   1.17179   1.19960   1.23443
+ Alpha virt. eigenvalues --    1.23623   1.25510   1.29752   1.30453   1.37559
+ Alpha virt. eigenvalues --    1.41295   1.43090   1.44463   1.48516   1.52222
+ Alpha virt. eigenvalues --    1.56508   1.57785   1.61539   1.62019   1.63305
+ Alpha virt. eigenvalues --    1.63971   1.66771   1.74392   1.78181   1.81170
+ Alpha virt. eigenvalues --    1.82177   1.84990   1.86371   1.87070   1.88797
+ Alpha virt. eigenvalues --    1.89894   1.91225   1.91619   1.92036   1.93015
+ Alpha virt. eigenvalues --    1.93653   1.94845   1.95860   1.97685   1.98858
+ Alpha virt. eigenvalues --    2.01160   2.02779   2.05362   2.07854   2.10438
+ Alpha virt. eigenvalues --    2.11344   2.13784   2.15770   2.21646   2.23416
+ Alpha virt. eigenvalues --    2.28833   2.29125   2.32886   2.33601   2.35649
+ Alpha virt. eigenvalues --    2.39197   2.40077   2.44648   2.47746   2.51150
+ Alpha virt. eigenvalues --    2.52514   2.54252   2.57707   2.57929   2.67230
+ Alpha virt. eigenvalues --    2.69141   2.69861   2.70395   2.72338   2.74974
+ Alpha virt. eigenvalues --    2.76557   2.78681   2.80098   2.86283   2.89344
+ Alpha virt. eigenvalues --    2.90432   2.95426   2.95914   2.97420   2.98154
+ Alpha virt. eigenvalues --    3.00214   3.06868   3.11056   3.11849   3.14818
+ Alpha virt. eigenvalues --    3.19020   3.24440   3.28897   3.30081   3.31762
+ Alpha virt. eigenvalues --    3.34748   3.47409   3.52525   3.99312
+  Beta  occ. eigenvalues --  -19.34536 -19.29415 -14.45227 -14.41667 -10.37896
+  Beta  occ. eigenvalues --  -10.32682 -10.32530 -10.32052 -10.30133  -1.25813
+  Beta  occ. eigenvalues --   -1.04524  -0.97146  -0.90898  -0.83831  -0.80923
+  Beta  occ. eigenvalues --   -0.77488  -0.70356  -0.66358  -0.60685  -0.60276
+  Beta  occ. eigenvalues --   -0.57110  -0.56118  -0.55370  -0.53035  -0.52459
+  Beta  occ. eigenvalues --   -0.50395  -0.48015  -0.47576  -0.46747  -0.46076
+  Beta  occ. eigenvalues --   -0.45637  -0.43478  -0.41683  -0.34826  -0.31744
+  Beta  occ. eigenvalues --   -0.30316
+  Beta virt. eigenvalues --   -0.01406   0.13292   0.14801   0.15993   0.17559
+  Beta virt. eigenvalues --    0.18360   0.19098   0.19616   0.20139   0.21389
+  Beta virt. eigenvalues --    0.22406   0.23365   0.24496   0.24988   0.26396
+  Beta virt. eigenvalues --    0.27979   0.29234   0.30524   0.32259   0.34078
+  Beta virt. eigenvalues --    0.35426   0.39128   0.49043   0.50994   0.51784
+  Beta virt. eigenvalues --    0.51976   0.55533   0.57368   0.59020   0.60072
+  Beta virt. eigenvalues --    0.61312   0.64727   0.67842   0.68989   0.70553
+  Beta virt. eigenvalues --    0.71159   0.72502   0.73441   0.74015   0.74460
+  Beta virt. eigenvalues --    0.74704   0.75239   0.75498   0.76700   0.77240
+  Beta virt. eigenvalues --    0.77631   0.78464   0.80548   0.81215   0.82407
+  Beta virt. eigenvalues --    0.84152   0.91087   0.93808   0.94334   0.95789
+  Beta virt. eigenvalues --    0.97518   1.02504   1.03520   1.07108   1.07664
+  Beta virt. eigenvalues --    1.12309   1.14640   1.15516   1.17413   1.20608
+  Beta virt. eigenvalues --    1.23533   1.24305   1.26105   1.30193   1.31421
+  Beta virt. eigenvalues --    1.37733   1.41854   1.43233   1.44707   1.48798
+  Beta virt. eigenvalues --    1.52443   1.56637   1.57921   1.61555   1.62068
+  Beta virt. eigenvalues --    1.63443   1.64028   1.67133   1.74484   1.78231
+  Beta virt. eigenvalues --    1.81201   1.82246   1.85073   1.86391   1.87096
+  Beta virt. eigenvalues --    1.88854   1.89918   1.91287   1.91684   1.92114
+  Beta virt. eigenvalues --    1.93074   1.93712   1.94887   1.95891   1.97706
+  Beta virt. eigenvalues --    1.98954   2.01221   2.02906   2.05435   2.07901
+  Beta virt. eigenvalues --    2.10557   2.11472   2.13903   2.15871   2.21701
+  Beta virt. eigenvalues --    2.23440   2.29122   2.31944   2.32964   2.33696
+  Beta virt. eigenvalues --    2.35937   2.39310   2.40102   2.44706   2.47938
+  Beta virt. eigenvalues --    2.51231   2.52647   2.54619   2.57965   2.58407
+  Beta virt. eigenvalues --    2.67582   2.69955   2.71730   2.73565   2.75317
+  Beta virt. eigenvalues --    2.76246   2.78282   2.79088   2.80815   2.86391
+  Beta virt. eigenvalues --    2.89460   2.91425   2.95561   2.96411   2.97474
+  Beta virt. eigenvalues --    2.98688   3.00253   3.07192   3.11171   3.12484
+  Beta virt. eigenvalues --    3.14951   3.19098   3.24692   3.29699   3.31750
+  Beta virt. eigenvalues --    3.33870   3.35372   3.48299   3.52568   4.01273
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  C    4.491986   0.335008  -0.049331  -0.041441  -0.002559  -0.000033
+     2  N    0.335008   6.642925   0.344031   0.387839  -0.062361   0.002818
+     3  C   -0.049331   0.344031   4.483988  -0.050132   0.003071  -0.000018
+     4  C   -0.041441   0.387839  -0.050132   4.758943   0.161485  -0.030945
+     5  O   -0.002559  -0.062361   0.003071   0.161485   8.060437   0.070472
+     6  O   -0.000033   0.002818  -0.000018  -0.030945   0.070472   8.096565
+     7  C   -0.011828  -0.055251   0.008795   0.383593  -0.056133  -0.008302
+     8  C    0.000401   0.006152  -0.000162  -0.048963   0.003633   0.010204
+     9  N    0.000001   0.000134   0.000015  -0.017978   0.000351  -0.008255
+    10  H    0.397459  -0.027826  -0.004791   0.006466  -0.000190   0.000006
+    11  H    0.400847  -0.024431   0.005681  -0.007986  -0.000886  -0.000002
+    12  H    0.402834  -0.040186  -0.001333  -0.005436   0.006733  -0.000143
+    13  H   -0.002279  -0.038532   0.404128  -0.009200   0.008285  -0.000253
+    14  H   -0.004830  -0.027988   0.399729   0.006126  -0.000125   0.000011
+    15  H    0.006269  -0.027585   0.394885   0.002394  -0.002101   0.000175
+    16  H    0.006868  -0.025740  -0.010801   0.363209  -0.033890   0.009826
+    17  H   -0.001508   0.007151  -0.000133  -0.027725   0.005210  -0.000262
+    18  H    0.002250  -0.006825  -0.000310  -0.010849  -0.001765   0.000087
+    19  H   -0.000008   0.000145  -0.000010  -0.020553   0.004240   0.003788
+    20  H   -0.000017  -0.000158   0.000010   0.009293  -0.000179   0.000151
+    21  H   -0.000009  -0.000097   0.000033   0.009640  -0.003878   0.022199
+    22  H    0.000001  -0.000002  -0.000002  -0.000067  -0.000004   0.000026
+               7          8          9         10         11         12
+     1  C   -0.011828   0.000401   0.000001   0.397459   0.400847   0.402834
+     2  N   -0.055251   0.006152   0.000134  -0.027826  -0.024431  -0.040186
+     3  C    0.008795  -0.000162   0.000015  -0.004791   0.005681  -0.001333
+     4  C    0.383593  -0.048963  -0.017978   0.006466  -0.007986  -0.005436
+     5  O   -0.056133   0.003633   0.000351  -0.000190  -0.000886   0.006733
+     6  O   -0.008302   0.010204  -0.008255   0.000006  -0.000002  -0.000143
+     7  C    4.814250   0.360136  -0.078533   0.000669   0.007372  -0.002955
+     8  C    0.360136   4.577755   0.371825  -0.000019  -0.000051   0.000143
+     9  N   -0.078533   0.371825   6.325829   0.000000  -0.000018  -0.000001
+    10  H    0.000669  -0.000019   0.000000   0.634818  -0.013788  -0.034044
+    11  H    0.007372  -0.000051  -0.000018  -0.013788   0.619940  -0.032375
+    12  H   -0.002955   0.000143  -0.000001  -0.034044  -0.032375   0.663155
+    13  H   -0.000222   0.000052  -0.000001  -0.003420  -0.000478   0.010185
+    14  H   -0.000217   0.000001   0.000000   0.006042   0.000552  -0.002703
+    15  H    0.000842  -0.000102  -0.000103   0.000570  -0.000321  -0.000458
+    16  H   -0.018858  -0.017372   0.030511  -0.000096   0.000120  -0.000362
+    17  H    0.354551  -0.002430   0.005086  -0.000283  -0.000968   0.000506
+    18  H    0.351686  -0.015998   0.005764  -0.000150   0.001167   0.000508
+    19  H   -0.035047   0.391384  -0.027913   0.000001  -0.000007  -0.000002
+    20  H   -0.013160   0.376122  -0.021077   0.000000   0.000024  -0.000004
+    21  H   -0.008302  -0.025714   0.348670   0.000001   0.000001   0.000001
+    22  H    0.011447  -0.022538   0.350450  -0.000000   0.000001  -0.000000
+              13         14         15         16         17         18
+     1  C   -0.002279  -0.004830   0.006269   0.006868  -0.001508   0.002250
+     2  N   -0.038532  -0.027988  -0.027585  -0.025740   0.007151  -0.006825
+     3  C    0.404128   0.399729   0.394885  -0.010801  -0.000133  -0.000310
+     4  C   -0.009200   0.006126   0.002394   0.363209  -0.027725  -0.010849
+     5  O    0.008285  -0.000125  -0.002101  -0.033890   0.005210  -0.001765
+     6  O   -0.000253   0.000011   0.000175   0.009826  -0.000262   0.000087
+     7  C   -0.000222  -0.000217   0.000842  -0.018858   0.354551   0.351686
+     8  C    0.000052   0.000001  -0.000102  -0.017372  -0.002430  -0.015998
+     9  N   -0.000001   0.000000  -0.000103   0.030511   0.005086   0.005764
+    10  H   -0.003420   0.006042   0.000570  -0.000096  -0.000283  -0.000150
+    11  H   -0.000478   0.000552  -0.000321   0.000120  -0.000968   0.001167
+    12  H    0.010185  -0.002703  -0.000458  -0.000362   0.000506   0.000508
+    13  H    0.664197  -0.035031  -0.029778  -0.002183   0.000079  -0.000012
+    14  H   -0.035031   0.633099  -0.015842   0.000696  -0.000077   0.000017
+    15  H   -0.029778  -0.015842   0.625050   0.005172  -0.000188  -0.000025
+    16  H   -0.002183   0.000696   0.005172   0.649330  -0.003823   0.008724
+    17  H    0.000079  -0.000077  -0.000188  -0.003823   0.640807  -0.021031
+    18  H   -0.000012   0.000017  -0.000025   0.008724  -0.021031   0.656650
+    19  H   -0.000003   0.000000  -0.000008   0.002987   0.008877  -0.003309
+    20  H   -0.000001  -0.000000   0.000001   0.000252  -0.012962  -0.002465
+    21  H   -0.000000   0.000001   0.000026  -0.001936  -0.001423  -0.000248
+    22  H   -0.000000   0.000000   0.000003  -0.001266  -0.000105  -0.000447
+              19         20         21         22
+     1  C   -0.000008  -0.000017  -0.000009   0.000001
+     2  N    0.000145  -0.000158  -0.000097  -0.000002
+     3  C   -0.000010   0.000010   0.000033  -0.000002
+     4  C   -0.020553   0.009293   0.009640  -0.000067
+     5  O    0.004240  -0.000179  -0.003878  -0.000004
+     6  O    0.003788   0.000151   0.022199   0.000026
+     7  C   -0.035047  -0.013160  -0.008302   0.011447
+     8  C    0.391384   0.376122  -0.025714  -0.022538
+     9  N   -0.027913  -0.021077   0.348670   0.350450
+    10  H    0.000001   0.000000   0.000001  -0.000000
+    11  H   -0.000007   0.000024   0.000001   0.000001
+    12  H   -0.000002  -0.000004   0.000001  -0.000000
+    13  H   -0.000003  -0.000001  -0.000000  -0.000000
+    14  H    0.000000  -0.000000   0.000001   0.000000
+    15  H   -0.000008   0.000001   0.000026   0.000003
+    16  H    0.002987   0.000252  -0.001936  -0.001266
+    17  H    0.008877  -0.012962  -0.001423  -0.000105
+    18  H   -0.003309  -0.002465  -0.000248  -0.000447
+    19  H    0.693575  -0.031535  -0.014594  -0.000787
+    20  H   -0.031535   0.670910   0.008392  -0.012120
+    21  H   -0.014594   0.008392   0.571550  -0.020652
+    22  H   -0.000787  -0.012120  -0.020652   0.585747
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  C   -0.000325   0.000049  -0.000131   0.000042  -0.000293   0.000011
+     2  N    0.000049  -0.000628  -0.000951   0.004409  -0.002239   0.000404
+     3  C   -0.000131  -0.000951   0.001380   0.000485   0.001887  -0.000472
+     4  C    0.000042   0.004409   0.000485  -0.015627  -0.011854   0.000623
+     5  O   -0.000293  -0.002239   0.001887  -0.011854   0.473762  -0.134910
+     6  O    0.000011   0.000404  -0.000472   0.000623  -0.134910   0.812736
+     7  C    0.000080   0.000539   0.000004   0.006099   0.003858   0.000287
+     8  C   -0.000036  -0.000285   0.000050   0.001923  -0.003642   0.001381
+     9  N    0.000001   0.000016  -0.000004   0.000033   0.000292  -0.000045
+    10  H    0.000280  -0.000074  -0.000098   0.000022  -0.000019   0.000001
+    11  H    0.000085   0.000028  -0.000020   0.000012   0.000015   0.000000
+    12  H   -0.000478   0.000052   0.000194  -0.000233  -0.000020  -0.000014
+    13  H   -0.000038   0.000121   0.000432  -0.000266   0.000555  -0.000355
+    14  H    0.000008   0.000178   0.000007  -0.000025  -0.000007  -0.000002
+    15  H    0.000019   0.000128  -0.000238  -0.000010  -0.000300   0.000130
+    16  H    0.000143   0.001785  -0.001381  -0.003425  -0.002857   0.001053
+    17  H    0.000031  -0.000199  -0.000074  -0.002184   0.000186  -0.000088
+    18  H    0.000004   0.000057  -0.000009  -0.000052   0.000096  -0.000110
+    19  H   -0.000005  -0.000023   0.000004  -0.000113  -0.001183  -0.000382
+    20  H   -0.000002  -0.000005   0.000001   0.000073  -0.000132   0.000066
+    21  H   -0.000002  -0.000021   0.000012   0.000193   0.000028  -0.001334
+    22  H   -0.000000  -0.000000   0.000000   0.000010  -0.000002   0.000016
+               7          8          9         10         11         12
+     1  C    0.000080  -0.000036   0.000001   0.000280   0.000085  -0.000478
+     2  N    0.000539  -0.000285   0.000016  -0.000074   0.000028   0.000052
+     3  C    0.000004   0.000050  -0.000004  -0.000098  -0.000020   0.000194
+     4  C    0.006099   0.001923   0.000033   0.000022   0.000012  -0.000233
+     5  O    0.003858  -0.003642   0.000292  -0.000019   0.000015  -0.000020
+     6  O    0.000287   0.001381  -0.000045   0.000001   0.000000  -0.000014
+     7  C   -0.005443   0.003005  -0.000861  -0.000024  -0.000126   0.000165
+     8  C    0.003005  -0.001737   0.000731  -0.000002   0.000001   0.000013
+     9  N   -0.000861   0.000731  -0.001690   0.000000  -0.000000  -0.000000
+    10  H   -0.000024  -0.000002   0.000000   0.000269  -0.000010  -0.000184
+    11  H   -0.000126   0.000001  -0.000000  -0.000010  -0.000107   0.000041
+    12  H    0.000165   0.000013  -0.000000  -0.000184   0.000041   0.000775
+    13  H    0.000001   0.000006  -0.000000  -0.000013   0.000002   0.000024
+    14  H   -0.000010  -0.000000   0.000000  -0.000012  -0.000005   0.000013
+    15  H   -0.000022  -0.000007   0.000001   0.000008   0.000000  -0.000013
+    16  H   -0.000924  -0.001579   0.000596   0.000015   0.000009  -0.000083
+    17  H    0.002424  -0.002434   0.000224   0.000020   0.000058  -0.000040
+    18  H    0.000389   0.000126   0.000029  -0.000000   0.000006  -0.000032
+    19  H    0.001190   0.000248   0.000333  -0.000000   0.000000   0.000002
+    20  H   -0.000781   0.000878  -0.000194  -0.000000  -0.000000   0.000001
+    21  H    0.000225  -0.000097   0.001254  -0.000000  -0.000000   0.000000
+    22  H   -0.000021   0.000032   0.000085  -0.000000  -0.000000   0.000000
+              13         14         15         16         17         18
+     1  C   -0.000038   0.000008   0.000019   0.000143   0.000031   0.000004
+     2  N    0.000121   0.000178   0.000128   0.001785  -0.000199   0.000057
+     3  C    0.000432   0.000007  -0.000238  -0.001381  -0.000074  -0.000009
+     4  C   -0.000266  -0.000025  -0.000010  -0.003425  -0.002184  -0.000052
+     5  O    0.000555  -0.000007  -0.000300  -0.002857   0.000186   0.000096
+     6  O   -0.000355  -0.000002   0.000130   0.001053  -0.000088  -0.000110
+     7  C    0.000001  -0.000010  -0.000022  -0.000924   0.002424   0.000389
+     8  C    0.000006  -0.000000  -0.000007  -0.001579  -0.002434   0.000126
+     9  N   -0.000000   0.000000   0.000001   0.000596   0.000224   0.000029
+    10  H   -0.000013  -0.000012   0.000008   0.000015   0.000020  -0.000000
+    11  H    0.000002  -0.000005   0.000000   0.000009   0.000058   0.000006
+    12  H    0.000024   0.000013  -0.000013  -0.000083  -0.000040  -0.000032
+    13  H   -0.000639   0.000060  -0.000042  -0.000195  -0.000006  -0.000001
+    14  H    0.000060  -0.000403   0.000022   0.000010   0.000003   0.000000
+    15  H   -0.000042   0.000022  -0.000043   0.000306   0.000015   0.000001
+    16  H   -0.000195   0.000010   0.000306   0.010669   0.001172   0.000020
+    17  H   -0.000006   0.000003   0.000015   0.001172   0.004234   0.000135
+    18  H   -0.000001   0.000000   0.000001   0.000020   0.000135  -0.000591
+    19  H    0.000001   0.000000  -0.000000  -0.000030  -0.000133  -0.000046
+    20  H    0.000000   0.000000  -0.000000  -0.000099  -0.000483  -0.000087
+    21  H    0.000002  -0.000000  -0.000006  -0.000796  -0.000058  -0.000024
+    22  H    0.000000  -0.000000  -0.000000  -0.000010   0.000000  -0.000000
+              19         20         21         22
+     1  C   -0.000005  -0.000002  -0.000002  -0.000000
+     2  N   -0.000023  -0.000005  -0.000021  -0.000000
+     3  C    0.000004   0.000001   0.000012   0.000000
+     4  C   -0.000113   0.000073   0.000193   0.000010
+     5  O   -0.001183  -0.000132   0.000028  -0.000002
+     6  O   -0.000382   0.000066  -0.001334   0.000016
+     7  C    0.001190  -0.000781   0.000225  -0.000021
+     8  C    0.000248   0.000878  -0.000097   0.000032
+     9  N    0.000333  -0.000194   0.001254   0.000085
+    10  H   -0.000000  -0.000000  -0.000000  -0.000000
+    11  H    0.000000  -0.000000  -0.000000  -0.000000
+    12  H    0.000002   0.000001   0.000000   0.000000
+    13  H    0.000001   0.000000   0.000002   0.000000
+    14  H    0.000000   0.000000  -0.000000  -0.000000
+    15  H   -0.000000  -0.000000  -0.000006  -0.000000
+    16  H   -0.000030  -0.000099  -0.000796  -0.000010
+    17  H   -0.000133  -0.000483  -0.000058   0.000000
+    18  H   -0.000046  -0.000087  -0.000024  -0.000000
+    19  H   -0.001157  -0.000086   0.000008   0.000003
+    20  H   -0.000086   0.001422   0.000062   0.000019
+    21  H    0.000008   0.000062  -0.001136  -0.000079
+    22  H    0.000003   0.000019  -0.000079  -0.000109
+ Mulliken charges and spin densities:
+               1          2
+     1  C    0.069919  -0.000556
+     2  N   -0.389219   0.003344
+     3  C    0.072657   0.001076
+     4  C    0.182286  -0.019864
+     5  O   -0.159846   0.323222
+     6  O   -0.168117   0.678994
+     7  C   -0.004532   0.010053
+     8  C    0.035542  -0.001427
+     9  N   -0.284760   0.000801
+    10  H    0.038576   0.000177
+    11  H    0.045608  -0.000011
+    12  H    0.035935   0.000182
+    13  H    0.034468  -0.000351
+    14  H    0.040541  -0.000163
+    15  H    0.041123  -0.000052
+    16  H    0.038633   0.004400
+    17  H    0.050651   0.002804
+    18  H    0.036583  -0.000089
+    19  H    0.028778  -0.001371
+    20  H    0.028523   0.000652
+    21  H    0.116338  -0.001769
+    22  H    0.110314  -0.000055
+ Sum of Mulliken charges =  -0.00000   1.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  C    0.190038  -0.000207
+     2  N   -0.389219   0.003344
+     3  C    0.188789   0.000512
+     4  C    0.220919  -0.015464
+     5  O   -0.159846   0.323222
+     6  O   -0.168117   0.678994
+     7  C    0.082702   0.012768
+     8  C    0.092842  -0.002145
+     9  N   -0.058108  -0.001023
+ APT charges:
+               1
+     1  C   -0.833817
+     2  N   -0.328539
+     3  C   -0.828960
+     4  C   -0.293529
+     5  O   -0.011198
+     6  O   -0.208808
+     7  C   -0.553044
+     8  C   -0.646741
+     9  N   -0.968970
+    10  H    0.581670
+    11  H    0.222172
+    12  H    0.255256
+    13  H    0.274907
+    14  H    0.581036
+    15  H    0.208875
+    16  H    0.208226
+    17  H    0.327376
+    18  H    0.287863
+    19  H    0.222416
+    20  H    0.529309
+    21  H    0.143296
+    22  H    0.831203
+ Sum of APT charges =  -0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  C    0.225280
+     2  N   -0.328539
+     3  C    0.235858
+     4  C   -0.085303
+     5  O   -0.011198
+     6  O   -0.208808
+     7  C    0.062195
+     8  C    0.104984
+     9  N    0.005530
+ Electronic spatial extent (au):  <R**2>=           1410.3225
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.6331    Y=             -1.5779    Z=              0.1452  Tot=              1.7064
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -47.0764   YY=            -57.4176   ZZ=            -58.9358
+   XY=              0.8845   XZ=              0.8982   YZ=              4.9147
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              7.4002   YY=             -2.9410   ZZ=             -4.4592
+   XY=              0.8845   XZ=              0.8982   YZ=              4.9147
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=            -21.2805  YYY=              1.0137  ZZZ=             -6.1761  XYY=             -0.1912
+  XXY=              3.2479  XXZ=              0.9739  XZZ=              3.4693  YZZ=              4.3737
+  YYZ=              2.4228  XYZ=             -1.2541
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=          -1012.1481 YYYY=           -417.4029 ZZZZ=           -239.8869 XXXY=            -15.1846
+ XXXZ=            -12.7678 YYYX=              0.3413 YYYZ=              2.1368 ZZZX=              8.0399
+ ZZZY=             -0.3405 XXYY=           -254.2008 XXZZ=           -239.5834 YYZZ=           -108.5276
+ XXYZ=              6.8147 YYXZ=             -6.3133 ZZXY=             -3.4548
+ N-N= 5.091333051656D+02 E-N=-2.085636041313D+03  KE= 4.533928070485D+02
+  Exact polarizability:   0.000   0.000   0.000   0.000   0.000   0.000
+ Approx polarizability:  83.033  -6.426  81.593  -1.375   1.597  73.018
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  C(13)             -0.00038      -0.42544      -0.15181      -0.14191
+     2  N(14)              0.00313       1.00983       0.36033       0.33684
+     3  C(13)             -0.00002      -0.02575      -0.00919      -0.00859
+     4  C(13)             -0.01405     -15.79615      -5.63646      -5.26903
+     5  O(17)              0.15597     -94.54602     -33.73637     -31.53716
+     6  O(17)              0.26271    -159.25518     -56.82621     -53.12181
+     7  C(13)              0.01057      11.87981       4.23901       3.96268
+     8  C(13)             -0.00134      -1.50718      -0.53780      -0.50274
+     9  N(14)             -0.00121      -0.38946      -0.13897      -0.12991
+    10  H(1)               0.00008       0.36153       0.12900       0.12059
+    11  H(1)              -0.00001      -0.05061      -0.01806      -0.01688
+    12  H(1)               0.00008       0.36248       0.12934       0.12091
+    13  H(1)              -0.00011      -0.47044      -0.16786      -0.15692
+    14  H(1)              -0.00005      -0.23770      -0.08482      -0.07929
+    15  H(1)              -0.00002      -0.07225      -0.02578      -0.02410
+    16  H(1)               0.00124       5.55288       1.98140       1.85224
+    17  H(1)               0.00119       5.33511       1.90370       1.77960
+    18  H(1)               0.00003       0.15193       0.05421       0.05068
+    19  H(1)               0.00019       0.83891       0.29934       0.27983
+    20  H(1)               0.00032       1.40935       0.50289       0.47011
+    21  H(1)               0.00003       0.13965       0.04983       0.04658
+    22  H(1)              -0.00004      -0.16979      -0.06059      -0.05664
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        0.001593      0.001473     -0.003066
+     2   Atom        0.001277      0.003056     -0.004333
+     3   Atom        0.003387     -0.003523      0.000137
+     4   Atom       -0.004946      0.007249     -0.002303
+     5   Atom        0.317327     -0.045850     -0.271477
+     6   Atom        0.618057     -0.079798     -0.538259
+     7   Atom       -0.004774      0.016042     -0.011268
+     8   Atom       -0.000669      0.005740     -0.005071
+     9   Atom       -0.000300     -0.001421      0.001722
+    10   Atom        0.001153      0.000228     -0.001381
+    11   Atom       -0.000431      0.002652     -0.002221
+    12   Atom        0.003044     -0.000169     -0.002875
+    13   Atom        0.007489     -0.004257     -0.003232
+    14   Atom        0.001765     -0.001310     -0.000456
+    15   Atom        0.000725     -0.003236      0.002511
+    16   Atom       -0.009495     -0.002625      0.012120
+    17   Atom       -0.002875      0.003659     -0.000784
+    18   Atom       -0.005080      0.009002     -0.003923
+    19   Atom        0.002984      0.004383     -0.007366
+    20   Atom        0.000091      0.002055     -0.002147
+    21   Atom        0.002875     -0.005384      0.002508
+    22   Atom        0.001808     -0.000930     -0.000878
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom       -0.004335      0.000435     -0.000360
+     2   Atom       -0.013506      0.011079     -0.010329
+     3   Atom       -0.001926      0.004654     -0.001707
+     4   Atom       -0.003478      0.004360     -0.012027
+     5   Atom        0.939258      0.775767      0.588931
+     6   Atom        1.655915      1.310027      1.061049
+     7   Atom        0.012327     -0.002818     -0.006499
+     8   Atom        0.005981     -0.001699     -0.002960
+     9   Atom        0.003438     -0.004479     -0.005593
+    10   Atom       -0.002050      0.000429     -0.000317
+    11   Atom       -0.002860     -0.000054      0.000073
+    12   Atom       -0.004476     -0.001817      0.001385
+    13   Atom        0.000391      0.004248      0.000250
+    14   Atom       -0.001046      0.002072     -0.000625
+    15   Atom       -0.000785      0.004960     -0.000536
+    16   Atom       -0.002065      0.002413     -0.013247
+    17   Atom        0.000226      0.000252     -0.003602
+    18   Atom        0.000550     -0.000048      0.001893
+    19   Atom        0.009966      0.002098      0.002487
+    20   Atom        0.002926     -0.000377     -0.000543
+    21   Atom        0.005243     -0.010709     -0.005124
+    22   Atom        0.002240     -0.002410     -0.001407
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -0.0031    -0.417    -0.149    -0.139 -0.1551 -0.0693  0.9855
+     1 C(13)  Bbb    -0.0028    -0.375    -0.134    -0.125  0.6860  0.7102  0.1579
+              Bcc     0.0059     0.792     0.283     0.264  0.7109 -0.7005  0.0626
+ 
+              Baa    -0.0130    -0.500    -0.178    -0.167 -0.6385 -0.0429  0.7684
+     2 N(14)  Bbb    -0.0109    -0.419    -0.149    -0.140  0.4665  0.7725  0.4308
+              Bcc     0.0238     0.919     0.328     0.306 -0.6121  0.6335 -0.4733
+ 
+              Baa    -0.0042    -0.563    -0.201    -0.188  0.0339  0.9418  0.3344
+     3 C(13)  Bbb    -0.0031    -0.416    -0.148    -0.139 -0.6123 -0.2448  0.7518
+              Bcc     0.0073     0.979     0.349     0.327  0.7899 -0.2303  0.5684
+ 
+              Baa    -0.0110    -1.478    -0.527    -0.493 -0.3136  0.4799  0.8194
+     4 C(13)  Bbb    -0.0057    -0.767    -0.274    -0.256  0.9188  0.3711  0.1343
+              Bcc     0.0167     2.245     0.801     0.749 -0.2396  0.7950 -0.5573
+ 
+              Baa    -0.8406    60.827    21.705    20.290  0.7248 -0.5338 -0.4356
+     5 O(17)  Bbb    -0.7583    54.870    19.579    18.303 -0.0031 -0.6347  0.7727
+              Bcc     1.5989  -115.697   -41.284   -38.592  0.6890  0.5587  0.4617
+ 
+              Baa    -1.4232   102.981    36.746    34.351 -0.6410  0.7670  0.0292
+     6 O(17)  Bbb    -1.3870   100.361    35.811    33.477 -0.3285 -0.3085  0.8927
+              Bcc     2.8102  -203.341   -72.557   -67.827  0.6937  0.5626  0.4497
+ 
+              Baa    -0.0127    -1.709    -0.610    -0.570  0.0125  0.2152  0.9765
+     7 C(13)  Bbb    -0.0105    -1.407    -0.502    -0.469  0.9113 -0.4045  0.0775
+              Bcc     0.0232     3.116     1.112     1.039  0.4116  0.8889 -0.2011
+ 
+              Baa    -0.0058    -0.784    -0.280    -0.261  0.0796  0.2081  0.9749
+     8 C(13)  Bbb    -0.0042    -0.570    -0.203    -0.190  0.8622 -0.5052  0.0374
+              Bcc     0.0101     1.354     0.483     0.452  0.5003  0.8375 -0.2196
+ 
+              Baa    -0.0057    -0.218    -0.078    -0.073 -0.0137  0.8009  0.5986
+     9 N(14)  Bbb    -0.0036    -0.140    -0.050    -0.047  0.8615 -0.2944  0.4136
+              Bcc     0.0093     0.358     0.128     0.119 -0.5075 -0.5213  0.6860
+ 
+              Baa    -0.0015    -0.778    -0.277    -0.259 -0.3444 -0.2489  0.9052
+    10 H(1)   Bbb    -0.0014    -0.748    -0.267    -0.250  0.5294  0.7449  0.4062
+              Bcc     0.0029     1.526     0.544     0.509  0.7754 -0.6191  0.1247
+ 
+              Baa    -0.0022    -1.186    -0.423    -0.396  0.1029  0.0456  0.9936
+    11 H(1)   Bbb    -0.0021    -1.140    -0.407    -0.380  0.8525  0.5107 -0.1117
+              Bcc     0.0044     2.327     0.830     0.776 -0.5125  0.8586  0.0137
+ 
+              Baa    -0.0035    -1.849    -0.660    -0.617 -0.1231 -0.5217  0.8442
+    12 H(1)   Bbb    -0.0033    -1.745    -0.622    -0.582  0.5946  0.6423  0.4836
+              Bcc     0.0067     3.594     1.282     1.199  0.7946 -0.5615 -0.2311
+ 
+              Baa    -0.0047    -2.527    -0.902    -0.843 -0.3133 -0.2259  0.9224
+    13 H(1)   Bbb    -0.0042    -2.266    -0.809    -0.756 -0.1057  0.9735  0.2025
+              Bcc     0.0090     4.793     1.710     1.599  0.9437  0.0341  0.3289
+ 
+              Baa    -0.0017    -0.905    -0.323    -0.302 -0.5179 -0.0194  0.8552
+    14 H(1)   Bbb    -0.0016    -0.870    -0.310    -0.290  0.2078  0.9669  0.1477
+              Bcc     0.0033     1.775     0.633     0.592  0.8298 -0.2542  0.4967
+ 
+              Baa    -0.0036    -1.939    -0.692    -0.647  0.6288  0.6324 -0.4524
+    15 H(1)   Bbb    -0.0031    -1.658    -0.592    -0.553 -0.4409  0.7692  0.4625
+              Bcc     0.0067     3.597     1.284     1.200  0.6405 -0.0914  0.7625
+ 
+              Baa    -0.0107    -5.733    -2.046    -1.912  0.5125  0.7654  0.3893
+    16 H(1)   Bbb    -0.0095    -5.064    -1.807    -1.689  0.8523 -0.3982 -0.3392
+              Bcc     0.0202    10.797     3.853     3.602  0.1046 -0.5057  0.8564
+ 
+              Baa    -0.0032    -1.691    -0.603    -0.564  0.7490 -0.3284 -0.5755
+    17 H(1)   Bbb    -0.0025    -1.335    -0.476    -0.445  0.6625  0.3597  0.6570
+              Bcc     0.0057     3.025     1.080     1.009  0.0087  0.8733 -0.4870
+ 
+              Baa    -0.0051    -2.730    -0.974    -0.911  0.9902 -0.0558  0.1284
+    18 H(1)   Bbb    -0.0042    -2.229    -0.795    -0.743 -0.1349 -0.1353  0.9816
+              Bcc     0.0093     4.959     1.769     1.654  0.0374  0.9892  0.1415
+ 
+              Baa    -0.0079    -4.201    -1.499    -1.401 -0.0270 -0.1777  0.9837
+    19 H(1)   Bbb    -0.0063    -3.357    -1.198    -1.120  0.7388 -0.6665 -0.1001
+              Bcc     0.0142     7.558     2.697     2.521  0.6734  0.7241  0.1493
+ 
+              Baa    -0.0022    -1.182    -0.422    -0.394  0.0152  0.1158  0.9932
+    20 H(1)   Bbb    -0.0020    -1.074    -0.383    -0.358  0.8140 -0.5782  0.0550
+              Bcc     0.0042     2.256     0.805     0.753  0.5806  0.8076 -0.1031
+ 
+              Baa    -0.0080    -4.281    -1.527    -1.428  0.7304 -0.1639  0.6630
+    21 H(1)   Bbb    -0.0079    -4.216    -1.504    -1.406 -0.1071  0.9313  0.3482
+              Bcc     0.0159     8.497     3.032     2.834  0.6745  0.3253 -0.6627
+ 
+              Baa    -0.0023    -1.246    -0.445    -0.416  0.2481  0.4589  0.8532
+    22 H(1)   Bbb    -0.0022    -1.160    -0.414    -0.387 -0.5841  0.7735 -0.2461
+              Bcc     0.0045     2.406     0.858     0.803  0.7728  0.4372 -0.4599
+ 
+
+ ---------------------------------------------------------------------------------
+
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Mon Jun 15 23:46:12 2020, MaxMem= 18790481920 cpu:              16.9 elap:               0.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ R6Disp: Adding Grimme-D2 dispersion energy 2nd derivatives to the Hessian.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    4371 NPrTT=   15207 LenC2=    4320 LenP2D=   11947.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ Leave Link  701 at Mon Jun 15 23:46:14 2020, MaxMem= 18790481920 cpu:              17.2 elap:               0.7
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Jun 15 23:46:14 2020, MaxMem= 18790481920 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100147 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100147 DoSepK=T KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         1 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100547 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Mon Jun 15 23:46:30 2020, MaxMem= 18790481920 cpu:             619.0 elap:              15.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        = 2.49095027D-01-6.20808894D-01 5.71170216D-02
+ Polarizability= 0.00000000D+00 0.00000000D+00 0.00000000D+00
+                 0.00000000D+00 0.00000000D+00 0.00000000D+00
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000000573   -0.000001088    0.000000171
+      2        7          -0.000000115    0.000000299    0.000000141
+      3        6          -0.000000080   -0.000000526   -0.000001703
+      4        6           0.000000676    0.000000341   -0.000000515
+      5        8           0.000000190   -0.000001045   -0.000000599
+      6        8           0.000000345   -0.000000147   -0.000001548
+      7        6          -0.000000584    0.000000456    0.000000489
+      8        6          -0.000000133   -0.000000095    0.000000741
+      9        7           0.000000719    0.000002164    0.000001062
+     10        1          -0.000000371   -0.000001315    0.000000190
+     11        1          -0.000000921   -0.000001488    0.000000990
+     12        1          -0.000000469   -0.000001922   -0.000000582
+     13        1           0.000000621   -0.000000644   -0.000002044
+     14        1           0.000000869   -0.000000094   -0.000001117
+     15        1           0.000000989    0.000000846   -0.000001565
+     16        1           0.000000585    0.000000802   -0.000000522
+     17        1          -0.000000331    0.000000308    0.000001957
+     18        1          -0.000000865   -0.000000724    0.000001320
+     19        1          -0.000000358   -0.000000020    0.000000501
+     20        1          -0.000000545    0.000000688    0.000001944
+     21        1           0.000000547    0.000001302   -0.000000211
+     22        1          -0.000000197    0.000001903    0.000000903
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000002164 RMS     0.000000941
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ GSVD:  received Info=                   1 from GESDD.
+ Leave Link  716 at Mon Jun 15 23:46:31 2020, MaxMem= 18790481920 cpu:               3.0 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000000595 RMS     0.000000139
+ Search for a local minimum.
+ Step number   1 out of a maximum of  118 on scan point     1 out of    46
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .14371D-06 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---    0.00363   0.00388   0.00609   0.00731   0.01852
+     Eigenvalues ---    0.03119   0.03290   0.03773   0.03905   0.04623
+     Eigenvalues ---    0.05301   0.06192   0.06945   0.07234   0.08179
+     Eigenvalues ---    0.08715   0.10229   0.10420   0.12416   0.12972
+     Eigenvalues ---    0.13190   0.14947   0.15000   0.16560   0.17271
+     Eigenvalues ---    0.17566   0.18378   0.19467   0.23775   0.24031
+     Eigenvalues ---    0.26568   0.30140   0.31935   0.32010   0.32098
+     Eigenvalues ---    0.33640   0.33878   0.34182   0.34292   0.34338
+     Eigenvalues ---    0.34427   0.34527   0.34827   0.35346   0.37847
+     Eigenvalues ---    0.38365   0.39344   0.43480   0.45284   0.46029
+     Eigenvalues ---    0.46507   0.559571000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.000001000.000001000.00000
+     Eigenvalues --- 1000.000001000.000001000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.62949557D-03
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00000413 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 2.42D-05 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.73832   0.00000   0.00000   0.00000   0.00000   2.73833
+    R2        2.07895   0.00000   0.00000   0.00000   0.00000   2.07895
+    R3        2.07423   0.00000   0.00000   0.00000   0.00000   2.07423
+    R4        2.09339   0.00000   0.00000   0.00000   0.00000   2.09339
+    R5        2.73791  -0.00000   0.00000  -0.00000  -0.00000   2.73791
+    R6        2.65827  -0.00000   0.00000  -0.00000  -0.00000   2.65827
+    R7        2.09346   0.00000   0.00000   0.00000   0.00000   2.09346
+    R8        2.07990   0.00000   0.00000   0.00000   0.00000   2.07990
+    R9        2.07817   0.00000   0.00000   0.00000   0.00000   2.07817
+   R10        2.83202  -0.00000   0.00000  -0.00000  -0.00000   2.83201
+   R11        2.87145   0.00000   0.00000   0.00000   0.00000   2.87145
+   R12        2.07872  -0.00000   0.00000  -0.00000  -0.00000   2.07872
+   R13        2.44181   0.00000   0.00000   0.00000   0.00000   2.44181
+   R14        2.89212  -0.00000   0.00000  -0.00000  -0.00000   2.89212
+   R15        2.08094   0.00000   0.00000   0.00000   0.00000   2.08094
+   R16        2.08014  -0.00000   0.00000  -0.00000  -0.00000   2.08014
+   R17        2.74882   0.00000   0.00000   0.00000   0.00000   2.74882
+   R18        2.09342   0.00000   0.00000   0.00000   0.00000   2.09342
+   R19        2.08103  -0.00000   0.00000  -0.00000  -0.00000   2.08103
+   R20        1.92677  -0.00000   0.00000  -0.00000  -0.00000   1.92677
+   R21        1.92086   0.00000   0.00000   0.00000   0.00000   1.92086
+    A1        1.90224  -0.00000   0.00000  -0.00000  -0.00000   1.90224
+    A2        1.93683   0.00000   0.00000   0.00000   0.00000   1.93683
+    A3        1.97659   0.00000   0.00000   0.00000   0.00000   1.97659
+    A4        1.86956  -0.00000   0.00000  -0.00000  -0.00000   1.86956
+    A5        1.88260  -0.00000   0.00000  -0.00000  -0.00000   1.88260
+    A6        1.89229   0.00000   0.00000   0.00000   0.00000   1.89229
+    A7        1.98191  -0.00000   0.00000   0.00000   0.00000   1.98191
+    A8        2.06938  -0.00000   0.00000   0.00000  -0.00000   2.06938
+    A9        2.00223   0.00000   0.00000   0.00000  -0.00000   2.00223
+   A10        1.97563   0.00000   0.00000   0.00000   0.00000   1.97563
+   A11        1.91551   0.00000   0.00000   0.00000   0.00000   1.91551
+   A12        1.91633   0.00000   0.00000   0.00000   0.00000   1.91633
+   A13        1.88684  -0.00000   0.00000  -0.00000  -0.00000   1.88684
+   A14        1.88417  -0.00000   0.00000  -0.00000  -0.00000   1.88417
+   A15        1.88281  -0.00000   0.00000  -0.00000  -0.00000   1.88281
+   A16        1.90710   0.00000   0.00000  -0.00000  -0.00000   1.90710
+   A17        2.02648   0.00000   0.00000  -0.00000  -0.00000   2.02648
+   A18        1.90981  -0.00000   0.00000  -0.00000  -0.00000   1.90981
+   A19        1.88389  -0.00000   0.00000   0.00000   0.00000   1.88389
+   A20        1.81224   0.00000   0.00000   0.00000   0.00000   1.81225
+   A21        1.91200  -0.00000   0.00000  -0.00000  -0.00000   1.91200
+   A22        1.97301   0.00000   0.00000   0.00000   0.00000   1.97301
+   A23        1.98369   0.00000   0.00000   0.00000   0.00000   1.98369
+   A24        1.85249  -0.00000   0.00000  -0.00000  -0.00000   1.85249
+   A25        1.92656   0.00000   0.00000   0.00000   0.00000   1.92656
+   A26        1.91374  -0.00000   0.00000  -0.00000  -0.00000   1.91374
+   A27        1.89889  -0.00000   0.00000  -0.00000  -0.00000   1.89889
+   A28        1.88588   0.00000   0.00000  -0.00000  -0.00000   1.88588
+   A29        1.95319  -0.00000   0.00000  -0.00000  -0.00000   1.95319
+   A30        1.90050   0.00000   0.00000   0.00000   0.00000   1.90050
+   A31        1.87252  -0.00000   0.00000   0.00000   0.00000   1.87252
+   A32        1.98080  -0.00000   0.00000  -0.00000  -0.00000   1.98080
+   A33        1.89892   0.00000   0.00000   0.00000   0.00000   1.89892
+   A34        1.85216   0.00000   0.00000   0.00000   0.00000   1.85216
+   A35        1.90387   0.00000   0.00000  -0.00000  -0.00000   1.90387
+   A36        1.92678  -0.00000   0.00000  -0.00000  -0.00000   1.92678
+   A37        1.85613   0.00000   0.00000   0.00000   0.00000   1.85614
+    D1       -2.42918  -0.00000   0.00000   0.00000   0.00000  -2.42918
+    D2        0.89585   0.00000   0.00000   0.00000   0.00000   0.89585
+    D3       -2.95816   0.00000   0.00000   0.00000   0.00000  -2.95816
+    D4        2.95060  -0.00000   0.00000   0.00000  -0.00000   2.95060
+    D5       -0.90341  -0.00000   0.00000   0.00000  -0.00000  -0.90341
+    D6       -1.19966   0.00000   0.00000   0.00000   0.00000  -1.19966
+    D7        1.22952   0.00000   0.00000   0.00000   0.00000   1.22952
+    D8        2.45746  -0.00000   0.00000   0.00000  -0.00000   2.45746
+    D9        1.12550  -0.00000   0.00000  -0.00000  -0.00000   1.12550
+   D10       -0.98412  -0.00000   0.00000   0.00000   0.00000  -0.98412
+   D11       -3.05090  -0.00000   0.00000   0.00000   0.00000  -3.05090
+   D12       -1.33196   0.00000   0.00000  -0.00000  -0.00000  -1.33196
+   D13        2.84160   0.00000   0.00000   0.00000   0.00000   2.84160
+   D14        0.77483   0.00000   0.00000   0.00000   0.00000   0.77483
+   D15       -1.23105   0.00000   0.00000   0.00000   0.00000  -1.23105
+   D16        0.90388   0.00000   0.00000   0.00000   0.00000   0.90388
+   D17        3.07869  -0.00000   0.00000  -0.00000  -0.00000   3.07869
+   D18        1.19019   0.00000   0.00000   0.00000   0.00000   1.19020
+   D19       -2.95806   0.00000   0.00000   0.00000   0.00000  -2.95806
+   D20       -0.78325  -0.00000   0.00000  -0.00000  -0.00000  -0.78325
+   D21       -1.98581  -0.00000   0.00000   0.00000   0.00000  -1.98581
+   D22        0.44571  -0.00000   0.00000   0.00000  -0.00000   0.44571
+   D23        2.42093   0.00000   0.00000   0.00000   0.00000   2.42093
+   D24       -2.44854  -0.00000   0.00000  -0.00002  -0.00002  -2.44856
+   D25        1.61635  -0.00000   0.00000  -0.00002  -0.00002   1.61633
+   D26       -0.41221  -0.00000   0.00000  -0.00002  -0.00002  -0.41223
+   D27        3.06603  -0.00000   0.00000  -0.00000  -0.00000   3.06603
+   D28        0.96127  -0.00000   0.00000  -0.00000  -0.00000   0.96127
+   D29       -1.07819  -0.00000   0.00000  -0.00000  -0.00000  -1.07819
+   D30       -1.07004   0.00000   0.00000  -0.00000  -0.00000  -1.07004
+   D31        3.10838   0.00000   0.00000  -0.00000  -0.00000   3.10838
+   D32        1.06892   0.00000   0.00000  -0.00000  -0.00000   1.06892
+   D33        0.89234   0.00000   0.00000   0.00000  -0.00000   0.89234
+   D34       -1.21242   0.00000   0.00000   0.00000   0.00000  -1.21242
+   D35        3.03130  -0.00000   0.00000   0.00000   0.00000   3.03131
+   D36       -0.90779   0.00000   0.00000   0.00000   0.00000  -0.90779
+   D37        1.29622  -0.00000   0.00000  -0.00000  -0.00000   1.29622
+   D38       -2.98949   0.00000   0.00000   0.00000   0.00000  -2.98949
+   D39        1.16215   0.00000   0.00000   0.00000   0.00000   1.16215
+   D40       -2.91703  -0.00000   0.00000  -0.00000  -0.00000  -2.91703
+   D41       -0.91955   0.00000   0.00000   0.00000   0.00000  -0.91955
+   D42       -3.06192  -0.00000   0.00000  -0.00000  -0.00000  -3.06192
+   D43       -0.85792  -0.00000   0.00000  -0.00000  -0.00000  -0.85792
+   D44        1.13957  -0.00000   0.00000  -0.00000  -0.00000   1.13956
+   D45        1.45697   0.00000   0.00000   0.00000   0.00000   1.45697
+   D46       -2.79267   0.00000   0.00000   0.00000   0.00000  -2.79267
+   D47       -0.70257   0.00000   0.00000   0.00000   0.00000  -0.70257
+   D48        1.33098   0.00000   0.00000   0.00000   0.00000   1.33098
+   D49       -2.76015  -0.00000   0.00000   0.00000   0.00000  -2.76015
+   D50       -0.72660  -0.00000   0.00000   0.00000   0.00000  -0.72660
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000024     0.001800     YES
+ RMS     Displacement     0.000004     0.001200     YES
+ Predicted change in Energy=-5.553444D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.4491         -DE/DX =    0.0                 !
+ ! R2    R(1,10)                 1.1001         -DE/DX =    0.0                 !
+ ! R3    R(1,11)                 1.0976         -DE/DX =    0.0                 !
+ ! R4    R(1,12)                 1.1078         -DE/DX =    0.0                 !
+ ! R5    R(2,3)                  1.4488         -DE/DX =    0.0                 !
+ ! R6    R(2,4)                  1.4067         -DE/DX =    0.0                 !
+ ! R7    R(3,13)                 1.1078         -DE/DX =    0.0                 !
+ ! R8    R(3,14)                 1.1006         -DE/DX =    0.0                 !
+ ! R9    R(3,15)                 1.0997         -DE/DX =    0.0                 !
+ ! R10   R(4,5)                  1.4986         -DE/DX =    0.0                 !
+ ! R11   R(4,7)                  1.5195         -DE/DX =    0.0                 !
+ ! R12   R(4,16)                 1.1            -DE/DX =    0.0                 !
+ ! R13   R(5,6)                  1.2922         -DE/DX =    0.0                 !
+ ! R14   R(7,8)                  1.5304         -DE/DX =    0.0                 !
+ ! R15   R(7,17)                 1.1012         -DE/DX =    0.0                 !
+ ! R16   R(7,18)                 1.1008         -DE/DX =    0.0                 !
+ ! R17   R(8,9)                  1.4546         -DE/DX =    0.0                 !
+ ! R18   R(8,19)                 1.1078         -DE/DX =    0.0                 !
+ ! R19   R(8,20)                 1.1012         -DE/DX =    0.0                 !
+ ! R20   R(9,21)                 1.0196         -DE/DX =    0.0                 !
+ ! R21   R(9,22)                 1.0165         -DE/DX =    0.0                 !
+ ! A1    A(2,1,10)             108.9904         -DE/DX =    0.0                 !
+ ! A2    A(2,1,11)             110.9721         -DE/DX =    0.0                 !
+ ! A3    A(2,1,12)             113.2501         -DE/DX =    0.0                 !
+ ! A4    A(10,1,11)            107.1181         -DE/DX =    0.0                 !
+ ! A5    A(10,1,12)            107.865          -DE/DX =    0.0                 !
+ ! A6    A(11,1,12)            108.4202         -DE/DX =    0.0                 !
+ ! A7    A(1,2,3)              113.5549         -DE/DX =    0.0                 !
+ ! A8    A(1,2,4)              118.5668         -DE/DX =    0.0                 !
+ ! A9    A(3,2,4)              114.7196         -DE/DX =    0.0                 !
+ ! A10   A(2,3,13)             113.195          -DE/DX =    0.0                 !
+ ! A11   A(2,3,14)             109.7504         -DE/DX =    0.0                 !
+ ! A12   A(2,3,15)             109.7974         -DE/DX =    0.0                 !
+ ! A13   A(13,3,14)            108.1082         -DE/DX =    0.0                 !
+ ! A14   A(13,3,15)            107.9551         -DE/DX =    0.0                 !
+ ! A15   A(14,3,15)            107.8769         -DE/DX =    0.0                 !
+ ! A16   A(2,4,5)              109.2685         -DE/DX =    0.0                 !
+ ! A17   A(2,4,7)              116.1089         -DE/DX =    0.0                 !
+ ! A18   A(2,4,16)             109.4241         -DE/DX =    0.0                 !
+ ! A19   A(5,4,7)              107.939          -DE/DX =    0.0                 !
+ ! A20   A(5,4,16)             103.8339         -DE/DX =    0.0                 !
+ ! A21   A(7,4,16)             109.5493         -DE/DX =    0.0                 !
+ ! A22   A(4,5,6)              113.0449         -DE/DX =    0.0                 !
+ ! A23   A(4,7,8)              113.6571         -DE/DX =    0.0                 !
+ ! A24   A(4,7,17)             106.14           -DE/DX =    0.0                 !
+ ! A25   A(4,7,18)             110.3839         -DE/DX =    0.0                 !
+ ! A26   A(8,7,17)             109.6493         -DE/DX =    0.0                 !
+ ! A27   A(8,7,18)             108.7985         -DE/DX =    0.0                 !
+ ! A28   A(17,7,18)            108.053          -DE/DX =    0.0                 !
+ ! A29   A(7,8,9)              111.9098         -DE/DX =    0.0                 !
+ ! A30   A(7,8,19)             108.8907         -DE/DX =    0.0                 !
+ ! A31   A(7,8,20)             107.2873         -DE/DX =    0.0                 !
+ ! A32   A(9,8,19)             113.4917         -DE/DX =    0.0                 !
+ ! A33   A(9,8,20)             108.8002         -DE/DX =    0.0                 !
+ ! A34   A(19,8,20)            106.1209         -DE/DX =    0.0                 !
+ ! A35   A(8,9,21)             109.0836         -DE/DX =    0.0                 !
+ ! A36   A(8,9,22)             110.3965         -DE/DX =    0.0                 !
+ ! A37   A(21,9,22)            106.3487         -DE/DX =    0.0                 !
+ ! D1    D(4,1,2,3)           -139.1815         -DE/DX =    0.0                 !
+ ! D2    D(10,1,2,3)            51.3284         -DE/DX =    0.0                 !
+ ! D3    D(10,1,2,4)          -169.4901         -DE/DX =    0.0                 !
+ ! D4    D(11,1,2,3)           169.0567         -DE/DX =    0.0                 !
+ ! D5    D(11,1,2,4)           -51.7618         -DE/DX =    0.0                 !
+ ! D6    D(12,1,2,3)           -68.7355         -DE/DX =    0.0                 !
+ ! D7    D(12,1,2,4)            70.446          -DE/DX =    0.0                 !
+ ! D8    D(1,2,3,4)            140.8021         -DE/DX =    0.0                 !
+ ! D9    D(1,2,3,13)            64.4864         -DE/DX =    0.0                 !
+ ! D10   D(1,2,3,14)           -56.386          -DE/DX =    0.0                 !
+ ! D11   D(1,2,3,15)          -174.8035         -DE/DX =    0.0                 !
+ ! D12   D(4,2,3,13)           -76.3157         -DE/DX =    0.0                 !
+ ! D13   D(4,2,3,14)           162.8119         -DE/DX =    0.0                 !
+ ! D14   D(4,2,3,15)            44.3944         -DE/DX =    0.0                 !
+ ! D15   D(1,2,4,5)            -70.5339         -DE/DX =    0.0                 !
+ ! D16   D(1,2,4,7)             51.7885         -DE/DX =    0.0                 !
+ ! D17   D(1,2,4,16)           176.3961         -DE/DX =    0.0                 !
+ ! D18   D(3,2,4,5)             68.1931         -DE/DX =    0.0                 !
+ ! D19   D(3,2,4,7)           -169.4844         -DE/DX =    0.0                 !
+ ! D20   D(3,2,4,16)           -44.8769         -DE/DX =    0.0                 !
+ ! D21   D(2,3,4,13)          -113.7788         -DE/DX =    0.0                 !
+ ! D22   D(2,3,4,14)            25.5373         -DE/DX =    0.0                 !
+ ! D23   D(2,3,4,15)           138.7093         -DE/DX =    0.0                 !
+ ! D24   D(2,4,5,6)           -140.2912         -DE/DX =    0.0                 !
+ ! D25   D(7,4,5,6)             92.6101         -DE/DX =    0.0                 !
+ ! D26   D(16,4,5,6)           -23.618          -DE/DX =    0.0                 !
+ ! D27   D(2,4,7,8)            175.6708         -DE/DX =    0.0                 !
+ ! D28   D(2,4,7,17)            55.0767         -DE/DX =    0.0                 !
+ ! D29   D(2,4,7,18)           -61.7757         -DE/DX =    0.0                 !
+ ! D30   D(5,4,7,8)            -61.3089         -DE/DX =    0.0                 !
+ ! D31   D(5,4,7,17)           178.0971         -DE/DX =    0.0                 !
+ ! D32   D(5,4,7,18)            61.2446         -DE/DX =    0.0                 !
+ ! D33   D(16,4,7,8)            51.1275         -DE/DX =    0.0                 !
+ ! D34   D(16,4,7,17)          -69.4665         -DE/DX =    0.0                 !
+ ! D35   D(16,4,7,18)          173.681          -DE/DX =    0.0                 !
+ ! D36   D(4,7,8,9)            -52.0125         -DE/DX =    0.0                 !
+ ! D37   D(4,7,8,19)            74.2679         -DE/DX =    0.0                 !
+ ! D38   D(4,7,8,20)          -171.2849         -DE/DX =    0.0                 !
+ ! D39   D(17,7,8,9)            66.5862         -DE/DX =    0.0                 !
+ ! D40   D(17,7,8,19)         -167.1334         -DE/DX =    0.0                 !
+ ! D41   D(17,7,8,20)          -52.6862         -DE/DX =    0.0                 !
+ ! D42   D(18,7,8,9)          -175.4353         -DE/DX =    0.0                 !
+ ! D43   D(18,7,8,19)          -49.1549         -DE/DX =    0.0                 !
+ ! D44   D(18,7,8,20)           65.2923         -DE/DX =    0.0                 !
+ ! D45   D(7,8,9,21)            83.4782         -DE/DX =    0.0                 !
+ ! D46   D(7,8,9,22)          -160.0081         -DE/DX =    0.0                 !
+ ! D47   D(19,8,9,21)          -40.2543         -DE/DX =    0.0                 !
+ ! D48   D(19,8,9,22)           76.2593         -DE/DX =    0.0                 !
+ ! D49   D(20,8,9,21)         -158.145          -DE/DX =    0.0                 !
+ ! D50   D(20,8,9,22)          -41.6313         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ Lowest energy point so far.  Saving SCF results.
+ Iteration  1 RMS(Cart)=  0.01475407 RMS(Int)=  0.01205998
+ Iteration  2 RMS(Cart)=  0.00018414 RMS(Int)=  0.01205957
+ Iteration  3 RMS(Cart)=  0.00000256 RMS(Int)=  0.01205957
+ Iteration  4 RMS(Cart)=  0.00000004 RMS(Int)=  0.01205957
+ Iteration  1 RMS(Cart)=  0.01075257 RMS(Int)=  0.01024625
+ Iteration  2 RMS(Cart)=  0.00853779 RMS(Int)=  0.01072871
+ Iteration  3 RMS(Cart)=  0.00717828 RMS(Int)=  0.01174580
+ Iteration  4 RMS(Cart)=  0.00626829 RMS(Int)=  0.01292103
+ Iteration  5 RMS(Cart)=  0.00561845 RMS(Int)=  0.01409575
+ Iteration  6 RMS(Cart)=  0.00513113 RMS(Int)=  0.01521280
+ Iteration  7 RMS(Cart)=  0.00475082 RMS(Int)=  0.01625778
+ Iteration  8 RMS(Cart)=  0.00444354 RMS(Int)=  0.01723316
+ Iteration  9 RMS(Cart)=  0.00418741 RMS(Int)=  0.01814707
+ Iteration 10 RMS(Cart)=  0.00396748 RMS(Int)=  0.01900864
+ Iteration 11 RMS(Cart)=  0.00377363 RMS(Int)=  0.01982609
+ Iteration 12 RMS(Cart)=  0.00359977 RMS(Int)=  0.02060640
+ Iteration 13 RMS(Cart)=  0.00344098 RMS(Int)=  0.02135500
+ Iteration 14 RMS(Cart)=  0.00329375 RMS(Int)=  0.02207600
+ Iteration 15 RMS(Cart)=  0.00315558 RMS(Int)=  0.02277235
+ Iteration 16 RMS(Cart)=  0.00302471 RMS(Int)=  0.02344616
+ Iteration 17 RMS(Cart)=  0.00289984 RMS(Int)=  0.02409885
+ Iteration 18 RMS(Cart)=  0.00278006 RMS(Int)=  0.02473137
+ Iteration 19 RMS(Cart)=  0.00266473 RMS(Int)=  0.02534431
+ Iteration 20 RMS(Cart)=  0.00255337 RMS(Int)=  0.02593803
+ Iteration 21 RMS(Cart)=  0.00244565 RMS(Int)=  0.02651275
+ Iteration 22 RMS(Cart)=  0.00234136 RMS(Int)=  0.02706861
+ Iteration 23 RMS(Cart)=  0.00224034 RMS(Int)=  0.02760569
+ Iteration 24 RMS(Cart)=  0.00214246 RMS(Int)=  0.02812409
+ Iteration 25 RMS(Cart)=  0.00204767 RMS(Int)=  0.02862391
+ Iteration 26 RMS(Cart)=  0.00195591 RMS(Int)=  0.02910528
+ Iteration 27 RMS(Cart)=  0.00186714 RMS(Int)=  0.02956836
+ Iteration 28 RMS(Cart)=  0.00178132 RMS(Int)=  0.03001336
+ Iteration 29 RMS(Cart)=  0.00169845 RMS(Int)=  0.03044053
+ Iteration 30 RMS(Cart)=  0.00161849 RMS(Int)=  0.03085017
+ Iteration 31 RMS(Cart)=  0.00154141 RMS(Int)=  0.03124260
+ Iteration 32 RMS(Cart)=  0.00146719 RMS(Int)=  0.03161819
+ Iteration 33 RMS(Cart)=  0.00139579 RMS(Int)=  0.03197734
+ Iteration 34 RMS(Cart)=  0.00132717 RMS(Int)=  0.03232046
+ Iteration 35 RMS(Cart)=  0.00126129 RMS(Int)=  0.03264799
+ Iteration 36 RMS(Cart)=  0.00119810 RMS(Int)=  0.03296041
+ Iteration 37 RMS(Cart)=  0.00113754 RMS(Int)=  0.03325818
+ Iteration 38 RMS(Cart)=  0.00107956 RMS(Int)=  0.03354180
+ Iteration 39 RMS(Cart)=  0.00102410 RMS(Int)=  0.03381174
+ Iteration 40 RMS(Cart)=  0.00097109 RMS(Int)=  0.03406852
+ Iteration 41 RMS(Cart)=  0.00092046 RMS(Int)=  0.03431262
+ Iteration 42 RMS(Cart)=  0.00087215 RMS(Int)=  0.03454455
+ Iteration 43 RMS(Cart)=  0.00082608 RMS(Int)=  0.03476478
+ Iteration 44 RMS(Cart)=  0.00078217 RMS(Int)=  0.03497380
+ Iteration 45 RMS(Cart)=  0.00074037 RMS(Int)=  0.03517210
+ Iteration 46 RMS(Cart)=  0.00070058 RMS(Int)=  0.03536012
+ Iteration 47 RMS(Cart)=  0.00066273 RMS(Int)=  0.03553834
+ Iteration 48 RMS(Cart)=  0.00062676 RMS(Int)=  0.03570719
+ Iteration 49 RMS(Cart)=  0.00059259 RMS(Int)=  0.03586711
+ Iteration 50 RMS(Cart)=  0.00056014 RMS(Int)=  0.03601851
+ Iteration 51 RMS(Cart)=  0.00052934 RMS(Int)=  0.03616180
+ Iteration 52 RMS(Cart)=  0.00050012 RMS(Int)=  0.03629738
+ Iteration 53 RMS(Cart)=  0.00047242 RMS(Int)=  0.03642561
+ Iteration 54 RMS(Cart)=  0.00044616 RMS(Int)=  0.03654686
+ Iteration 55 RMS(Cart)=  0.00042128 RMS(Int)=  0.03666148
+ Iteration 56 RMS(Cart)=  0.00039772 RMS(Int)=  0.03676981
+ Iteration 57 RMS(Cart)=  0.00037541 RMS(Int)=  0.03687217
+ Iteration 58 RMS(Cart)=  0.00035430 RMS(Int)=  0.03696886
+ Iteration 59 RMS(Cart)=  0.00033432 RMS(Int)=  0.03706018
+ Iteration 60 RMS(Cart)=  0.00031542 RMS(Int)=  0.03714641
+ Iteration 61 RMS(Cart)=  0.00029756 RMS(Int)=  0.03722782
+ Iteration 62 RMS(Cart)=  0.00028067 RMS(Int)=  0.03730467
+ Iteration 63 RMS(Cart)=  0.00026470 RMS(Int)=  0.03737720
+ Iteration 64 RMS(Cart)=  0.00024962 RMS(Int)=  0.03744563
+ Iteration 65 RMS(Cart)=  0.00023537 RMS(Int)=  0.03751020
+ Iteration 66 RMS(Cart)=  0.00022191 RMS(Int)=  0.03757112
+ Iteration 67 RMS(Cart)=  0.00020920 RMS(Int)=  0.03762857
+ Iteration 68 RMS(Cart)=  0.00019720 RMS(Int)=  0.03768276
+ Iteration 69 RMS(Cart)=  0.00018587 RMS(Int)=  0.03773386
+ Iteration 70 RMS(Cart)=  0.00017518 RMS(Int)=  0.03778204
+ Iteration 71 RMS(Cart)=  0.00016509 RMS(Int)=  0.03782746
+ Iteration 72 RMS(Cart)=  0.00015558 RMS(Int)=  0.03787029
+ Iteration 73 RMS(Cart)=  0.00014660 RMS(Int)=  0.03791065
+ Iteration 74 RMS(Cart)=  0.00013813 RMS(Int)=  0.03794870
+ Iteration 75 RMS(Cart)=  0.00013014 RMS(Int)=  0.03798456
+ Iteration 76 RMS(Cart)=  0.00012261 RMS(Int)=  0.03801835
+ Iteration 77 RMS(Cart)=  0.00011550 RMS(Int)=  0.03805020
+ Iteration 78 RMS(Cart)=  0.00010881 RMS(Int)=  0.03808021
+ Iteration 79 RMS(Cart)=  0.00010249 RMS(Int)=  0.03810848
+ Iteration 80 RMS(Cart)=  0.00009654 RMS(Int)=  0.03813512
+ Iteration 81 RMS(Cart)=  0.00009093 RMS(Int)=  0.03816022
+ Iteration 82 RMS(Cart)=  0.00008564 RMS(Int)=  0.03818386
+ Iteration 83 RMS(Cart)=  0.00008066 RMS(Int)=  0.03820613
+ Iteration 84 RMS(Cart)=  0.00007597 RMS(Int)=  0.03822711
+ Iteration 85 RMS(Cart)=  0.00007154 RMS(Int)=  0.03824687
+ Iteration 86 RMS(Cart)=  0.00006737 RMS(Int)=  0.03826548
+ Iteration 87 RMS(Cart)=  0.00006345 RMS(Int)=  0.03828301
+ Iteration 88 RMS(Cart)=  0.00005974 RMS(Int)=  0.03829952
+ Iteration 89 RMS(Cart)=  0.00005626 RMS(Int)=  0.03831507
+ Iteration 90 RMS(Cart)=  0.00005297 RMS(Int)=  0.03832971
+ Iteration 91 RMS(Cart)=  0.00004988 RMS(Int)=  0.03834350
+ Iteration 92 RMS(Cart)=  0.00004697 RMS(Int)=  0.03835648
+ Iteration 93 RMS(Cart)=  0.00004422 RMS(Int)=  0.03836871
+ Iteration 94 RMS(Cart)=  0.00004164 RMS(Int)=  0.03838023
+ Iteration 95 RMS(Cart)=  0.00003920 RMS(Int)=  0.03839107
+ Iteration 96 RMS(Cart)=  0.00003691 RMS(Int)=  0.03840128
+ Iteration 97 RMS(Cart)=  0.00003475 RMS(Int)=  0.03841089
+ Iteration 98 RMS(Cart)=  0.00003272 RMS(Int)=  0.03841994
+ Iteration 99 RMS(Cart)=  0.00003080 RMS(Int)=  0.03842846
+ Iteration100 RMS(Cart)=  0.00002900 RMS(Int)=  0.03843649
+ New curvilinear step not converged.
+ Error imposing constraints
+ Error termination via Lnk1e in /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe at Mon Jun 15 23:46:32 2020.
+ Job cpu time:       0 days  0 hours 33 minutes 15.7 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes 52.8 seconds.
+ File lengths (MBytes):  RWF=    185 Int=      0 D2E=      0 Chk=     12 Scr=      1


### PR DESCRIPTION
ARC crashes when it cannot compute the angle from 1d rotor scan gaussian files. The underlying reason is Gaussian failed because angles between certain atoms become 180 during scan. In the future, we should troubleshoot this type of error in Gaussian, but now this PR avoids ARC crashes.