### PR TITLE
BugFix: Only parsing the last frequencies from Gaussian log file

### DIFF
--- a/arc/parser.py
+++ b/arc/parser.py
@@ -47,6 +47,9 @@ def parse_frequencies(path: str,
         with open(path, 'r') as f:
             line = f.readline()
             while line != '':
+                # this line intends to only capture the last occurrence of the frequencies
+                if 'and normal coordinates' in line:
+                    freqs = np.array([], np.float64)
                 if 'Frequencies --' in line:
                     freqs = np.append(freqs, [float(frq) for frq in line.split()[2:]])
                 line = f.readline()

--- a/arc/parserTest.py
+++ b/arc/parserTest.py
@@ -39,6 +39,7 @@ class TestParser(unittest.TestCase):
         ncc_path_terachem_output = os.path.join(arc_path, 'arc', 'testing', 'freq',
                                                 'ethylamine_freq_terachem_output.out')
         orca_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'orca_example_freq.log')
+        dual_freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'dual_freq_output.out')
 
         no3_freqs = parser.parse_frequencies(path=no3_path, software='QChem')
         c2h6_freqs = parser.parse_frequencies(path=c2h6_path, software='QChem')
@@ -48,6 +49,7 @@ class TestParser(unittest.TestCase):
         ch2o_terachem_output_freqs = parser.parse_frequencies(path=ch2o_path_terachem_output, software='TeraChem')
         ncc_terachem_output_freqs = parser.parse_frequencies(path=ncc_path_terachem_output, software='TeraChem')
         orca_freqs = parser.parse_frequencies(path=orca_path, software='Orca')
+        dual_freqs = parser.parse_frequencies(path=dual_freq_path, software='Gaussian')
 
         np.testing.assert_almost_equal(no3_freqs,
                                        np.array([-390.08, -389.96, 822.75, 1113.23, 1115.24, 1195.35], np.float64))
@@ -75,6 +77,15 @@ class TestParser(unittest.TestCase):
                                                  3087.60678739, 3447.41720077, 3529.23879182], np.float64))
         np.testing.assert_almost_equal(orca_freqs,
                                        np.array([1151.03, 1250.19, 1526.12, 1846.4, 3010.49, 3070.82], np.float64))
+        np.testing.assert_almost_equal(dual_freqs,
+                                       np.array([-1617.8276,    56.9527,    76.681,    121.4038,   182.1572,   194.9796,
+                                                   202.4056,   209.9621,   273.506,    342.468,    431.985,    464.0768,
+                                                   577.758,    594.4119,   615.5216,   764.1286,   962.2969,   968.0013,
+                                                  1004.7852,  1098.0136,  1129.3888,  1137.0454,  1150.7824,  1185.4531,
+                                                  1249.0746,  1387.4803,  1401.5073,  1413.8079,  1420.6471,  1453.6296,
+                                                  1481.9425,  1487.0125,  1496.0713,  1498.382,   1507.7379,  2280.9881,
+                                                  3015.0638,  3018.8871,  3030.1281,  3074.8208,  3079.5256,  3103.8434,
+                                                  3109.1728,  3156.4352,  3783.7315], np.float64))
 
     def test_parse_normal_displacement_modes(self):
         """Test parsing frequencies and normal displacement modes"""

--- a/arc/testing/freq/dual_freq_output.out
+++ b/arc/testing/freq/dual_freq_output.out
@@ -1,0 +1,6772 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/gridsan/oscarwu/GRPAPI/Software/g16/l1.exe "/home/gridsan/oscarwu/scratch/optsr1001-1816736/Gau-68610.inp" -scrdir="/home/gridsan/oscarwu/scratch/optsr1001-1816736/"
+ Entering Link 1 = /home/gridsan/oscarwu/GRPAPI/Software/g16/l1.exe PID=     68612.
+  
+ Copyright (c) 1988-2017, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision B.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevB.01 20-Dec-2017
+                 7-Jul-2020 
+ ******************************************
+ %chk=0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk
+ %mem=300000mb
+ %NProcShared=40
+ Will use up to   40 processors via shared memory.
+ ----------------------------------------------------------------------
+ #p opt=(calcall,ts,noeigentest,maxcycles=120) freq guess=mix scf=xqc i
+ op(2/9=2000) uB3LYP/CBSB7
+ ----------------------------------------------------------------------
+ 1/5=1,6=120,10=4,11=1,18=20,26=3,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=4,6=6,7=700,11=2,25=1,30=1,71=2,74=-5,116=2,140=1/1,2,3;
+ 4/13=-1/1;
+ 5/5=2,8=3,13=1,38=5/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,18=1,28=1/1;
+ 7/10=1,25=1/1,2,3,16;
+ 1/5=1,6=120,10=4,11=1,18=20,26=3/3(3);
+ 2/9=2000/2;
+ 7/8=1,9=1,25=1,44=-1/16;
+ 99//99;
+ 2/9=2000/2;
+ 3/5=4,6=6,7=700,11=2,25=1,30=1,71=2,74=-5,116=2,140=1/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,8=3,13=1,38=5/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 7/10=1,25=1/1,2,3,16;
+ 1/5=1,6=120,10=4,11=1,18=20,26=3/3(-8);
+ 2/9=2000/2;
+ 6/7=2,8=2,9=2,10=2,18=1,19=2,28=1/1;
+ 7/8=1,9=1,25=1,44=-1/16;
+ 99//99;
+ Leave Link    1 at Tue Jul  7 12:14:46 2020, MaxMem= 39321600000 cpu:              18.6 elap:               0.8
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l101.exe)
+ ----------------------------------
+ 0xd628bc800d04214f0f9db0fec47002f2
+ ----------------------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 2
+ N                    -2.54506  -1.35029   0.11997 
+ C                    -1.68633  -0.57208   0.06492 
+ C                    -0.57285   0.34231  -0.01006 
+ C                    -0.22311   1.01563   1.30605 
+ C                    -0.58749   1.26162  -1.21912 
+ H                     0.76098   1.50083   1.21758 
+ H                    -0.18625   0.29112   2.13309 
+ H                    -0.96075   1.79129   1.57043 
+ H                     0.41329   1.68043  -1.41623 
+ H                    -1.28515   2.09965  -1.07972 
+ H                    -0.90011   0.69442  -2.10936 
+ C                     1.49248  -1.38069  -0.18877 
+ O                     1.2089   -2.28857   0.79811 
+ H                     1.52724  -1.77579  -1.21671 
+ H                     0.47846  -0.44235  -0.2287 
+ H                     2.37244  -0.78102   0.07474 
+ H                     0.5756   -2.9317    0.46622 
+ 
+ Add virtual bond connecting atoms H15        and C3         Dist= 2.51D+00.
+ Add virtual bond connecting atoms H15        and C12        Dist= 2.61D+00.
+ ITRead=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ NAtoms=     17 NQM=       17 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          14          12          12          12          12           1           1           1           1           1
+ AtmWgt=  14.0030740  12.0000000  12.0000000  12.0000000  12.0000000   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           2           0           0           0           0           1           1           1           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.4037610   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   7.0000000   6.0000000   6.0000000   6.0000000   6.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        11          12          13          14          15          16          17
+ IAtWgt=           1          12          16           1           1           1           1
+ AtmWgt=   1.0078250  12.0000000  15.9949146   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           0           0           1           1           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   6.0000000   8.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Tue Jul  7 12:14:49 2020, MaxMem= 39321600000 cpu:              30.5 elap:               1.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1602         calculate D2E/DX2 analytically  !
+ ! R2    R(2,3)                  1.4428         calculate D2E/DX2 analytically  !
+ ! R3    R(3,4)                  1.5191         calculate D2E/DX2 analytically  !
+ ! R4    R(3,5)                  1.5189         calculate D2E/DX2 analytically  !
+ ! R5    R(3,15)                 1.3299         calculate D2E/DX2 analytically  !
+ ! R6    R(4,6)                  1.1008         calculate D2E/DX2 analytically  !
+ ! R7    R(4,7)                  1.1001         calculate D2E/DX2 analytically  !
+ ! R8    R(4,8)                  1.1026         calculate D2E/DX2 analytically  !
+ ! R9    R(5,9)                  1.1026         calculate D2E/DX2 analytically  !
+ ! R10   R(5,10)                 1.0993         calculate D2E/DX2 analytically  !
+ ! R11   R(5,11)                 1.1009         calculate D2E/DX2 analytically  !
+ ! R12   R(12,13)                1.3706         calculate D2E/DX2 analytically  !
+ ! R13   R(12,14)                1.1018         calculate D2E/DX2 analytically  !
+ ! R14   R(12,15)                1.3821         calculate D2E/DX2 analytically  !
+ ! R15   R(12,16)                1.097          calculate D2E/DX2 analytically  !
+ ! R16   R(13,17)                0.9617         calculate D2E/DX2 analytically  !
+ ! A1    A(2,3,4)              114.4284         calculate D2E/DX2 analytically  !
+ ! A2    A(2,3,5)              114.6773         calculate D2E/DX2 analytically  !
+ ! A3    A(2,3,15)             104.164          calculate D2E/DX2 analytically  !
+ ! A4    A(4,3,5)              115.06           calculate D2E/DX2 analytically  !
+ ! A5    A(4,3,15)             102.8231         calculate D2E/DX2 analytically  !
+ ! A6    A(5,3,15)             103.5236         calculate D2E/DX2 analytically  !
+ ! A7    A(3,4,6)              109.3631         calculate D2E/DX2 analytically  !
+ ! A8    A(3,4,7)              111.5379         calculate D2E/DX2 analytically  !
+ ! A9    A(3,4,8)              111.4403         calculate D2E/DX2 analytically  !
+ ! A10   A(6,4,7)              108.7082         calculate D2E/DX2 analytically  !
+ ! A11   A(6,4,8)              107.896          calculate D2E/DX2 analytically  !
+ ! A12   A(7,4,8)              107.7853         calculate D2E/DX2 analytically  !
+ ! A13   A(3,5,9)              111.3107         calculate D2E/DX2 analytically  !
+ ! A14   A(3,5,10)             111.5046         calculate D2E/DX2 analytically  !
+ ! A15   A(3,5,11)             109.5475         calculate D2E/DX2 analytically  !
+ ! A16   A(9,5,10)             108.0068         calculate D2E/DX2 analytically  !
+ ! A17   A(9,5,11)             107.9912         calculate D2E/DX2 analytically  !
+ ! A18   A(10,5,11)            108.366          calculate D2E/DX2 analytically  !
+ ! A19   A(13,12,14)           116.1517         calculate D2E/DX2 analytically  !
+ ! A20   A(13,12,15)           108.5845         calculate D2E/DX2 analytically  !
+ ! A21   A(13,12,16)           110.8002         calculate D2E/DX2 analytically  !
+ ! A22   A(14,12,15)           103.8653         calculate D2E/DX2 analytically  !
+ ! A23   A(14,12,16)           113.2556         calculate D2E/DX2 analytically  !
+ ! A24   A(15,12,16)           102.9634         calculate D2E/DX2 analytically  !
+ ! A25   A(12,13,17)           109.3136         calculate D2E/DX2 analytically  !
+ ! A26   L(1,2,3,13,-1)        177.3555         calculate D2E/DX2 analytically  !
+ ! A27   L(3,15,12,6,-1)       177.6025         calculate D2E/DX2 analytically  !
+ ! A28   L(1,2,3,13,-2)        179.0371         calculate D2E/DX2 analytically  !
+ ! A29   L(3,15,12,6,-2)       166.03           calculate D2E/DX2 analytically  !
+ ! D1    D(2,3,4,6)            166.8301         calculate D2E/DX2 analytically  !
+ ! D2    D(2,3,4,7)             46.5517         calculate D2E/DX2 analytically  !
+ ! D3    D(2,3,4,8)            -73.9647         calculate D2E/DX2 analytically  !
+ ! D4    D(5,3,4,6)            -57.2313         calculate D2E/DX2 analytically  !
+ ! D5    D(5,3,4,7)           -177.5097         calculate D2E/DX2 analytically  !
+ ! D6    D(5,3,4,8)             61.9739         calculate D2E/DX2 analytically  !
+ ! D7    D(15,3,4,6)            54.5571         calculate D2E/DX2 analytically  !
+ ! D8    D(15,3,4,7)           -65.7213         calculate D2E/DX2 analytically  !
+ ! D9    D(15,3,4,8)           173.7623         calculate D2E/DX2 analytically  !
+ ! D10   D(2,3,5,9)           -160.6568         calculate D2E/DX2 analytically  !
+ ! D11   D(2,3,5,10)            78.6564         calculate D2E/DX2 analytically  !
+ ! D12   D(2,3,5,11)           -41.295          calculate D2E/DX2 analytically  !
+ ! D13   D(4,3,5,9)             63.5149         calculate D2E/DX2 analytically  !
+ ! D14   D(4,3,5,10)           -57.1719         calculate D2E/DX2 analytically  !
+ ! D15   D(4,3,5,11)          -177.1233         calculate D2E/DX2 analytically  !
+ ! D16   D(15,3,5,9)           -47.859          calculate D2E/DX2 analytically  !
+ ! D17   D(15,3,5,10)         -168.5459         calculate D2E/DX2 analytically  !
+ ! D18   D(15,3,5,11)           71.5028         calculate D2E/DX2 analytically  !
+ ! D19   D(2,3,12,13)          -46.6358         calculate D2E/DX2 analytically  !
+ ! D20   D(2,3,12,14)           76.7081         calculate D2E/DX2 analytically  !
+ ! D21   D(2,3,12,16)         -162.2875         calculate D2E/DX2 analytically  !
+ ! D22   D(4,3,12,13)           70.6991         calculate D2E/DX2 analytically  !
+ ! D23   D(4,3,12,14)         -165.9569         calculate D2E/DX2 analytically  !
+ ! D24   D(4,3,12,16)          -44.9526         calculate D2E/DX2 analytically  !
+ ! D25   D(5,3,12,13)         -168.1427         calculate D2E/DX2 analytically  !
+ ! D26   D(5,3,12,14)          -44.7988         calculate D2E/DX2 analytically  !
+ ! D27   D(5,3,12,16)           76.2056         calculate D2E/DX2 analytically  !
+ ! D28   D(14,12,13,17)        -35.8316         calculate D2E/DX2 analytically  !
+ ! D29   D(15,12,13,17)         80.7039         calculate D2E/DX2 analytically  !
+ ! D30   D(16,12,13,17)       -166.9069         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=    102 maximum allowed number of steps=    102.
+ Search for a saddle point of order  1.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:14:50 2020, MaxMem= 39321600000 cpu:               3.9 elap:               0.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.545062   -1.350286    0.119966
+      2          6           0       -1.686332   -0.572083    0.064922
+      3          6           0       -0.572845    0.342310   -0.010058
+      4          6           0       -0.223111    1.015630    1.306045
+      5          6           0       -0.587492    1.261624   -1.219116
+      6          1           0        0.760981    1.500828    1.217577
+      7          1           0       -0.186247    0.291121    2.133090
+      8          1           0       -0.960749    1.791285    1.570433
+      9          1           0        0.413291    1.680434   -1.416229
+     10          1           0       -1.285149    2.099650   -1.079723
+     11          1           0       -0.900114    0.694424   -2.109357
+     12          6           0        1.492484   -1.380689   -0.188768
+     13          8           0        1.208900   -2.288567    0.798108
+     14          1           0        1.527238   -1.775793   -1.216705
+     15          1           0        0.478462   -0.442347   -0.228702
+     16          1           0        2.372443   -0.781017    0.074739
+     17          1           0        0.575597   -2.931701    0.466217
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.160193   0.000000
+     3  C    2.602197   1.442772   0.000000
+     4  C    3.520767   2.490429   1.519145   0.000000
+     5  C    3.528072   2.493729   1.518938   2.563147   0.000000
+     6  H    4.501502   3.408066   2.151359   1.100764   2.795187
+     7  H    3.508688   2.696793   2.178339   1.100125   3.512856
+     8  H    3.805702   2.894571   2.178979   1.102566   2.863817
+     9  H    4.505220   3.417025   2.177236   2.873630   1.102643
+    10  H    3.863767   2.934164   2.177109   2.827528   1.099293
+    11  H    3.443338   2.636222   2.153635   3.496638   1.100899
+    12  C    4.049447   3.289844   2.695598   3.304554   3.517064
+    13  O    3.928419   3.444742   3.278606   3.636808   4.460949
+    14  H    4.307131   3.663130   3.217563   4.149703   3.701080
+    15  H    3.176101   2.188465   1.329939   2.230101   2.240691
+    16  H    4.950553   4.064161   3.153376   3.388356   3.821997
+    17  H    3.515576   3.293199   3.502129   4.113960   4.666594
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.788518   0.000000
+     8  H    1.781355   1.779587   0.000000
+     9  H    2.662721   3.858407   3.289441   0.000000
+    10  H    3.134138   3.847146   2.687685   1.781482   0.000000
+    11  H    3.804999   4.320951   3.840265   1.782603   1.784114
+    12  C    3.288776   3.317245   4.378877   3.470129   4.541124
+    13  O    3.838763   3.222328   4.684982   4.614028   5.385441
+    14  H    4.153207   4.292936   5.165488   3.636784   4.790339
+    15  H    2.438743   2.560835   3.208945   2.433242   3.208787
+    16  H    3.018229   3.454445   4.468111   3.481380   4.796771
+    17  H    4.499580   3.707486   5.087853   4.984149   5.582724
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.703954   0.000000
+    13  O    4.668996   1.370616   0.000000
+    14  H    3.576428   1.101803   2.103271   0.000000
+    15  H    2.594144   1.382144   2.235264   1.963202   0.000000
+    16  H    4.202003   1.096982   2.037107   1.836241   1.947804
+    17  H    4.686159   1.917114   0.961689   2.252548   2.586355
+                   16         17
+    16  H    0.000000
+    17  H    2.829727   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.867103    2.309891   -0.085772
+      2          6           0        0.846204    1.151375   -0.027040
+      3          6           0        0.752171   -0.287288    0.027706
+      4          6           0        0.777222   -0.865522    1.432276
+      5          6           0        1.617128   -1.018321   -0.984526
+      6          1           0        0.467444   -1.921238    1.397917
+      7          1           0        0.099038   -0.320515    2.105559
+      8          1           0        1.789398   -0.823422    1.867452
+      9          1           0        1.266537   -2.052314   -1.138685
+     10          1           0        2.667156   -1.060076   -0.661814
+     11          1           0        1.572289   -0.496164   -1.952679
+     12          6           0       -1.854318   -0.651811   -0.555034
+     13          8           0       -2.471324    0.267229    0.253210
+     14          1           0       -1.990369   -0.513540   -1.639626
+     15          1           0       -0.487657   -0.548005   -0.376761
+     16          1           0       -2.069522   -1.673405   -0.218279
+     17          1           0       -2.443886    1.131011   -0.168658
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.6251989           1.7261039           1.3799135
+ Leave Link  202 at Tue Jul  7 12:14:52 2020, MaxMem= 39321600000 cpu:               5.2 elap:               0.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: 6-311G(2d,d,p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   193 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   186 symmetry adapted basis functions of A   symmetry.
+   186 basis functions,   304 primitive gaussians,   193 cartesian basis functions
+    28 alpha electrons       27 beta electrons
+       nuclear repulsion energy       289.3280449240 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   17 NActive=   17 NUniq=   17 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Jul  7 12:14:55 2020, MaxMem= 39321600000 cpu:              27.1 elap:               1.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   186 RedAO= T EigKep=  1.33D-03  NBF=   186
+ NBsUse=   186 1.00D-06 EigRej= -1.00D+00 NBFU=   186
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   193   193   193   193   193 MxSgAt=    17 MxSgA2=    17.
+ Leave Link  302 at Tue Jul  7 12:14:57 2020, MaxMem= 39321600000 cpu:              15.9 elap:               0.7
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Jul  7 12:14:59 2020, MaxMem= 39321600000 cpu:               8.0 elap:               0.8
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ ExpMin= 1.03D-01 ExpMax= 8.59D+03 ExpMxC= 1.30D+03 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -326.564253468048    
+ JPrj=0 DoOrth=F DoCkMO=T.
+ Mixing orbitals, IMix= 1 IMixAn=  0 NRI=1 NE=   28 Coef=  7.07106781D-01  7.07106781D-01
+ Mixing orbitals, IMix= 1 IMixAn=  0 NRI=1 NE=   27 Coef= -7.07106781D-01  7.07106781D-01
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.0000 S= 0.6180
+ Leave Link  401 at Tue Jul  7 12:15:01 2020, MaxMem= 39321600000 cpu:              14.1 elap:               1.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 39321600000 LenX= 39321515670 LenY= 39321477980
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 960000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -326.138579020599    
+ DIIS: error= 3.07D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.138579020599     IErMin= 1 ErrMin= 3.07D-02
+ ErrMax= 3.07D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.10D+00 BMatP= 1.10D+00
+ IDIUse=3 WtCom= 6.93D-01 WtEn= 3.07D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.044 Goal=   None    Shift=    0.000
+ Gap=     0.046 Goal=   None    Shift=    0.000
+ GapD=    0.044 DampG=0.250 DampE=0.500 DampFc=0.2500 IDamp=-1.
+ Damping current iteration by 2.50D-01
+ RMSDP=7.06D-03 MaxDP=3.11D-01              OVMax= 6.30D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  1.74D-03    CP:  9.80D-01
+ E= -326.251246453448     Delta-E=       -0.112667432849 Rises=F Damp=T
+ DIIS: error= 2.30D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -326.251246453448     IErMin= 2 ErrMin= 2.30D-02
+ ErrMax= 2.30D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.73D-01 BMatP= 1.10D+00
+ IDIUse=3 WtCom= 7.70D-01 WtEn= 2.30D-01
+ Coeff-Com: -0.758D+00 0.176D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.584D+00 0.158D+01
+ Gap=     0.172 Goal=   None    Shift=    0.000
+ Gap=     0.188 Goal=   None    Shift=    0.000
+ RMSDP=3.51D-03 MaxDP=8.67D-02 DE=-1.13D-01 OVMax= 2.16D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  2.46D-03    CP:  9.19D-01  2.35D+00
+ E= -326.487218802112     Delta-E=       -0.235972348665 Rises=F Damp=F
+ DIIS: error= 1.69D-02 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.487218802112     IErMin= 3 ErrMin= 1.69D-02
+ ErrMax= 1.69D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.26D-01 BMatP= 2.73D-01
+ IDIUse=3 WtCom= 8.31D-01 WtEn= 1.69D-01
+ Coeff-Com: -0.436D+00 0.100D+01 0.436D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.362D+00 0.831D+00 0.531D+00
+ Gap=     0.192 Goal=   None    Shift=    0.000
+ Gap=     0.185 Goal=   None    Shift=    0.000
+ RMSDP=1.12D-03 MaxDP=3.07D-02 DE=-2.36D-01 OVMax= 9.11D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  1.08D-03    CP:  9.21D-01  2.47D+00  9.05D-01
+ E= -326.505817777923     Delta-E=       -0.018598975810 Rises=F Damp=F
+ DIIS: error= 1.25D-02 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.505817777923     IErMin= 4 ErrMin= 1.25D-02
+ ErrMax= 1.25D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.20D-02 BMatP= 1.26D-01
+ IDIUse=3 WtCom= 8.75D-01 WtEn= 1.25D-01
+ Coeff-Com:  0.734D-02 0.347D-01 0.398D+00 0.560D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.327D+00 0.673D+00
+ Coeff:      0.642D-02 0.303D-01 0.389D+00 0.574D+00
+ Gap=     0.207 Goal=   None    Shift=    0.000
+ Gap=     0.201 Goal=   None    Shift=    0.000
+ RMSDP=6.57D-04 MaxDP=2.83D-02 DE=-1.86D-02 OVMax= 5.09D-02
+
+ Cycle   5  Pass 0  IDiag  1:
+ RMSU=  4.07D-04    CP:  9.13D-01  2.37D+00  1.08D+00  8.13D-01
+ E= -326.520005564108     Delta-E=       -0.014187786185 Rises=F Damp=F
+ DIIS: error= 3.02D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.520005564108     IErMin= 5 ErrMin= 3.02D-03
+ ErrMax= 3.02D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.59D-03 BMatP= 6.20D-02
+ IDIUse=3 WtCom= 9.70D-01 WtEn= 3.02D-02
+ Coeff-Com:  0.376D-01-0.562D-01 0.174D+00 0.343D+00 0.502D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.365D-01-0.546D-01 0.168D+00 0.333D+00 0.517D+00
+ Gap=     0.206 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=2.11D-04 MaxDP=4.73D-03 DE=-1.42D-02 OVMax= 1.63D-02
+
+ Cycle   6  Pass 0  IDiag  1:
+ RMSU=  1.90D-04    CP:  9.12D-01  2.39D+00  1.07D+00  8.85D-01  9.86D-01
+ E= -326.521221185827     Delta-E=       -0.001215621719 Rises=F Damp=F
+ DIIS: error= 1.32D-03 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.521221185827     IErMin= 6 ErrMin= 1.32D-03
+ ErrMax= 1.32D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.70D-04 BMatP= 5.59D-03
+ IDIUse=3 WtCom= 9.87D-01 WtEn= 1.32D-02
+ Coeff-Com:  0.756D-02-0.201D-01-0.377D-01-0.225D-01 0.227D+00 0.846D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.746D-02-0.198D-01-0.372D-01-0.222D-01 0.224D+00 0.848D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.21D-04 MaxDP=4.16D-03 DE=-1.22D-03 OVMax= 1.46D-02
+
+ Cycle   7  Pass 0  IDiag  1:
+ RMSU=  6.10D-05    CP:  9.11D-01  2.39D+00  1.08D+00  9.33D-01  1.17D+00
+                    CP:  1.19D+00
+ E= -326.521426496033     Delta-E=       -0.000205310206 Rises=F Damp=F
+ DIIS: error= 2.77D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.521426496033     IErMin= 7 ErrMin= 2.77D-04
+ ErrMax= 2.77D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.42D-05 BMatP= 5.70D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 2.77D-03
+ Coeff-Com: -0.521D-02 0.654D-02-0.317D-01-0.515D-01 0.172D-01 0.305D+00
+ Coeff-Com:  0.760D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00
+ Coeff-En:   0.100D+01
+ Coeff:     -0.520D-02 0.652D-02-0.316D-01-0.514D-01 0.171D-01 0.304D+00
+ Coeff:      0.761D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=4.28D-05 MaxDP=1.81D-03 DE=-2.05D-04 OVMax= 2.91D-03
+
+ Cycle   8  Pass 0  IDiag  1:
+ RMSU=  2.70D-05    CP:  9.11D-01  2.39D+00  1.09D+00  9.44D-01  1.22D+00
+                    CP:  1.29D+00  9.99D-01
+ E= -326.521450340748     Delta-E=       -0.000023844716 Rises=F Damp=F
+ DIIS: error= 1.38D-04 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.521450340748     IErMin= 8 ErrMin= 1.38D-04
+ ErrMax= 1.38D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.41D-05 BMatP= 7.42D-05
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.38D-03
+ Coeff-Com: -0.320D-02 0.604D-02-0.586D-02-0.157D-01-0.174D-01-0.411D-02
+ Coeff-Com:  0.321D+00 0.719D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.320D-02 0.603D-02-0.585D-02-0.157D-01-0.174D-01-0.411D-02
+ Coeff:      0.321D+00 0.720D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.18D-05 MaxDP=3.70D-04 DE=-2.38D-05 OVMax= 1.10D-03
+
+ Cycle   9  Pass 0  IDiag  1:
+ RMSU=  8.38D-06    CP:  9.11D-01  2.39D+00  1.09D+00  9.43D-01  1.23D+00
+                    CP:  1.31D+00  1.10D+00  8.94D-01
+ E= -326.521454949499     Delta-E=       -0.000004608751 Rises=F Damp=F
+ DIIS: error= 4.83D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -326.521454949499     IErMin= 9 ErrMin= 4.83D-05
+ ErrMax= 4.83D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.15D-06 BMatP= 1.41D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.964D-04 0.382D-05 0.117D-02 0.118D-02-0.508D-02-0.356D-01
+ Coeff-Com: -0.940D-02 0.184D+00 0.864D+00
+ Coeff:      0.964D-04 0.382D-05 0.117D-02 0.118D-02-0.508D-02-0.356D-01
+ Coeff:     -0.940D-02 0.184D+00 0.864D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=6.00D-06 MaxDP=2.63D-04 DE=-4.61D-06 OVMax= 5.14D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle  10  Pass 1  IDiag  1:
+ E= -326.521457761251     Delta-E=       -0.000002811752 Rises=F Damp=F
+ DIIS: error= 3.03D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.521457761251     IErMin= 1 ErrMin= 3.03D-05
+ ErrMax= 3.03D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.76D-07 BMatP= 4.76D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=6.00D-06 MaxDP=2.63D-04 DE=-2.81D-06 OVMax= 3.17D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  3.87D-06    CP:  1.00D+00
+ E= -326.521457709344     Delta-E=        0.000000051906 Rises=F Damp=F
+ DIIS: error= 3.97D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -326.521457761251     IErMin= 1 ErrMin= 3.03D-05
+ ErrMax= 3.97D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.63D-07 BMatP= 4.76D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.595D+00 0.405D+00
+ Coeff:      0.595D+00 0.405D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=2.29D-06 MaxDP=8.47D-05 DE= 5.19D-08 OVMax= 1.61D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  1.34D-06    CP:  1.00D+00  5.22D-01
+ E= -326.521457944464     Delta-E=       -0.000000235120 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.521457944464     IErMin= 3 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.97D-08 BMatP= 4.76D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.239D+00 0.202D+00 0.559D+00
+ Coeff:      0.239D+00 0.202D+00 0.559D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=7.44D-07 MaxDP=2.66D-05 DE=-2.35D-07 OVMax= 7.37D-05
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  7.25D-07    CP:  1.00D+00  5.60D-01  9.84D-01
+ E= -326.521457956148     Delta-E=       -0.000000011684 Rises=F Damp=F
+ DIIS: error= 1.27D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.521457956148     IErMin= 4 ErrMin= 1.27D-05
+ ErrMax= 1.27D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.56D-08 BMatP= 4.97D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.242D+00-0.123D+00 0.571D+00 0.795D+00
+ Coeff:     -0.242D+00-0.123D+00 0.571D+00 0.795D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=6.65D-07 MaxDP=2.63D-05 DE=-1.17D-08 OVMax= 1.01D-04
+
+ Cycle  14  Pass 1  IDiag  1:
+ RMSU=  4.69D-07    CP:  1.00D+00  5.97D-01  1.31D+00  9.11D-01
+ E= -326.521457972274     Delta-E=       -0.000000016126 Rises=F Damp=F
+ DIIS: error= 3.30D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.521457972274     IErMin= 5 ErrMin= 3.30D-06
+ ErrMax= 3.30D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.22D-09 BMatP= 3.56D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.147D+00-0.907D-01 0.131D+00 0.358D+00 0.748D+00
+ Coeff:     -0.147D+00-0.907D-01 0.131D+00 0.358D+00 0.748D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=2.84D-07 MaxDP=8.69D-06 DE=-1.61D-08 OVMax= 2.70D-05
+
+ Cycle  15  Pass 1  IDiag  1:
+ RMSU=  2.08D-07    CP:  1.00D+00  6.07D-01  1.42D+00  1.07D+00  1.10D+00
+ E= -326.521457974291     Delta-E=       -0.000000002017 Rises=F Damp=F
+ DIIS: error= 1.01D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.521457974291     IErMin= 6 ErrMin= 1.01D-06
+ ErrMax= 1.01D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.58D-10 BMatP= 3.22D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.145D-02-0.598D-02-0.825D-01-0.441D-01 0.252D+00 0.879D+00
+ Coeff:      0.145D-02-0.598D-02-0.825D-01-0.441D-01 0.252D+00 0.879D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.16D-07 MaxDP=3.96D-06 DE=-2.02D-09 OVMax= 1.26D-05
+
+ Cycle  16  Pass 1  IDiag  1:
+ RMSU=  5.73D-08    CP:  1.00D+00  6.10D-01  1.45D+00  1.14D+00  1.26D+00
+                    CP:  1.05D+00
+ E= -326.521457974675     Delta-E=       -0.000000000384 Rises=F Damp=F
+ DIIS: error= 5.24D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.521457974675     IErMin= 7 ErrMin= 5.24D-07
+ ErrMax= 5.24D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.24D-11 BMatP= 4.58D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.232D-01 0.115D-01-0.491D-01-0.725D-01-0.228D-01 0.303D+00
+ Coeff-Com:  0.806D+00
+ Coeff:      0.232D-01 0.115D-01-0.491D-01-0.725D-01-0.228D-01 0.303D+00
+ Coeff:      0.806D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=4.44D-08 MaxDP=1.59D-06 DE=-3.84D-10 OVMax= 5.96D-06
+
+ Cycle  17  Pass 1  IDiag  1:
+ RMSU=  3.03D-08    CP:  1.00D+00  6.10D-01  1.46D+00  1.16D+00  1.31D+00
+                    CP:  1.10D+00  1.19D+00
+ E= -326.521457974747     Delta-E=       -0.000000000072 Rises=F Damp=F
+ DIIS: error= 2.31D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.521457974747     IErMin= 8 ErrMin= 2.31D-07
+ ErrMax= 2.31D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.91D-11 BMatP= 9.24D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.350D-02 0.382D-02 0.174D-01 0.860D-03-0.829D-01-0.223D+00
+ Coeff-Com:  0.173D+00 0.111D+01
+ Coeff:      0.350D-02 0.382D-02 0.174D-01 0.860D-03-0.829D-01-0.223D+00
+ Coeff:      0.173D+00 0.111D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=3.01D-08 MaxDP=1.10D-06 DE=-7.23D-11 OVMax= 4.89D-06
+
+ Cycle  18  Pass 1  IDiag  1:
+ RMSU=  1.33D-08    CP:  1.00D+00  6.11D-01  1.46D+00  1.16D+00  1.33D+00
+                    CP:  1.15D+00  1.53D+00  1.27D+00
+ E= -326.521457974766     Delta-E=       -0.000000000019 Rises=F Damp=F
+ DIIS: error= 1.38D-07 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -326.521457974766     IErMin= 9 ErrMin= 1.38D-07
+ ErrMax= 1.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.27D-12 BMatP= 1.91D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.277D-03 0.116D-02 0.152D-01 0.814D-02-0.461D-01-0.161D+00
+ Coeff-Com: -0.645D-04 0.629D+00 0.554D+00
+ Coeff:     -0.277D-03 0.116D-02 0.152D-01 0.814D-02-0.461D-01-0.161D+00
+ Coeff:     -0.645D-04 0.629D+00 0.554D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=8.08D-09 MaxDP=2.29D-07 DE=-1.91D-11 OVMax= 1.07D-06
+
+ SCF Done:  E(UB3LYP) =  -326.521457975     A.U. after   18 cycles
+            NFock= 18  Conv=0.81D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7577 S= 0.5038
+ <L.S>=  0.00000000000    
+ KE= 3.251881718808D+02 PE=-1.339674356802D+03 EE= 3.986366820228D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7577,   after     0.7500
+ Leave Link  502 at Tue Jul  7 12:15:09 2020, MaxMem= 39321600000 cpu:             262.5 elap:               7.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Tue Jul  7 12:15:10 2020, MaxMem= 39321600000 cpu:               0.2 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   186
+ NBasis=   186 NAE=    28 NBE=    27 NFC=     0 NFV=     0
+ NROrb=    186 NOA=    28 NOB=    27 NVA=   158 NVB=   159
+ Leave Link  801 at Tue Jul  7 12:15:12 2020, MaxMem= 39321600000 cpu:               1.0 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    17.
+ Will process     18 centers per pass.
+ Leave Link 1101 at Tue Jul  7 12:15:14 2020, MaxMem= 39321600000 cpu:              16.7 elap:               0.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Tue Jul  7 12:15:16 2020, MaxMem= 39321600000 cpu:               1.6 elap:               1.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    17.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   39321598504.
+ G2DrvN: will do    18 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Tue Jul  7 12:15:25 2020, MaxMem= 39321600000 cpu:             304.3 elap:               7.8
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=11111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         5067 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=343229629.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  17391 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   39321600000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    54 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     51 vectors produced by pass  0 Test12= 1.61D-14 1.85D-09 XBig12= 1.57D+02 8.41D+00.
+ AX will form    51 AO Fock derivatives at one time.
+     51 vectors produced by pass  1 Test12= 1.61D-14 1.85D-09 XBig12= 5.97D+01 1.38D+00.
+     51 vectors produced by pass  2 Test12= 1.61D-14 1.85D-09 XBig12= 1.55D+00 1.64D-01.
+     51 vectors produced by pass  3 Test12= 1.61D-14 1.85D-09 XBig12= 9.48D-03 1.14D-02.
+     51 vectors produced by pass  4 Test12= 1.61D-14 1.85D-09 XBig12= 7.88D-05 8.99D-04.
+     51 vectors produced by pass  5 Test12= 1.61D-14 1.85D-09 XBig12= 3.25D-07 5.03D-05.
+     29 vectors produced by pass  6 Test12= 1.61D-14 1.85D-09 XBig12= 9.02D-10 2.92D-06.
+      4 vectors produced by pass  7 Test12= 1.61D-14 1.85D-09 XBig12= 3.44D-12 2.19D-07.
+      2 vectors produced by pass  8 Test12= 1.61D-14 1.85D-09 XBig12= 1.49D-14 1.40D-08.
+ InvSVY:  IOpt=1 It=  1 EMax= 5.33D-15
+ Solved reduced A of dimension   341 with    54 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       74.92 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Tue Jul  7 12:15:39 2020, MaxMem= 39321600000 cpu:             494.0 elap:              12.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 1 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A)
+ Beta  Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ The electronic state is 2-A.
+ Alpha  occ. eigenvalues --  -19.15650 -14.30042 -10.23910 -10.22085 -10.19778
+ Alpha  occ. eigenvalues --  -10.18555 -10.18213  -1.06906  -0.90396  -0.82560
+ Alpha  occ. eigenvalues --   -0.70960  -0.70166  -0.64636  -0.54946  -0.51417
+ Alpha  occ. eigenvalues --   -0.48008  -0.46515  -0.44465  -0.42411  -0.40668
+ Alpha  occ. eigenvalues --   -0.40252  -0.37478  -0.36929  -0.35989  -0.35087
+ Alpha  occ. eigenvalues --   -0.32434  -0.31790  -0.18843
+ Alpha virt. eigenvalues --    0.01957   0.02795   0.03305   0.05351   0.06892
+ Alpha virt. eigenvalues --    0.07940   0.09616   0.10379   0.11179   0.12688
+ Alpha virt. eigenvalues --    0.13602   0.14170   0.17656   0.21721   0.22445
+ Alpha virt. eigenvalues --    0.22950   0.25047   0.27468   0.29408   0.30141
+ Alpha virt. eigenvalues --    0.33631   0.36476   0.38300   0.39739   0.43111
+ Alpha virt. eigenvalues --    0.45974   0.46432   0.48428   0.50367   0.50817
+ Alpha virt. eigenvalues --    0.52456   0.53766   0.55099   0.55571   0.56651
+ Alpha virt. eigenvalues --    0.58934   0.59352   0.60868   0.61066   0.62294
+ Alpha virt. eigenvalues --    0.63193   0.64354   0.72268   0.75881   0.77063
+ Alpha virt. eigenvalues --    0.81610   0.82628   0.83702   0.88296   0.89559
+ Alpha virt. eigenvalues --    0.91289   0.96076   0.99977   1.01814   1.08614
+ Alpha virt. eigenvalues --    1.13135   1.15680   1.18959   1.26200   1.26703
+ Alpha virt. eigenvalues --    1.28990   1.32855   1.34899   1.36564   1.37175
+ Alpha virt. eigenvalues --    1.39145   1.42333   1.43301   1.43831   1.45340
+ Alpha virt. eigenvalues --    1.47883   1.48825   1.50261   1.53414   1.56755
+ Alpha virt. eigenvalues --    1.57471   1.59628   1.61061   1.62213   1.64342
+ Alpha virt. eigenvalues --    1.66051   1.67654   1.69963   1.73541   1.74114
+ Alpha virt. eigenvalues --    1.82420   1.87379   1.89294   1.92584   1.96339
+ Alpha virt. eigenvalues --    1.97981   2.01020   2.04285   2.07301   2.07630
+ Alpha virt. eigenvalues --    2.10034   2.10736   2.13714   2.21903   2.24888
+ Alpha virt. eigenvalues --    2.29422   2.31890   2.33249   2.36156   2.38771
+ Alpha virt. eigenvalues --    2.39510   2.41707   2.46127   2.47134   2.47405
+ Alpha virt. eigenvalues --    2.50157   2.51111   2.52449   2.54076   2.57346
+ Alpha virt. eigenvalues --    2.58974   2.61941   2.63275   2.71132   2.75575
+ Alpha virt. eigenvalues --    2.80632   2.82767   2.83863   2.85860   2.88908
+ Alpha virt. eigenvalues --    2.94527   2.95868   3.02284   3.06899   3.07750
+ Alpha virt. eigenvalues --    3.12054   3.13996   3.31963   3.36159   3.49281
+ Alpha virt. eigenvalues --    3.68118   3.72786   3.75014   3.75368   3.78723
+ Alpha virt. eigenvalues --    3.79469   3.87933   3.89604   3.91546   3.97607
+ Alpha virt. eigenvalues --    4.09194   4.27759   4.52162   4.82371   5.22367
+ Alpha virt. eigenvalues --    5.63711  23.69633  23.76397  23.86735  23.90403
+ Alpha virt. eigenvalues --   24.39011  35.82716  49.84870
+  Beta  occ. eigenvalues --  -19.15307 -14.29779 -10.23016 -10.21310 -10.19882
+  Beta  occ. eigenvalues --  -10.18591 -10.18248  -1.06129  -0.89961  -0.81605
+  Beta  occ. eigenvalues --   -0.70867  -0.68441  -0.64004  -0.54152  -0.50113
+  Beta  occ. eigenvalues --   -0.47220  -0.45821  -0.44164  -0.40903  -0.40272
+  Beta  occ. eigenvalues --   -0.40040  -0.37341  -0.36269  -0.35360  -0.34105
+  Beta  occ. eigenvalues --   -0.32240  -0.29846
+  Beta virt. eigenvalues --   -0.08814   0.02151   0.03126   0.03529   0.06083
+  Beta virt. eigenvalues --    0.07146   0.08076   0.09792   0.10749   0.11478
+  Beta virt. eigenvalues --    0.12749   0.13736   0.14660   0.18187   0.22537
+  Beta virt. eigenvalues --    0.22818   0.23523   0.25267   0.28227   0.29907
+  Beta virt. eigenvalues --    0.30576   0.34143   0.36650   0.38674   0.40159
+  Beta virt. eigenvalues --    0.43243   0.46404   0.47387   0.48756   0.50493
+  Beta virt. eigenvalues --    0.51194   0.53295   0.54321   0.55588   0.56251
+  Beta virt. eigenvalues --    0.56856   0.59037   0.59652   0.61174   0.61774
+  Beta virt. eigenvalues --    0.62527   0.63496   0.64575   0.72551   0.76429
+  Beta virt. eigenvalues --    0.77235   0.82137   0.83093   0.83981   0.88680
+  Beta virt. eigenvalues --    0.89965   0.91938   0.96731   1.00806   1.02499
+  Beta virt. eigenvalues --    1.09145   1.14068   1.16401   1.19403   1.26495
+  Beta virt. eigenvalues --    1.27070   1.29270   1.33193   1.35081   1.36971
+  Beta virt. eigenvalues --    1.37376   1.39456   1.43105   1.43553   1.44034
+  Beta virt. eigenvalues --    1.45971   1.48046   1.49176   1.50455   1.54028
+  Beta virt. eigenvalues --    1.57104   1.58064   1.60009   1.61324   1.62705
+  Beta virt. eigenvalues --    1.64659   1.66246   1.68210   1.70169   1.73676
+  Beta virt. eigenvalues --    1.74217   1.83239   1.88198   1.90213   1.93171
+  Beta virt. eigenvalues --    1.96676   1.98487   2.01793   2.04663   2.07714
+  Beta virt. eigenvalues --    2.08114   2.10786   2.11435   2.14246   2.23116
+  Beta virt. eigenvalues --    2.25220   2.29784   2.32037   2.33658   2.36680
+  Beta virt. eigenvalues --    2.39235   2.39751   2.42255   2.46368   2.47293
+  Beta virt. eigenvalues --    2.47803   2.50779   2.51538   2.52740   2.54298
+  Beta virt. eigenvalues --    2.57487   2.59336   2.62121   2.63434   2.71647
+  Beta virt. eigenvalues --    2.75889   2.80633   2.82723   2.84158   2.86473
+  Beta virt. eigenvalues --    2.88959   2.94763   2.96799   3.02965   3.07326
+  Beta virt. eigenvalues --    3.08197   3.13036   3.14375   3.32445   3.37961
+  Beta virt. eigenvalues --    3.49883   3.68928   3.72912   3.75093   3.75970
+  Beta virt. eigenvalues --    3.79007   3.79733   3.88452   3.90659   3.91832
+  Beta virt. eigenvalues --    3.98527   4.10145   4.28303   4.52445   4.83793
+  Beta virt. eigenvalues --    5.22776   5.64117  23.70356  23.77381  23.86726
+  Beta virt. eigenvalues --   23.90368  24.39060  35.82991  49.85207
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.318487   1.031108  -0.106716   0.001061   0.000110  -0.000149
+     2  C    1.031108   4.868003   0.193460  -0.061200  -0.064696   0.009346
+     3  C   -0.106716   0.193460   5.645294   0.346535   0.354192  -0.040686
+     4  C    0.001061  -0.061200   0.346535   4.857194  -0.058574   0.400800
+     5  C    0.000110  -0.064696   0.354192  -0.058574   4.858417  -0.006038
+     6  H   -0.000149   0.009346  -0.040686   0.400800  -0.006038   0.584466
+     7  H    0.000391  -0.006508  -0.026775   0.400512   0.007898  -0.023993
+     8  H    0.000659  -0.006593  -0.036557   0.403576  -0.004039  -0.032168
+     9  H   -0.000151   0.008456  -0.038347  -0.004946   0.400381   0.005261
+    10  H    0.000671  -0.004642  -0.038360  -0.004050   0.404933  -0.001677
+    11  H    0.000939  -0.006165  -0.033126   0.007760   0.400836   0.000019
+    12  C    0.001032  -0.000737  -0.171721   0.000067   0.000376   0.005763
+    13  O   -0.000879   0.001848   0.007872  -0.000399   0.000454  -0.000633
+    14  H   -0.000124  -0.000415   0.006065   0.000693   0.001448  -0.000297
+    15  H    0.002385  -0.037276   0.179045  -0.034587  -0.044865  -0.008485
+    16  H   -0.000038   0.000972   0.005592   0.000427   0.000489   0.000525
+    17  H    0.001486   0.003594  -0.001417   0.000074   0.000012   0.000083
+               7          8          9         10         11         12
+     1  N    0.000391   0.000659  -0.000151   0.000671   0.000939   0.001032
+     2  C   -0.006508  -0.006593   0.008456  -0.004642  -0.006165  -0.000737
+     3  C   -0.026775  -0.036557  -0.038347  -0.038360  -0.033126  -0.171721
+     4  C    0.400512   0.403576  -0.004946  -0.004050   0.007760   0.000067
+     5  C    0.007898  -0.004039   0.400381   0.404933   0.400836   0.000376
+     6  H   -0.023993  -0.032168   0.005261  -0.001677   0.000019   0.005763
+     7  H    0.545446  -0.026548  -0.000074  -0.000219  -0.000418  -0.001433
+     8  H   -0.026548   0.569203  -0.001491   0.006057  -0.000231  -0.000826
+     9  H   -0.000074  -0.001491   0.581346  -0.033123  -0.024146   0.004524
+    10  H   -0.000219   0.006057  -0.033123   0.567044  -0.025914  -0.000850
+    11  H   -0.000418  -0.000231  -0.024146  -0.025914   0.560041   0.001198
+    12  C   -0.001433  -0.000826   0.004524  -0.000850   0.001198   5.058795
+    13  O    0.006248  -0.000009  -0.000024  -0.000006  -0.000023   0.270383
+    14  H    0.000463  -0.000009  -0.000449   0.000015   0.000348   0.379853
+    15  H   -0.007257   0.005572  -0.007460   0.005972  -0.003346   0.230745
+    16  H   -0.000287   0.000034   0.000076  -0.000011  -0.000106   0.386596
+    17  H   -0.000260  -0.000019   0.000017  -0.000008  -0.000011  -0.037438
+              13         14         15         16         17
+     1  N   -0.000879  -0.000124   0.002385  -0.000038   0.001486
+     2  C    0.001848  -0.000415  -0.037276   0.000972   0.003594
+     3  C    0.007872   0.006065   0.179045   0.005592  -0.001417
+     4  C   -0.000399   0.000693  -0.034587   0.000427   0.000074
+     5  C    0.000454   0.001448  -0.044865   0.000489   0.000012
+     6  H   -0.000633  -0.000297  -0.008485   0.000525   0.000083
+     7  H    0.006248   0.000463  -0.007257  -0.000287  -0.000260
+     8  H   -0.000009  -0.000009   0.005572   0.000034  -0.000019
+     9  H   -0.000024  -0.000449  -0.007460   0.000076   0.000017
+    10  H   -0.000006   0.000015   0.005972  -0.000011  -0.000008
+    11  H   -0.000023   0.000348  -0.003346  -0.000106  -0.000011
+    12  C    0.270383   0.379853   0.230745   0.386596  -0.037438
+    13  O    7.814425  -0.026083  -0.027800  -0.029970   0.317622
+    14  H   -0.026083   0.599160  -0.027520  -0.031991  -0.012150
+    15  H   -0.027800  -0.027520   0.635925  -0.030712  -0.003931
+    16  H   -0.029970  -0.031991  -0.030712   0.567672   0.008408
+    17  H    0.317622  -0.012150  -0.003931   0.008408   0.462763
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  N    0.143348  -0.004538  -0.010058   0.000160   0.000249   0.000017
+     2  C   -0.004538  -0.059544  -0.017792   0.002898  -0.000499   0.001208
+     3  C   -0.010058  -0.017792   0.730292  -0.027765  -0.018469  -0.009978
+     4  C    0.000160   0.002898  -0.027765  -0.019925  -0.000160   0.001707
+     5  C    0.000249  -0.000499  -0.018469  -0.000160  -0.024343  -0.000424
+     6  H    0.000017   0.001208  -0.009978   0.001707  -0.000424   0.012971
+     7  H    0.000025   0.000048  -0.000845   0.001698  -0.000199  -0.000012
+     8  H    0.000239  -0.003222  -0.007506   0.003709   0.001512  -0.006569
+     9  H    0.000017   0.001207  -0.008381   0.000057  -0.001643   0.001713
+    10  H    0.000228  -0.003098  -0.009811   0.000596   0.010760  -0.001272
+    11  H    0.000025   0.001091  -0.003139  -0.000013   0.000460   0.000131
+    12  C    0.002366   0.009018  -0.178338   0.007563   0.001980   0.005791
+    13  O   -0.000526  -0.000976   0.017995  -0.001294  -0.000094  -0.000475
+    14  H   -0.000292  -0.000702   0.012498  -0.000353  -0.000472  -0.000278
+    15  H    0.001020   0.011002  -0.071954   0.009913   0.008874   0.003432
+    16  H   -0.000047  -0.000439   0.010717  -0.000844  -0.000252  -0.001334
+    17  H    0.000285  -0.000091  -0.001235   0.000070   0.000007   0.000030
+               7          8          9         10         11         12
+     1  N    0.000025   0.000239   0.000017   0.000228   0.000025   0.002366
+     2  C    0.000048  -0.003222   0.001207  -0.003098   0.001091   0.009018
+     3  C   -0.000845  -0.007506  -0.008381  -0.009811  -0.003139  -0.178338
+     4  C    0.001698   0.003709   0.000057   0.000596  -0.000013   0.007563
+     5  C   -0.000199   0.001512  -0.001643   0.010760   0.000460   0.001980
+     6  H   -0.000012  -0.006569   0.001713  -0.001272   0.000131   0.005791
+     7  H    0.000782  -0.000119  -0.000034   0.000072  -0.000007  -0.000683
+     8  H   -0.000119   0.031696  -0.001047   0.003032  -0.000152  -0.001479
+     9  H   -0.000034  -0.001047   0.014912  -0.006423   0.001442   0.004585
+    10  H    0.000072   0.003032  -0.006423   0.028661  -0.002296  -0.001131
+    11  H   -0.000007  -0.000152   0.001442  -0.002296   0.002181   0.001214
+    12  C   -0.000683  -0.001479   0.004585  -0.001131   0.001214   0.688143
+    13  O   -0.000061   0.000138  -0.000083   0.000022  -0.000029  -0.092602
+    14  H    0.000003   0.000063  -0.000655   0.000129  -0.000276  -0.023479
+    15  H    0.001233  -0.002444   0.003793  -0.002471   0.001218   0.081031
+    16  H    0.000013   0.000191  -0.000693   0.000105  -0.000077  -0.019587
+    17  H   -0.000011  -0.000014   0.000014  -0.000005   0.000008   0.000959
+              13         14         15         16         17
+     1  N   -0.000526  -0.000292   0.001020  -0.000047   0.000285
+     2  C   -0.000976  -0.000702   0.011002  -0.000439  -0.000091
+     3  C    0.017995   0.012498  -0.071954   0.010717  -0.001235
+     4  C   -0.001294  -0.000353   0.009913  -0.000844   0.000070
+     5  C   -0.000094  -0.000472   0.008874  -0.000252   0.000007
+     6  H   -0.000475  -0.000278   0.003432  -0.001334   0.000030
+     7  H   -0.000061   0.000003   0.001233   0.000013  -0.000011
+     8  H    0.000138   0.000063  -0.002444   0.000191  -0.000014
+     9  H   -0.000083  -0.000655   0.003793  -0.000693   0.000014
+    10  H    0.000022   0.000129  -0.002471   0.000105  -0.000005
+    11  H   -0.000029  -0.000276   0.001218  -0.000077   0.000008
+    12  C   -0.092602  -0.023479   0.081031  -0.019587   0.000959
+    13  O    0.179569  -0.000265  -0.003391   0.000198   0.000828
+    14  H   -0.000265   0.009029  -0.002789   0.008020  -0.000639
+    15  H   -0.003391  -0.002789  -0.096730  -0.001496   0.000923
+    16  H    0.000198   0.008020  -0.001496   0.000065  -0.000618
+    17  H    0.000828  -0.000639   0.000923  -0.000618  -0.003320
+ Mulliken charges and spin densities:
+               1          2
+     1  N   -0.250273   0.132517
+     2  C    0.071445  -0.064428
+     3  C   -0.244351   0.406233
+     4  C   -0.254945  -0.021983
+     5  C   -0.251337  -0.022712
+     6  H    0.107863   0.006659
+     7  H    0.132816   0.001902
+     8  H    0.123388   0.018028
+     9  H    0.110151   0.008780
+    10  H    0.124167   0.017099
+    11  H    0.122346   0.001780
+    12  C   -0.126328   0.485352
+    13  O   -0.333026   0.098954
+    14  H    0.110991  -0.000458
+    15  H    0.173595  -0.058835
+    16  H    0.122324  -0.006077
+    17  H    0.261175  -0.002810
+ Sum of Mulliken charges =  -0.00000   1.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  N   -0.250273   0.132517
+     2  C    0.071445  -0.064428
+     3  C   -0.070756   0.347398
+     4  C    0.109122   0.004606
+     5  C    0.105327   0.004946
+    12  C    0.106987   0.478817
+    13  O   -0.071851   0.096144
+ APT charges:
+               1
+     1  N   -0.358113
+     2  C    0.091955
+     3  C    0.197226
+     4  C    0.030611
+     5  C    0.046313
+     6  H   -0.008483
+     7  H    0.010594
+     8  H   -0.018364
+     9  H   -0.010512
+    10  H   -0.026820
+    11  H   -0.002812
+    12  C    0.629501
+    13  O   -0.621635
+    14  H   -0.079308
+    15  H   -0.130715
+    16  H   -0.036219
+    17  H    0.286781
+ Sum of APT charges =   0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.358113
+     2  C    0.091955
+     3  C    0.066510
+     4  C    0.014359
+     5  C    0.006169
+    12  C    0.513974
+    13  O   -0.334855
+ Electronic spatial extent (au):  <R**2>=            974.4578
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.7708    Y=             -3.4015    Z=             -1.1235  Tot=              3.6642
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -44.4743   YY=            -50.9011   ZZ=            -43.1184
+   XY=             -5.5838   XZ=              3.4640   YZ=             -0.1523
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.6903   YY=             -4.7365   ZZ=              3.0462
+   XY=             -5.5838   XZ=              3.4640   YZ=             -0.1523
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -4.5988  YYY=            -26.5517  ZZZ=             -0.3266  XYY=            -20.8553
+  XXY=              2.5855  XXZ=             -6.9881  XZZ=             -3.7397  YZZ=              0.5373
+  YYZ=              0.8442  XYZ=              1.7025
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -658.1716 YYYY=           -476.2639 ZZZZ=           -230.7006 XXXY=            -26.9331
+ XXXZ=             18.5719 YYYX=            -32.9908 YYYZ=              2.9116 ZZZX=              0.3726
+ ZZZY=              0.3938 XXYY=           -166.7860 XXZZ=           -144.8675 YYZZ=           -109.8853
+ XXYZ=             -4.2980 YYXZ=              0.6551 ZZXY=             -1.8565
+ N-N= 2.893280449240D+02 E-N=-1.339674356359D+03  KE= 3.251881718808D+02
+  Exact polarizability:  85.787   2.788  78.674   3.410   0.209  60.291
+ Approx polarizability: 113.695   6.367 123.769   3.174   0.059  80.531
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  N(14)              0.00648       2.09377       0.74711       0.69841
+     2  C(13)             -0.01955     -21.97745      -7.84210      -7.33089
+     3  C(13)              0.14624     164.40280      58.66301      54.83887
+     4  C(13)             -0.01251     -14.06088      -5.01727      -4.69020
+     5  C(13)             -0.01324     -14.88887      -5.31272      -4.96639
+     6  H(1)               0.00208       9.27802       3.31063       3.09481
+     7  H(1)               0.00130       5.82558       2.07871       1.94321
+     8  H(1)               0.00843      37.69773      13.45149      12.57461
+     9  H(1)               0.00300      13.42878       4.79172       4.47936
+    10  H(1)               0.00856      38.28078      13.65953      12.76909
+    11  H(1)               0.00079       3.53197       1.26029       1.17814
+    12  C(13)              0.16125     181.27209      64.68239      60.46586
+    13  O(17)              0.01359      -8.23795      -2.93951      -2.74789
+    14  H(1)               0.00062       2.78013       0.99202       0.92735
+    15  H(1)              -0.02705    -120.89053     -43.13675     -40.32474
+    16  H(1)              -0.00108      -4.81523      -1.71819      -1.60619
+    17  H(1)              -0.00160      -7.14723      -2.55031      -2.38406
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        0.240511     -0.154119     -0.086392
+     2   Atom       -0.045764      0.059899     -0.014135
+     3   Atom        0.447868     -0.254139     -0.193729
+     4   Atom        0.000118     -0.005426      0.005308
+     5   Atom        0.007347     -0.003530     -0.003818
+     6   Atom       -0.002198      0.000950      0.001248
+     7   Atom       -0.002734     -0.005963      0.008696
+     8   Atom       -0.000199     -0.003426      0.003626
+     9   Atom        0.000189      0.002015     -0.002203
+    10   Atom        0.004847     -0.002609     -0.002238
+    11   Atom        0.001040     -0.005317      0.004277
+    12   Atom        0.600056     -0.301519     -0.298537
+    13   Atom        0.522317     -0.267812     -0.254505
+    14   Atom       -0.005848     -0.033648      0.039496
+    15   Atom        0.172065     -0.088657     -0.083408
+    16   Atom       -0.004870      0.031183     -0.026312
+    17   Atom       -0.007774      0.021936     -0.014162
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom       -0.027957      0.113167     -0.007027
+     2   Atom       -0.004669     -0.010262     -0.006177
+     3   Atom        0.117538      0.237218      0.038828
+     4   Atom       -0.002583      0.007155     -0.005383
+     5   Atom       -0.006398     -0.005863      0.004002
+     6   Atom       -0.001676      0.002232     -0.007331
+     7   Atom        0.000752      0.000816     -0.000310
+     8   Atom       -0.000778      0.004295     -0.002862
+     9   Atom       -0.005183     -0.002365      0.004995
+    10   Atom       -0.003393     -0.002526      0.002030
+    11   Atom       -0.000404     -0.005916      0.001873
+    12   Atom        0.154380      0.167325      0.024441
+    13   Atom        0.121315      0.200612      0.021384
+    14   Atom        0.006343      0.010310     -0.011151
+    15   Atom        0.041883      0.058391      0.010644
+    16   Atom        0.015221      0.003906     -0.023980
+    17   Atom       -0.006894      0.002511     -0.013183
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -0.1561    -6.021    -2.148    -2.008  0.0775  0.9967 -0.0253
+     1 N(14)  Bbb    -0.1217    -4.692    -1.674    -1.565 -0.2946  0.0471  0.9545
+              Bcc     0.2778    10.713     3.823     3.574  0.9525 -0.0665  0.2973
+ 
+              Baa    -0.0492    -6.597    -2.354    -2.200  0.9553  0.0573  0.2900
+     2 C(13)  Bbb    -0.0114    -1.528    -0.545    -0.510 -0.2934  0.0634  0.9539
+              Bcc     0.0605     8.125     2.899     2.710 -0.0363  0.9963 -0.0774
+ 
+              Baa    -0.2733   -36.676   -13.087   -12.234 -0.1261  0.9864 -0.1054
+     3 C(13)  Bbb    -0.2719   -36.487   -13.019   -12.171 -0.3213  0.0600  0.9451
+              Bcc     0.5452    73.163    26.106    24.405  0.9386  0.1530  0.3093
+ 
+              Baa    -0.0077    -1.032    -0.368    -0.344 -0.0886  0.9021  0.4223
+     4 C(13)  Bbb    -0.0046    -0.617    -0.220    -0.206  0.8435  0.2934 -0.4499
+              Bcc     0.0123     1.649     0.588     0.550  0.5298 -0.3164  0.7869
+ 
+              Baa    -0.0077    -1.032    -0.368    -0.344  0.0394  0.7238 -0.6889
+     5 C(13)  Bbb    -0.0055    -0.740    -0.264    -0.247  0.5577  0.5561  0.6162
+              Bcc     0.0132     1.771     0.632     0.591  0.8291 -0.4085 -0.3817
+ 
+              Baa    -0.0063    -3.346    -1.194    -1.116 -0.1023  0.6969  0.7098
+     6 H(1)   Bbb    -0.0028    -1.514    -0.540    -0.505  0.9659  0.2402 -0.0967
+              Bcc     0.0091     4.860     1.734     1.621  0.2379 -0.6758  0.6977
+ 
+              Baa    -0.0061    -3.279    -1.170    -1.094 -0.2226  0.9744  0.0326
+     7 H(1)   Bbb    -0.0026    -1.395    -0.498    -0.465  0.9724  0.2243 -0.0640
+              Bcc     0.0088     4.673     1.668     1.559  0.0697 -0.0174  0.9974
+ 
+              Baa    -0.0046    -2.478    -0.884    -0.826 -0.2740  0.8559  0.4385
+     8 H(1)   Bbb    -0.0025    -1.349    -0.482    -0.450  0.8176  0.4474 -0.3625
+              Bcc     0.0072     3.827     1.366     1.277  0.5065 -0.2592  0.8224
+ 
+              Baa    -0.0058    -3.080    -1.099    -1.027 -0.2736 -0.6416  0.7165
+     9 H(1)   Bbb    -0.0032    -1.700    -0.607    -0.567  0.7945  0.2690  0.5444
+              Bcc     0.0090     4.780     1.706     1.595 -0.5421  0.7183  0.4362
+ 
+              Baa    -0.0046    -2.445    -0.873    -0.816  0.1477  0.8210 -0.5516
+    10 H(1)   Bbb    -0.0026    -1.387    -0.495    -0.463  0.4610  0.4363  0.7728
+              Bcc     0.0072     3.832     1.367     1.278  0.8750 -0.3684 -0.3140
+ 
+              Baa    -0.0058    -3.099    -1.106    -1.034 -0.1929  0.9382 -0.2873
+    11 H(1)   Bbb    -0.0032    -1.705    -0.608    -0.569  0.7795  0.3244  0.5359
+              Bcc     0.0090     4.803     1.714     1.602 -0.5959  0.1207  0.7939
+ 
+              Baa    -0.3312   -44.449   -15.860   -14.826 -0.2369  0.6066  0.7589
+    12 C(13)  Bbb    -0.3245   -43.542   -15.537   -14.524 -0.0164  0.7785 -0.6274
+              Bcc     0.6557    87.990    31.397    29.350  0.9714  0.1611  0.1745
+ 
+              Baa    -0.3062    22.155     7.905     7.390 -0.2685  0.3483  0.8981
+    13 O(17)  Bbb    -0.2825    20.444     7.295     6.819 -0.0466  0.9265 -0.3733
+              Bcc     0.5887   -42.599   -15.200   -14.209  0.9622  0.1421  0.2325
+ 
+              Baa    -0.0373   -19.907    -7.103    -6.640 -0.2485  0.9533  0.1718
+    14 H(1)   Bbb    -0.0056    -3.006    -1.073    -1.003  0.9500  0.2745 -0.1492
+              Bcc     0.0429    22.913     8.176     7.643  0.1894 -0.1261  0.9738
+ 
+              Baa    -0.0972   -51.885   -18.514   -17.307 -0.0793 -0.5998  0.7962
+    15 H(1)   Bbb    -0.0942   -50.257   -17.933   -16.764 -0.2479  0.7855  0.5671
+              Bcc     0.1914   102.142    36.447    34.071  0.9655  0.1524  0.2110
+ 
+              Baa    -0.0376   -20.046    -7.153    -6.687 -0.2784  0.3707  0.8861
+    16 H(1)   Bbb    -0.0059    -3.127    -1.116    -1.043  0.9233 -0.1508  0.3532
+              Bcc     0.0434    23.174     8.269     7.730  0.2645  0.9164 -0.3003
+ 
+              Baa    -0.0185    -9.855    -3.516    -3.287 -0.0262  0.3060  0.9517
+    17 H(1)   Bbb    -0.0093    -4.952    -1.767    -1.652  0.9790  0.2004 -0.0375
+              Bcc     0.0278    14.807     5.283     4.939 -0.2022  0.9307 -0.3048
+ 
+
+ ---------------------------------------------------------------------------------
+
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Tue Jul  7 12:15:41 2020, MaxMem= 39321600000 cpu:              28.8 elap:               1.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ Leave Link  701 at Tue Jul  7 12:15:44 2020, MaxMem= 39321600000 cpu:              24.5 elap:               1.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Jul  7 12:15:45 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Tue Jul  7 12:15:58 2020, MaxMem= 39321600000 cpu:             458.0 elap:              11.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        =-3.03249613D-01-1.33825226D+00-4.42012839D-01
+ Polarizability= 8.57873175D+01 2.78849305D+00 7.86738496D+01
+                 3.40989359D+00 2.08669271D-01 6.02909893D+01
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.003201325    0.001676805   -0.000446255
+      2        6           0.001734820    0.001711871    0.000115030
+      3        6          -0.002866684    0.000531849    0.001096846
+      4        6           0.000763707    0.001864899    0.006991901
+      5        6          -0.001362295   -0.001250268   -0.009119707
+      6        1          -0.004109109   -0.001631751    0.001461029
+      7        1           0.000923831    0.003442584   -0.004330384
+      8        1           0.002773157   -0.002922749   -0.001305549
+      9        1          -0.004756105   -0.001974042    0.002738272
+     10        1           0.001366276   -0.001924530   -0.000869511
+     11        1           0.001495443    0.005428624    0.002566087
+     12        6           0.009189670    0.006500494   -0.010591767
+     13        8          -0.000309944   -0.003103463    0.004397682
+     14        1          -0.000259383    0.001152470    0.004618890
+     15        1          -0.001932848   -0.005401580    0.002881530
+     16        1          -0.003618109   -0.003822823   -0.000542681
+     17        1          -0.002233753   -0.000278389    0.000338588
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.010591767 RMS     0.003660193
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Leave Link  716 at Tue Jul  7 12:15:59 2020, MaxMem= 39321600000 cpu:               4.0 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.006175368 RMS     0.002371387
+ Search for a saddle point.
+ Step number   1 out of a maximum of  102
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Swapping is turned off.
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---   -0.04918   0.00066   0.00170   0.00203   0.00457
+     Eigenvalues ---    0.00983   0.02243   0.02877   0.03045   0.04190
+     Eigenvalues ---    0.04460   0.04465   0.04532   0.04581   0.04774
+     Eigenvalues ---    0.05046   0.06695   0.07186   0.08286   0.09701
+     Eigenvalues ---    0.09777   0.10627   0.11864   0.12045   0.12423
+     Eigenvalues ---    0.14331   0.14582   0.15110   0.15386   0.16840
+     Eigenvalues ---    0.17454   0.29061   0.29338   0.31382   0.31428
+     Eigenvalues ---    0.31529   0.31869   0.32002   0.32688   0.32739
+     Eigenvalues ---    0.32842   0.34180   0.43528   0.53177   1.18182
+ Eigenvectors required to have negative eigenvalues:
+                          R14       R5        D28       D30       D4
+   1                    0.71995  -0.62225   0.09227  -0.07480  -0.06894
+                          D13       D6        A23       A24       D12
+   1                    0.06722  -0.06462   0.06448  -0.06358  -0.06167
+ RFO step:  Lambda0=1.465425042D-05 Lambda=-3.67788299D-03.
+ Linear search not attempted -- option 19 set.
+ Iteration  1 RMS(Cart)=  0.17619852 RMS(Int)=  0.01321370
+ Iteration  2 RMS(Cart)=  0.02064582 RMS(Int)=  0.00185541
+ Iteration  3 RMS(Cart)=  0.00040736 RMS(Int)=  0.00183673
+ Iteration  4 RMS(Cart)=  0.00000171 RMS(Int)=  0.00183673
+ Iteration  5 RMS(Cart)=  0.00000002 RMS(Int)=  0.00183673
+ ITry= 1 IFail=0 DXMaxC= 6.87D-01 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.19245  -0.00352   0.00000  -0.00194  -0.00194   2.19051
+    R2        2.72644  -0.00598   0.00000  -0.01377  -0.01377   2.71268
+    R3        2.87077   0.00288   0.00000   0.00967   0.00964   2.88041
+    R4        2.87038   0.00393   0.00000   0.00837   0.00837   2.87874
+    R5        2.51322   0.00343   0.00000   0.00916   0.00935   2.52257
+    R6        2.08014  -0.00460   0.00000  -0.01421  -0.01420   2.06594
+    R7        2.07894  -0.00549   0.00000  -0.01687  -0.01687   2.06207
+    R8        2.08355  -0.00422   0.00000  -0.01344  -0.01344   2.07011
+    R9        2.08369  -0.00556   0.00000  -0.01736  -0.01736   2.06633
+   R10        2.07736  -0.00244   0.00000  -0.00663  -0.00663   2.07073
+   R11        2.08040  -0.00530   0.00000  -0.01751  -0.01751   2.06289
+   R12        2.59009   0.00618   0.00000   0.01626   0.01626   2.60635
+   R13        2.08211  -0.00473   0.00000  -0.01598  -0.01598   2.06613
+   R14        2.61187   0.00169   0.00000   0.03079   0.03063   2.64251
+   R15        2.07300  -0.00512   0.00000  -0.01853  -0.01853   2.05447
+   R16        1.81733   0.00154   0.00000   0.00572   0.00572   1.82305
+    A1        1.99715  -0.00018   0.00000  -0.00241  -0.00160   1.99555
+    A2        2.00150   0.00013   0.00000   0.00615   0.00967   2.01116
+    A3        1.81800  -0.00178   0.00000  -0.08346  -0.08318   1.73483
+    A4        2.00818  -0.00002   0.00000   0.00775   0.00268   2.01086
+    A5        1.79460   0.00029   0.00000   0.01586   0.01503   1.80964
+    A6        1.80683   0.00157   0.00000   0.05205   0.05216   1.85899
+    A7        1.90875   0.00172   0.00000   0.00856   0.00851   1.91726
+    A8        1.94670  -0.00022   0.00000  -0.00835  -0.00832   1.93838
+    A9        1.94500  -0.00054   0.00000  -0.00295  -0.00295   1.94205
+   A10        1.89732  -0.00099   0.00000  -0.00625  -0.00620   1.89111
+   A11        1.88314  -0.00055   0.00000   0.00022   0.00023   1.88337
+   A12        1.88121   0.00052   0.00000   0.00883   0.00882   1.89003
+   A13        1.94274  -0.00297   0.00000  -0.02323  -0.02330   1.91943
+   A14        1.94612   0.00004   0.00000  -0.00641  -0.00659   1.93953
+   A15        1.91196   0.00516   0.00000   0.03557   0.03563   1.94759
+   A16        1.88507   0.00046   0.00000  -0.00425  -0.00456   1.88051
+   A17        1.88480  -0.00058   0.00000   0.00672   0.00689   1.89169
+   A18        1.89134  -0.00220   0.00000  -0.00828  -0.00832   1.88302
+   A19        2.02723   0.00123   0.00000   0.00154  -0.00609   2.02114
+   A20        1.89516  -0.00407   0.00000  -0.07396  -0.07467   1.82049
+   A21        1.93383  -0.00025   0.00000  -0.00455  -0.00006   1.93377
+   A22        1.81279   0.00063   0.00000  -0.01186  -0.01254   1.80025
+   A23        1.97668  -0.00028   0.00000   0.01949   0.02086   1.99754
+   A24        1.79705   0.00272   0.00000   0.07138   0.07227   1.86932
+   A25        1.90788   0.00073   0.00000  -0.00091  -0.00091   1.90697
+   A26        3.09544  -0.00179   0.00000  -0.04717  -0.04717   3.04827
+   A27        3.09975   0.00229   0.00000   0.13002   0.12904   3.22879
+   A28        3.12479  -0.00102   0.00000  -0.02382  -0.02382   3.10097
+   A29        2.89777   0.00121   0.00000  -0.12417  -0.12337   2.77440
+    D1        2.91173  -0.00057   0.00000  -0.00183  -0.00191   2.90983
+    D2        0.81248  -0.00033   0.00000   0.00563   0.00555   0.81803
+    D3       -1.29093  -0.00047   0.00000   0.00214   0.00204  -1.28888
+    D4       -0.99888  -0.00059   0.00000   0.01397   0.01475  -0.98413
+    D5       -3.09813  -0.00035   0.00000   0.02143   0.02221  -3.07592
+    D6        1.08165  -0.00049   0.00000   0.01794   0.01870   1.10035
+    D7        0.95220   0.00144   0.00000   0.08845   0.08781   1.04001
+    D8       -1.14705   0.00168   0.00000   0.09592   0.09527  -1.05178
+    D9        3.03272   0.00153   0.00000   0.09243   0.09176   3.12449
+   D10       -2.80399  -0.00066   0.00000  -0.03538  -0.03588  -2.83987
+   D11        1.37281   0.00077   0.00000  -0.00953  -0.01023   1.36258
+   D12       -0.72073   0.00009   0.00000  -0.01856  -0.01924  -0.73998
+   D13        1.10854  -0.00050   0.00000  -0.04743  -0.04767   1.06087
+   D14       -0.99784   0.00093   0.00000  -0.02158  -0.02202  -1.01985
+   D15       -3.09138   0.00025   0.00000  -0.03061  -0.03103  -3.12242
+   D16       -0.83530  -0.00177   0.00000  -0.10074  -0.09962  -0.93492
+   D17       -2.94168  -0.00034   0.00000  -0.07489  -0.07397  -3.01565
+   D18        1.24796  -0.00102   0.00000  -0.08392  -0.08298   1.16498
+   D19       -0.81395  -0.00011   0.00000   0.01609   0.01111  -0.80284
+   D20        1.33881  -0.00098   0.00000  -0.07053  -0.06888   1.26993
+   D21       -2.83245   0.00022   0.00000   0.01357   0.01350  -2.81895
+   D22        1.23393  -0.00043   0.00000  -0.01704  -0.02304   1.21089
+   D23       -2.89649  -0.00130   0.00000  -0.10366  -0.10303  -2.99953
+   D24       -0.78457  -0.00011   0.00000  -0.01956  -0.02065  -0.80522
+   D25       -2.93464   0.00071   0.00000   0.06127   0.06058  -2.87407
+   D26       -0.78189  -0.00016   0.00000  -0.02535  -0.01942  -0.80130
+   D27        1.33004   0.00104   0.00000   0.05874   0.06297   1.39301
+   D28       -0.62538  -0.00031   0.00000  -0.10799  -0.10760  -0.73298
+   D29        1.40855  -0.00167   0.00000  -0.17517  -0.17659   1.23195
+   D30       -2.91307  -0.00081   0.00000  -0.13326  -0.13223  -3.04530
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.006175     0.000450     NO 
+ RMS     Force            0.002371     0.000300     NO 
+ Maximum Displacement     0.686992     0.001800     NO 
+ RMS     Displacement     0.184537     0.001200     NO 
+ Predicted change in Energy=-2.199912D-03
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:15:59 2020, MaxMem= 39321600000 cpu:              13.3 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.192578   -1.586666    0.082106
+      2          6           0       -1.482887   -0.670905    0.044863
+      3          6           0       -0.495142    0.368530   -0.022653
+      4          6           0       -0.212635    1.054055    1.309102
+      5          6           0       -0.615713    1.302103   -1.220380
+      6          1           0        0.697561    1.654685    1.231742
+      7          1           0       -0.074072    0.321298    2.105711
+      8          1           0       -1.033239    1.721226    1.594599
+      9          1           0        0.320183    1.849216   -1.363247
+     10          1           0       -1.413098    2.038245   -1.068661
+     11          1           0       -0.836715    0.752555   -2.137343
+     12          6           0        1.493968   -1.445770   -0.207637
+     13          8           0        1.035969   -2.256171    0.810076
+     14          1           0        1.415869   -1.859060   -1.216845
+     15          1           0        0.592230   -0.377254   -0.230870
+     16          1           0        2.470539   -1.034781    0.035993
+     17          1           0        0.212056   -2.676483    0.535883
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.159166   0.000000
+     3  C    2.591342   1.435487   0.000000
+     4  C    3.521236   2.487434   1.524246   0.000000
+     5  C    3.539486   2.499118   1.523366   2.573379   0.000000
+     6  H    4.492318   3.401677   2.156442   1.093251   2.803908
+     7  H    3.496193   2.686321   2.170130   1.091200   3.509734
+     8  H    3.817571   2.885508   2.175969   1.095453   2.876473
+     9  H    4.495364   3.403651   2.157400   2.838596   1.093455
+    10  H    3.882245   2.929897   2.173643   2.839630   1.095786
+    11  H    3.498038   2.684361   2.176249   3.515446   1.091635
+    12  C    3.700597   3.086395   2.698603   3.385575   3.609322
+    13  O    3.376639   3.072988   3.150682   3.572904   4.417252
+    14  H    3.844783   3.377337   3.168629   4.185532   3.757697
+    15  H    3.052177   2.113851   1.334888   2.251215   2.293141
+    16  H    4.695887   3.970146   3.281460   3.630905   4.069944
+    17  H    2.678784   2.671382   3.175563   3.833425   4.427054
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.771203   0.000000
+     8  H    1.769678   1.772297   0.000000
+     9  H    2.629491   3.810989   3.255301   0.000000
+    10  H    3.145449   3.849355   2.708828   1.768269   0.000000
+    11  H    3.810325   4.332564   3.860613   1.772090   1.768416
+    12  C    3.509829   3.306487   4.434489   3.683766   4.618522
+    13  O    3.948053   3.090988   4.551570   4.699988   5.288628
+    14  H    4.342574   4.244203   5.169216   3.869530   4.818090
+    15  H    2.505815   2.528150   3.221507   2.512659   3.249287
+    16  H    3.436058   3.549327   4.722424   3.859966   5.074089
+    17  H    4.413497   3.396015   4.691640   4.909210   5.238735
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.740117   0.000000
+    13  O    4.609409   1.379222   0.000000
+    14  H    3.569591   1.093348   2.100103   0.000000
+    15  H    2.636852   1.398355   2.193354   1.961192   0.000000
+    16  H    4.342336   1.087179   2.036907   1.833403   2.007885
+    17  H    4.472623   1.926337   0.964715   2.278026   2.453344
+                   16         17
+    16  H    0.000000
+    17  H    2.836515   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ RotChk:  IX=0 Diff= 3.17D-01
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.024502    2.283966   -0.019656
+      2          6           0        0.439940    1.202402    0.016345
+      3          6           0        0.823055   -0.181017    0.015393
+      4          6           0        1.019042   -0.779480    1.403470
+      5          6           0        1.883302   -0.560502   -1.010527
+      6          1           0        1.074150   -1.869101    1.333560
+      7          1           0        0.189980   -0.519026    2.063424
+      8          1           0        1.948221   -0.423920    1.861968
+      9          1           0        1.891917   -1.644282   -1.155404
+     10          1           0        2.882484   -0.260398   -0.675385
+     11          1           0        1.696607   -0.085592   -1.975552
+     12          6           0       -1.685317   -0.941278   -0.626896
+     13          8           0       -2.314840   -0.130678    0.294451
+     14          1           0       -1.813799   -0.659102   -1.675360
+     15          1           0       -0.322069   -0.724037   -0.403825
+     16          1           0       -1.880759   -1.989716   -0.415857
+     17          1           0       -2.199655    0.792083    0.037701
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.7334119           1.8208187           1.4797608
+ Leave Link  202 at Tue Jul  7 12:15:59 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: 6-311G(2d,d,p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   193 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   186 symmetry adapted basis functions of A   symmetry.
+   186 basis functions,   304 primitive gaussians,   193 cartesian basis functions
+    28 alpha electrons       27 beta electrons
+       nuclear repulsion energy       293.3190927160 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   17 NActive=   17 NUniq=   17 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Jul  7 12:16:00 2020, MaxMem= 39321600000 cpu:               1.9 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   186 RedAO= T EigKep=  1.31D-03  NBF=   186
+ NBsUse=   186 1.00D-06 EigRej= -1.00D+00 NBFU=   186
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   193   193   193   193   193 MxSgAt=    17 MxSgA2=    17.
+ Leave Link  302 at Tue Jul  7 12:16:00 2020, MaxMem= 39321600000 cpu:               6.2 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Jul  7 12:16:00 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ Initial guess from the checkpoint file:  "0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    0.993023   -0.025467   -0.001907   -0.115119 Ang= -13.54 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7580 S= 0.5040
+ Generating alternative initial guess.
+ ExpMin= 1.03D-01 ExpMax= 8.59D+03 ExpMxC= 1.30D+03 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -326.566167148464    
+ Leave Link  401 at Tue Jul  7 12:16:01 2020, MaxMem= 39321600000 cpu:              29.0 elap:               0.8
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 39321600000 LenX= 39321515670 LenY= 39321477980
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 970000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -326.462119031531    
+ DIIS: error= 1.30D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.462119031531     IErMin= 1 ErrMin= 1.30D-02
+ ErrMax= 1.30D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.62D-01 BMatP= 1.62D-01
+ IDIUse=3 WtCom= 8.70D-01 WtEn= 1.30D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Recover alternate guess density for next cycle.
+ RMSDP=2.63D-03 MaxDP=9.32D-02              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  2.60D-03    CP:  9.75D-01
+ E= -326.297982974551     Delta-E=        0.164136056981 Rises=F Damp=F
+ Switch densities from cycles 1 and 2 for lowest energy.
+ DIIS: error= 2.80D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -326.462119031531     IErMin= 1 ErrMin= 1.30D-02
+ ErrMax= 2.80D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.05D+00 BMatP= 1.62D-01
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.870D+00 0.130D+00
+ Coeff:      0.870D+00 0.130D+00
+ Gap=     0.221 Goal=   None    Shift=    0.000
+ Gap=     0.207 Goal=   None    Shift=    0.000
+ RMSDP=1.39D-03 MaxDP=3.33D-02 DE= 1.64D-01 OVMax= 9.00D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  1.30D-03    CP:  9.94D-01  1.86D-01
+ E= -326.516765209441     Delta-E=       -0.218782234890 Rises=F Damp=F
+ DIIS: error= 7.46D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.516765209441     IErMin= 3 ErrMin= 7.46D-03
+ ErrMax= 7.46D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.20D-02 BMatP= 1.62D-01
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.577D-02 0.134D+00 0.860D+00
+ Coeff:      0.577D-02 0.134D+00 0.860D+00
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ Gap=     0.214 Goal=   None    Shift=    0.000
+ RMSDP=4.80D-04 MaxDP=1.43D-02 DE=-2.19D-01 OVMax= 2.18D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  3.01D-04    CP:  9.89D-01  3.14D-01  8.73D-01
+ E= -326.521372182060     Delta-E=       -0.004606972620 Rises=F Damp=F
+ DIIS: error= 4.55D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.521372182060     IErMin= 4 ErrMin= 4.55D-03
+ ErrMax= 4.55D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.07D-02 BMatP= 3.20D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.242D-01 0.599D-01 0.499D+00 0.466D+00
+ Coeff:     -0.242D-01 0.599D-01 0.499D+00 0.466D+00
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ RMSDP=2.23D-04 MaxDP=6.27D-03 DE=-4.61D-03 OVMax= 1.79D-02
+
+ Cycle   5  Pass 0  IDiag  1:
+ RMSU=  1.36D-04    CP:  9.91D-01  3.04D-01  9.22D-01  4.67D-01
+ E= -326.523151649430     Delta-E=       -0.001779467370 Rises=F Damp=F
+ DIIS: error= 1.73D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.523151649430     IErMin= 5 ErrMin= 1.73D-03
+ ErrMax= 1.73D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.28D-03 BMatP= 1.07D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.125D-01 0.178D-01 0.185D+00 0.290D+00 0.519D+00
+ Coeff:     -0.125D-01 0.178D-01 0.185D+00 0.290D+00 0.519D+00
+ Gap=     0.207 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=9.71D-05 MaxDP=3.80D-03 DE=-1.78D-03 OVMax= 7.28D-03
+
+ Cycle   6  Pass 0  IDiag  1:
+ RMSU=  6.80D-05    CP:  9.90D-01  3.12D-01  9.20D-01  5.47D-01  5.56D-01
+ E= -326.523390029114     Delta-E=       -0.000238379684 Rises=F Damp=F
+ DIIS: error= 7.29D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.523390029114     IErMin= 6 ErrMin= 7.29D-04
+ ErrMax= 7.29D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.16D-04 BMatP= 1.28D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.409D-02 0.190D-02 0.497D-01 0.130D+00 0.366D+00 0.457D+00
+ Coeff:     -0.409D-02 0.190D-02 0.497D-01 0.130D+00 0.366D+00 0.457D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=3.79D-05 MaxDP=1.07D-03 DE=-2.38D-04 OVMax= 2.83D-03
+
+ Cycle   7  Pass 0  IDiag  1:
+ RMSU=  2.06D-05    CP:  9.90D-01  3.08D-01  9.22D-01  5.75D-01  6.62D-01
+                    CP:  6.35D-01
+ E= -326.523454194923     Delta-E=       -0.000064165808 Rises=F Damp=F
+ DIIS: error= 1.69D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.523454194923     IErMin= 7 ErrMin= 1.69D-04
+ ErrMax= 1.69D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.62D-05 BMatP= 3.16D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.568D-03-0.153D-02-0.158D-02 0.257D-01 0.119D+00 0.231D+00
+ Coeff-Com:  0.628D+00
+ Coeff:     -0.568D-03-0.153D-02-0.158D-02 0.257D-01 0.119D+00 0.231D+00
+ Coeff:      0.628D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-05 MaxDP=4.05D-04 DE=-6.42D-05 OVMax= 6.92D-04
+
+ Cycle   8  Pass 0  IDiag  1:
+ RMSU=  8.76D-06    CP:  9.90D-01  3.08D-01  9.22D-01  5.82D-01  6.85D-01
+                    CP:  6.75D-01  8.56D-01
+ E= -326.523457588557     Delta-E=       -0.000003393634 Rises=F Damp=F
+ DIIS: error= 5.05D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.523457588557     IErMin= 8 ErrMin= 5.05D-05
+ ErrMax= 5.05D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.99D-06 BMatP= 1.62D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.369D-03-0.939D-03-0.893D-02-0.104D-01-0.813D-02 0.258D-01
+ Coeff-Com:  0.279D+00 0.724D+00
+ Coeff:      0.369D-03-0.939D-03-0.893D-02-0.104D-01-0.813D-02 0.258D-01
+ Coeff:      0.279D+00 0.724D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=4.56D-06 MaxDP=1.76D-04 DE=-3.39D-06 OVMax= 2.93D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   9  Pass 1  IDiag  1:
+ E= -326.523446752973     Delta-E=        0.000010835584 Rises=F Damp=F
+ DIIS: error= 1.41D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.523446752973     IErMin= 1 ErrMin= 1.41D-05
+ ErrMax= 1.41D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.85D-07 BMatP= 1.85D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=4.56D-06 MaxDP=1.76D-04 DE= 1.08D-05 OVMax= 1.38D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  2.31D-06    CP:  1.00D+00
+ E= -326.523446780338     Delta-E=       -0.000000027364 Rises=F Damp=F
+ DIIS: error= 1.95D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -326.523446780338     IErMin= 1 ErrMin= 1.41D-05
+ ErrMax= 1.95D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.16D-07 BMatP= 1.85D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.523D+00 0.477D+00
+ Coeff:      0.523D+00 0.477D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-06 MaxDP=4.70D-05 DE=-2.74D-08 OVMax= 9.60D-05
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  1.02D-06    CP:  1.00D+00  7.96D-01
+ E= -326.523446831656     Delta-E=       -0.000000051319 Rises=F Damp=F
+ DIIS: error= 5.00D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.523446831656     IErMin= 3 ErrMin= 5.00D-06
+ ErrMax= 5.00D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.60D-08 BMatP= 1.85D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.460D-03 0.156D+00 0.844D+00
+ Coeff:      0.460D-03 0.156D+00 0.844D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=4.80D-07 MaxDP=1.03D-05 DE=-5.13D-08 OVMax= 4.00D-05
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  4.31D-07    CP:  1.00D+00  8.86D-01  9.59D-01
+ E= -326.523446838993     Delta-E=       -0.000000007337 Rises=F Damp=F
+ DIIS: error= 3.69D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.523446838993     IErMin= 4 ErrMin= 3.69D-06
+ ErrMax= 3.69D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.23D-09 BMatP= 1.60D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.143D+00-0.446D-01 0.450D+00 0.738D+00
+ Coeff:     -0.143D+00-0.446D-01 0.450D+00 0.738D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=3.19D-07 MaxDP=9.36D-06 DE=-7.34D-09 OVMax= 2.96D-05
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  2.17D-07    CP:  1.00D+00  9.49D-01  1.13D+00  1.04D+00
+ E= -326.523446842006     Delta-E=       -0.000000003012 Rises=F Damp=F
+ DIIS: error= 1.83D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.523446842006     IErMin= 5 ErrMin= 1.83D-06
+ ErrMax= 1.83D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.54D-09 BMatP= 6.23D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.745D-01-0.604D-01 0.330D-01 0.388D+00 0.714D+00
+ Coeff:     -0.745D-01-0.604D-01 0.330D-01 0.388D+00 0.714D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.44D-07 MaxDP=5.25D-06 DE=-3.01D-09 OVMax= 1.93D-05
+
+ Cycle  14  Pass 1  IDiag  1:
+ RMSU=  9.81D-08    CP:  1.00D+00  9.68D-01  1.18D+00  1.23D+00  1.09D+00
+ E= -326.523446842775     Delta-E=       -0.000000000769 Rises=F Damp=F
+ DIIS: error= 1.28D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.523446842775     IErMin= 6 ErrMin= 1.28D-06
+ ErrMax= 1.28D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.21D-10 BMatP= 1.54D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.124D-01-0.223D-01-0.726D-01 0.631D-01 0.382D+00 0.662D+00
+ Coeff:     -0.124D-01-0.223D-01-0.726D-01 0.631D-01 0.382D+00 0.662D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=9.08D-08 MaxDP=3.58D-06 DE=-7.69D-10 OVMax= 1.22D-05
+
+ Cycle  15  Pass 1  IDiag  1:
+ RMSU=  6.58D-08    CP:  1.00D+00  9.65D-01  1.19D+00  1.35D+00  1.24D+00
+                    CP:  9.42D-01
+ E= -326.523446842944     Delta-E=       -0.000000000170 Rises=F Damp=F
+ DIIS: error= 9.88D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.523446842944     IErMin= 7 ErrMin= 9.88D-07
+ ErrMax= 9.88D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.86D-10 BMatP= 4.21D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.230D-01 0.867D-02-0.753D-01-0.123D+00 0.240D-03 0.561D+00
+ Coeff-Com:  0.605D+00
+ Coeff:      0.230D-01 0.867D-02-0.753D-01-0.123D+00 0.240D-03 0.561D+00
+ Coeff:      0.605D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=5.80D-08 MaxDP=2.36D-06 DE=-1.70D-10 OVMax= 8.84D-06
+
+ Cycle  16  Pass 1  IDiag  1:
+ RMSU=  3.96D-08    CP:  1.00D+00  9.68D-01  1.18D+00  1.39D+00  1.33D+00
+                    CP:  1.22D+00  8.55D-01
+ E= -326.523446843053     Delta-E=       -0.000000000108 Rises=F Damp=F
+ DIIS: error= 3.91D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.523446843053     IErMin= 8 ErrMin= 3.91D-07
+ ErrMax= 3.91D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.00D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.178D-01 0.116D-01-0.279D-01-0.953D-01-0.997D-01 0.163D+00
+ Coeff-Com:  0.383D+00 0.647D+00
+ Coeff:      0.178D-01 0.116D-01-0.279D-01-0.953D-01-0.997D-01 0.163D+00
+ Coeff:      0.383D+00 0.647D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=2.50D-08 MaxDP=1.00D-06 DE=-1.08D-10 OVMax= 3.58D-06
+
+ Cycle  17  Pass 1  IDiag  1:
+ RMSU=  1.53D-08    CP:  1.00D+00  9.69D-01  1.19D+00  1.41D+00  1.38D+00
+                    CP:  1.34D+00  9.94D-01  9.60D-01
+ E= -326.523446843073     Delta-E=       -0.000000000021 Rises=F Damp=F
+ DIIS: error= 1.06D-07 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -326.523446843073     IErMin= 9 ErrMin= 1.06D-07
+ ErrMax= 1.06D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.95D-12 BMatP= 5.00D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.153D-02 0.299D-02 0.879D-02-0.998D-02-0.446D-01-0.807D-01
+ Coeff-Com:  0.109D-01 0.291D+00 0.820D+00
+ Coeff:      0.153D-02 0.299D-02 0.879D-02-0.998D-02-0.446D-01-0.807D-01
+ Coeff:      0.109D-01 0.291D+00 0.820D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=1.24D-08 MaxDP=4.57D-07 DE=-2.07D-11 OVMax= 1.33D-06
+
+ Cycle  18  Pass 1  IDiag  1:
+ RMSU=  5.07D-09    CP:  1.00D+00  9.69D-01  1.19D+00  1.42D+00  1.39D+00
+                    CP:  1.39D+00  1.08D+00  1.13D+00  9.80D-01
+ E= -326.523446843077     Delta-E=       -0.000000000004 Rises=F Damp=F
+ DIIS: error= 3.84D-08 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -326.523446843077     IErMin=10 ErrMin= 3.84D-08
+ ErrMax= 3.84D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.58D-13 BMatP= 5.95D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.112D-02 0.933D-04 0.663D-02 0.540D-02-0.935D-02-0.515D-01
+ Coeff-Com: -0.351D-01 0.609D-01 0.358D+00 0.666D+00
+ Coeff:     -0.112D-02 0.933D-04 0.663D-02 0.540D-02-0.935D-02-0.515D-01
+ Coeff:     -0.351D-01 0.609D-01 0.358D+00 0.666D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.210 Goal=   None    Shift=    0.000
+ RMSDP=2.46D-09 MaxDP=1.46D-07 DE=-3.75D-12 OVMax= 2.17D-07
+
+ SCF Done:  E(UB3LYP) =  -326.523446843     A.U. after   18 cycles
+            NFock= 18  Conv=0.25D-08     -V/T= 2.0039
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5037
+ <L.S>=  0.00000000000    
+ KE= 3.252468525956D+02 PE=-1.347646536191D+03 EE= 4.025571440367D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7575,   after     0.7500
+ Leave Link  502 at Tue Jul  7 12:16:06 2020, MaxMem= 39321600000 cpu:             196.7 elap:               5.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Tue Jul  7 12:16:06 2020, MaxMem= 39321600000 cpu:               0.1 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   186
+ NBasis=   186 NAE=    28 NBE=    27 NFC=     0 NFV=     0
+ NROrb=    186 NOA=    28 NOB=    27 NVA=   158 NVB=   159
+
+ **** Warning!!: The largest alpha MO coefficient is  0.10283923D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.10760876D+02
+
+ Leave Link  801 at Tue Jul  7 12:16:06 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    17.
+ Will process     18 centers per pass.
+ Leave Link 1101 at Tue Jul  7 12:16:07 2020, MaxMem= 39321600000 cpu:              61.3 elap:               1.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Tue Jul  7 12:16:07 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    17.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   39321598504.
+ G2DrvN: will do    18 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Tue Jul  7 12:16:15 2020, MaxMem= 39321600000 cpu:             295.5 elap:               7.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=11111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         5053 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=343229615.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  17391 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   39321600000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    54 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     51 vectors produced by pass  0 Test12= 1.61D-14 1.85D-09 XBig12= 1.49D+02 7.35D+00.
+ AX will form    51 AO Fock derivatives at one time.
+     51 vectors produced by pass  1 Test12= 1.61D-14 1.85D-09 XBig12= 3.60D+01 9.13D-01.
+     51 vectors produced by pass  2 Test12= 1.61D-14 1.85D-09 XBig12= 9.55D-01 1.02D-01.
+     51 vectors produced by pass  3 Test12= 1.61D-14 1.85D-09 XBig12= 6.31D-03 1.24D-02.
+     51 vectors produced by pass  4 Test12= 1.61D-14 1.85D-09 XBig12= 4.90D-05 8.02D-04.
+     51 vectors produced by pass  5 Test12= 1.61D-14 1.85D-09 XBig12= 1.91D-07 4.15D-05.
+     28 vectors produced by pass  6 Test12= 1.61D-14 1.85D-09 XBig12= 4.65D-10 1.73D-06.
+      5 vectors produced by pass  7 Test12= 1.61D-14 1.85D-09 XBig12= 1.73D-12 1.18D-07.
+      2 vectors produced by pass  8 Test12= 1.61D-14 1.85D-09 XBig12= 6.39D-15 8.94D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 3.55D-15
+ Solved reduced A of dimension   341 with    54 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       73.50 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Tue Jul  7 12:16:27 2020, MaxMem= 39321600000 cpu:             499.7 elap:              12.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ Leave Link  701 at Tue Jul  7 12:16:27 2020, MaxMem= 39321600000 cpu:               6.1 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Jul  7 12:16:28 2020, MaxMem= 39321600000 cpu:               0.6 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:             454.6 elap:              11.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        = 3.85665452D-01-1.27309224D+00-4.22225647D-01
+ Polarizability= 8.40919206D+01 7.52335051D-01 7.64759606D+01
+                 3.37733000D+00 1.33373696D+00 5.99185733D+01
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000046186   -0.000692850    0.000106472
+      2        6          -0.000840159    0.001928952   -0.000383435
+      3        6           0.000955646    0.001313360    0.000362052
+      4        6          -0.000358078   -0.000328216    0.000524236
+      5        6          -0.000629696   -0.000724708   -0.000527079
+      6        1          -0.000096949    0.000209965   -0.000136762
+      7        1           0.000271936   -0.000053785    0.000068422
+      8        1          -0.000109155   -0.000134644    0.000100110
+      9        1          -0.000053163    0.000235060    0.000238403
+     10        1          -0.000105934   -0.000134156   -0.000102378
+     11        1           0.000241827    0.000082706   -0.000262720
+     12        6          -0.000197039   -0.001092904   -0.000107126
+     13        8           0.002268959   -0.000390278    0.000394870
+     14        1           0.000233682    0.000214665   -0.000216079
+     15        1          -0.000720092   -0.000328516   -0.000411772
+     16        1           0.000172401   -0.000077347    0.000465307
+     17        1          -0.000988000   -0.000027304   -0.000112521
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.002268959 RMS     0.000609015
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Leave Link  716 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               0.8 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.001994336 RMS     0.000551737
+ Search for a saddle point.
+ Step number   2 out of a maximum of  102
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Swapping is turned off.
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0  0
+     Eigenvalues ---   -0.05192   0.00154   0.00178   0.00216   0.00776
+     Eigenvalues ---    0.02336   0.02391   0.03259   0.03395   0.04252
+     Eigenvalues ---    0.04455   0.04531   0.04546   0.04570   0.04922
+     Eigenvalues ---    0.05164   0.06381   0.07190   0.08474   0.09356
+     Eigenvalues ---    0.10174   0.10731   0.11969   0.12340   0.14288
+     Eigenvalues ---    0.14515   0.14909   0.15315   0.16339   0.17310
+     Eigenvalues ---    0.17954   0.28580   0.28989   0.32683   0.32825
+     Eigenvalues ---    0.32954   0.33387   0.33503   0.34212   0.34333
+     Eigenvalues ---    0.34667   0.35008   0.41577   0.51969   1.18925
+ Eigenvectors required to have negative eigenvalues:
+                          R14       R5        D28       A20       D2
+   1                    0.72667  -0.61740   0.10368  -0.10106   0.06235
+                          D30       D13       D12       A23       D4
+   1                   -0.06189   0.06120  -0.06119   0.06004  -0.05858
+ RFO step:  Lambda0=1.963263216D-06 Lambda=-4.17044678D-04.
+ Linear search not attempted -- option 19 set.
+ Iteration  1 RMS(Cart)=  0.03689874 RMS(Int)=  0.00097851
+ Iteration  2 RMS(Cart)=  0.00106752 RMS(Int)=  0.00002791
+ Iteration  3 RMS(Cart)=  0.00000092 RMS(Int)=  0.00002790
+ ITry= 1 IFail=0 DXMaxC= 1.50D-01 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.19051   0.00058   0.00000   0.00040   0.00040   2.19090
+    R2        2.71268  -0.00030   0.00000   0.00098   0.00098   2.71365
+    R3        2.88041   0.00026   0.00000  -0.00031  -0.00031   2.88010
+    R4        2.87874   0.00023   0.00000  -0.00043  -0.00043   2.87831
+    R5        2.52257   0.00167   0.00000   0.01547   0.01547   2.53804
+    R6        2.06594  -0.00001   0.00000  -0.00014  -0.00014   2.06580
+    R7        2.06207   0.00012   0.00000   0.00081   0.00081   2.06288
+    R8        2.07011   0.00003   0.00000   0.00010   0.00010   2.07020
+    R9        2.06633   0.00004   0.00000  -0.00015  -0.00015   2.06618
+   R10        2.07073  -0.00003   0.00000   0.00012   0.00012   2.07086
+   R11        2.06289   0.00013   0.00000   0.00061   0.00061   2.06350
+   R12        2.60635   0.00003   0.00000   0.00044   0.00044   2.60679
+   R13        2.06613   0.00010   0.00000   0.00108   0.00108   2.06720
+   R14        2.64251   0.00199   0.00000   0.00020   0.00020   2.64271
+   R15        2.05447   0.00023   0.00000   0.00095   0.00095   2.05542
+   R16        1.82305   0.00089   0.00000   0.00207   0.00207   1.82511
+    A1        1.99555  -0.00032   0.00000  -0.00525  -0.00527   1.99028
+    A2        2.01116  -0.00069   0.00000  -0.00809  -0.00803   2.00313
+    A3        1.73483   0.00046   0.00000  -0.00391  -0.00389   1.73094
+    A4        2.01086   0.00087   0.00000   0.00867   0.00862   2.01948
+    A5        1.80964   0.00003   0.00000   0.00801   0.00797   1.81760
+    A6        1.85899  -0.00033   0.00000   0.00148   0.00140   1.86038
+    A7        1.91726  -0.00013   0.00000  -0.00027  -0.00027   1.91699
+    A8        1.93838   0.00011   0.00000  -0.00132  -0.00132   1.93706
+    A9        1.94205  -0.00001   0.00000   0.00133   0.00133   1.94338
+   A10        1.89111   0.00004   0.00000   0.00092   0.00092   1.89203
+   A11        1.88337   0.00001   0.00000   0.00042   0.00041   1.88378
+   A12        1.89003  -0.00001   0.00000  -0.00105  -0.00105   1.88898
+   A13        1.91943  -0.00015   0.00000  -0.00129  -0.00129   1.91814
+   A14        1.93953  -0.00002   0.00000   0.00106   0.00106   1.94059
+   A15        1.94759   0.00034   0.00000   0.00066   0.00066   1.94825
+   A16        1.88051  -0.00001   0.00000  -0.00041  -0.00041   1.88010
+   A17        1.89169  -0.00006   0.00000   0.00067   0.00067   1.89236
+   A18        1.88302  -0.00010   0.00000  -0.00071  -0.00071   1.88231
+   A19        2.02114  -0.00019   0.00000   0.00205   0.00210   2.02324
+   A20        1.82049   0.00192   0.00000   0.01624   0.01626   1.83675
+   A21        1.93377  -0.00117   0.00000  -0.00673  -0.00670   1.92707
+   A22        1.80025  -0.00054   0.00000  -0.00464  -0.00470   1.79554
+   A23        1.99754   0.00037   0.00000  -0.00258  -0.00267   1.99487
+   A24        1.86932  -0.00014   0.00000  -0.00230  -0.00232   1.86700
+   A25        1.90697  -0.00006   0.00000  -0.00163  -0.00163   1.90534
+   A26        3.04827  -0.00087   0.00000  -0.01020  -0.01020   3.03807
+   A27        3.22879  -0.00063   0.00000   0.00081   0.00079   3.22958
+   A28        3.10097  -0.00003   0.00000   0.00346   0.00346   3.10443
+   A29        2.77440   0.00186   0.00000   0.02833   0.02836   2.80276
+    D1        2.90983   0.00050   0.00000   0.05998   0.05996   2.96979
+    D2        0.81803   0.00047   0.00000   0.05984   0.05982   0.87786
+    D3       -1.28888   0.00042   0.00000   0.06117   0.06115  -1.22773
+    D4       -0.98413   0.00004   0.00000   0.05093   0.05091  -0.93321
+    D5       -3.07592   0.00001   0.00000   0.05079   0.05078  -3.02515
+    D6        1.10035  -0.00005   0.00000   0.05212   0.05210   1.15245
+    D7        1.04001   0.00008   0.00000   0.06221   0.06224   1.10225
+    D8       -1.05178   0.00005   0.00000   0.06207   0.06210  -0.98968
+    D9        3.12449  -0.00000   0.00000   0.06340   0.06343  -3.09527
+   D10       -2.83987  -0.00034   0.00000  -0.07691  -0.07693  -2.91680
+   D11        1.36258  -0.00021   0.00000  -0.07623  -0.07625   1.28633
+   D12       -0.73998  -0.00030   0.00000  -0.07651  -0.07653  -0.81650
+   D13        1.06087  -0.00003   0.00000  -0.06910  -0.06909   0.99179
+   D14       -1.01985   0.00009   0.00000  -0.06842  -0.06841  -1.08827
+   D15       -3.12242   0.00001   0.00000  -0.06870  -0.06869   3.09208
+   D16       -0.93492  -0.00031   0.00000  -0.08458  -0.08458  -1.01949
+   D17       -3.01565  -0.00019   0.00000  -0.08391  -0.08390  -3.09955
+   D18        1.16498  -0.00027   0.00000  -0.08418  -0.08417   1.08080
+   D19       -0.80284  -0.00044   0.00000   0.00296   0.00294  -0.79990
+   D20        1.26993   0.00019   0.00000   0.01382   0.01373   1.28366
+   D21       -2.81895  -0.00028   0.00000  -0.00147  -0.00148  -2.82043
+   D22        1.21089  -0.00045   0.00000   0.00101   0.00103   1.21193
+   D23       -2.99953   0.00018   0.00000   0.01187   0.01183  -2.98770
+   D24       -0.80522  -0.00029   0.00000  -0.00343  -0.00338  -0.80860
+   D25       -2.87407  -0.00005   0.00000   0.01159   0.01163  -2.86244
+   D26       -0.80130   0.00058   0.00000   0.02244   0.02243  -0.77888
+   D27        1.39301   0.00012   0.00000   0.00715   0.00721   1.40022
+   D28       -0.73298  -0.00068   0.00000  -0.04866  -0.04869  -0.78166
+   D29        1.23195  -0.00021   0.00000  -0.04306  -0.04302   1.18893
+   D30       -3.04530   0.00012   0.00000  -0.04009  -0.04011  -3.08541
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001994     0.000450     NO 
+ RMS     Force            0.000552     0.000300     NO 
+ Maximum Displacement     0.150216     0.001800     NO 
+ RMS     Displacement     0.036918     0.001200     NO 
+ Predicted change in Energy=-2.267645D-04
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               1.1 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.213451   -1.556968    0.100076
+      2          6           0       -1.498035   -0.645753    0.055125
+      3          6           0       -0.494362    0.378822   -0.015544
+      4          6           0       -0.214216    1.066217    1.315558
+      5          6           0       -0.606053    1.299339   -1.223898
+      6          1           0        0.670510    1.702006    1.225745
+      7          1           0       -0.033154    0.332971    2.103733
+      8          1           0       -1.054407    1.698744    1.622346
+      9          1           0        0.307381    1.891452   -1.326406
+     10          1           0       -1.444775    1.996138   -1.114796
+     11          1           0       -0.757224    0.735510   -2.146730
+     12          6           0        1.489355   -1.460227   -0.216118
+     13          8           0        1.058745   -2.296398    0.792987
+     14          1           0        1.404908   -1.854843   -1.232879
+     15          1           0        0.585594   -0.393037   -0.219931
+     16          1           0        2.466685   -1.047736    0.024140
+     17          1           0        0.214794   -2.691414    0.539030
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.159376   0.000000
+     3  C    2.591509   1.436004   0.000000
+     4  C    3.515030   2.483490   1.524083   0.000000
+     5  C    3.534845   2.492973   1.523137   2.580062   0.000000
+     6  H    4.495028   3.403661   2.156048   1.093176   2.791506
+     7  H    3.512863   2.701957   2.169367   1.091629   3.512152
+     8  H    3.776288   2.854760   2.176816   1.095504   2.908892
+     9  H    4.503448   3.406694   2.156201   2.816568   1.093374
+    10  H    3.832928   2.889834   2.174248   2.878481   1.095850
+    11  H    3.524796   2.702749   2.176758   3.520180   1.091959
+    12  C    3.717541   3.108285   2.712465   3.410441   3.608540
+    13  O    3.425515   3.131484   3.197291   3.633276   4.446201
+    14  H    3.867560   3.398224   3.174648   4.201034   3.740710
+    15  H    3.048244   2.116844   1.343073   2.264254   2.300459
+    16  H    4.708371   3.985167   3.287011   3.650177   4.063014
+    17  H    2.715883   2.711582   3.199501   3.860938   4.439349
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.772079   0.000000
+     8  H    1.769926   1.772012   0.000000
+     9  H    2.584808   3.782947   3.253728   0.000000
+    10  H    3.168451   3.888153   2.780788   1.767990   0.000000
+    11  H    3.787629   4.330445   3.901548   1.772715   1.768276
+    12  C    3.570602   3.303832   4.453063   3.723380   4.622035
+    13  O    4.040451   3.134307   4.595042   4.753364   5.322887
+    14  H    4.385812   4.241171   5.179625   3.904874   4.792149
+    15  H    2.546841   2.511842   3.234058   2.553543   3.260574
+    16  H    3.497311   3.532741   4.742942   3.889139   5.085457
+    17  H    4.470056   3.414188   4.696587   4.948848   5.240464
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.687227   0.000000
+    13  O    4.596971   1.379456   0.000000
+    14  H    3.495692   1.093917   2.102126   0.000000
+    15  H    2.605635   1.398461   2.207409   1.958115   0.000000
+    16  H    4.276241   1.087680   2.032875   1.832727   2.006665
+    17  H    4.461158   1.926286   0.965809   2.292571   2.448683
+                   16         17
+    16  H    0.000000
+    17  H    2.835103   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ RotChk:  IX=0 Diff= 2.94D-02
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.071395    2.285829   -0.036529
+      2          6           0        0.474482    1.199594    0.005518
+      3          6           0        0.828196   -0.192107    0.018295
+      4          6           0        1.036284   -0.766909    1.414408
+      5          6           0        1.862342   -0.597335   -1.023951
+      6          1           0        1.128252   -1.854736    1.357763
+      7          1           0        0.194343   -0.525652    2.066009
+      8          1           0        1.949563   -0.374719    1.875098
+      9          1           0        1.904955   -1.687095   -1.101884
+     10          1           0        2.862139   -0.243270   -0.748393
+     11          1           0        1.622577   -0.190056   -2.008335
+     12          6           0       -1.706531   -0.928959   -0.605943
+     13          8           0       -2.356197   -0.108444    0.292717
+     14          1           0       -1.822865   -0.668432   -1.661996
+     15          1           0       -0.343152   -0.714456   -0.380377
+     16          1           0       -1.905487   -1.973747   -0.378167
+     17          1           0       -2.209150    0.813210    0.044288
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.7250465           1.7916286           1.4625067
+ Leave Link  202 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: 6-311G(2d,d,p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   193 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   186 symmetry adapted basis functions of A   symmetry.
+   186 basis functions,   304 primitive gaussians,   193 cartesian basis functions
+    28 alpha electrons       27 beta electrons
+       nuclear repulsion energy       292.4313834318 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   17 NActive=   17 NUniq=   17 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               1.9 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   186 RedAO= T EigKep=  1.33D-03  NBF=   186
+ NBsUse=   186 1.00D-06 EigRej= -1.00D+00 NBFU=   186
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   193   193   193   193   193 MxSgAt=    17 MxSgA2=    17.
+ Leave Link  302 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               6.3 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Jul  7 12:16:39 2020, MaxMem= 39321600000 cpu:               1.1 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ Initial guess from the checkpoint file:  "0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk"
+ B after Tr=     0.000000   -0.000000    0.000000
+         Rot=    0.999959    0.006326   -0.003115    0.005662 Ang=   1.04 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5037
+ Generating alternative initial guess.
+ ExpMin= 1.03D-01 ExpMax= 8.59D+03 ExpMxC= 1.30D+03 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -326.566396100759    
+ Leave Link  401 at Tue Jul  7 12:16:40 2020, MaxMem= 39321600000 cpu:              13.3 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 39321600000 LenX= 39321515670 LenY= 39321477980
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 970000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -326.521441276757    
+ DIIS: error= 3.03D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.521441276757     IErMin= 1 ErrMin= 3.03D-03
+ ErrMax= 3.03D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.35D-03 BMatP= 5.35D-03
+ IDIUse=3 WtCom= 9.70D-01 WtEn= 3.03D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.494 Goal=   None    Shift=    0.000
+ Gap=     0.612 Goal=   None    Shift=    0.000
+ GapD=    0.494 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.38D-04 MaxDP=4.44D-03              OVMax= 1.49D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  2.38D-04    CP:  1.00D+00
+ E= -326.523656881944     Delta-E=       -0.002215605187 Rises=F Damp=F
+ DIIS: error= 3.50D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -326.523656881944     IErMin= 2 ErrMin= 3.50D-04
+ ErrMax= 3.50D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.11D-05 BMatP= 5.35D-03
+ IDIUse=3 WtCom= 9.96D-01 WtEn= 3.50D-03
+ Coeff-Com: -0.697D-01 0.107D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.695D-01 0.107D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=4.05D-05 MaxDP=7.24D-04 DE=-2.22D-03 OVMax= 2.71D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  3.24D-05    CP:  9.99D-01  1.10D+00
+ E= -326.523675483843     Delta-E=       -0.000018601899 Rises=F Damp=F
+ DIIS: error= 2.65D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.523675483843     IErMin= 3 ErrMin= 2.65D-04
+ ErrMax= 2.65D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.71D-05 BMatP= 7.11D-05
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 2.65D-03
+ Coeff-Com: -0.418D-01 0.565D+00 0.477D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.417D-01 0.564D+00 0.478D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ RMSDP=1.88D-05 MaxDP=6.65D-04 DE=-1.86D-05 OVMax= 1.55D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  1.57D-05    CP:  9.99D-01  1.11D+00  6.95D-01
+ E= -326.523683143575     Delta-E=       -0.000007659732 Rises=F Damp=F
+ DIIS: error= 1.83D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.523683143575     IErMin= 4 ErrMin= 1.83D-04
+ ErrMax= 1.83D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.64D-05 BMatP= 5.71D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.83D-03
+ Coeff-Com: -0.136D-01 0.167D+00 0.339D+00 0.508D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.272D+00 0.728D+00
+ Coeff:     -0.136D-01 0.167D+00 0.339D+00 0.508D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=9.36D-06 MaxDP=3.69D-04 DE=-7.66D-06 OVMax= 7.70D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   5  Pass 1  IDiag  1:
+ E= -326.523676583630     Delta-E=        0.000006559945 Rises=F Damp=F
+ DIIS: error= 6.48D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.523676583630     IErMin= 1 ErrMin= 6.48D-05
+ ErrMax= 6.48D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.48D-06 BMatP= 2.48D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=9.36D-06 MaxDP=3.69D-04 DE= 6.56D-06 OVMax= 7.17D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ RMSU=  9.50D-06    CP:  1.00D+00
+ E= -326.523674242336     Delta-E=        0.000002341294 Rises=F Damp=F
+ DIIS: error= 1.63D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -326.523676583630     IErMin= 1 ErrMin= 6.48D-05
+ ErrMax= 1.63D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.36D-05 BMatP= 2.48D-06
+ IDIUse=3 WtCom= 4.39D-01 WtEn= 5.61D-01
+ Coeff-Com:  0.704D+00 0.296D+00
+ Coeff-En:   0.787D+00 0.213D+00
+ Coeff:      0.750D+00 0.250D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=5.67D-06 MaxDP=2.00D-04 DE= 2.34D-06 OVMax= 4.81D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ RMSU=  1.54D-06    CP:  1.00D+00  4.28D-01
+ E= -326.523677071152     Delta-E=       -0.000002828816 Rises=F Damp=F
+ DIIS: error= 2.08D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.523677071152     IErMin= 3 ErrMin= 2.08D-05
+ ErrMax= 2.08D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.45D-07 BMatP= 2.48D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.412D+00 0.110D+00 0.478D+00
+ Coeff:      0.412D+00 0.110D+00 0.478D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-06 MaxDP=3.04D-05 DE=-2.83D-06 OVMax= 5.34D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ RMSU=  6.48D-07    CP:  1.00D+00  3.45D-01  8.92D-01
+ E= -326.523677141405     Delta-E=       -0.000000070253 Rises=F Damp=F
+ DIIS: error= 3.29D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.523677141405     IErMin= 4 ErrMin= 3.29D-06
+ ErrMax= 3.29D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.33D-09 BMatP= 3.45D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.496D-01-0.348D-01 0.102D+00 0.982D+00
+ Coeff:     -0.496D-01-0.348D-01 0.102D+00 0.982D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=3.23D-07 MaxDP=7.34D-06 DE=-7.03D-08 OVMax= 2.64D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ RMSU=  2.35D-07    CP:  1.00D+00  3.48D-01  1.03D+00  1.10D+00
+ E= -326.523677143171     Delta-E=       -0.000000001766 Rises=F Damp=F
+ DIIS: error= 2.05D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.523677143171     IErMin= 5 ErrMin= 2.05D-06
+ ErrMax= 2.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-09 BMatP= 5.33D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.816D-01-0.327D-01-0.123D-01 0.539D+00 0.588D+00
+ Coeff:     -0.816D-01-0.327D-01-0.123D-01 0.539D+00 0.588D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.52D-07 MaxDP=5.06D-06 DE=-1.77D-09 OVMax= 1.15D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  1.26D-07    CP:  1.00D+00  3.52D-01  1.06D+00  1.14D+00  8.14D-01
+ E= -326.523677143714     Delta-E=       -0.000000000543 Rises=F Damp=F
+ DIIS: error= 8.24D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.523677143714     IErMin= 6 ErrMin= 8.24D-07
+ ErrMax= 8.24D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.50D-10 BMatP= 2.10D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.324D-01-0.109D-01-0.204D-01 0.125D+00 0.292D+00 0.647D+00
+ Coeff:     -0.324D-01-0.109D-01-0.204D-01 0.125D+00 0.292D+00 0.647D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=4.38D-08 MaxDP=1.57D-06 DE=-5.43D-10 OVMax= 4.58D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  3.66D-08    CP:  1.00D+00  3.52D-01  1.07D+00  1.16D+00  8.86D-01
+                    CP:  9.33D-01
+ E= -326.523677143796     Delta-E=       -0.000000000082 Rises=F Damp=F
+ DIIS: error= 2.29D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.523677143796     IErMin= 7 ErrMin= 2.29D-07
+ ErrMax= 2.29D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.74D-11 BMatP= 2.50D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.432D-02 0.257D-02-0.533D-02-0.602D-01-0.126D-01 0.205D+00
+ Coeff-Com:  0.867D+00
+ Coeff:      0.432D-02 0.257D-02-0.533D-02-0.602D-01-0.126D-01 0.205D+00
+ Coeff:      0.867D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-08 MaxDP=9.14D-07 DE=-8.19D-11 OVMax= 2.31D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  1.86D-08    CP:  1.00D+00  3.52D-01  1.07D+00  1.16D+00  9.31D-01
+                    CP:  1.05D+00  9.39D-01
+ E= -326.523677143811     Delta-E=       -0.000000000015 Rises=F Damp=F
+ DIIS: error= 1.03D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.523677143811     IErMin= 8 ErrMin= 1.03D-07
+ ErrMax= 1.03D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.35D-12 BMatP= 2.74D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.753D-02 0.301D-02 0.143D-02-0.446D-01-0.568D-01-0.324D-01
+ Coeff-Com:  0.357D+00 0.765D+00
+ Coeff:      0.753D-02 0.301D-02 0.143D-02-0.446D-01-0.568D-01-0.324D-01
+ Coeff:      0.357D+00 0.765D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.11D-08 MaxDP=3.27D-07 DE=-1.50D-11 OVMax= 1.16D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  9.00D-09    CP:  1.00D+00  3.52D-01  1.07D+00  1.17D+00  9.38D-01
+                    CP:  1.06D+00  1.10D+00  1.08D+00
+ E= -326.523677143816     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 5.29D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -326.523677143816     IErMin= 9 ErrMin= 5.29D-08
+ ErrMax= 5.29D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.38D-12 BMatP= 7.35D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.226D-03-0.141D-03 0.189D-02 0.966D-02-0.884D-02-0.752D-01
+ Coeff-Com: -0.197D+00 0.174D+00 0.109D+01
+ Coeff:      0.226D-03-0.141D-03 0.189D-02 0.966D-02-0.884D-02-0.752D-01
+ Coeff:     -0.197D+00 0.174D+00 0.109D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=7.95D-09 MaxDP=2.97D-07 DE=-5.00D-12 OVMax= 9.81D-07
+
+ SCF Done:  E(UB3LYP) =  -326.523677144     A.U. after   13 cycles
+            NFock= 13  Conv=0.79D-08     -V/T= 2.0040
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5038
+ <L.S>=  0.00000000000    
+ KE= 3.252351875855D+02 PE=-1.345859469066D+03 EE= 4.016692209046D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7575,   after     0.7500
+ Leave Link  502 at Tue Jul  7 12:16:44 2020, MaxMem= 39321600000 cpu:             184.1 elap:               4.7
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Tue Jul  7 12:16:44 2020, MaxMem= 39321600000 cpu:               0.1 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   186
+ NBasis=   186 NAE=    28 NBE=    27 NFC=     0 NFV=     0
+ NROrb=    186 NOA=    28 NOB=    27 NVA=   158 NVB=   159
+
+ **** Warning!!: The largest alpha MO coefficient is  0.10463701D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.10904717D+02
+
+ Leave Link  801 at Tue Jul  7 12:16:45 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    17.
+ Will process     18 centers per pass.
+ Leave Link 1101 at Tue Jul  7 12:16:45 2020, MaxMem= 39321600000 cpu:               7.0 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Tue Jul  7 12:16:45 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    17.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   39321598504.
+ G2DrvN: will do    18 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Tue Jul  7 12:16:52 2020, MaxMem= 39321600000 cpu:             297.5 elap:               7.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=11111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         5053 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=343229615.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  17391 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   39321600000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    54 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     51 vectors produced by pass  0 Test12= 1.61D-14 1.85D-09 XBig12= 1.51D+02 7.53D+00.
+ AX will form    51 AO Fock derivatives at one time.
+     51 vectors produced by pass  1 Test12= 1.61D-14 1.85D-09 XBig12= 3.65D+01 9.52D-01.
+     51 vectors produced by pass  2 Test12= 1.61D-14 1.85D-09 XBig12= 9.93D-01 1.00D-01.
+     51 vectors produced by pass  3 Test12= 1.61D-14 1.85D-09 XBig12= 6.71D-03 1.30D-02.
+     51 vectors produced by pass  4 Test12= 1.61D-14 1.85D-09 XBig12= 5.40D-05 8.86D-04.
+     51 vectors produced by pass  5 Test12= 1.61D-14 1.85D-09 XBig12= 2.01D-07 4.41D-05.
+     28 vectors produced by pass  6 Test12= 1.61D-14 1.85D-09 XBig12= 4.93D-10 1.96D-06.
+      5 vectors produced by pass  7 Test12= 1.61D-14 1.85D-09 XBig12= 1.81D-12 1.28D-07.
+      2 vectors produced by pass  8 Test12= 1.61D-14 1.85D-09 XBig12= 6.74D-15 9.42D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 8.88D-15
+ Solved reduced A of dimension   341 with    54 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       73.74 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Tue Jul  7 12:17:04 2020, MaxMem= 39321600000 cpu:             464.2 elap:              11.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ Leave Link  701 at Tue Jul  7 12:17:04 2020, MaxMem= 39321600000 cpu:               6.6 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Jul  7 12:17:04 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:             451.6 elap:              11.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        = 3.91024850D-01-1.27938931D+00-3.98445237D-01
+ Polarizability= 8.47270362D+01 9.34288087D-01 7.64515392D+01
+                 3.28178042D+00 1.22144471D+00 6.00273446D+01
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000021072    0.000009988   -0.000005022
+      2        6          -0.000037725    0.000033628   -0.000003771
+      3        6          -0.000046330    0.000085729    0.000009144
+      4        6           0.000043865    0.000009062    0.000044812
+      5        6           0.000010252    0.000031006   -0.000050144
+      6        1          -0.000021532    0.000029969    0.000006130
+      7        1           0.000041301    0.000015857    0.000005223
+      8        1          -0.000003706   -0.000041269    0.000016676
+      9        1          -0.000025268    0.000037483   -0.000002895
+     10        1          -0.000012842   -0.000048433   -0.000036072
+     11        1           0.000051361    0.000008696   -0.000021652
+     12        6          -0.000017981    0.000034133   -0.000012713
+     13        8           0.000054730   -0.000055001   -0.000024961
+     14        1           0.000019083   -0.000002846    0.000001169
+     15        1          -0.000042170   -0.000160207    0.000057742
+     16        1           0.000005867    0.000009669   -0.000000781
+     17        1           0.000002165    0.000002537    0.000017116
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000160207 RMS     0.000038250
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Leave Link  716 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               0.8 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000235287 RMS     0.000045755
+ Search for a saddle point.
+ Step number   3 out of a maximum of  102
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Swapping is turned off.
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0  0  0
+     Eigenvalues ---   -0.05288   0.00139   0.00181   0.00216   0.00792
+     Eigenvalues ---    0.02098   0.02247   0.02912   0.03257   0.04209
+     Eigenvalues ---    0.04449   0.04532   0.04541   0.04564   0.04864
+     Eigenvalues ---    0.05050   0.06438   0.07167   0.08369   0.09450
+     Eigenvalues ---    0.10156   0.10590   0.11967   0.12329   0.13819
+     Eigenvalues ---    0.14498   0.14713   0.15305   0.15445   0.17112
+     Eigenvalues ---    0.17863   0.28568   0.28920   0.32680   0.32802
+     Eigenvalues ---    0.32826   0.33374   0.33493   0.34158   0.34274
+     Eigenvalues ---    0.34563   0.34974   0.41556   0.51572   1.18806
+ Eigenvectors required to have negative eigenvalues:
+                          R14       R5        D28       A20       D2
+   1                    0.72331  -0.62468   0.10392  -0.09165   0.06088
+                          D13       D12       A23       A22       D4
+   1                    0.06041  -0.05980   0.05933  -0.05917  -0.05778
+ RFO step:  Lambda0=4.914604178D-08 Lambda=-9.18458177D-06.
+ Linear search not attempted -- option 19 set.
+ Iteration  1 RMS(Cart)=  0.00761409 RMS(Int)=  0.00004104
+ Iteration  2 RMS(Cart)=  0.00004731 RMS(Int)=  0.00000133
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000133
+ ITry= 1 IFail=0 DXMaxC= 3.28D-02 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.19090   0.00000   0.00000  -0.00007  -0.00007   2.19084
+    R2        2.71365   0.00001   0.00000   0.00026   0.00026   2.71391
+    R3        2.88010   0.00008   0.00000   0.00024   0.00024   2.88034
+    R4        2.87831   0.00010   0.00000   0.00034   0.00034   2.87865
+    R5        2.53804   0.00012   0.00000  -0.00041  -0.00041   2.53763
+    R6        2.06580  -0.00001   0.00000  -0.00008  -0.00008   2.06573
+    R7        2.06288   0.00000   0.00000   0.00011   0.00011   2.06299
+    R8        2.07020  -0.00002   0.00000  -0.00006  -0.00006   2.07014
+    R9        2.06618  -0.00000   0.00000  -0.00010  -0.00010   2.06608
+   R10        2.07086  -0.00002   0.00000  -0.00011  -0.00011   2.07075
+   R11        2.06350   0.00001   0.00000   0.00013   0.00013   2.06364
+   R12        2.60679   0.00001   0.00000   0.00010   0.00010   2.60690
+   R13        2.06720  -0.00000   0.00000   0.00004   0.00004   2.06725
+   R14        2.64271   0.00005   0.00000   0.00027   0.00027   2.64298
+   R15        2.05542   0.00001   0.00000   0.00003   0.00003   2.05545
+   R16        1.82511  -0.00001   0.00000  -0.00009  -0.00009   1.82502
+    A1        1.99028  -0.00002   0.00000  -0.00023  -0.00023   1.99006
+    A2        2.00313  -0.00004   0.00000  -0.00092  -0.00092   2.00221
+    A3        1.73094   0.00003   0.00000  -0.00010  -0.00010   1.73084
+    A4        2.01948   0.00006   0.00000   0.00086   0.00085   2.02034
+    A5        1.81760   0.00000   0.00000   0.00078   0.00078   1.81838
+    A6        1.86038  -0.00004   0.00000  -0.00035  -0.00035   1.86003
+    A7        1.91699   0.00002   0.00000   0.00011   0.00011   1.91710
+    A8        1.93706   0.00003   0.00000  -0.00012  -0.00012   1.93695
+    A9        1.94338  -0.00001   0.00000   0.00030   0.00030   1.94368
+   A10        1.89203  -0.00002   0.00000   0.00001   0.00001   1.89204
+   A11        1.88378  -0.00001   0.00000   0.00011   0.00011   1.88390
+   A12        1.88898  -0.00001   0.00000  -0.00042  -0.00042   1.88855
+   A13        1.91814   0.00004   0.00000   0.00009   0.00009   1.91823
+   A14        1.94059   0.00001   0.00000   0.00044   0.00044   1.94103
+   A15        1.94825   0.00001   0.00000  -0.00028  -0.00028   1.94796
+   A16        1.88010  -0.00001   0.00000   0.00026   0.00026   1.88036
+   A17        1.89236  -0.00003   0.00000  -0.00017  -0.00017   1.89219
+   A18        1.88231  -0.00001   0.00000  -0.00035  -0.00035   1.88197
+   A19        2.02324  -0.00005   0.00000  -0.00006  -0.00006   2.02318
+   A20        1.83675   0.00014   0.00000   0.00115   0.00115   1.83790
+   A21        1.92707  -0.00006   0.00000  -0.00014  -0.00014   1.92693
+   A22        1.79554  -0.00001   0.00000   0.00010   0.00010   1.79565
+   A23        1.99487   0.00003   0.00000  -0.00026  -0.00026   1.99461
+   A24        1.86700  -0.00003   0.00000  -0.00070  -0.00070   1.86630
+   A25        1.90534   0.00002   0.00000   0.00005   0.00005   1.90539
+   A26        3.03807   0.00005   0.00000   0.00111   0.00111   3.03917
+   A27        3.22958  -0.00005   0.00000   0.00108   0.00108   3.23066
+   A28        3.10443   0.00000   0.00000   0.00040   0.00040   3.10483
+   A29        2.80276   0.00024   0.00000   0.00716   0.00716   2.80992
+    D1        2.96979   0.00004   0.00000   0.01055   0.01055   2.98034
+    D2        0.87786   0.00004   0.00000   0.01055   0.01055   0.88840
+    D3       -1.22773   0.00004   0.00000   0.01096   0.01096  -1.21677
+    D4       -0.93321   0.00003   0.00000   0.00981   0.00981  -0.92341
+    D5       -3.02515   0.00002   0.00000   0.00980   0.00980  -3.01534
+    D6        1.15245   0.00003   0.00000   0.01021   0.01021   1.16266
+    D7        1.10225   0.00002   0.00000   0.01034   0.01034   1.11259
+    D8       -0.98968   0.00001   0.00000   0.01033   0.01033  -0.97935
+    D9       -3.09527   0.00001   0.00000   0.01074   0.01074  -3.08453
+   D10       -2.91680  -0.00002   0.00000  -0.01552  -0.01552  -2.93232
+   D11        1.28633  -0.00003   0.00000  -0.01618  -0.01619   1.27015
+   D12       -0.81650  -0.00003   0.00000  -0.01585  -0.01586  -0.83236
+   D13        0.99179  -0.00002   0.00000  -0.01508  -0.01508   0.97671
+   D14       -1.08827  -0.00003   0.00000  -0.01574  -0.01574  -1.10401
+   D15        3.09208  -0.00003   0.00000  -0.01541  -0.01541   3.07667
+   D16       -1.01949  -0.00003   0.00000  -0.01628  -0.01628  -1.03577
+   D17       -3.09955  -0.00004   0.00000  -0.01694  -0.01694  -3.11649
+   D18        1.08080  -0.00004   0.00000  -0.01661  -0.01661   1.06419
+   D19       -0.79990  -0.00002   0.00000   0.00155   0.00155  -0.79835
+   D20        1.28366   0.00001   0.00000   0.00271   0.00271   1.28637
+   D21       -2.82043  -0.00004   0.00000   0.00026   0.00025  -2.82017
+   D22        1.21193   0.00000   0.00000   0.00220   0.00220   1.21412
+   D23       -2.98770   0.00003   0.00000   0.00336   0.00335  -2.98434
+   D24       -0.80860  -0.00002   0.00000   0.00090   0.00090  -0.80770
+   D25       -2.86244   0.00000   0.00000   0.00248   0.00248  -2.85996
+   D26       -0.77888   0.00003   0.00000   0.00364   0.00364  -0.77524
+   D27        1.40022  -0.00002   0.00000   0.00118   0.00119   1.40140
+   D28       -0.78166  -0.00004   0.00000  -0.00182  -0.00182  -0.78349
+   D29        1.18893   0.00001   0.00000  -0.00099  -0.00099   1.18794
+   D30       -3.08541   0.00002   0.00000  -0.00125  -0.00125  -3.08666
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000235     0.000450     YES
+ RMS     Force            0.000046     0.000300     YES
+ Maximum Displacement     0.032812     0.001800     NO 
+ RMS     Displacement     0.007615     0.001200     NO 
+ Predicted change in Energy=-4.583271D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               1.0 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.220288   -1.550157    0.103656
+      2          6           0       -1.501207   -0.641905    0.058124
+      3          6           0       -0.494536    0.379848   -0.013509
+      4          6           0       -0.213890    1.068746    1.316859
+      5          6           0       -0.603683    1.297832   -1.224247
+      6          1           0        0.666311    1.710292    1.224070
+      7          1           0       -0.025165    0.336346    2.104100
+      8          1           0       -1.056993    1.695472    1.627415
+      9          1           0        0.304645    1.898970   -1.318716
+     10          1           0       -1.450623    1.986018   -1.124973
+     11          1           0       -0.739861    0.731073   -2.147703
+     12          6           0        1.488104   -1.461591   -0.217717
+     13          8           0        1.061368   -2.302539    0.789136
+     14          1           0        1.402761   -1.852759   -1.235758
+     15          1           0        0.583065   -0.395292   -0.216477
+     16          1           0        2.465120   -1.048084    0.022153
+     17          1           0        0.217166   -2.697448    0.536026
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.159341   0.000000
+     3  C    2.591692   1.436140   0.000000
+     4  C    3.515131   2.483531   1.524212   0.000000
+     5  C    3.533805   2.492510   1.523316   2.581016   0.000000
+     6  H    4.496477   3.404467   2.156212   1.093136   2.788775
+     7  H    3.518413   2.705863   2.169441   1.091685   3.512412
+     8  H    3.769510   2.850146   2.177122   1.095470   2.914719
+     9  H    4.504986   3.407761   2.156382   2.811478   1.093321
+    10  H    3.821838   2.882405   2.174681   2.886770   1.095793
+    11  H    3.530480   2.707469   2.176769   3.520491   1.092030
+    12  C    3.723344   3.111905   2.713570   3.413841   3.605980
+    13  O    3.435873   3.139884   3.203167   3.642847   4.448458
+    14  H    3.874542   3.401959   3.174612   4.202928   3.735261
+    15  H    3.048768   2.116699   1.342856   2.264876   2.300139
+    16  H    4.712936   3.987233   3.286309   3.651620   4.058866
+    17  H    2.728443   2.721480   3.205973   3.870365   4.442366
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.772095   0.000000
+     8  H    1.769940   1.771757   0.000000
+     9  H    2.575299   3.777068   3.251947   0.000000
+    10  H    3.174183   3.896186   2.795532   1.768072   0.000000
+    11  H    3.782201   4.329484   3.909239   1.772623   1.768063
+    12  C    3.579796   3.303543   4.455231   3.729095   4.620091
+    13  O    4.055620   3.142196   4.601550   4.761129   5.325940
+    14  H    4.391861   4.240967   5.180550   3.910014   4.784379
+    15  H    2.552565   2.508050   3.234351   2.560486   3.260658
+    16  H    3.505561   3.528834   4.744392   3.892391   5.084753
+    17  H    4.483671   3.423665   4.702378   4.957296   5.241688
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.673751   0.000000
+    13  O    4.590452   1.379510   0.000000
+    14  H    3.478313   1.093939   2.102153   0.000000
+    15  H    2.597781   1.398603   2.208534   1.958327   0.000000
+    16  H    4.259762   1.087698   2.032841   1.832607   2.006293
+    17  H    4.457921   1.926331   0.965761   2.293110   2.449503
+                   16         17
+    16  H    0.000000
+    17  H    2.835095   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ RotChk:  IX=0 Diff= 5.90D-03
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.083056    2.287615   -0.039494
+      2          6           0        0.480209    1.199291    0.003997
+      3          6           0        0.827971   -0.194027    0.019008
+      4          6           0        1.039134   -0.765826    1.416032
+      5          6           0        1.856280   -0.605204   -1.026940
+      6          1           0        1.136922   -1.853188    1.361015
+      7          1           0        0.195815   -0.528089    2.067240
+      8          1           0        1.949997   -0.368005    1.876599
+      9          1           0        1.905874   -1.695476   -1.091740
+     10          1           0        2.855870   -0.240539   -0.765019
+     11          1           0        1.605021   -0.212024   -2.014264
+     12          6           0       -1.710047   -0.926764   -0.601494
+     13          8           0       -2.362197   -0.103135    0.292589
+     14          1           0       -1.824565   -0.670564   -1.658826
+     15          1           0       -0.346794   -0.712050   -0.374491
+     16          1           0       -1.909119   -1.970754   -0.370103
+     17          1           0       -2.214113    0.817641    0.041718
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.7213737           1.7880931           1.4598657
+ Leave Link  202 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: 6-311G(2d,d,p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   193 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   186 symmetry adapted basis functions of A   symmetry.
+   186 basis functions,   304 primitive gaussians,   193 cartesian basis functions
+    28 alpha electrons       27 beta electrons
+       nuclear repulsion energy       292.2913579452 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   17 NActive=   17 NUniq=   17 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               1.9 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   186 RedAO= T EigKep=  1.33D-03  NBF=   186
+ NBsUse=   186 1.00D-06 EigRej= -1.00D+00 NBFU=   186
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   193   193   193   193   193 MxSgAt=    17 MxSgA2=    17.
+ Leave Link  302 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               6.0 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ Initial guess from the checkpoint file:  "0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    0.999998    0.001144   -0.000706    0.001307 Ang=   0.21 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5038
+ Generating alternative initial guess.
+ ExpMin= 1.03D-01 ExpMax= 8.59D+03 ExpMxC= 1.30D+03 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -326.566468366176    
+ Leave Link  401 at Tue Jul  7 12:17:16 2020, MaxMem= 39321600000 cpu:              13.3 elap:               0.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 39321600000 LenX= 39321515670 LenY= 39321477980
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 970000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -326.523601937993    
+ DIIS: error= 6.03D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.523601937993     IErMin= 1 ErrMin= 6.03D-04
+ ErrMax= 6.03D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-04 BMatP= 2.09D-04
+ IDIUse=3 WtCom= 9.94D-01 WtEn= 6.03D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.493 Goal=   None    Shift=    0.000
+ Gap=     0.612 Goal=   None    Shift=    0.000
+ RMSDP=4.34D-05 MaxDP=7.42D-04              OVMax= 3.06D-03
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  4.34D-05    CP:  1.00D+00
+ E= -326.523689256024     Delta-E=       -0.000087318031 Rises=F Damp=F
+ DIIS: error= 7.46D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -326.523689256024     IErMin= 2 ErrMin= 7.46D-05
+ ErrMax= 7.46D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.39D-06 BMatP= 2.09D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.715D-01 0.107D+01
+ Coeff:     -0.715D-01 0.107D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=8.33D-06 MaxDP=2.58D-04 DE=-8.73D-05 OVMax= 4.35D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   3  Pass 1  IDiag  1:
+ E= -326.523681025654     Delta-E=        0.000008230371 Rises=F Damp=F
+ DIIS: error= 8.63D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.523681025654     IErMin= 1 ErrMin= 8.63D-05
+ ErrMax= 8.63D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.58D-06 BMatP= 3.58D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=8.33D-06 MaxDP=2.58D-04 DE= 8.23D-06 OVMax= 1.04D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ RMSU=  1.22D-05    CP:  1.00D+00
+ E= -326.523676657074     Delta-E=        0.000004368580 Rises=F Damp=F
+ DIIS: error= 2.34D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -326.523681025654     IErMin= 1 ErrMin= 8.63D-05
+ ErrMax= 2.34D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.41D-05 BMatP= 3.58D-06
+ IDIUse=3 WtCom= 3.95D-01 WtEn= 6.05D-01
+ Coeff-Com:  0.723D+00 0.277D+00
+ Coeff-En:   0.807D+00 0.193D+00
+ Coeff:      0.774D+00 0.226D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=7.16D-06 MaxDP=2.89D-04 DE= 4.37D-06 OVMax= 6.22D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ RMSU=  1.14D-06    CP:  1.00D+00  4.25D-01
+ E= -326.523681638685     Delta-E=       -0.000004981611 Rises=F Damp=F
+ DIIS: error= 3.91D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -326.523681638685     IErMin= 3 ErrMin= 3.91D-05
+ ErrMax= 3.91D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.81D-07 BMatP= 3.58D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.312D+00-0.359D-02 0.691D+00
+ Coeff:      0.312D+00-0.359D-02 0.691D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.67D-06 MaxDP=7.17D-05 DE=-4.98D-06 OVMax= 1.33D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ RMSU=  4.73D-07    CP:  1.00D+00  2.95D-01  1.09D+00
+ E= -326.523681804769     Delta-E=       -0.000000166084 Rises=F Damp=F
+ DIIS: error= 3.75D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -326.523681804769     IErMin= 4 ErrMin= 3.75D-06
+ ErrMax= 3.75D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.44D-09 BMatP= 7.81D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.949D-01-0.320D-01 0.381D+00 0.556D+00
+ Coeff:      0.949D-01-0.320D-01 0.381D+00 0.556D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.78D-07 MaxDP=5.89D-06 DE=-1.66D-07 OVMax= 1.65D-05
+
+ Cycle   7  Pass 1  IDiag  1:
+ RMSU=  1.56D-07    CP:  1.00D+00  2.96D-01  1.15D+00  8.99D-01
+ E= -326.523681806024     Delta-E=       -0.000000001255 Rises=F Damp=F
+ DIIS: error= 1.26D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -326.523681806024     IErMin= 5 ErrMin= 1.26D-06
+ ErrMax= 1.26D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.71D-10 BMatP= 6.44D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.211D-01-0.108D-01 0.139D-01 0.218D+00 0.800D+00
+ Coeff:     -0.211D-01-0.108D-01 0.139D-01 0.218D+00 0.800D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.06D-07 MaxDP=3.06D-06 DE=-1.25D-09 OVMax= 9.66D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ RMSU=  7.62D-08    CP:  1.00D+00  2.98D-01  1.20D+00  9.72D-01  9.83D-01
+ E= -326.523681806206     Delta-E=       -0.000000000183 Rises=F Damp=F
+ DIIS: error= 3.92D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -326.523681806206     IErMin= 6 ErrMin= 3.92D-07
+ ErrMax= 3.92D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.30D-10 BMatP= 5.71D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.246D-01-0.327D-03-0.511D-01 0.246D-01 0.387D+00 0.665D+00
+ Coeff:     -0.246D-01-0.327D-03-0.511D-01 0.246D-01 0.387D+00 0.665D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=3.75D-08 MaxDP=1.01D-06 DE=-1.83D-10 OVMax= 4.66D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ RMSU=  3.03D-08    CP:  1.00D+00  2.97D-01  1.21D+00  9.97D-01  1.09D+00
+                    CP:  9.21D-01
+ E= -326.523681806258     Delta-E=       -0.000000000052 Rises=F Damp=F
+ DIIS: error= 1.50D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -326.523681806258     IErMin= 7 ErrMin= 1.50D-07
+ ErrMax= 1.50D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.44D-11 BMatP= 1.30D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.133D-02 0.193D-02-0.133D-01-0.309D-01-0.602D-01 0.148D+00
+ Coeff-Com:  0.955D+00
+ Coeff:     -0.133D-02 0.193D-02-0.133D-01-0.309D-01-0.602D-01 0.148D+00
+ Coeff:      0.955D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=2.24D-08 MaxDP=6.42D-07 DE=-5.23D-11 OVMax= 2.20D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  1.28D-08    CP:  1.00D+00  2.98D-01  1.21D+00  1.01D+00  1.13D+00
+                    CP:  1.10D+00  1.12D+00
+ E= -326.523681806270     Delta-E=       -0.000000000012 Rises=F Damp=F
+ DIIS: error= 8.11D-08 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -326.523681806270     IErMin= 8 ErrMin= 8.11D-08
+ ErrMax= 8.11D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.20D-12 BMatP= 1.44D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.475D-02 0.894D-03 0.549D-02-0.195D-01-0.115D+00-0.798D-01
+ Coeff-Com:  0.441D+00 0.762D+00
+ Coeff:      0.475D-02 0.894D-03 0.549D-02-0.195D-01-0.115D+00-0.798D-01
+ Coeff:      0.441D+00 0.762D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=1.01D-08 MaxDP=3.14D-07 DE=-1.16D-11 OVMax= 1.24D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  6.94D-09    CP:  1.00D+00  2.98D-01  1.21D+00  1.01D+00  1.14D+00
+                    CP:  1.15D+00  1.32D+00  1.07D+00
+ E= -326.523681806275     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 4.29D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -326.523681806275     IErMin= 9 ErrMin= 4.29D-08
+ ErrMax= 4.29D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.91D-13 BMatP= 5.20D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.187D-02-0.239D-03 0.539D-02 0.194D-02-0.204D-01-0.649D-01
+ Coeff-Com: -0.113D+00 0.234D+00 0.955D+00
+ Coeff:      0.187D-02-0.239D-03 0.539D-02 0.194D-02-0.204D-01-0.649D-01
+ Coeff:     -0.113D+00 0.234D+00 0.955D+00
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=6.05D-09 MaxDP=1.99D-07 DE=-4.89D-12 OVMax= 6.52D-07
+
+ SCF Done:  E(UB3LYP) =  -326.523681806     A.U. after   11 cycles
+            NFock= 11  Conv=0.61D-08     -V/T= 2.0040
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5037
+ <L.S>=  0.00000000000    
+ KE= 3.252345030773D+02 PE=-1.345579858058D+03 EE= 4.015303152295D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7575,   after     0.7500
+ Leave Link  502 at Tue Jul  7 12:17:20 2020, MaxMem= 39321600000 cpu:             142.7 elap:               3.6
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Tue Jul  7 12:17:20 2020, MaxMem= 39321600000 cpu:               0.1 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   186
+ NBasis=   186 NAE=    28 NBE=    27 NFC=     0 NFV=     0
+ NROrb=    186 NOA=    28 NOB=    27 NVA=   158 NVB=   159
+
+ **** Warning!!: The largest alpha MO coefficient is  0.10461310D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.10893524D+02
+
+ Leave Link  801 at Tue Jul  7 12:17:20 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    17.
+ Will process     18 centers per pass.
+ Leave Link 1101 at Tue Jul  7 12:17:20 2020, MaxMem= 39321600000 cpu:               7.1 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Tue Jul  7 12:17:20 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    17.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   39321598504.
+ G2DrvN: will do    18 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Tue Jul  7 12:17:28 2020, MaxMem= 39321600000 cpu:             300.0 elap:               7.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=11111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         5053 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=343229615.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  17391 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   39321600000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    54 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     51 vectors produced by pass  0 Test12= 1.61D-14 1.85D-09 XBig12= 1.51D+02 7.55D+00.
+ AX will form    51 AO Fock derivatives at one time.
+     51 vectors produced by pass  1 Test12= 1.61D-14 1.85D-09 XBig12= 3.69D+01 9.64D-01.
+     51 vectors produced by pass  2 Test12= 1.61D-14 1.85D-09 XBig12= 1.01D+00 1.01D-01.
+     51 vectors produced by pass  3 Test12= 1.61D-14 1.85D-09 XBig12= 6.80D-03 1.31D-02.
+     51 vectors produced by pass  4 Test12= 1.61D-14 1.85D-09 XBig12= 5.48D-05 9.01D-04.
+     51 vectors produced by pass  5 Test12= 1.61D-14 1.85D-09 XBig12= 2.03D-07 4.51D-05.
+     28 vectors produced by pass  6 Test12= 1.61D-14 1.85D-09 XBig12= 4.99D-10 2.00D-06.
+      5 vectors produced by pass  7 Test12= 1.61D-14 1.85D-09 XBig12= 1.82D-12 1.29D-07.
+      2 vectors produced by pass  8 Test12= 1.61D-14 1.85D-09 XBig12= 6.76D-15 9.53D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 8.88D-15
+ Solved reduced A of dimension   341 with    54 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       73.75 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Tue Jul  7 12:17:41 2020, MaxMem= 39321600000 cpu:             526.8 elap:              13.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ Leave Link  701 at Tue Jul  7 12:17:41 2020, MaxMem= 39321600000 cpu:               6.5 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Jul  7 12:17:41 2020, MaxMem= 39321600000 cpu:               0.6 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:             454.6 elap:              11.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        = 3.84678085D-01-1.28207786D+00-3.96426369D-01
+ Polarizability= 8.47434459D+01 9.71548635D-01 7.64749257D+01
+                 3.25634292D+00 1.19244959D+00 6.00374514D+01
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000000236   -0.000000628   -0.000000771
+      2        6           0.000000190    0.000000845   -0.000000741
+      3        6          -0.000003012    0.000000342    0.000001186
+      4        6           0.000000122   -0.000000503    0.000001630
+      5        6          -0.000000286    0.000001174   -0.000002197
+      6        1          -0.000000957    0.000000316    0.000000666
+      7        1          -0.000000172    0.000000640    0.000000350
+      8        1          -0.000000436   -0.000000727   -0.000000360
+      9        1          -0.000000507    0.000000575   -0.000001011
+     10        1           0.000000402   -0.000000937   -0.000001035
+     11        1           0.000000778    0.000000274   -0.000000792
+     12        6           0.000000364    0.000001028    0.000000150
+     13        8           0.000002378    0.000000373   -0.000000451
+     14        1           0.000000570    0.000000022    0.000000529
+     15        1          -0.000000234   -0.000002704    0.000002054
+     16        1           0.000000272    0.000000536    0.000000990
+     17        1           0.000000764   -0.000000627   -0.000000198
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000003012 RMS     0.000001008
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Leave Link  716 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:               0.8 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000007207 RMS     0.000001421
+ Search for a saddle point.
+ Step number   4 out of a maximum of  102
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Swapping is turned off.
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0  0  0  0
+     Eigenvalues ---   -0.05281   0.00136   0.00182   0.00216   0.00787
+     Eigenvalues ---    0.02055   0.02221   0.02853   0.03248   0.04199
+     Eigenvalues ---    0.04450   0.04533   0.04540   0.04562   0.04857
+     Eigenvalues ---    0.05039   0.06437   0.07164   0.08352   0.09460
+     Eigenvalues ---    0.10151   0.10577   0.11963   0.12324   0.13749
+     Eigenvalues ---    0.14489   0.14665   0.15294   0.15371   0.17088
+     Eigenvalues ---    0.17841   0.28547   0.28900   0.32691   0.32798
+     Eigenvalues ---    0.32831   0.33375   0.33496   0.34149   0.34268
+     Eigenvalues ---    0.34559   0.34960   0.41551   0.51593   1.18845
+ Eigenvectors required to have negative eigenvalues:
+                          R14       R5        D28       A20       D2
+   1                   -0.72350   0.62459  -0.10390   0.09099  -0.06083
+                          D13       D12       A22       A23       D4
+   1                   -0.06052   0.05970   0.05926  -0.05924   0.05786
+ RFO step:  Lambda0=3.238338417D-11 Lambda= 0.00000000D+00.
+ Linear search not attempted -- option 19 set.
+ Iteration  1 RMS(Cart)=  0.00013618 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000001 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 4.34D-04 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.19084   0.00000   0.00000  -0.00000  -0.00000   2.19084
+    R2        2.71391  -0.00000   0.00000   0.00000   0.00000   2.71391
+    R3        2.88034   0.00000   0.00000   0.00001   0.00001   2.88035
+    R4        2.87865   0.00000   0.00000   0.00002   0.00002   2.87867
+    R5        2.53763   0.00000   0.00000  -0.00002  -0.00002   2.53761
+    R6        2.06573  -0.00000   0.00000  -0.00000  -0.00000   2.06573
+    R7        2.06299  -0.00000   0.00000   0.00000   0.00000   2.06299
+    R8        2.07014  -0.00000   0.00000  -0.00000  -0.00000   2.07014
+    R9        2.06608   0.00000   0.00000   0.00000   0.00000   2.06608
+   R10        2.07075  -0.00000   0.00000  -0.00000  -0.00000   2.07075
+   R11        2.06364   0.00000   0.00000   0.00000   0.00000   2.06364
+   R12        2.60690  -0.00000   0.00000   0.00000   0.00000   2.60690
+   R13        2.06725  -0.00000   0.00000   0.00000   0.00000   2.06725
+   R14        2.64298   0.00000   0.00000   0.00001   0.00001   2.64299
+   R15        2.05545   0.00000   0.00000   0.00000   0.00000   2.05545
+   R16        1.82502   0.00000   0.00000  -0.00000  -0.00000   1.82502
+    A1        1.99006  -0.00000   0.00000   0.00001   0.00001   1.99006
+    A2        2.00221  -0.00000   0.00000  -0.00001  -0.00001   2.00220
+    A3        1.73084   0.00000   0.00000   0.00002   0.00002   1.73085
+    A4        2.02034   0.00000   0.00000   0.00001   0.00001   2.02035
+    A5        1.81838  -0.00000   0.00000   0.00000   0.00000   1.81838
+    A6        1.86003  -0.00000   0.00000  -0.00002  -0.00002   1.86001
+    A7        1.91710   0.00000   0.00000   0.00000   0.00000   1.91711
+    A8        1.93695   0.00000   0.00000   0.00001   0.00001   1.93695
+    A9        1.94368  -0.00000   0.00000   0.00000   0.00000   1.94368
+   A10        1.89204  -0.00000   0.00000  -0.00001  -0.00001   1.89204
+   A11        1.88390  -0.00000   0.00000  -0.00000  -0.00000   1.88390
+   A12        1.88855  -0.00000   0.00000  -0.00000  -0.00000   1.88855
+   A13        1.91823   0.00000   0.00000   0.00001   0.00001   1.91824
+   A14        1.94103   0.00000   0.00000   0.00001   0.00001   1.94104
+   A15        1.94796   0.00000   0.00000  -0.00000  -0.00000   1.94796
+   A16        1.88036  -0.00000   0.00000   0.00000   0.00000   1.88036
+   A17        1.89219  -0.00000   0.00000  -0.00001  -0.00001   1.89219
+   A18        1.88197  -0.00000   0.00000  -0.00000  -0.00000   1.88196
+   A19        2.02318  -0.00000   0.00000  -0.00000  -0.00000   2.02318
+   A20        1.83790   0.00000   0.00000   0.00003   0.00003   1.83793
+   A21        1.92693  -0.00000   0.00000  -0.00001  -0.00001   1.92693
+   A22        1.79565  -0.00000   0.00000   0.00000   0.00000   1.79565
+   A23        1.99461   0.00000   0.00000   0.00000   0.00000   1.99462
+   A24        1.86630  -0.00000   0.00000  -0.00002  -0.00002   1.86628
+   A25        1.90539   0.00000   0.00000  -0.00000  -0.00000   1.90539
+   A26        3.03917   0.00000   0.00000   0.00003   0.00003   3.03920
+   A27        3.23066  -0.00000   0.00000  -0.00000  -0.00000   3.23066
+   A28        3.10483  -0.00000   0.00000   0.00001   0.00001   3.10484
+   A29        2.80992   0.00001   0.00000   0.00025   0.00025   2.81017
+    D1        2.98034   0.00000   0.00000   0.00005   0.00005   2.98039
+    D2        0.88840   0.00000   0.00000   0.00005   0.00005   0.88845
+    D3       -1.21677   0.00000   0.00000   0.00005   0.00005  -1.21672
+    D4       -0.92341   0.00000   0.00000   0.00005   0.00005  -0.92336
+    D5       -3.01534   0.00000   0.00000   0.00005   0.00005  -3.01530
+    D6        1.16266   0.00000   0.00000   0.00005   0.00005   1.16271
+    D7        1.11259  -0.00000   0.00000   0.00003   0.00003   1.11261
+    D8       -0.97935  -0.00000   0.00000   0.00002   0.00002  -0.97932
+    D9       -3.08453  -0.00000   0.00000   0.00003   0.00003  -3.08450
+   D10       -2.93232   0.00000   0.00000  -0.00007  -0.00007  -2.93239
+   D11        1.27015  -0.00000   0.00000  -0.00008  -0.00008   1.27007
+   D12       -0.83236  -0.00000   0.00000  -0.00007  -0.00007  -0.83243
+   D13        0.97671  -0.00000   0.00000  -0.00007  -0.00007   0.97664
+   D14       -1.10401  -0.00000   0.00000  -0.00008  -0.00008  -1.10409
+   D15        3.07667  -0.00000   0.00000  -0.00008  -0.00008   3.07660
+   D16       -1.03577   0.00000   0.00000  -0.00007  -0.00007  -1.03584
+   D17       -3.11649  -0.00000   0.00000  -0.00008  -0.00008  -3.11656
+   D18        1.06419  -0.00000   0.00000  -0.00007  -0.00007   1.06412
+   D19       -0.79835  -0.00000   0.00000   0.00002   0.00002  -0.79833
+   D20        1.28637   0.00000   0.00000   0.00005   0.00005   1.28642
+   D21       -2.82017  -0.00000   0.00000  -0.00001  -0.00001  -2.82019
+   D22        1.21412  -0.00000   0.00000   0.00006   0.00006   1.21418
+   D23       -2.98434   0.00000   0.00000   0.00009   0.00009  -2.98425
+   D24       -0.80770  -0.00000   0.00000   0.00003   0.00003  -0.80768
+   D25       -2.85996  -0.00000   0.00000   0.00002   0.00002  -2.85994
+   D26       -0.77524   0.00000   0.00000   0.00005   0.00005  -0.77518
+   D27        1.40140  -0.00000   0.00000  -0.00001  -0.00001   1.40139
+   D28       -0.78349  -0.00000   0.00000   0.00004   0.00004  -0.78345
+   D29        1.18794   0.00000   0.00000   0.00005   0.00005   1.18800
+   D30       -3.08666   0.00000   0.00000   0.00005   0.00005  -3.08662
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000007     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000434     0.001800     YES
+ RMS     Displacement     0.000136     0.001200     YES
+ Predicted change in Energy=-1.249718D-09
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1593         -DE/DX =    0.0                 !
+ ! R2    R(2,3)                  1.4361         -DE/DX =    0.0                 !
+ ! R3    R(3,4)                  1.5242         -DE/DX =    0.0                 !
+ ! R4    R(3,5)                  1.5233         -DE/DX =    0.0                 !
+ ! R5    R(3,15)                 1.3429         -DE/DX =    0.0                 !
+ ! R6    R(4,6)                  1.0931         -DE/DX =    0.0                 !
+ ! R7    R(4,7)                  1.0917         -DE/DX =    0.0                 !
+ ! R8    R(4,8)                  1.0955         -DE/DX =    0.0                 !
+ ! R9    R(5,9)                  1.0933         -DE/DX =    0.0                 !
+ ! R10   R(5,10)                 1.0958         -DE/DX =    0.0                 !
+ ! R11   R(5,11)                 1.092          -DE/DX =    0.0                 !
+ ! R12   R(12,13)                1.3795         -DE/DX =    0.0                 !
+ ! R13   R(12,14)                1.0939         -DE/DX =    0.0                 !
+ ! R14   R(12,15)                1.3986         -DE/DX =    0.0                 !
+ ! R15   R(12,16)                1.0877         -DE/DX =    0.0                 !
+ ! R16   R(13,17)                0.9658         -DE/DX =    0.0                 !
+ ! A1    A(2,3,4)              114.0219         -DE/DX =    0.0                 !
+ ! A2    A(2,3,5)              114.7185         -DE/DX =    0.0                 !
+ ! A3    A(2,3,15)              99.1696         -DE/DX =    0.0                 !
+ ! A4    A(4,3,5)              115.7567         -DE/DX =    0.0                 !
+ ! A5    A(4,3,15)             104.1854         -DE/DX =    0.0                 !
+ ! A6    A(5,3,15)             106.572          -DE/DX =    0.0                 !
+ ! A7    A(3,4,6)              109.8419         -DE/DX =    0.0                 !
+ ! A8    A(3,4,7)              110.9789         -DE/DX =    0.0                 !
+ ! A9    A(3,4,8)              111.3648         -DE/DX =    0.0                 !
+ ! A10   A(6,4,7)              108.4059         -DE/DX =    0.0                 !
+ ! A11   A(6,4,8)              107.9394         -DE/DX =    0.0                 !
+ ! A12   A(7,4,8)              108.2062         -DE/DX =    0.0                 !
+ ! A13   A(3,5,9)              109.9065         -DE/DX =    0.0                 !
+ ! A14   A(3,5,10)             111.213          -DE/DX =    0.0                 !
+ ! A15   A(3,5,11)             111.6101         -DE/DX =    0.0                 !
+ ! A16   A(9,5,10)             107.7369         -DE/DX =    0.0                 !
+ ! A17   A(9,5,11)             108.4147         -DE/DX =    0.0                 !
+ ! A18   A(10,5,11)            107.8287         -DE/DX =    0.0                 !
+ ! A19   A(13,12,14)           115.9198         -DE/DX =    0.0                 !
+ ! A20   A(13,12,15)           105.3039         -DE/DX =    0.0                 !
+ ! A21   A(13,12,16)           110.405          -DE/DX =    0.0                 !
+ ! A22   A(14,12,15)           102.883          -DE/DX =    0.0                 !
+ ! A23   A(14,12,16)           114.283          -DE/DX =    0.0                 !
+ ! A24   A(15,12,16)           106.9309         -DE/DX =    0.0                 !
+ ! A25   A(12,13,17)           109.171          -DE/DX =    0.0                 !
+ ! A26   L(1,2,3,13,-1)        174.1317         -DE/DX =    0.0                 !
+ ! A27   L(3,15,12,6,-1)       185.1033         -DE/DX =    0.0                 !
+ ! A28   L(1,2,3,13,-2)        177.8936         -DE/DX =    0.0                 !
+ ! A29   L(3,15,12,6,-2)       160.9966         -DE/DX =    0.0                 !
+ ! D1    D(2,3,4,6)            170.7609         -DE/DX =    0.0                 !
+ ! D2    D(2,3,4,7)             50.9018         -DE/DX =    0.0                 !
+ ! D3    D(2,3,4,8)            -69.716          -DE/DX =    0.0                 !
+ ! D4    D(5,3,4,6)            -52.9073         -DE/DX =    0.0                 !
+ ! D5    D(5,3,4,7)           -172.7665         -DE/DX =    0.0                 !
+ ! D6    D(5,3,4,8)             66.6157         -DE/DX =    0.0                 !
+ ! D7    D(15,3,4,6)            63.7466         -DE/DX =    0.0                 !
+ ! D8    D(15,3,4,7)           -56.1126         -DE/DX =    0.0                 !
+ ! D9    D(15,3,4,8)          -176.7304         -DE/DX =    0.0                 !
+ ! D10   D(2,3,5,9)           -168.0097         -DE/DX =    0.0                 !
+ ! D11   D(2,3,5,10)            72.774          -DE/DX =    0.0                 !
+ ! D12   D(2,3,5,11)           -47.6907         -DE/DX =    0.0                 !
+ ! D13   D(4,3,5,9)             55.9613         -DE/DX =    0.0                 !
+ ! D14   D(4,3,5,10)           -63.2549         -DE/DX =    0.0                 !
+ ! D15   D(4,3,5,11)           176.2804         -DE/DX =    0.0                 !
+ ! D16   D(15,3,5,9)           -59.3454         -DE/DX =    0.0                 !
+ ! D17   D(15,3,5,10)         -178.5617         -DE/DX =    0.0                 !
+ ! D18   D(15,3,5,11)           60.9736         -DE/DX =    0.0                 !
+ ! D19   D(2,3,12,13)          -45.7421         -DE/DX =    0.0                 !
+ ! D20   D(2,3,12,14)           73.7036         -DE/DX =    0.0                 !
+ ! D21   D(2,3,12,16)         -161.5841         -DE/DX =    0.0                 !
+ ! D22   D(4,3,12,13)           69.5641         -DE/DX =    0.0                 !
+ ! D23   D(4,3,12,14)         -170.9903         -DE/DX =    0.0                 !
+ ! D24   D(4,3,12,16)          -46.278          -DE/DX =    0.0                 !
+ ! D25   D(5,3,12,13)         -163.8634         -DE/DX =    0.0                 !
+ ! D26   D(5,3,12,14)          -44.4178         -DE/DX =    0.0                 !
+ ! D27   D(5,3,12,16)           80.2946         -DE/DX =    0.0                 !
+ ! D28   D(14,12,13,17)        -44.8905         -DE/DX =    0.0                 !
+ ! D29   D(15,12,13,17)         68.0641         -DE/DX =    0.0                 !
+ ! D30   D(16,12,13,17)       -176.8528         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ Lowest energy point so far.  Saving SCF results.
+ Largest change from initial coordinates is atom   10       0.442 Angstoms.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:               1.0 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.220288   -1.550157    0.103656
+      2          6           0       -1.501207   -0.641905    0.058124
+      3          6           0       -0.494536    0.379848   -0.013509
+      4          6           0       -0.213890    1.068746    1.316859
+      5          6           0       -0.603683    1.297832   -1.224247
+      6          1           0        0.666311    1.710292    1.224070
+      7          1           0       -0.025165    0.336346    2.104100
+      8          1           0       -1.056993    1.695472    1.627415
+      9          1           0        0.304645    1.898970   -1.318716
+     10          1           0       -1.450623    1.986018   -1.124973
+     11          1           0       -0.739861    0.731073   -2.147703
+     12          6           0        1.488104   -1.461591   -0.217717
+     13          8           0        1.061368   -2.302539    0.789136
+     14          1           0        1.402761   -1.852759   -1.235758
+     15          1           0        0.583065   -0.395292   -0.216477
+     16          1           0        2.465120   -1.048084    0.022153
+     17          1           0        0.217166   -2.697448    0.536026
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.159341   0.000000
+     3  C    2.591692   1.436140   0.000000
+     4  C    3.515131   2.483531   1.524212   0.000000
+     5  C    3.533805   2.492510   1.523316   2.581016   0.000000
+     6  H    4.496477   3.404467   2.156212   1.093136   2.788775
+     7  H    3.518413   2.705863   2.169441   1.091685   3.512412
+     8  H    3.769510   2.850146   2.177122   1.095470   2.914719
+     9  H    4.504986   3.407761   2.156382   2.811478   1.093321
+    10  H    3.821838   2.882405   2.174681   2.886770   1.095793
+    11  H    3.530480   2.707469   2.176769   3.520491   1.092030
+    12  C    3.723344   3.111905   2.713570   3.413841   3.605980
+    13  O    3.435873   3.139884   3.203167   3.642847   4.448458
+    14  H    3.874542   3.401959   3.174612   4.202928   3.735261
+    15  H    3.048768   2.116699   1.342856   2.264876   2.300139
+    16  H    4.712936   3.987233   3.286309   3.651620   4.058866
+    17  H    2.728443   2.721480   3.205973   3.870365   4.442366
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.772095   0.000000
+     8  H    1.769940   1.771757   0.000000
+     9  H    2.575299   3.777068   3.251947   0.000000
+    10  H    3.174183   3.896186   2.795532   1.768072   0.000000
+    11  H    3.782201   4.329484   3.909239   1.772623   1.768063
+    12  C    3.579796   3.303543   4.455231   3.729095   4.620091
+    13  O    4.055620   3.142196   4.601550   4.761129   5.325940
+    14  H    4.391861   4.240967   5.180550   3.910014   4.784379
+    15  H    2.552565   2.508050   3.234351   2.560486   3.260658
+    16  H    3.505561   3.528834   4.744392   3.892391   5.084753
+    17  H    4.483671   3.423665   4.702378   4.957296   5.241688
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.673751   0.000000
+    13  O    4.590452   1.379510   0.000000
+    14  H    3.478313   1.093939   2.102153   0.000000
+    15  H    2.597781   1.398603   2.208534   1.958327   0.000000
+    16  H    4.259762   1.087698   2.032841   1.832607   2.006293
+    17  H    4.457921   1.926331   0.965761   2.293110   2.449503
+                   16         17
+    16  H    0.000000
+    17  H    2.835095   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ RotChk:  IX=0 Diff= 1.29D-15
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.083056    2.287615   -0.039494
+      2          6           0        0.480209    1.199291    0.003997
+      3          6           0        0.827971   -0.194027    0.019008
+      4          6           0        1.039134   -0.765826    1.416032
+      5          6           0        1.856280   -0.605204   -1.026940
+      6          1           0        1.136922   -1.853188    1.361015
+      7          1           0        0.195815   -0.528089    2.067240
+      8          1           0        1.949997   -0.368005    1.876599
+      9          1           0        1.905874   -1.695476   -1.091740
+     10          1           0        2.855870   -0.240539   -0.765019
+     11          1           0        1.605021   -0.212024   -2.014264
+     12          6           0       -1.710047   -0.926764   -0.601494
+     13          8           0       -2.362197   -0.103135    0.292589
+     14          1           0       -1.824565   -0.670564   -1.658826
+     15          1           0       -0.346794   -0.712050   -0.374491
+     16          1           0       -1.909119   -1.970754   -0.370103
+     17          1           0       -2.214113    0.817641    0.041718
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.7213737           1.7880931           1.4598657
+ Leave Link  202 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 1 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A)
+ Beta  Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ The electronic state is 2-A.
+ Alpha  occ. eigenvalues --  -19.15103 -14.30560 -10.23643 -10.22387 -10.20323
+ Alpha  occ. eigenvalues --  -10.18596 -10.18253  -1.06063  -0.91093  -0.82732
+ Alpha  occ. eigenvalues --   -0.71341  -0.69881  -0.65256  -0.54361  -0.50946
+ Alpha  occ. eigenvalues --   -0.48444  -0.46180  -0.44693  -0.42558  -0.41017
+ Alpha  occ. eigenvalues --   -0.40623  -0.38052  -0.37007  -0.36350  -0.35138
+ Alpha  occ. eigenvalues --   -0.32979  -0.31771  -0.19071
+ Alpha virt. eigenvalues --    0.01770   0.02844   0.04327   0.05097   0.07179
+ Alpha virt. eigenvalues --    0.07809   0.09334   0.10700   0.10948   0.13059
+ Alpha virt. eigenvalues --    0.13712   0.14204   0.17681   0.20870   0.22080
+ Alpha virt. eigenvalues --    0.23178   0.24266   0.26965   0.28772   0.30455
+ Alpha virt. eigenvalues --    0.34529   0.36354   0.38169   0.39652   0.42921
+ Alpha virt. eigenvalues --    0.44769   0.46613   0.49277   0.49612   0.51195
+ Alpha virt. eigenvalues --    0.51792   0.54082   0.55325   0.56146   0.56418
+ Alpha virt. eigenvalues --    0.58971   0.59388   0.60093   0.60827   0.62205
+ Alpha virt. eigenvalues --    0.63265   0.64941   0.70966   0.75030   0.76343
+ Alpha virt. eigenvalues --    0.81392   0.82834   0.84861   0.89529   0.90520
+ Alpha virt. eigenvalues --    0.91628   0.97524   0.99998   1.01649   1.06813
+ Alpha virt. eigenvalues --    1.14209   1.16737   1.19715   1.25024   1.26407
+ Alpha virt. eigenvalues --    1.28573   1.33196   1.35136   1.35994   1.37957
+ Alpha virt. eigenvalues --    1.39711   1.42882   1.43864   1.43947   1.45704
+ Alpha virt. eigenvalues --    1.48293   1.48913   1.51302   1.54363   1.56854
+ Alpha virt. eigenvalues --    1.57102   1.58706   1.60042   1.62095   1.64352
+ Alpha virt. eigenvalues --    1.65564   1.68323   1.69575   1.73919   1.74560
+ Alpha virt. eigenvalues --    1.82059   1.86383   1.89061   1.92090   1.95844
+ Alpha virt. eigenvalues --    1.97414   2.00684   2.04630   2.06328   2.07993
+ Alpha virt. eigenvalues --    2.09680   2.10564   2.13848   2.21155   2.25424
+ Alpha virt. eigenvalues --    2.29677   2.32610   2.32856   2.36789   2.39987
+ Alpha virt. eigenvalues --    2.40896   2.42775   2.45976   2.47608   2.48142
+ Alpha virt. eigenvalues --    2.49929   2.51808   2.53397   2.54880   2.57694
+ Alpha virt. eigenvalues --    2.58393   2.61718   2.63242   2.69651   2.75756
+ Alpha virt. eigenvalues --    2.80727   2.82288   2.84083   2.84725   2.90162
+ Alpha virt. eigenvalues --    2.93733   2.94864   3.00687   3.06684   3.07599
+ Alpha virt. eigenvalues --    3.11857   3.14058   3.31362   3.35519   3.48772
+ Alpha virt. eigenvalues --    3.67477   3.74159   3.76248   3.77333   3.79946
+ Alpha virt. eigenvalues --    3.81110   3.88020   3.90494   3.91548   3.94208
+ Alpha virt. eigenvalues --    4.09781   4.27576   4.52354   4.84499   5.21675
+ Alpha virt. eigenvalues --    5.62584  23.68105  23.76699  23.87901  23.91479
+ Alpha virt. eigenvalues --   24.39157  35.82494  49.84690
+  Beta  occ. eigenvalues --  -19.14756 -14.30316 -10.22745 -10.21631 -10.20419
+  Beta  occ. eigenvalues --  -10.18628 -10.18284  -1.05263  -0.90690  -0.81802
+  Beta  occ. eigenvalues --   -0.71251  -0.68115  -0.64633  -0.53499  -0.49796
+  Beta  occ. eigenvalues --   -0.47563  -0.45552  -0.44395  -0.41112  -0.40564
+  Beta  occ. eigenvalues --   -0.40463  -0.37928  -0.36199  -0.35804  -0.34118
+  Beta  occ. eigenvalues --   -0.32776  -0.29865
+  Beta virt. eigenvalues --   -0.09006   0.02118   0.02964   0.04844   0.05575
+  Beta virt. eigenvalues --    0.07483   0.07894   0.09490   0.11003   0.11242
+  Beta virt. eigenvalues --    0.13201   0.13780   0.14691   0.18218   0.21827
+  Beta virt. eigenvalues --    0.22475   0.23629   0.24788   0.27283   0.29278
+  Beta virt. eigenvalues --    0.31025   0.34916   0.36621   0.38645   0.39991
+  Beta virt. eigenvalues --    0.43072   0.45770   0.47107   0.49553   0.50037
+  Beta virt. eigenvalues --    0.51526   0.52524   0.54628   0.55720   0.56619
+  Beta virt. eigenvalues --    0.56706   0.59215   0.59593   0.60513   0.61472
+  Beta virt. eigenvalues --    0.62363   0.63492   0.65279   0.71335   0.75461
+  Beta virt. eigenvalues --    0.76516   0.81865   0.83269   0.85150   0.90102
+  Beta virt. eigenvalues --    0.91119   0.92226   0.98029   1.00741   1.02232
+  Beta virt. eigenvalues --    1.07433   1.14795   1.17553   1.20413   1.25277
+  Beta virt. eigenvalues --    1.26810   1.28762   1.33381   1.35638   1.36268
+  Beta virt. eigenvalues --    1.38443   1.40097   1.43712   1.44032   1.44517
+  Beta virt. eigenvalues --    1.46023   1.48476   1.49073   1.51548   1.54848
+  Beta virt. eigenvalues --    1.57328   1.57676   1.59190   1.60415   1.62342
+  Beta virt. eigenvalues --    1.64597   1.65868   1.68800   1.69687   1.74067
+  Beta virt. eigenvalues --    1.74701   1.82844   1.87274   1.89956   1.92725
+  Beta virt. eigenvalues --    1.96310   1.97774   2.01463   2.04941   2.06711
+  Beta virt. eigenvalues --    2.08540   2.10340   2.11244   2.14372   2.22602
+  Beta virt. eigenvalues --    2.25684   2.29983   2.32794   2.33247   2.37312
+  Beta virt. eigenvalues --    2.40345   2.41152   2.43595   2.46262   2.47785
+  Beta virt. eigenvalues --    2.48294   2.50314   2.52393   2.53605   2.55042
+  Beta virt. eigenvalues --    2.58020   2.58626   2.61928   2.63377   2.70200
+  Beta virt. eigenvalues --    2.76068   2.80794   2.82527   2.84560   2.84866
+  Beta virt. eigenvalues --    2.90448   2.94410   2.95119   3.01342   3.07288
+  Beta virt. eigenvalues --    3.07870   3.12312   3.14922   3.31993   3.37236
+  Beta virt. eigenvalues --    3.49303   3.68305   3.74281   3.76369   3.77986
+  Beta virt. eigenvalues --    3.80207   3.81315   3.88738   3.91059   3.92083
+  Beta virt. eigenvalues --    3.95210   4.10677   4.28097   4.52626   4.85878
+  Beta virt. eigenvalues --    5.22141   5.62988  23.68812  23.77697  23.87882
+  Beta virt. eigenvalues --   23.91447  24.39211  35.82750  49.85031
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.349238   1.005723  -0.103322   0.001274   0.000111  -0.000133
+     2  C    1.005723   4.883828   0.202403  -0.064848  -0.067021   0.008993
+     3  C   -0.103322   0.202403   5.637976   0.342987   0.354828  -0.039164
+     4  C    0.001274  -0.064848   0.342987   4.850180  -0.055489   0.404081
+     5  C    0.000111  -0.067021   0.354828  -0.055489   4.844811  -0.006747
+     6  H   -0.000133   0.008993  -0.039164   0.404081  -0.006747   0.574819
+     7  H    0.000226  -0.005510  -0.026256   0.399096   0.007904  -0.024011
+     8  H    0.000588  -0.007874  -0.035954   0.403544  -0.002686  -0.031024
+     9  H   -0.000157   0.008487  -0.038220  -0.005822   0.403183   0.005097
+    10  H    0.000604  -0.006686  -0.037262  -0.003336   0.405700  -0.001335
+    11  H    0.000822  -0.004352  -0.032100   0.007234   0.401831   0.000147
+    12  C    0.002323  -0.005089  -0.166720   0.003287   0.001537   0.003327
+    13  O   -0.003341   0.001725   0.012186  -0.002030   0.000568  -0.000384
+    14  H   -0.000189   0.000574   0.006340   0.000504   0.001223  -0.000171
+    15  H    0.002165  -0.039774   0.169461  -0.029190  -0.042389  -0.005846
+    16  H   -0.000040   0.001091   0.005156   0.000058   0.000199   0.000151
+    17  H    0.009265   0.007727  -0.002408   0.000228   0.000013   0.000111
+               7          8          9         10         11         12
+     1  N    0.000226   0.000588  -0.000157   0.000604   0.000822   0.002323
+     2  C   -0.005510  -0.007874   0.008487  -0.006686  -0.004352  -0.005089
+     3  C   -0.026256  -0.035954  -0.038220  -0.037262  -0.032100  -0.166720
+     4  C    0.399096   0.403544  -0.005822  -0.003336   0.007234   0.003287
+     5  C    0.007904  -0.002686   0.403183   0.405700   0.401831   0.001537
+     6  H   -0.024011  -0.031024   0.005097  -0.001335   0.000147   0.003327
+     7  H    0.546453  -0.026801   0.000067  -0.000335  -0.000350  -0.001114
+     8  H   -0.026801   0.567378  -0.001244   0.005094  -0.000387  -0.000765
+     9  H    0.000067  -0.001244   0.572881  -0.031239  -0.023360   0.002463
+    10  H   -0.000335   0.005094  -0.031239   0.566986  -0.028557  -0.000752
+    11  H   -0.000350  -0.000387  -0.023360  -0.028557   0.558068   0.001733
+    12  C   -0.001114  -0.000765   0.002463  -0.000752   0.001733   5.046149
+    13  O    0.008752  -0.000016  -0.000005  -0.000004  -0.000030   0.271788
+    14  H    0.000621  -0.000016  -0.000157  -0.000004   0.000477   0.383214
+    15  H   -0.009833   0.005349  -0.006273   0.005475  -0.003336   0.232083
+    16  H   -0.000535   0.000034   0.000033   0.000009  -0.000124   0.389975
+    17  H   -0.000513  -0.000066   0.000019  -0.000025  -0.000009  -0.037343
+              13         14         15         16         17
+     1  N   -0.003341  -0.000189   0.002165  -0.000040   0.009265
+     2  C    0.001725   0.000574  -0.039774   0.001091   0.007727
+     3  C    0.012186   0.006340   0.169461   0.005156  -0.002408
+     4  C   -0.002030   0.000504  -0.029190   0.000058   0.000228
+     5  C    0.000568   0.001223  -0.042389   0.000199   0.000013
+     6  H   -0.000384  -0.000171  -0.005846   0.000151   0.000111
+     7  H    0.008752   0.000621  -0.009833  -0.000535  -0.000513
+     8  H   -0.000016  -0.000016   0.005349   0.000034  -0.000066
+     9  H   -0.000005  -0.000157  -0.006273   0.000033   0.000019
+    10  H   -0.000004  -0.000004   0.005475   0.000009  -0.000025
+    11  H   -0.000030   0.000477  -0.003336  -0.000124  -0.000009
+    12  C    0.271788   0.383214   0.232083   0.389975  -0.037343
+    13  O    7.823072  -0.027341  -0.033363  -0.029899   0.318957
+    14  H   -0.027341   0.597024  -0.033520  -0.033259  -0.010448
+    15  H   -0.033363  -0.033520   0.650174  -0.022681  -0.004184
+    16  H   -0.029899  -0.033259  -0.022681   0.555063   0.007816
+    17  H    0.318957  -0.010448  -0.004184   0.007816   0.449360
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  N    0.134973  -0.006016  -0.012425   0.000387   0.000240   0.000036
+     2  C   -0.006016  -0.052887  -0.017321   0.003822  -0.001297   0.001125
+     3  C   -0.012425  -0.017321   0.735814  -0.034630  -0.018192  -0.008176
+     4  C    0.000387   0.003822  -0.034630  -0.015121  -0.000199   0.002913
+     5  C    0.000240  -0.001297  -0.018192  -0.000199  -0.021995  -0.000283
+     6  H    0.000036   0.001125  -0.008176   0.002913  -0.000283   0.008624
+     7  H    0.000017   0.000010  -0.001043   0.002237  -0.000208  -0.000009
+     8  H    0.000092  -0.003641  -0.006011   0.001860   0.001446  -0.005445
+     9  H    0.000031   0.001037  -0.005864   0.000367  -0.000731   0.001147
+    10  H    0.000109  -0.003679  -0.009546   0.000132   0.011124  -0.001008
+    11  H    0.000123   0.001491  -0.004739   0.000095   0.000030   0.000167
+    12  C    0.004625   0.008511  -0.175548   0.009039   0.001444   0.003346
+    13  O   -0.001647  -0.000516   0.020437  -0.001638  -0.000084  -0.000304
+    14  H   -0.000745  -0.000742   0.013110  -0.000413  -0.000413  -0.000149
+    15  H    0.002208   0.013538  -0.085852   0.010917   0.007760   0.002879
+    16  H   -0.000092  -0.000367   0.008325  -0.000690  -0.000142  -0.000475
+    17  H    0.001387  -0.000400  -0.003303   0.000257   0.000014   0.000052
+               7          8          9         10         11         12
+     1  N    0.000017   0.000092   0.000031   0.000109   0.000123   0.004625
+     2  C    0.000010  -0.003641   0.001037  -0.003679   0.001491   0.008511
+     3  C   -0.001043  -0.006011  -0.005864  -0.009546  -0.004739  -0.175548
+     4  C    0.002237   0.001860   0.000367   0.000132   0.000095   0.009039
+     5  C   -0.000208   0.001446  -0.000731   0.011124   0.000030   0.001444
+     6  H   -0.000009  -0.005445   0.001147  -0.001008   0.000167   0.003346
+     7  H    0.000948  -0.000106  -0.000036   0.000076  -0.000014  -0.000913
+     8  H   -0.000106   0.031969  -0.000799   0.002653  -0.000206  -0.001257
+     9  H   -0.000036  -0.000799   0.009039  -0.005012   0.001730   0.002337
+    10  H    0.000076   0.002653  -0.005012   0.029631  -0.003566  -0.000986
+    11  H   -0.000014  -0.000206   0.001730  -0.003566   0.004677   0.001815
+    12  C   -0.000913  -0.001257   0.002337  -0.000986   0.001815   0.676958
+    13  O   -0.000113   0.000172  -0.000049   0.000027  -0.000049  -0.090045
+    14  H   -0.000000   0.000058  -0.000302   0.000129  -0.000467  -0.021802
+    15  H    0.001583  -0.002648   0.002851  -0.002581   0.002093   0.090962
+    16  H    0.000042   0.000096  -0.000230   0.000052  -0.000088  -0.015087
+    17  H   -0.000019  -0.000055   0.000021  -0.000022   0.000036   0.002652
+              13         14         15         16         17
+     1  N   -0.001647  -0.000745   0.002208  -0.000092   0.001387
+     2  C   -0.000516  -0.000742   0.013538  -0.000367  -0.000400
+     3  C    0.020437   0.013110  -0.085852   0.008325  -0.003303
+     4  C   -0.001638  -0.000413   0.010917  -0.000690   0.000257
+     5  C   -0.000084  -0.000413   0.007760  -0.000142   0.000014
+     6  H   -0.000304  -0.000149   0.002879  -0.000475   0.000052
+     7  H   -0.000113  -0.000000   0.001583   0.000042  -0.000019
+     8  H    0.000172   0.000058  -0.002648   0.000096  -0.000055
+     9  H   -0.000049  -0.000302   0.002851  -0.000230   0.000021
+    10  H    0.000027   0.000129  -0.002581   0.000052  -0.000022
+    11  H   -0.000049  -0.000467   0.002093  -0.000088   0.000036
+    12  C   -0.090045  -0.021802   0.090962  -0.015087   0.002652
+    13  O    0.178380  -0.000262  -0.005068   0.000524   0.001154
+    14  H   -0.000262   0.009033  -0.003340   0.007298  -0.001395
+    15  H   -0.005068  -0.003340  -0.090422  -0.003245   0.001936
+    16  H    0.000524   0.007298  -0.003245  -0.003895  -0.000887
+    17  H    0.001154  -0.001395   0.001936  -0.000887  -0.002829
+ Mulliken charges and spin densities:
+               1          2
+     1  N   -0.265157   0.123305
+     2  C    0.080603  -0.057333
+     3  C   -0.249928   0.395034
+     4  C   -0.251757  -0.020664
+     5  C   -0.247575  -0.021486
+     6  H    0.112091   0.004441
+     7  H    0.132139   0.002452
+     8  H    0.124848   0.018177
+     9  H    0.114247   0.005536
+    10  H    0.125667   0.017533
+    11  H    0.122292   0.003127
+    12  C   -0.126096   0.496051
+    13  O   -0.340634   0.100920
+    14  H    0.115127  -0.000402
+    15  H    0.165681  -0.056428
+    16  H    0.126952  -0.008862
+    17  H    0.261498  -0.001402
+ Sum of Mulliken charges =  -0.00000   1.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  N   -0.265157   0.123305
+     2  C    0.080603  -0.057333
+     3  C   -0.084247   0.338606
+     4  C    0.117321   0.004406
+     5  C    0.114632   0.004710
+    12  C    0.115983   0.486788
+    13  O   -0.079136   0.099518
+ APT charges:
+               1
+     1  N   -0.368332
+     2  C    0.100968
+     3  C    0.180248
+     4  C    0.027378
+     5  C    0.042929
+     6  H   -0.006387
+     7  H    0.014230
+     8  H   -0.016142
+     9  H   -0.007566
+    10  H   -0.025657
+    11  H   -0.000635
+    12  C    0.584348
+    13  O   -0.610082
+    14  H   -0.078567
+    15  H   -0.112730
+    16  H   -0.017908
+    17  H    0.293905
+ Sum of APT charges =   0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.368332
+     2  C    0.100968
+     3  C    0.067518
+     4  C    0.019079
+     5  C    0.009072
+    12  C    0.487873
+    13  O   -0.316177
+ Electronic spatial extent (au):  <R**2>=            941.7429
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.9778    Y=             -3.2587    Z=             -1.0076  Tot=              3.5483
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -44.2587   YY=            -51.1196   ZZ=            -43.0441
+   XY=             -1.8018   XZ=              2.6070   YZ=              0.4877
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.8821   YY=             -4.9788   ZZ=              3.0967
+   XY=             -1.8018   XZ=              2.6070   YZ=              0.4877
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              1.5637  YYY=            -30.8656  ZZZ=             -0.3461  XYY=             -8.5191
+  XXY=              4.8569  XXZ=             -5.1576  XZZ=             -2.8193  YZZ=             -0.2041
+  YYZ=              0.9053  XYZ=             -0.7145
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -648.8150 YYYY=           -444.5250 ZZZZ=           -233.0740 XXXY=            -12.6068
+ XXXZ=             10.9457 YYYX=              0.7387 YYYZ=              1.5968 ZZZX=             -0.5557
+ ZZZY=             -0.1018 XXYY=           -156.2376 XXZZ=           -143.1281 YYZZ=           -105.9954
+ XXYZ=              1.8069 YYXZ=             -1.3227 ZZXY=              0.1278
+ N-N= 2.922913579452D+02 E-N=-1.345579856003D+03  KE= 3.252345030773D+02
+  Exact polarizability:  84.743   0.972  76.475   3.256   1.192  60.037
+ Approx polarizability: 113.984  -1.991 120.875   2.878   1.947  80.313
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  N(14)              0.00596       1.92549       0.68706       0.64228
+     2  C(13)             -0.01929     -21.68507      -7.73777      -7.23336
+     3  C(13)              0.14325     161.03794      57.46234      53.71647
+     4  C(13)             -0.01147     -12.89077      -4.59975      -4.29990
+     5  C(13)             -0.01200     -13.49085      -4.81387      -4.50006
+     6  H(1)               0.00155       6.92954       2.47263       2.31145
+     7  H(1)               0.00179       7.99507       2.85284       2.66687
+     8  H(1)               0.00867      38.74203      13.82412      12.92295
+     9  H(1)               0.00218       9.76668       3.48499       3.25781
+    10  H(1)               0.00903      40.34255      14.39522      13.45683
+    11  H(1)               0.00130       5.82316       2.07785       1.94240
+    12  C(13)              0.15165     170.47847      60.83096      56.86550
+    13  O(17)              0.01258      -7.62794      -2.72184      -2.54441
+    14  H(1)               0.00092       4.09930       1.46273       1.36738
+    15  H(1)              -0.02680    -119.80271     -42.74859     -39.96188
+    16  H(1)              -0.00150      -6.70882      -2.39387      -2.23782
+    17  H(1)              -0.00098      -4.39487      -1.56820      -1.46597
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        0.197113     -0.108894     -0.088219
+     2   Atom       -0.027449      0.041186     -0.013736
+     3   Atom        0.324435     -0.134926     -0.189509
+     4   Atom        0.001780     -0.006756      0.004976
+     5   Atom        0.010414     -0.006952     -0.003462
+     6   Atom       -0.001111      0.000560      0.000551
+     7   Atom       -0.003213     -0.005426      0.008639
+     8   Atom       -0.000038     -0.003516      0.003555
+     9   Atom        0.002880     -0.000577     -0.002303
+    10   Atom        0.005886     -0.003933     -0.001954
+    11   Atom        0.000678     -0.004982      0.004305
+    12   Atom        0.594867     -0.306410     -0.288457
+    13   Atom        0.518536     -0.282268     -0.236268
+    14   Atom       -0.007101     -0.030434      0.037535
+    15   Atom        0.148983     -0.068650     -0.080333
+    16   Atom       -0.005952      0.037262     -0.031310
+    17   Atom       -0.009435      0.027379     -0.017944
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.112246      0.090376      0.030305
+     2   Atom       -0.031692     -0.004683     -0.006093
+     3   Atom        0.278089      0.211627      0.100066
+     4   Atom       -0.000851      0.009049     -0.003195
+     5   Atom       -0.000824     -0.007153      0.001408
+     6   Atom       -0.002648      0.003803     -0.006149
+     7   Atom        0.001003      0.001117     -0.001132
+     8   Atom        0.000321      0.004929     -0.001442
+     9   Atom       -0.005079     -0.003486      0.004076
+    10   Atom       -0.000149     -0.003263      0.001131
+    11   Atom        0.001056     -0.005965      0.000248
+    12   Atom        0.153749      0.209768      0.031822
+    13   Atom        0.069941      0.246195      0.014645
+    14   Atom        0.006863      0.009479     -0.019440
+    15   Atom        0.072960      0.057941      0.019361
+    16   Atom        0.014718      0.006420     -0.018294
+    17   Atom       -0.005011      0.001108     -0.007790
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -0.1457    -5.618    -2.005    -1.874 -0.3063  0.9517 -0.0201
+     1 N(14)  Bbb    -0.1143    -4.408    -1.573    -1.470 -0.2573 -0.0625  0.9643
+              Bcc     0.2600    10.026     3.578     3.344  0.9165  0.3006  0.2640
+ 
+              Baa    -0.0414    -5.558    -1.983    -1.854  0.9022  0.3633  0.2326
+     2 C(13)  Bbb    -0.0124    -1.664    -0.594    -0.555 -0.2380 -0.0304  0.9708
+              Bcc     0.0538     7.222     2.577     2.409 -0.3597  0.9312 -0.0591
+ 
+              Baa    -0.2661   -35.708   -12.742   -11.911 -0.2361  0.8541 -0.4634
+     3 C(13)  Bbb    -0.2653   -35.606   -12.705   -11.877 -0.4517  0.3258  0.8306
+              Bcc     0.5314    71.314    25.447    23.788  0.8604  0.4054  0.3088
+ 
+              Baa    -0.0081    -1.082    -0.386    -0.361 -0.3231  0.8427  0.4307
+     4 C(13)  Bbb    -0.0050    -0.666    -0.237    -0.222  0.7091  0.5170 -0.4795
+              Bcc     0.0130     1.748     0.624     0.583  0.6268 -0.1505  0.7645
+ 
+              Baa    -0.0078    -1.043    -0.372    -0.348 -0.1903  0.7954 -0.5755
+     5 C(13)  Bbb    -0.0058    -0.772    -0.275    -0.257  0.3484  0.6028  0.7178
+              Bcc     0.0135     1.815     0.648     0.605  0.9178 -0.0639 -0.3918
+ 
+              Baa    -0.0058    -3.102    -1.107    -1.035 -0.2586  0.6129  0.7467
+     6 H(1)   Bbb    -0.0030    -1.599    -0.571    -0.534  0.8703  0.4833 -0.0952
+              Bcc     0.0088     4.702     1.678     1.568  0.4192 -0.6252  0.6584
+ 
+              Baa    -0.0060    -3.180    -1.135    -1.061 -0.3771  0.9207  0.1003
+     7 H(1)   Bbb    -0.0029    -1.525    -0.544    -0.509  0.9221  0.3834 -0.0519
+              Bcc     0.0088     4.705     1.679     1.569  0.0862 -0.0729  0.9936
+ 
+              Baa    -0.0046    -2.474    -0.883    -0.825 -0.5274  0.7239  0.4448
+     8 H(1)   Bbb    -0.0025    -1.314    -0.469    -0.438  0.6365  0.6834 -0.3576
+              Bcc     0.0071     3.787     1.351     1.263  0.5628 -0.0945  0.8212
+ 
+              Baa    -0.0057    -3.023    -1.079    -1.008 -0.1195 -0.6906  0.7133
+     9 H(1)   Bbb    -0.0033    -1.754    -0.626    -0.585  0.6922  0.4571  0.5585
+              Bcc     0.0090     4.777     1.705     1.593  0.7118 -0.5605 -0.4234
+ 
+              Baa    -0.0046    -2.475    -0.883    -0.825 -0.1549  0.8289 -0.5375
+    10 H(1)   Bbb    -0.0025    -1.309    -0.467    -0.437  0.3111  0.5573  0.7698
+              Bcc     0.0071     3.784     1.350     1.262  0.9377 -0.0480 -0.3442
+ 
+              Baa    -0.0055    -2.959    -1.056    -0.987 -0.4041  0.8749 -0.2668
+    11 H(1)   Bbb    -0.0032    -1.704    -0.608    -0.568  0.6929  0.4832  0.5352
+              Bcc     0.0087     4.663     1.664     1.555 -0.5972 -0.0315  0.8015
+ 
+              Baa    -0.3371   -45.238   -16.142   -15.090 -0.2659  0.4452  0.8550
+    12 C(13)  Bbb    -0.3303   -44.328   -15.817   -14.786 -0.0396  0.8812 -0.4711
+              Bcc     0.6675    89.566    31.959    29.876  0.9632  0.1591  0.2167
+ 
+              Baa    -0.3110    22.502     8.029     7.506 -0.2948  0.2473  0.9230
+    13 O(17)  Bbb    -0.2865    20.733     7.398     6.916 -0.0043  0.9656 -0.2601
+              Bcc     0.5975   -43.235   -15.427   -14.422  0.9556  0.0807  0.2836
+ 
+              Baa    -0.0383   -20.433    -7.291    -6.816 -0.2847  0.9194  0.2713
+    14 H(1)   Bbb    -0.0055    -2.937    -1.048    -0.980  0.9473  0.3132 -0.0672
+              Bcc     0.0438    23.370     8.339     7.795  0.1467 -0.2379  0.9602
+ 
+              Baa    -0.0950   -50.690   -18.088   -16.908 -0.0939 -0.4074  0.9084
+    15 H(1)   Bbb    -0.0902   -48.136   -17.176   -16.056 -0.3501  0.8677  0.3530
+              Bcc     0.1852    98.826    35.264    32.965  0.9320  0.2849  0.2241
+ 
+              Baa    -0.0390   -20.798    -7.421    -6.937 -0.3008  0.2770  0.9126
+    16 H(1)   Bbb    -0.0061    -3.256    -1.162    -1.086  0.9211 -0.1636  0.3533
+              Bcc     0.0451    24.054     8.583     8.024  0.2471  0.9468 -0.2060
+ 
+              Baa    -0.0193   -10.273    -3.665    -3.427 -0.0288  0.1617  0.9864
+    17 H(1)   Bbb    -0.0101    -5.391    -1.924    -1.798  0.9910  0.1339  0.0070
+              Bcc     0.0294    15.664     5.589     5.225 -0.1310  0.9777 -0.1641
+ 
+
+ ---------------------------------------------------------------------------------
+
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:               7.1 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Rotating derivatives to standard orientation.
+ Dipole        = 3.84678085D-01-1.28207786D+00-3.96426369D-01
+ Polarizability= 8.47434459D+01 9.71548635D-01 7.64749257D+01
+                 3.25634292D+00 1.19244959D+00 6.00374514D+01
+ Full mass-weighted force constant matrix:
+ Low frequencies ----1617.8294   -5.6283   -2.5954    0.0002    0.0004    0.0012
+ Low frequencies ---    0.2106   56.9536   76.6818
+ ******    1 imaginary frequencies (negative Signs) ****** 
+ Diagonal vibrational polarizability:
+       77.0287192      10.4508637      12.5143954
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                      A                      A                      A
+ Frequencies --  -1617.8294                56.9524                76.6808
+ Red. masses --      1.1404                 3.5974                 5.6207
+ Frc consts  --      1.7586                 0.0069                 0.0195
+ IR Inten    --    175.5710                 3.8192                 4.9602
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00   0.00     0.11   0.08  -0.07     0.34   0.19   0.08
+     2   6     0.00   0.02   0.00     0.04   0.05  -0.08     0.11   0.11   0.04
+     3   6    -0.06  -0.04  -0.02    -0.03   0.03  -0.07    -0.04   0.07   0.03
+     4   6     0.01   0.00   0.01    -0.24  -0.00  -0.05     0.04   0.08   0.02
+     5   6     0.01   0.00   0.00     0.09   0.01   0.06    -0.16  -0.03  -0.05
+     6   1    -0.00   0.00  -0.00    -0.23   0.00  -0.06    -0.07   0.07   0.03
+     7   1     0.00  -0.00  -0.00    -0.35  -0.02  -0.18     0.14   0.18   0.10
+     8   1     0.00  -0.00   0.01    -0.32  -0.01   0.10     0.13  -0.00  -0.09
+     9   1    -0.00   0.00   0.00     0.04   0.01   0.03    -0.25  -0.04  -0.04
+    10   1     0.01   0.00  -0.01     0.07  -0.05   0.20    -0.11  -0.11  -0.15
+    11   1    -0.00  -0.00   0.00     0.24   0.05   0.03    -0.21  -0.03  -0.04
+    12   6    -0.08  -0.01  -0.01    -0.02   0.04  -0.06     0.01  -0.15   0.02
+    13   8     0.01  -0.00  -0.00     0.07  -0.18   0.21    -0.23  -0.20  -0.10
+    14   1     0.09   0.04   0.00    -0.18   0.27   0.01     0.03  -0.26  -0.01
+    15   1     0.91   0.30   0.24    -0.00   0.07  -0.18    -0.06   0.09   0.10
+    16   1     0.05  -0.01   0.03     0.07  -0.02  -0.26     0.18  -0.17   0.09
+    17   1    -0.01   0.00  -0.01    -0.06  -0.12   0.35    -0.40  -0.20  -0.17
+                      4                      5                      6
+                      A                      A                      A
+ Frequencies --    121.4038               182.1570               194.9794
+ Red. masses --      2.2071                 4.1869                 1.0843
+ Frc consts  --      0.0192                 0.0819                 0.0243
+ IR Inten    --      4.9786                 3.5846                 0.1072
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.05  -0.04  -0.03    -0.06   0.02   0.28     0.04   0.01   0.00
+     2   6     0.02  -0.01   0.00    -0.01   0.03  -0.06    -0.02  -0.02   0.00
+     3   6     0.03  -0.01   0.05    -0.03   0.02  -0.09    -0.02  -0.02   0.00
+     4   6     0.12   0.07   0.07    -0.09   0.21   0.00    -0.03  -0.01   0.00
+     5   6    -0.05  -0.09   0.00    -0.10  -0.20  -0.06    -0.01   0.04  -0.00
+     6   1     0.10   0.07   0.13    -0.05   0.20   0.17    -0.13  -0.02   0.02
+     7   1     0.18   0.13   0.12    -0.15   0.28  -0.10     0.02   0.07   0.03
+     8   1     0.17   0.09  -0.03    -0.14   0.31   0.01     0.03  -0.09  -0.03
+     9   1    -0.05  -0.09   0.09    -0.22  -0.22   0.09     0.42   0.03   0.36
+    10   1    -0.03  -0.06  -0.11    -0.05  -0.27  -0.16    -0.11   0.53  -0.28
+    11   1    -0.14  -0.17  -0.01    -0.11  -0.32  -0.11    -0.31  -0.40  -0.10
+    12   6     0.01   0.16  -0.14     0.06  -0.07  -0.06    -0.01  -0.01  -0.01
+    13   8    -0.07  -0.09   0.04     0.20   0.00  -0.03     0.03   0.00   0.00
+    14   1     0.17   0.52  -0.07    -0.00  -0.10  -0.06    -0.02   0.00  -0.01
+    15   1    -0.00   0.02   0.07     0.04  -0.03  -0.09    -0.01  -0.04  -0.01
+    16   1    -0.08   0.10  -0.51     0.04  -0.05   0.00    -0.04  -0.00  -0.02
+    17   1    -0.03  -0.03   0.30     0.27  -0.01  -0.04     0.04   0.00   0.00
+                      7                      8                      9
+                      A                      A                      A
+ Frequencies --    202.4046               209.9619               273.5058
+ Red. masses --      1.1609                 3.4238                 2.3572
+ Frc consts  --      0.0280                 0.0889                 0.1039
+ IR Inten    --      0.1836                 1.7958                 0.2316
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.05  -0.01   0.03     0.07   0.05  -0.16     0.13  -0.01   0.04
+     2   6    -0.00  -0.03  -0.02    -0.07   0.01   0.10    -0.12  -0.10  -0.03
+     3   6     0.00  -0.03  -0.02    -0.09   0.00   0.13    -0.11  -0.09  -0.03
+     4   6     0.02   0.03   0.01    -0.02  -0.08   0.08     0.08   0.09   0.02
+     5   6     0.03   0.00  -0.01    -0.23   0.07  -0.03     0.03   0.09   0.05
+     6   1     0.58   0.09  -0.00     0.27  -0.04  -0.02    -0.03   0.08   0.20
+     7   1    -0.23  -0.40  -0.16    -0.12  -0.36   0.05     0.25   0.29   0.16
+     8   1    -0.28   0.49   0.20    -0.15   0.11   0.19     0.22   0.10  -0.26
+     9   1     0.12   0.01   0.04    -0.34   0.07  -0.20     0.06   0.10  -0.16
+    10   1    -0.00   0.10  -0.03    -0.17  -0.05  -0.13    -0.02   0.04   0.31
+    11   1    -0.01  -0.06  -0.02    -0.34   0.23   0.06     0.22   0.29   0.09
+    12   6    -0.04   0.01   0.00     0.08  -0.04  -0.07    -0.13  -0.06  -0.07
+    13   8    -0.05   0.01  -0.00     0.20  -0.01  -0.01     0.05   0.01   0.01
+    14   1    -0.03   0.02   0.01     0.13   0.05  -0.05    -0.14   0.03  -0.05
+    15   1    -0.03  -0.04  -0.00     0.03  -0.06   0.06    -0.14  -0.23  -0.07
+    16   1    -0.07   0.01  -0.01    -0.01  -0.03  -0.13    -0.32  -0.03  -0.13
+    17   1    -0.03   0.01   0.01     0.28  -0.02   0.02     0.19  -0.00   0.05
+                     10                     11                     12
+                      A                      A                      A
+ Frequencies --    342.4680               431.9850               464.0768
+ Red. masses --      2.3374                 1.2060                 3.2721
+ Frc consts  --      0.1615                 0.1326                 0.4152
+ IR Inten    --      1.0482               117.2844                 5.4605
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.03   0.12  -0.01    -0.00   0.03   0.01     0.08   0.03   0.04
+     2   6    -0.07   0.10   0.00     0.00   0.03  -0.03    -0.24  -0.09  -0.11
+     3   6    -0.08   0.07  -0.01     0.01   0.02  -0.01    -0.09  -0.05  -0.04
+     4   6     0.12  -0.09  -0.11    -0.01  -0.02  -0.02    -0.02  -0.02  -0.05
+     5   6     0.00  -0.11   0.16     0.01  -0.00   0.00    -0.02  -0.01   0.02
+     6   1     0.29  -0.06  -0.35    -0.04  -0.02  -0.08    -0.02  -0.02  -0.07
+     7   1     0.20  -0.34   0.08    -0.03  -0.04  -0.03     0.01  -0.03  -0.00
+     8   1     0.15  -0.05  -0.20    -0.02  -0.06   0.02     0.01  -0.02  -0.11
+     9   1    -0.04  -0.13   0.43    -0.00  -0.00   0.02     0.02  -0.01   0.02
+    10   1    -0.02  -0.11   0.23     0.01  -0.01   0.01    -0.05   0.00   0.14
+    11   1     0.17  -0.33   0.03     0.03  -0.02  -0.01     0.09  -0.00   0.00
+    12   6    -0.04  -0.02  -0.04     0.01  -0.05   0.06     0.27   0.11   0.13
+    13   8     0.05  -0.00   0.00    -0.06  -0.00  -0.04    -0.03   0.01   0.00
+    14   1    -0.15  -0.06  -0.04     0.35   0.09   0.06     0.61   0.24   0.12
+    15   1    -0.07   0.03  -0.07     0.02  -0.09   0.14     0.13  -0.06   0.19
+    16   1    -0.01  -0.02   0.01    -0.28  -0.03  -0.11     0.23   0.08  -0.05
+    17   1    -0.01  -0.01  -0.05     0.72   0.01   0.44    -0.40   0.02  -0.14
+                     13                     14                     15
+                      A                      A                      A
+ Frequencies --    577.7580               594.4120               615.5217
+ Red. masses --      1.8475                 5.3559                 1.8418
+ Frc consts  --      0.3634                 1.1150                 0.4111
+ IR Inten    --     47.9657                 1.9389                31.7256
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.08  -0.03     0.06   0.07  -0.12    -0.03  -0.05  -0.03
+     2   6     0.09  -0.03   0.09    -0.29  -0.04   0.45     0.14   0.02   0.14
+     3   6    -0.12  -0.05  -0.05     0.11   0.02  -0.07    -0.07  -0.01  -0.05
+     4   6    -0.01   0.05  -0.08    -0.02   0.07  -0.07    -0.03   0.05  -0.11
+     5   6    -0.06   0.02   0.05     0.15  -0.11  -0.14    -0.03   0.01   0.03
+     6   1     0.09   0.05   0.04    -0.09   0.06   0.16     0.01   0.05  -0.03
+     7   1     0.06   0.07   0.02    -0.09   0.25  -0.22    -0.01   0.08  -0.09
+     8   1     0.02   0.19  -0.26    -0.07   0.11   0.01    -0.03   0.13  -0.17
+     9   1     0.05   0.03   0.06    -0.07  -0.14   0.08     0.03   0.01   0.07
+    10   1    -0.13   0.11   0.19     0.23  -0.27  -0.22    -0.07   0.06   0.14
+    11   1     0.04   0.02   0.03     0.18  -0.28  -0.21     0.07  -0.02  -0.01
+    12   6     0.09   0.07  -0.00    -0.01   0.01  -0.00     0.01  -0.06   0.06
+    13   8    -0.03  -0.01  -0.02    -0.03   0.00  -0.00     0.03   0.01   0.01
+    14   1    -0.19  -0.20  -0.04    -0.07  -0.03  -0.00     0.44   0.25   0.09
+    15   1    -0.04   0.20  -0.13     0.09   0.00  -0.09    -0.08  -0.14   0.13
+    16   1     0.53   0.05   0.26     0.04   0.01   0.05    -0.48  -0.04  -0.29
+    17   1     0.36   0.03   0.34     0.16   0.01   0.14    -0.31  -0.03  -0.32
+                     16                     17                     18
+                      A                      A                      A
+ Frequencies --    764.1285               962.2970               968.0014
+ Red. masses --      3.3871                 1.6903                 1.5548
+ Frc consts  --      1.1652                 0.9222                 0.8584
+ IR Inten    --      4.3441                 1.8298                 1.1161
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.08   0.16  -0.01     0.02  -0.07   0.00     0.02  -0.05   0.00
+     2   6     0.06   0.17   0.03     0.01  -0.05   0.00     0.01  -0.03   0.00
+     3   6    -0.17  -0.16  -0.07    -0.06   0.11  -0.07    -0.08   0.08   0.04
+     4   6    -0.01  -0.11   0.17     0.04  -0.01   0.12    -0.11   0.06   0.05
+     5   6     0.10  -0.09  -0.15    -0.04   0.07  -0.11     0.11  -0.01  -0.05
+     6   1     0.14  -0.11   0.46    -0.08  -0.01  -0.04     0.16   0.10  -0.40
+     7   1     0.10  -0.02   0.28    -0.04  -0.09   0.05     0.19  -0.31   0.56
+     8   1     0.02   0.14  -0.10     0.01  -0.15   0.29     0.13  -0.02  -0.35
+     9   1     0.40  -0.07  -0.30    -0.12   0.03   0.41    -0.07  -0.02  -0.09
+    10   1    -0.05   0.13   0.11    -0.10  -0.08   0.33     0.20  -0.10  -0.30
+    11   1     0.25   0.02  -0.15     0.52  -0.27  -0.38    -0.09  -0.03  -0.01
+    12   6     0.05   0.01   0.01    -0.01   0.00  -0.00    -0.00  -0.00   0.01
+    13   8     0.00   0.00   0.00     0.01  -0.00  -0.00     0.00  -0.00  -0.00
+    14   1     0.05   0.00   0.01     0.04   0.01  -0.00     0.05   0.03   0.01
+    15   1    -0.19  -0.09  -0.04    -0.06   0.07   0.04    -0.02   0.05  -0.05
+    16   1     0.01   0.01  -0.02     0.04  -0.01   0.00    -0.01  -0.01  -0.02
+    17   1    -0.03   0.00  -0.01     0.00  -0.00  -0.01     0.01  -0.01  -0.02
+                     19                     20                     21
+                      A                      A                      A
+ Frequencies --   1004.7854              1098.0135              1129.3892
+ Red. masses --      1.3170                 1.1868                 1.6227
+ Frc consts  --      0.7834                 0.8430                 1.2195
+ IR Inten    --      0.6368                73.6310                 7.1445
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.00   0.00     0.00  -0.00   0.00     0.01  -0.01   0.00
+     2   6     0.01   0.00  -0.03    -0.01  -0.01  -0.00    -0.03  -0.02  -0.01
+     3   6     0.02   0.00  -0.05     0.03   0.03   0.01     0.12   0.10   0.06
+     4   6    -0.03  -0.10   0.01    -0.01  -0.02  -0.01    -0.08  -0.06  -0.02
+     5   6     0.01   0.10   0.04    -0.02  -0.02  -0.01    -0.07  -0.06  -0.05
+     6   1     0.15  -0.11   0.47     0.05  -0.02   0.08     0.21  -0.04   0.23
+     7   1     0.09   0.17   0.06     0.03   0.04   0.03     0.14   0.10   0.19
+     8   1    -0.04   0.27  -0.30    -0.01   0.07  -0.09    -0.02   0.26  -0.41
+     9   1    -0.42   0.06   0.30     0.10  -0.01  -0.04     0.29  -0.03  -0.04
+    10   1     0.21  -0.25  -0.24    -0.06   0.06   0.07    -0.24   0.19   0.31
+    11   1    -0.10  -0.18  -0.04     0.04   0.04   0.00     0.22   0.10  -0.05
+    12   6     0.01  -0.01   0.02    -0.04  -0.07   0.00    -0.04   0.02  -0.01
+    13   8    -0.01   0.00  -0.00    -0.03   0.05   0.04     0.03  -0.02  -0.02
+    14   1    -0.00   0.04   0.03     0.02   0.34   0.11     0.17  -0.13  -0.07
+    15   1     0.06   0.00  -0.15    -0.06   0.15  -0.02     0.08   0.18   0.08
+    16   1    -0.07  -0.01  -0.04     0.54  -0.24  -0.34    -0.17   0.08   0.16
+    17   1     0.01  -0.00  -0.02     0.32  -0.13  -0.44    -0.12   0.05   0.17
+                     22                     23                     24
+                      A                      A                      A
+ Frequencies --   1137.0453              1150.7824              1185.4532
+ Red. masses --      1.2764                 4.6969                 3.2299
+ Frc consts  --      0.9723                 3.6648                 2.6743
+ IR Inten    --     18.3319                97.1904                 3.3994
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00   0.00     0.00   0.01   0.00    -0.01   0.00   0.01
+     2   6     0.01   0.00  -0.01    -0.00  -0.01  -0.00     0.02   0.01  -0.06
+     3   6    -0.04  -0.01   0.04    -0.02   0.01  -0.01    -0.11  -0.05   0.36
+     4   6     0.01  -0.01  -0.03     0.02  -0.01  -0.01     0.01   0.00  -0.15
+     5   6     0.04   0.02  -0.00     0.02  -0.01   0.02     0.07   0.04  -0.14
+     6   1    -0.03  -0.01   0.06    -0.02  -0.02   0.09    -0.07  -0.01   0.07
+     7   1    -0.02   0.05  -0.10    -0.00   0.03  -0.04    -0.06   0.22  -0.31
+     8   1    -0.03   0.02   0.04    -0.03   0.00   0.09    -0.10   0.18  -0.09
+     9   1    -0.06   0.01   0.01     0.01  -0.00  -0.06    -0.02   0.01   0.18
+    10   1     0.10  -0.08  -0.12     0.04  -0.00  -0.08     0.11  -0.20   0.04
+    11   1    -0.02  -0.05  -0.02    -0.05   0.01   0.04     0.30  -0.23  -0.30
+    12   6    -0.11   0.00  -0.06    -0.22   0.22   0.29     0.05   0.01   0.01
+    13   8     0.02   0.01   0.03     0.15  -0.19  -0.23    -0.00  -0.01  -0.01
+    14   1     0.71  -0.15  -0.17    -0.11   0.53   0.35    -0.41   0.04   0.06
+    15   1    -0.26  -0.06   0.16    -0.28   0.05  -0.00     0.03  -0.03   0.27
+    16   1     0.41  -0.01   0.25     0.27   0.09   0.10    -0.10   0.01  -0.09
+    17   1    -0.10   0.06   0.13     0.13  -0.18  -0.17     0.07  -0.04  -0.08
+                     25                     26                     27
+                      A                      A                      A
+ Frequencies --   1249.0749              1387.4803              1401.5075
+ Red. masses --      2.5195                 1.2454                 1.2002
+ Frc consts  --      2.3160                 1.4126                 1.3890
+ IR Inten    --      5.2118                33.4841                 6.6804
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.03  -0.07   0.00    -0.00   0.00  -0.00    -0.00  -0.00   0.00
+     2   6    -0.01  -0.04  -0.01     0.00   0.00  -0.00     0.00   0.00  -0.00
+     3   6    -0.18   0.25  -0.01    -0.00  -0.01   0.02    -0.00   0.01  -0.00
+     4   6     0.09  -0.09  -0.01     0.00   0.01  -0.00    -0.02   0.03  -0.09
+     5   6     0.08  -0.09   0.03    -0.01   0.00  -0.00     0.06  -0.02  -0.06
+     6   1    -0.15  -0.12   0.34    -0.00   0.00  -0.00     0.08   0.00   0.40
+     7   1    -0.03   0.22  -0.26    -0.01  -0.00  -0.01     0.23  -0.17   0.32
+     8   1    -0.15   0.17   0.24     0.01  -0.01   0.01    -0.10  -0.22   0.33
+     9   1     0.10  -0.06  -0.36     0.05   0.00  -0.00    -0.28  -0.04   0.25
+    10   1     0.05   0.18  -0.25     0.00  -0.03  -0.00    -0.12   0.17   0.32
+    11   1    -0.17   0.16   0.18     0.04  -0.01  -0.02    -0.33   0.15   0.12
+    12   6     0.04  -0.02  -0.00    -0.01  -0.10   0.03     0.00  -0.01  -0.00
+    13   8    -0.00   0.01   0.01     0.02   0.05  -0.06     0.00   0.01  -0.00
+    14   1    -0.04  -0.03  -0.00    -0.08   0.32   0.16    -0.06   0.01   0.01
+    15   1    -0.05   0.33  -0.06     0.04   0.01  -0.28    -0.01  -0.07   0.14
+    16   1    -0.19   0.00  -0.06     0.23  -0.20  -0.17     0.04  -0.02  -0.02
+    17   1    -0.02   0.02   0.04    -0.42   0.29   0.61    -0.03   0.02   0.04
+                     28                     29                     30
+                      A                      A                      A
+ Frequencies --   1413.8082              1420.6473              1453.6298
+ Red. masses --      1.1030                 1.2073                 1.0800
+ Frc consts  --      1.2990                 1.4356                 1.3445
+ IR Inten    --      1.2522                 0.4948                 1.6361
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.01  -0.00     0.00  -0.00   0.00     0.00   0.01  -0.00
+     2   6     0.01   0.00   0.01    -0.00   0.00   0.00    -0.02  -0.00  -0.00
+     3   6     0.00   0.05  -0.05    -0.00   0.00   0.00     0.02  -0.05  -0.03
+     4   6    -0.02  -0.03   0.01    -0.02   0.03  -0.08    -0.01   0.01   0.00
+     5   6    -0.00  -0.00   0.03    -0.07   0.03   0.06     0.01   0.02   0.02
+     6   1     0.05  -0.02  -0.04     0.07   0.01   0.37     0.04   0.01   0.04
+     7   1    -0.00   0.09  -0.00     0.21  -0.16   0.29    -0.03  -0.06  -0.00
+     8   1    -0.01   0.06  -0.09    -0.09  -0.22   0.32     0.04  -0.08  -0.03
+     9   1     0.00   0.01  -0.10     0.32   0.05  -0.26    -0.00   0.03  -0.07
+    10   1     0.02   0.03  -0.10     0.13  -0.20  -0.35     0.04  -0.07   0.00
+    11   1     0.06  -0.02   0.00     0.36  -0.16  -0.13    -0.04  -0.12  -0.03
+    12   6     0.00  -0.00  -0.02     0.01   0.00  -0.01     0.00  -0.00   0.03
+    13   8     0.01   0.01  -0.01    -0.01  -0.00   0.01     0.02   0.01  -0.01
+    14   1    -0.29   0.06   0.03    -0.01   0.01  -0.00    -0.06  -0.31  -0.05
+    15   1    -0.00  -0.48   0.75     0.05  -0.04  -0.04    -0.30   0.64   0.40
+    16   1     0.19  -0.05  -0.03    -0.03   0.02   0.03    -0.05  -0.10  -0.40
+    17   1    -0.07   0.05   0.12     0.03  -0.01  -0.03    -0.07   0.05   0.11
+                     31                     32                     33
+                      A                      A                      A
+ Frequencies --   1481.9428              1487.0130              1496.0713
+ Red. masses --      1.0481                 1.0458                 1.1044
+ Frc consts  --      1.3561                 1.3625                 1.4564
+ IR Inten    --      2.7114                 4.2153                 7.2454
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.00   0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+     2   6     0.00   0.00  -0.00     0.00   0.00   0.00    -0.01  -0.00  -0.00
+     3   6    -0.00   0.00  -0.01     0.01   0.00  -0.01     0.01  -0.01  -0.02
+     4   6     0.03   0.02  -0.00     0.02  -0.03  -0.01     0.01   0.02   0.00
+     5   6    -0.03  -0.02  -0.03    -0.01   0.03  -0.01     0.00   0.02  -0.00
+     6   1    -0.39  -0.04   0.14    -0.29  -0.03  -0.25    -0.19  -0.01   0.13
+     7   1    -0.08  -0.37   0.01     0.26   0.12   0.26    -0.09  -0.26  -0.03
+     8   1     0.01   0.18  -0.14    -0.29   0.41   0.21     0.06   0.03  -0.13
+     9   1     0.23  -0.03   0.44     0.26   0.03  -0.07     0.14   0.02  -0.02
+    10   1     0.09  -0.14  -0.22     0.05  -0.34   0.27     0.05  -0.20   0.12
+    11   1     0.11   0.46   0.14    -0.31  -0.17  -0.00    -0.17  -0.08   0.01
+    12   6    -0.01   0.02   0.01    -0.00   0.01   0.01     0.03  -0.06  -0.06
+    13   8     0.00   0.00  -0.00     0.00   0.00   0.00    -0.00  -0.00  -0.00
+    14   1    -0.01  -0.15  -0.03     0.01  -0.09  -0.02    -0.06   0.50   0.10
+    15   1     0.02  -0.07   0.04     0.03  -0.06  -0.02    -0.17   0.28   0.22
+    16   1     0.04  -0.03  -0.16     0.03  -0.02  -0.09    -0.11   0.11   0.52
+    17   1    -0.01   0.01   0.01    -0.01   0.00   0.01     0.02  -0.01  -0.02
+                     34                     35                     36
+                      A                      A                      A
+ Frequencies --   1498.3823              1507.7382              2280.9880
+ Red. masses --      1.0468                 1.0770                12.2842
+ Frc consts  --      1.3848                 1.4425                37.6567
+ IR Inten    --      7.1790                 6.0726                38.7708
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00   0.00    -0.00   0.01  -0.00     0.20  -0.55   0.02
+     2   6    -0.00  -0.00   0.00    -0.00  -0.00  -0.00    -0.26   0.74  -0.03
+     3   6    -0.03  -0.00  -0.01     0.02  -0.06  -0.01     0.04  -0.09   0.01
+     4   6    -0.03  -0.02   0.01     0.00  -0.02  -0.01    -0.00  -0.01   0.00
+     5   6    -0.02  -0.00  -0.03    -0.00  -0.02   0.01     0.00  -0.01  -0.01
+     6   1     0.45   0.04  -0.14    -0.12  -0.01  -0.27    -0.01  -0.01  -0.01
+     7   1     0.06   0.42  -0.06     0.24   0.18   0.22    -0.01   0.01   0.00
+     8   1     0.00  -0.23   0.15    -0.23   0.27   0.22     0.02   0.03  -0.02
+     9   1     0.33  -0.01   0.35    -0.27  -0.03   0.13    -0.01  -0.02   0.00
+    10   1     0.12  -0.31  -0.06    -0.04   0.32  -0.30     0.00   0.02   0.03
+    11   1    -0.10   0.32   0.13     0.34   0.19   0.00    -0.00   0.01  -0.01
+    12   6     0.01  -0.01  -0.01     0.01  -0.03  -0.02    -0.00   0.00   0.00
+    13   8     0.00  -0.00  -0.00     0.00  -0.00  -0.00     0.00  -0.00  -0.00
+    14   1    -0.02   0.08   0.02    -0.02   0.18   0.04     0.03   0.02   0.00
+    15   1    -0.06   0.10   0.06    -0.13   0.25   0.10    -0.15  -0.07  -0.05
+    16   1    -0.04   0.02   0.08    -0.06   0.03   0.17     0.01   0.00   0.01
+    17   1     0.01  -0.00  -0.00    -0.01   0.00   0.01     0.01  -0.02   0.01
+                     37                     38                     39
+                      A                      A                      A
+ Frequencies --   3015.0637              3018.8870              3030.1281
+ Red. masses --      1.0386                 1.0387                 1.0551
+ Frc consts  --      5.5629                 5.5774                 5.7077
+ IR Inten    --     20.6466                35.8238                30.5308
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00  -0.00    -0.00   0.00  -0.00    -0.00   0.00   0.00
+     2   6     0.00  -0.00   0.00     0.00  -0.00   0.00    -0.00  -0.00  -0.00
+     3   6    -0.00   0.00  -0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+     4   6     0.01  -0.00   0.02    -0.03   0.01  -0.04    -0.00   0.00   0.00
+     5   6    -0.05   0.00   0.01    -0.02   0.00   0.01     0.00   0.00   0.00
+     6   1    -0.01   0.20   0.02     0.03  -0.44  -0.03     0.00   0.00   0.00
+     7   1     0.13  -0.04  -0.09    -0.30   0.08   0.21     0.00  -0.00  -0.00
+     8   1    -0.26  -0.12  -0.12     0.59   0.27   0.29    -0.00  -0.00  -0.00
+     9   1     0.01  -0.44  -0.02     0.00  -0.19  -0.01     0.00  -0.01  -0.00
+    10   1     0.64   0.25   0.18     0.29   0.11   0.08    -0.01  -0.00  -0.00
+    11   1    -0.10   0.13  -0.33    -0.04   0.06  -0.15    -0.00   0.00  -0.01
+    12   6     0.00  -0.00  -0.00     0.00  -0.00  -0.00    -0.01  -0.01  -0.06
+    13   8    -0.00   0.00   0.00    -0.00   0.00   0.00    -0.00  -0.00  -0.00
+    14   1    -0.00   0.00  -0.00    -0.00  -0.00   0.00     0.08  -0.23   0.87
+    15   1     0.00   0.00   0.00     0.01   0.00   0.00    -0.01   0.00  -0.00
+    16   1    -0.00  -0.00   0.00    -0.00   0.00  -0.00     0.06   0.41  -0.11
+    17   1     0.00   0.00   0.00     0.00   0.00  -0.00     0.00  -0.01   0.00
+                     40                     41                     42
+                      A                      A                      A
+ Frequencies --   3074.8207              3079.5256              3103.8434
+ Red. masses --      1.0970                 1.0976                 1.1021
+ Frc consts  --      6.1108                 6.1331                 6.2556
+ IR Inten    --     13.6394                19.5317                18.2868
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00  -0.00    -0.00   0.00   0.00    -0.00  -0.00   0.00
+     2   6     0.00  -0.00   0.00     0.00  -0.00  -0.00     0.00   0.00  -0.00
+     3   6    -0.00  -0.00   0.00    -0.00  -0.00  -0.00    -0.00   0.00  -0.00
+     4   6     0.01   0.01   0.00    -0.06  -0.07  -0.01     0.01  -0.00  -0.00
+     5   6    -0.05  -0.06  -0.04    -0.01  -0.01  -0.01    -0.02   0.07  -0.06
+     6   1     0.01  -0.10  -0.01    -0.08   0.70   0.04    -0.00   0.02   0.00
+     7   1    -0.02   0.01   0.02     0.25  -0.09  -0.21    -0.07   0.02   0.05
+     8   1    -0.07  -0.03  -0.03     0.50   0.21   0.25    -0.02  -0.01  -0.01
+     9   1    -0.04   0.68   0.03    -0.01   0.08   0.00     0.01  -0.54  -0.04
+    10   1     0.55   0.19   0.14     0.08   0.03   0.02     0.08   0.05   0.01
+    11   1     0.08  -0.15   0.34     0.02  -0.03   0.07     0.20  -0.29   0.75
+    12   6    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.00  -0.00   0.00
+    13   8     0.00  -0.00  -0.00     0.00  -0.00  -0.00     0.00   0.00   0.00
+    14   1     0.00  -0.00   0.02     0.00  -0.00   0.01     0.00  -0.00   0.00
+    15   1     0.00   0.00  -0.00     0.00   0.00   0.00     0.00   0.00   0.00
+    16   1     0.00   0.01  -0.00    -0.00  -0.01   0.00     0.00   0.01  -0.00
+    17   1    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.00  -0.00  -0.00
+                     43                     44                     45
+                      A                      A                      A
+ Frequencies --   3109.1728              3156.4351              3783.7315
+ Red. masses --      1.1019                 1.1101                 1.0664
+ Frc consts  --      6.2763                 6.5163                 8.9948
+ IR Inten    --     14.8226                18.5554                45.8418
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00  -0.00    -0.00  -0.00  -0.00     0.00  -0.00   0.00
+     2   6     0.00   0.00   0.00     0.00   0.00   0.00    -0.00   0.00  -0.00
+     3   6    -0.00   0.00   0.00     0.00   0.00  -0.00     0.00  -0.00   0.00
+     4   6    -0.06   0.05   0.04    -0.00  -0.00  -0.00    -0.00  -0.00  -0.00
+     5   6    -0.00   0.01  -0.00     0.00  -0.00   0.00    -0.00  -0.00  -0.00
+     6   1     0.03  -0.50  -0.03    -0.00   0.01   0.00     0.00   0.00   0.00
+     7   1     0.66  -0.18  -0.50     0.00  -0.00  -0.00     0.00   0.00   0.00
+     8   1     0.09   0.06   0.06     0.01   0.00   0.00    -0.00   0.00  -0.00
+     9   1     0.00  -0.06  -0.01    -0.00   0.01   0.00     0.00   0.00   0.00
+    10   1     0.00   0.00  -0.00    -0.00  -0.00  -0.00    -0.00   0.00   0.00
+    11   1     0.02  -0.02   0.06    -0.00   0.00  -0.01     0.00   0.00   0.00
+    12   6     0.00   0.00   0.00    -0.01  -0.08   0.05    -0.00  -0.00   0.00
+    13   8    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.01  -0.06   0.02
+    14   1    -0.00   0.00  -0.00    -0.05   0.10  -0.40    -0.00   0.00  -0.00
+    15   1     0.00  -0.00   0.00    -0.00  -0.00   0.00    -0.00  -0.00  -0.00
+    16   1    -0.00  -0.00   0.00     0.16   0.87  -0.20     0.00   0.02  -0.00
+    17   1     0.00  -0.00   0.00    -0.01  -0.01   0.01     0.14   0.96  -0.25
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  7 and mass  14.00307
+ Atom     2 has atomic number  6 and mass  12.00000
+ Atom     3 has atomic number  6 and mass  12.00000
+ Atom     4 has atomic number  6 and mass  12.00000
+ Atom     5 has atomic number  6 and mass  12.00000
+ Atom     6 has atomic number  1 and mass   1.00783
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  1 and mass   1.00783
+ Atom     9 has atomic number  1 and mass   1.00783
+ Atom    10 has atomic number  1 and mass   1.00783
+ Atom    11 has atomic number  1 and mass   1.00783
+ Atom    12 has atomic number  6 and mass  12.00000
+ Atom    13 has atomic number  8 and mass  15.99491
+ Atom    14 has atomic number  1 and mass   1.00783
+ Atom    15 has atomic number  1 and mass   1.00783
+ Atom    16 has atomic number  1 and mass   1.00783
+ Atom    17 has atomic number  1 and mass   1.00783
+ Molecular mass:   100.07624 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   663.172881009.310541236.23784
+           X            0.99909  -0.04118   0.01132
+           Y            0.04112   0.99914   0.00503
+           Z           -0.01152  -0.00456   0.99992
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Warning -- assumption of classical behavior for rotation
+           may cause significant error
+ Rotational temperatures (Kelvin)      0.13061     0.08581     0.07006
+ Rotational constants (GHZ):           2.72137     1.78809     1.45987
+    1 imaginary frequencies ignored.
+ Zero-point vibrational energy     360040.4 (Joules/Mol)
+                                   86.05172 (Kcal/Mol)
+ Warning -- explicit consideration of  14 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:     81.94   110.33   174.67   262.08   280.53
+          (Kelvin)            291.22   302.09   393.51   492.74   621.53
+                              667.70   831.26   855.23   885.60  1099.41
+                             1384.53  1392.74  1445.66  1579.80  1624.94
+                             1635.95  1655.72  1705.60  1797.14  1996.27
+                             2016.46  2034.15  2043.99  2091.45  2132.19
+                             2139.48  2152.51  2155.84  2169.30  3281.83
+                             4338.00  4343.51  4359.68  4423.98  4430.75
+                             4465.74  4473.41  4541.41  5443.95
+ 
+ Zero-point correction=                           0.137132 (Hartree/Particle)
+ Thermal correction to Energy=                    0.146754
+ Thermal correction to Enthalpy=                  0.147698
+ Thermal correction to Gibbs Free Energy=         0.101942
+ Sum of electronic and zero-point Energies=           -326.386550
+ Sum of electronic and thermal Energies=              -326.376928
+ Sum of electronic and thermal Enthalpies=            -326.375984
+ Sum of electronic and thermal Free Energies=         -326.421740
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   92.089             32.595             96.301
+ Electronic               0.000              0.000              1.377
+ Translational            0.889              2.981             39.720
+ Rotational               0.889              2.981             28.205
+ Vibrational             90.312             26.633             26.998
+ Vibration     1          0.596              1.975              4.560
+ Vibration     2          0.599              1.965              3.974
+ Vibration     3          0.609              1.931              3.078
+ Vibration     4          0.630              1.864              2.306
+ Vibration     5          0.636              1.847              2.180
+ Vibration     6          0.639              1.836              2.111
+ Vibration     7          0.642              1.826              2.044
+ Vibration     8          0.676              1.722              1.574
+ Vibration     9          0.722              1.591              1.201
+ Vibration    10          0.793              1.401              0.852
+ Vibration    11          0.822              1.330              0.754
+ Vibration    12          0.934              1.079              0.490
+ Vibration    13          0.952              1.044              0.459
+ Vibration    14          0.975              0.999              0.424
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.128780D-46        -46.890150       -107.968560
+ Total V=0       0.153533D+17         16.186203         37.270109
+ Vib (Bot)       0.502513D-60        -60.298853       -138.843239
+ Vib (Bot)    1  0.362713D+01          0.559563          1.288442
+ Vib (Bot)    2  0.268707D+01          0.429280          0.988453
+ Vib (Bot)    3  0.168273D+01          0.226016          0.520420
+ Vib (Bot)    4  0.110180D+01          0.042102          0.096944
+ Vib (Bot)    5  0.102459D+01          0.010549          0.024290
+ Vib (Bot)    6  0.984221D+00         -0.006907         -0.015905
+ Vib (Bot)    7  0.945977D+00         -0.024120         -0.055537
+ Vib (Bot)    8  0.705338D+00         -0.151602         -0.349078
+ Vib (Bot)    9  0.541348D+00         -0.266523         -0.613693
+ Vib (Bot)   10  0.402718D+00         -0.394998         -0.909518
+ Vib (Bot)   11  0.365270D+00         -0.437387         -1.007120
+ Vib (Bot)   12  0.264339D+00         -0.577839         -1.330523
+ Vib (Bot)   13  0.252648D+00         -0.597484         -1.375758
+ Vib (Bot)   14  0.238710D+00         -0.622130         -1.432507
+ Vib (V=0)       0.599101D+03          2.777500          6.395430
+ Vib (V=0)    1  0.416143D+01          0.619243          1.425859
+ Vib (V=0)    2  0.323320D+01          0.509632          1.173472
+ Vib (V=0)    3  0.225545D+01          0.353233          0.813349
+ Vib (V=0)    4  0.170994D+01          0.232981          0.536459
+ Vib (V=0)    5  0.164008D+01          0.214865          0.494744
+ Vib (V=0)    6  0.160394D+01          0.205189          0.472465
+ Vib (V=0)    7  0.156999D+01          0.195896          0.451067
+ Vib (V=0)    8  0.136458D+01          0.135000          0.310848
+ Vib (V=0)    9  0.123692D+01          0.092343          0.212628
+ Vib (V=0)   10  0.114201D+01          0.057671          0.132793
+ Vib (V=0)   11  0.111921D+01          0.048912          0.112624
+ Vib (V=0)   12  0.106557D+01          0.027584          0.063515
+ Vib (V=0)   13  0.106021D+01          0.025390          0.058463
+ Vib (V=0)   14  0.105406D+01          0.022865          0.052649
+ Electronic      0.200000D+01          0.301030          0.693147
+ Translational   0.393505D+08          7.594950         17.488019
+ Rotational      0.325628D+06          5.512722         12.693512
+ 
+                                                  0xd628bc800d04214f0f9db0fec4700
+ 2f2
+                                                             IR Spectrum
+ 
+     3                  33333333                        2                    1111111111    111111 1                                  
+     7                  11100000                        2                    5444444443    211110 099      7   655   44  322211 1    
+     8                  50087311                        8                    0998852108    485329 066      6   197   63  471098 2 75 
+     4                  69405095                        1                    8867241427    951798 582      4   648   42  240252 1 77 
+ 
+     X                  XXXXXXXX                        X                    XXXXXXXXXX    XXXXXX XXX      X   XXX   XX  XXXXXX X XX 
+     X                  XXXXXXXX                        X                             X      XX X              X X    X              
+     X                  XXXX XXX                        X                             X      XX X              X X    X              
+     X                       XXX                        X                             X      X  X              X X    X              
+     X                       XX                         X                             X      X  X              X X    X              
+     X                        X                         X                             X      X  X                X    X              
+     X                                                  X                                    X  X                X    X              
+     X                                                                                       X  X                X    X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                                                      X              
+                                                                                                                      X              
+                                                                                                                      X              
+ 
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000000236   -0.000000628   -0.000000771
+      2        6           0.000000190    0.000000845   -0.000000741
+      3        6          -0.000003012    0.000000342    0.000001186
+      4        6           0.000000122   -0.000000503    0.000001630
+      5        6          -0.000000286    0.000001174   -0.000002197
+      6        1          -0.000000957    0.000000316    0.000000666
+      7        1          -0.000000172    0.000000640    0.000000350
+      8        1          -0.000000436   -0.000000727   -0.000000360
+      9        1          -0.000000507    0.000000575   -0.000001011
+     10        1           0.000000402   -0.000000937   -0.000001035
+     11        1           0.000000778    0.000000274   -0.000000792
+     12        6           0.000000364    0.000001028    0.000000150
+     13        8           0.000002378    0.000000373   -0.000000451
+     14        1           0.000000570    0.000000022    0.000000529
+     15        1          -0.000000234   -0.000002704    0.000002054
+     16        1           0.000000272    0.000000536    0.000000990
+     17        1           0.000000764   -0.000000627   -0.000000198
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000003012 RMS     0.000001008
+ Red2BG is reusing G-inverse.
+ Leave Link  716 at Tue Jul  7 12:17:53 2020, MaxMem= 39321600000 cpu:               1.5 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l9999.exe)
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.139601D+01      0.354831D+01      0.118359D+02
+   x          0.921413D+00      0.234200D+01      0.781207D+01
+   y          0.931873D+00      0.236858D+01      0.790074D+01
+   z         -0.481109D+00     -0.122286D+01     -0.407901D+01
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.737519D+02      0.109289D+02      0.121601D+02
+   aniso      0.226579D+02      0.335756D+01      0.373579D+01
+   xx         0.798487D+02      0.118324D+02      0.131653D+02
+   yx        -0.441030D+01     -0.653540D+00     -0.727161D+00
+   yy         0.817053D+02      0.121075D+02      0.134714D+02
+   zx        -0.657969D+00     -0.975010D-01     -0.108484D+00
+   zy        -0.152496D+01     -0.225975D+00     -0.251431D+00
+   zz         0.597017D+02      0.884688D+01      0.984349D+01
+
+ ----------------------------------------------------------------------
+
+ Dipole orientation:
+     7         -1.74723810          0.45308000         -4.79225014
+     6         -1.44780146         -0.19181083         -2.72000082
+     6         -0.88381015         -0.76911210         -0.12887069
+     6          0.70748865         -3.14393756          0.22376107
+     6         -3.10178279         -0.46930055          1.68147173
+     1          1.31895247         -3.29246903          2.19131829
+     1          2.38398899         -3.09474589         -0.97741918
+     1         -0.37027620         -4.84960044         -0.23949952
+     1         -2.43146180         -0.54724081          3.63423224
+     1         -4.48603070         -1.98847465          1.42855331
+     1         -4.07661925          1.32736152          1.39809695
+     6          2.53448001          3.04278718          0.15416418
+     8          3.76587045          2.57101202         -2.09461717
+     1          1.39788415          4.76837945          0.21729120
+     1          0.71961046          1.13355543          0.36959151
+     1          3.82574298          2.82270269          1.73817357
+     1          2.61624579          2.86653699         -3.48088528
+
+ Electric dipole moment (dipole orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.139601D+01      0.354831D+01      0.118359D+02
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.139601D+01      0.354831D+01      0.118359D+02
+
+ Dipole polarizability, Alpha (dipole orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.737519D+02      0.109289D+02      0.121601D+02
+   aniso      0.226579D+02      0.335756D+01      0.373579D+01
+   xx         0.732975D+02      0.108616D+02      0.120851D+02
+   yx         0.122442D+02      0.181441D+01      0.201880D+01
+   yy         0.725605D+02      0.107524D+02      0.119636D+02
+   zx         0.216291D+01      0.320510D+00      0.356615D+00
+   zy        -0.378946D+01     -0.561540D+00     -0.624798D+00
+   zz         0.753979D+02      0.111728D+02      0.124314D+02
+
+ ----------------------------------------------------------------------
+
+ Test job not archived.
+ 1\1\GINC-D-9-16-1\Freq\UB3LYP\6-311G(2d,d,p)\C5H10N1O1(2)\OSCARWU\07-J
+ ul-2020\0\\#p opt=(calcall,ts,noeigentest,maxcycles=120) freq guess=mi
+ x scf=xqc iop(2/9=2000) uB3LYP/CBSB7\\0xd628bc800d04214f0f9db0fec47002
+ f2\\0,2\N,-2.2202876923,-1.5501565753,0.1036559546\C,-1.5012068224,-0.
+ 6419053456,0.0581241721\C,-0.4945356011,0.3798484731,-0.0135094585\C,-
+ 0.2138899047,1.0687455836,1.3168592617\C,-0.6036834219,1.297831931,-1.
+ 2242471143\H,0.6663114676,1.7102922089,1.2240699293\H,-0.0251647907,0.
+ 3363455457,2.1041002808\H,-1.0569933839,1.6954722525,1.6274151366\H,0.
+ 3046448608,1.8989700606,-1.3187162314\H,-1.4506227291,1.9860184815,-1.
+ 1249729362\H,-0.7398607902,0.7310731154,-2.1477026784\C,1.488103561,-1
+ .4615914537,-0.2177171828\O,1.0613679078,-2.3025390672,0.7891357931\H,
+ 1.4027608339,-1.8527590104,-1.2357582018\H,0.5830653683,-0.3952918117,
+ -0.2164769588\H,2.4651203266,-1.0480839174,0.0221525568\H,0.2171661904
+ ,-2.6974478709,0.5360259171\\Version=ES64L-G16RevB.01\State=2-A\HF=-32
+ 6.5236818\S2=0.757508\S2-1=0.\S2A=0.750039\RMSD=6.055e-09\RMSF=1.008e-
+ 06\ZeroPoint=0.1371321\Thermal=0.1467539\Dipole=0.9214133,0.9318726,-0
+ .4811089\DipoleDeriv=-0.4529087,-0.0091939,0.0098982,-0.1977867,-0.359
+ 0448,0.0077704,0.0017206,-0.0035619,-0.2930434,0.3018654,0.1326976,-0.
+ 0291066,0.3747734,0.0677999,-0.0072813,-0.0186785,-0.0019604,-0.066762
+ 3,0.0638912,-0.247502,0.042467,-0.2206568,0.2724832,-0.0120551,-0.0155
+ 832,0.0620045,0.2043686,0.0458412,0.0921941,0.0196114,0.003026,0.02499
+ 74,0.0338947,-0.0109861,0.0996503,0.0112961,0.0327116,0.0743271,-0.049
+ 685,0.0026468,0.0461247,-0.0024154,0.0112383,-0.1173378,0.0499514,-0.0
+ 540151,-0.1255045,0.0019504,-0.0882245,-0.0130982,-0.0140205,0.0398598
+ ,-0.0002247,0.0479524,0.0742947,0.0019039,-0.0331672,0.0216746,0.00070
+ 81,0.0979892,-0.0169948,0.0488022,-0.0323135,-0.0377003,0.0954667,0.04
+ 65489,0.0853139,-0.0364302,-0.069388,0.0294379,-0.0869315,0.0257052,-0
+ .0669656,-0.1209059,0.0241133,-0.0738186,-0.0123816,0.0315688,-0.01871
+ 56,0.0287052,0.0566498,-0.0404271,0.1219544,0.0022842,0.1065195,-0.069
+ 2286,0.0335362,0.0134371,0.0378826,0.032686,0.0767262,-0.0107241,-0.01
+ 95536,-0.0096743,0.0124878,-0.0952954,-0.0287963,-0.0396384,-0.0911187
+ ,0.398595,-0.0377502,-0.1028037,-0.3371413,0.8468679,-0.1994282,0.1744
+ 768,-0.3916258,0.5075806,-0.2882427,-0.1364076,0.1871227,0.3175065,-0.
+ 9798463,0.2444468,-0.122181,0.4418759,-0.5621568,-0.0577392,0.054938,-
+ 0.0059061,0.0453949,-0.0395844,-0.074447,0.0250381,-0.0346616,-0.13837
+ 73,-0.105362,0.2069033,-0.038537,0.0583553,-0.2278969,0.0388569,0.0332
+ 558,-0.0322618,-0.0049306,-0.1074579,-0.0484868,-0.0093523,0.0122656,0
+ .0211333,-0.0011236,-0.0207936,-0.0288808,0.0326007,0.2168934,-0.04391
+ 02,-0.0458845,-0.1001743,0.4449086,-0.0126086,-0.0757355,0.0181639,0.2
+ 199118\Polar=79.8487448,-4.4103033,81.7053427,-0.6579692,-1.5249568,59
+ .7017355\PG=C01 [X(C5H10N1O1)]\NImag=1\\0.47342211,0.56917758,0.730210
+ 20,-0.02915135,-0.03608913,0.02107120,-0.47218259,-0.54788332,0.027437
+ 98,0.65117358,-0.54376293,-0.72391259,0.03409407,0.66487067,0.91997493
+ ,0.02819739,0.03493252,-0.04107288,-0.03235688,-0.04423305,0.12579879,
+ -0.01117046,-0.03136415,0.00272714,-0.12474940,-0.07241225,0.00189166,
+ 0.26847756,-0.02140909,-0.00499842,0.00119574,-0.10870283,-0.16699274,
+ 0.01013462,0.13935039,0.43624795,0.00309016,0.00297460,0.02010692,-0.0
+ 0139784,0.00420374,-0.07723401,0.03990225,-0.02671409,0.44104413,0.001
+ 81647,0.00192715,0.00304917,-0.01353995,-0.02212834,-0.02489325,-0.059
+ 96446,-0.01284220,-0.01648369,0.54800250,-0.00070171,0.00151629,0.0022
+ 0631,-0.00685027,-0.01779152,-0.02212890,-0.02054888,-0.09458310,-0.04
+ 478955,0.00055408,0.54316693,0.00386177,0.00462408,-0.00192435,-0.0073
+ 7205,-0.00877607,0.00318190,-0.02012435,-0.03428546,-0.15817103,-0.015
+ 49956,-0.05340992,0.48331487,-0.00037507,0.00133975,-0.00333980,-0.003
+ 83660,-0.02353597,0.02389986,-0.05862039,-0.00010022,-0.01413705,0.000
+ 35704,0.00394161,-0.00356191,0.54929123,-0.00066023,0.00234942,-0.0014
+ 7064,-0.00129090,-0.02220610,0.01942174,-0.00621317,-0.11207562,0.0585
+ 4148,-0.00046700,0.01162768,-0.01160279,0.01878686,0.51860653,-0.00450
+ 815,-0.00455885,-0.00050678,0.00943259,0.01184514,-0.00186002,-0.01123
+ 223,0.04686871,-0.14471665,-0.00531827,0.01841513,-0.02730257,0.000001
+ 33,0.05690034,0.50304987,0.00037801,0.00039422,-0.00010167,-0.00009770
+ ,-0.00097240,-0.00098659,-0.00361946,-0.00269391,0.00060114,-0.2168654
+ 0,-0.12276580,0.01988309,0.00009817,0.00014062,0.00062120,0.23344780,-
+ 0.00014015,-0.00009729,0.00030481,-0.00114090,-0.00092242,-0.00318566,
+ -0.01136465,-0.01096441,0.00018975,-0.12201479,-0.13479267,0.01558667,
+ 0.00067064,0.00044921,0.00099779,0.13620731,0.14539874,-0.00051828,-0.
+ 00063183,0.00121374,-0.00151238,-0.00275180,-0.00576671,-0.02305973,-0
+ .01836373,0.00078981,0.02154126,0.01691244,-0.04956761,-0.00072187,-0.
+ 00036400,0.00183013,-0.02205173,-0.01344147,0.05385240,-0.00014214,-0.
+ 00024227,0.00024665,0.00038289,0.00093256,-0.00062399,-0.00257050,0.00
+ 367752,-0.00351838,-0.05551793,0.02997820,-0.03298091,0.00013875,-0.00
+ 091662,-0.00063645,0.00578239,-0.01743608,0.01975458,0.05521002,0.0003
+ 6658,-0.00001238,-0.00003110,-0.00049237,0.00103678,-0.00019921,-0.002
+ 76216,0.01202572,-0.01268967,0.03038692,-0.17131361,0.13076997,-0.0005
+ 0924,-0.00154833,-0.00255851,0.00416864,-0.01185809,0.01171548,-0.0328
+ 4940,0.18267047,-0.00026881,-0.00064803,0.00025302,0.00076058,0.001315
+ 52,0.00026050,-0.00383140,0.01843238,-0.02138683,-0.03246079,0.1275021
+ 9,-0.18054587,-0.00125047,-0.00432960,-0.00393323,0.00017466,0.0009196
+ 0,-0.00150872,0.03648607,-0.13867087,0.19990014,0.00001150,0.00073181,
+ 0.00003628,0.00100205,-0.00077221,0.00001813,0.00607880,-0.00358862,-0
+ .00134445,-0.20159026,0.11210076,0.05258593,0.00032745,-0.00030711,0.0
+ 0049619,-0.01984942,0.01511219,0.00630257,-0.00418808,0.00195549,0.000
+ 99481,0.21676083,-0.00100450,-0.00075618,0.00026478,0.00207421,0.00175
+ 884,-0.00032798,0.00826466,-0.01127153,-0.00732104,0.11368686,-0.12734
+ 240,-0.03687549,-0.00050191,0.00043592,0.00074896,-0.01492347,0.011870
+ 00,0.00572037,0.01712013,-0.01221881,-0.00643789,-0.12394896,0.1370689
+ 2,-0.00123333,-0.00120743,0.00006256,0.00258855,0.00280231,0.00027609,
+ 0.01818624,-0.01874777,-0.01219703,0.05542418,-0.03844927,-0.06322036,
+ 0.00067549,-0.00051001,0.00183978,0.00261913,-0.00149192,-0.00147934,-
+ 0.01874202,0.01239147,0.00733604,-0.05852447,0.04580293,0.06997062,0.0
+ 0064275,0.00051296,0.00034343,0.00006973,0.00006066,-0.00079454,0.0034
+ 3157,0.00252140,-0.00089152,0.00023066,0.00024784,-0.00005541,-0.22920
+ 223,-0.11913743,0.01694647,0.00025513,0.00006382,0.00046587,0.00024469
+ ,0.00020807,0.00005932,-0.00013489,-0.00005069,0.00000707,0.24714740,-
+ 0.00034636,-0.00016799,-0.00045277,-0.00023105,-0.00204342,0.00419500,
+ -0.01545929,-0.01393330,0.00249880,0.00021663,0.00051806,-0.00128615,-
+ 0.11802191,-0.12210436,0.00979268,0.00025616,0.00057793,0.00043554,0.0
+ 0024151,0.00000164,-0.00018840,0.00007376,0.00008817,-0.00001048,0.130
+ 30598,0.13366120,0.00057122,0.00027082,0.00093621,-0.00006720,0.003450
+ 70,-0.00467405,0.02070865,0.01518465,-0.00302003,0.00120965,0.00018952
+ ,0.00136444,0.01575606,0.00909873,-0.04919440,-0.00061158,-0.00036831,
+ -0.00033668,-0.00023252,-0.00009959,0.00036806,-0.00007145,-0.00003542
+ ,-0.00011128,-0.01744701,-0.01525659,0.05151391,0.00034701,0.00101356,
+ 0.00000230,0.00004784,-0.00146668,-0.00026808,0.00015354,0.00223641,-0
+ .00208526,0.00023640,-0.00023291,0.00003558,-0.20047205,0.12176199,0.0
+ 2242894,-0.00017011,0.00007268,0.00004946,0.00015428,-0.00014350,-0.00
+ 012077,-0.00008327,-0.00001255,-0.00055291,-0.02081629,0.01697667,0.00
+ 331361,0.21555219,-0.00126709,-0.00098542,-0.00001686,0.00261822,0.002
+ 19773,-0.00016977,0.01309402,-0.01644202,0.00284182,-0.00072647,0.0007
+ 2328,-0.00092643,0.12333901,-0.14262524,-0.01942633,-0.00003219,0.0000
+ 7773,0.00011073,-0.00022842,-0.00002118,-0.00003255,0.00005577,0.00052
+ 276,0.00069828,-0.01393598,0.01209846,0.00173262,-0.13593670,0.1557733
+ 6,0.00102870,0.00087714,-0.00008924,-0.00242417,-0.00226808,0.00055589
+ ,-0.01838218,0.01885749,-0.00098546,-0.00021825,0.00010795,0.00210480,
+ 0.01987769,-0.01711305,-0.04812612,-0.00005544,-0.00000283,-0.00014823
+ ,0.00033923,-0.00011205,0.00019785,0.00046270,-0.00045125,-0.00036742,
+ 0.00127424,-0.00151269,-0.00096144,-0.02279447,0.01549499,0.05198283,-
+ 0.00009095,-0.00000987,-0.00013059,0.00038398,0.00040428,0.00062232,-0
+ .00244209,-0.00106626,-0.00197792,0.00045750,0.00024086,-0.00032731,-0
+ .05109367,-0.01815848,-0.02710184,0.00029782,0.00027021,0.00028319,0.0
+ 0048465,0.00001203,-0.00025445,0.00009854,-0.00012715,-0.00043112,-0.0
+ 0236654,-0.01343050,-0.02349228,0.00370071,0.01337099,0.02206254,0.050
+ 43367,0.00029324,-0.00009250,-0.00014314,-0.00018991,0.00127248,0.0003
+ 1481,0.00336085,0.01177166,0.01910523,0.00002919,-0.00275560,0.0026708
+ 5,-0.01841256,-0.12246606,-0.11914580,0.00024042,-0.00002225,-0.000040
+ 00,0.00026589,0.00062668,0.00110457,-0.00011320,-0.00000700,0.00020193
+ ,-0.00048231,-0.00908324,-0.01360128,-0.00351355,-0.01076023,-0.016251
+ 60,0.01883606,0.13087569,0.00052401,0.00069253,0.00032466,-0.00093107,
+ -0.00146693,0.00025601,-0.00323712,-0.01295222,-0.02097580,-0.00007245
+ ,0.00477774,-0.00277403,-0.02692800,-0.11656503,-0.23202527,0.00002078
+ ,0.00005233,0.00035372,-0.00020766,-0.00083944,-0.00126161,0.00013313,
+ 0.00001255,0.00025501,-0.00011262,0.00211981,0.00369261,0.00007120,-0.
+ 00179616,-0.00238382,0.03085608,0.12605074,0.25424836,-0.00041320,-0.0
+ 0321790,0.00024540,0.00519893,0.00916005,-0.00064562,-0.06963575,0.046
+ 05165,0.01276128,0.00487548,-0.00383471,-0.00280913,0.00510595,-0.0045
+ 2318,-0.00008305,0.00010256,0.00014839,0.00035228,0.00002183,0.0001965
+ 2,0.00073954,-0.00053307,-0.00025799,-0.00042795,0.00010148,0.00051120
+ ,-0.00026810,-0.00028896,-0.00007587,0.00064762,-0.00016859,0.00006513
+ ,-0.00026759,0.44605589,0.00343317,0.00099131,0.00022322,-0.01158627,-
+ 0.00518707,0.00155177,0.08588228,-0.04851467,-0.01465591,-0.00788798,0
+ .00605276,0.00259967,-0.00793598,0.00651371,0.00109478,-0.00012878,-0.
+ 00049935,-0.00011816,0.00005792,0.00065870,0.00041179,0.00062125,0.001
+ 02820,0.00203781,-0.00013442,-0.00061117,0.00020591,0.00000409,0.00087
+ 021,-0.00179935,0.00030938,-0.00017953,0.00003695,0.21609345,0.3002673
+ 4,0.00156031,0.00493809,-0.00101150,-0.00289503,-0.00612659,0.00129846
+ ,0.00073200,0.00282632,0.00467732,0.00268723,-0.00165537,0.00103912,0.
+ 00134490,-0.00062534,-0.00032740,-0.00031434,0.00023767,-0.00003173,-0
+ .00002639,-0.00021771,-0.00095630,-0.00065198,0.00012700,-0.00077777,-
+ 0.00016675,-0.00007161,0.00018148,0.00015413,-0.00088942,0.00054831,-0
+ .00013751,-0.00005703,-0.00003383,0.03483063,0.02290691,0.55396041,-0.
+ 00061841,0.00406429,-0.00096633,-0.00182797,-0.00344214,0.00028489,0.0
+ 0166143,-0.00111251,-0.00036792,0.00097528,-0.00045274,0.00044368,0.00
+ 037326,-0.00005265,-0.00001067,-0.00007750,0.00034820,-0.00009062,-0.0
+ 0034592,-0.00032118,-0.00064589,-0.00013091,-0.00006362,-0.00045643,-0
+ .00002330,0.00014566,0.00000303,0.00008669,-0.00022108,0.00018628,-0.0
+ 0007637,-0.00004061,0.00009208,-0.09769406,-0.06802827,0.04636186,0.48
+ 389614,0.00234508,0.00524843,-0.00008194,-0.00363360,-0.00631598,-0.00
+ 050019,-0.00992701,0.01142195,0.00213013,0.00245869,-0.00117241,0.0000
+ 4562,0.00255347,-0.00131510,-0.00168159,-0.00027214,0.00005224,0.00005
+ 355,-0.00009705,-0.00020614,-0.00007134,-0.00026521,-0.00071227,-0.000
+ 93570,-0.00041198,0.00019770,0.00010640,-0.00016055,-0.00055031,0.0009
+ 0266,-0.00019675,0.00014501,0.00015879,-0.06787787,-0.12927970,0.11770
+ 466,0.25024287,0.25040925,-0.00203898,-0.00441182,0.00087024,0.0029240
+ 9,0.00583484,0.00001589,0.00380293,-0.00697739,-0.00119573,-0.00246866
+ ,0.00159398,-0.00088654,-0.00158474,0.00075593,0.00103148,0.00027609,-
+ 0.00016954,0.00014460,-0.00000578,0.00037791,0.00109129,0.00049566,0.0
+ 0030229,0.00108698,0.00031150,-0.00011276,-0.00016733,0.00006453,0.000
+ 49676,-0.00054660,0.00029117,-0.00012069,0.00006633,0.02704908,0.07957
+ 039,-0.19947842,0.06843762,-0.09243808,0.30200779,-0.00062708,-0.00134
+ 425,-0.00010975,0.00062559,0.00166136,-0.00004395,0.00448664,-0.004096
+ 40,-0.00108984,-0.00112517,0.00054112,-0.00008240,-0.00080383,0.000540
+ 59,0.00052018,0.00012374,0.00006288,-0.00001907,0.00002755,-0.00006198
+ ,0.00005195,0.00025023,0.00011441,0.00031224,0.00007684,0.00002957,-0.
+ 00006546,0.00001046,0.00021881,-0.00039900,-0.00007764,0.00006985,-0.0
+ 0021534,-0.04522747,-0.02288606,-0.01772876,0.00400291,0.00163772,0.01
+ 147367,0.04208609,0.00029053,0.00093418,0.00003770,0.00004472,-0.00121
+ 244,0.00000991,-0.00284934,0.00297122,0.00082115,0.00078345,-0.0004890
+ 0,0.00005914,0.00053250,-0.00039763,-0.00042528,-0.00010443,0.00016057
+ ,0.00000844,-0.00008665,-0.00007163,0.00006842,-0.00010594,-0.00002622
+ ,-0.00010219,-0.00007162,-0.00009249,-0.00000751,-0.00004426,-0.000132
+ 20,0.00034370,0.00020682,-0.00005171,0.00026371,-0.02788746,-0.0842619
+ 7,-0.10591130,-0.00029996,0.00860082,0.03182123,0.02185055,0.08280775,
+ -0.00001793,0.00008367,0.00024816,0.00014176,-0.00026873,-0.00022764,0
+ .00102567,-0.00015856,0.00009925,-0.00028629,0.00024916,0.00004903,0.0
+ 0017914,-0.00015067,-0.00012917,-0.00002171,0.00001322,0.00001787,-0.0
+ 0006629,0.00012391,0.00013917,0.00003631,0.00002891,0.00009165,-0.0000
+ 4558,0.00000430,-0.00001012,-0.00005994,0.00004062,0.00006509,0.000038
+ 58,0.00000541,0.00010646,-0.02844861,-0.08810658,-0.26367466,0.0064996
+ 0,0.00047085,-0.02775647,0.02191803,0.09180336,0.29244555,0.00949732,0
+ .00850998,-0.00070865,-0.04519386,-0.01264448,0.00591330,0.04685244,-0
+ .03712736,-0.01290556,-0.00709492,0.00751516,0.00583586,-0.01019731,0.
+ 01018995,-0.00184103,0.00010683,-0.00101281,-0.00077058,0.00019083,-0.
+ 00002150,-0.00051380,0.00168075,-0.00063342,0.00017069,0.00025159,-0.0
+ 0126234,0.00072035,0.00141142,-0.00051024,-0.00129141,0.00032270,-0.00
+ 036569,0.00031738,0.03232881,-0.07222833,0.00307913,0.00259764,0.01063
+ 171,-0.00619246,-0.00620857,0.00350555,-0.00061120,-0.01662005,-0.0060
+ 6819,-0.01074622,0.00021794,0.01085994,0.02159156,0.00016430,-0.074297
+ 84,0.00540430,0.01269949,0.01559555,-0.01316580,-0.00896729,0.01756792
+ ,-0.01514261,0.00095798,0.00039897,0.00064478,0.00082786,-0.00037846,0
+ .00041803,0.00089890,-0.00143084,-0.00042088,-0.00234115,0.00023671,0.
+ 00092232,-0.00086934,-0.00049751,-0.00077592,0.00290020,-0.00064004,0.
+ 00075244,-0.00053440,-0.05389811,0.03720638,-0.00619739,0.00609081,-0.
+ 02883177,0.01500157,0.01115282,-0.00883961,-0.00144013,0.07508330,0.00
+ 896764,-0.00126792,-0.00124569,0.00042369,0.00509657,0.00186641,-0.000
+ 76360,-0.00792588,0.00375352,-0.02730971,0.01354535,-0.01136223,-0.006
+ 82312,-0.01027293,0.00815481,0.00043046,-0.00005828,0.00035324,0.00068
+ 593,0.00030652,0.00007258,0.00015448,-0.00093774,-0.00151402,-0.002661
+ 07,0.00011346,-0.00020199,0.00039739,-0.00027455,0.00185478,-0.0018782
+ 9,-0.00028030,-0.00010213,0.00018799,-0.00558743,0.00338177,-0.0274997
+ 1,-0.00529150,0.01556407,-0.00407805,0.00854243,-0.01060753,-0.0002586
+ 2,0.00700251,-0.01240599,0.06886468,0.00002151,0.00019668,-0.00011495,
+ -0.00018224,0.00001050,0.00019202,0.00130352,-0.00049061,0.00012469,-0
+ .00063064,0.00016117,-0.00007842,-0.00046445,0.00015168,0.00032961,0.0
+ 0009935,0.00032579,0.00006178,-0.00009184,-0.00007159,0.00011088,0.000
+ 20893,0.00015269,0.00024852,0.00007529,0.00016349,-0.00008351,0.000058
+ 20,0.00010740,-0.00018030,0.00003992,-0.00006515,0.00000826,-0.2684524
+ 9,-0.10757329,-0.06559522,-0.00903415,-0.00565563,0.00321429,0.0018978
+ 4,0.00201020,0.00150974,-0.00901089,-0.00101834,-0.00252078,0.28232128
+ ,-0.00036812,0.00001099,0.00001806,0.00094766,-0.00005518,-0.00024729,
+ -0.00359100,0.00190730,0.00053174,0.00065184,-0.00023040,0.00000032,0.
+ 00068295,-0.00037321,-0.00031308,-0.00001033,-0.00023477,-0.00009966,0
+ .00003198,-0.00003499,-0.00011546,-0.00012982,-0.00022761,-0.00029601,
+ -0.00001621,-0.00013262,0.00008248,-0.00002547,-0.00018431,0.00025667,
+ -0.00002396,0.00002372,0.00002694,-0.08549366,-0.06818981,-0.02039955,
+ -0.02480200,-0.01354293,-0.00105631,-0.01137708,-0.00122346,-0.0032980
+ 3,0.01271168,0.00108522,0.00217675,0.11228207,0.08177227,0.00016278,0.
+ 00020316,0.00013549,-0.00001046,-0.00024827,-0.00007142,-0.00118821,0.
+ 00103641,0.00031232,0.00011908,-0.00005435,0.00004819,0.00018249,-0.00
+ 025088,-0.00015482,-0.00000191,-0.00007160,0.00002263,0.00008631,0.000
+ 00668,-0.00007118,-0.00004771,-0.00005686,-0.00010008,-0.00001294,0.00
+ 005904,0.00003210,0.00001888,-0.00003379,0.00010687,0.00001307,-0.0000
+ 3090,0.00006533,-0.07111514,-0.02831474,-0.07218305,0.02967259,0.01455
+ 294,0.00560430,-0.02434314,-0.00763090,-0.00211207,0.00240903,-0.00192
+ 051,-0.00005492,0.06143461,0.01860888,0.07170446,-0.00051679,-0.003806
+ 23,0.00053474,0.00272573,0.00403733,-0.00040670,0.00032702,-0.00060736
+ ,-0.00028006,-0.00062263,0.00010622,0.00024554,-0.00062624,0.00015509,
+ -0.00004482,-0.00001221,-0.00017273,-0.00006673,0.00021855,-0.00006132
+ ,-0.00003143,0.00009082,0.00011128,0.00013611,0.00001613,-0.00016918,0
+ .00005654,0.00007196,0.00012982,-0.00013378,0.00009635,0.00002236,-0.0
+ 0005106,-0.01137735,-0.00801215,-0.00323423,-0.38376476,-0.18137175,-0
+ .10605000,0.00048188,0.00222534,-0.00179129,-0.00091471,0.00124329,-0.
+ 00018953,0.00184086,-0.00147054,0.00262067,0.39196538,-0.00017780,0.00
+ 050818,-0.00027706,0.00058599,-0.00119287,0.00026738,0.00083752,-0.001
+ 97431,-0.00036766,-0.00022358,0.00003151,-0.00022671,-0.00039691,0.000
+ 27180,0.00048790,0.00009712,0.00016003,0.00002624,-0.00007076,-0.00015
+ 285,-0.00015923,0.00001091,0.00021010,0.00015721,0.00008320,0.00010310
+ ,-0.00008378,-0.00003172,0.00021331,-0.00022989,0.00000239,-0.00004956
+ ,-0.00003792,-0.02515966,-0.01686536,-0.00658933,-0.16205507,-0.094148
+ 79,-0.03046831,0.00188608,0.00132382,0.00059927,-0.00234117,0.00093013
+ ,0.00026166,-0.00068706,-0.00037021,0.00414567,0.18764052,0.11100196,0
+ .00000839,-0.00080386,-0.00104114,0.00058495,0.00072679,0.00002680,0.0
+ 0000456,-0.00009062,0.00016255,0.00012530,-0.00010482,0.00011314,-0.00
+ 012019,0.00010895,0.00009470,0.00000716,0.00007624,-0.00007180,-0.0001
+ 7899,-0.00003984,-0.00003683,0.00001609,0.00001216,-0.00000440,0.00000
+ 503,-0.00001174,-0.00001087,0.00001736,0.00002072,-0.00007501,-0.00003
+ 363,0.00003902,-0.00010212,0.03302677,0.01897377,0.00426928,-0.1441522
+ 7,-0.05598082,-0.07780975,0.00127821,-0.00055205,0.00090653,-0.0006135
+ 6,0.00100797,0.00018246,0.00133878,0.00412356,-0.00328415,0.10868604,0
+ .03249458,0.07668062\\0.00000024,0.00000063,0.00000077,-0.00000019,-0.
+ 00000084,0.00000074,0.00000301,-0.00000034,-0.00000119,-0.00000012,0.0
+ 0000050,-0.00000163,0.00000029,-0.00000117,0.00000220,0.00000096,-0.00
+ 000032,-0.00000067,0.00000017,-0.00000064,-0.00000035,0.00000044,0.000
+ 00073,0.00000036,0.00000051,-0.00000057,0.00000101,-0.00000040,0.00000
+ 094,0.00000103,-0.00000078,-0.00000027,0.00000079,-0.00000036,-0.00000
+ 103,-0.00000015,-0.00000238,-0.00000037,0.00000045,-0.00000057,-0.0000
+ 0002,-0.00000053,0.00000023,0.00000270,-0.00000205,-0.00000027,-0.0000
+ 0054,-0.00000099,-0.00000076,0.00000063,0.00000020\\\@
+
+
+ CONFIDENCE: THAT QUIET ASSURED FEELING YOU HAVE
+ JUST BEFORE YOU FALL FLAT ON YOUR FACE.
+ Leave Link 9999 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:               1.9 elap:               0.1
+ Job cpu time:       0 days  1 hours 43 minutes 23.4 seconds.
+ Elapsed time:       0 days  0 hours  2 minutes 45.4 seconds.
+ File lengths (MBytes):  RWF=    121 Int=      0 D2E=      0 Chk=      5 Scr=      1
+ Normal termination of Gaussian 16 at Tue Jul  7 12:17:54 2020.
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1.exe)
+ Link1:  Proceeding to internal job step number  2.
+ ----------------------------------------------------------------------
+ #P Geom=AllCheck Guess=TCheck SCRF=Check Test GenChk UB3LYP/6-311G(2d,
+ d,p) Freq
+ ----------------------------------------------------------------------
+ 1/5=1,6=120,10=4,11=1,29=7,30=1,38=1,40=1/1,3;
+ 2/12=2,40=1/2;
+ 3/5=4,6=6,7=700,11=2,14=-4,25=1,30=1,70=2,71=2,74=-5,116=2,140=1/1,2,3;
+ 4/5=101/1;
+ 5/5=2,8=3,13=1,38=6,98=1/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/8=1,10=1,25=1/1,2,3,16;
+ 1/5=1,6=120,10=4,11=1,30=1/3;
+ 99//99;
+ Leave Link    1 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:              10.9 elap:               0.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l101.exe)
+ Structure from the checkpoint file:  "0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk"
+ ----------------------------------
+ 0xd628bc800d04214f0f9db0fec47002f2
+ ----------------------------------
+ Charge =  0 Multiplicity = 2
+ Redundant internal coordinates found in file.  (old form).
+ N,0,-2.2202876923,-1.5501565753,0.1036559546
+ C,0,-1.5012068224,-0.6419053456,0.0581241721
+ C,0,-0.4945356011,0.3798484731,-0.0135094585
+ C,0,-0.2138899047,1.0687455836,1.3168592617
+ C,0,-0.6036834219,1.297831931,-1.2242471143
+ H,0,0.6663114676,1.7102922089,1.2240699293
+ H,0,-0.0251647907,0.3363455457,2.1041002808
+ H,0,-1.0569933839,1.6954722525,1.6274151366
+ H,0,0.3046448608,1.8989700606,-1.3187162314
+ H,0,-1.4506227291,1.9860184815,-1.1249729362
+ H,0,-0.7398607902,0.7310731154,-2.1477026784
+ C,0,1.488103561,-1.4615914537,-0.2177171828
+ O,0,1.0613679078,-2.3025390672,0.7891357931
+ H,0,1.4027608339,-1.8527590104,-1.2357582018
+ H,0,0.5830653683,-0.3952918117,-0.2164769588
+ H,0,2.4651203266,-1.0480839174,0.0221525568
+ H,0,0.2171661904,-2.6974478709,0.5360259171
+ Recover connectivity data from disk.
+ ITRead=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ NAtoms=     17 NQM=       17 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          14          12          12          12          12           1           1           1           1           1
+ AtmWgt=  14.0030740  12.0000000  12.0000000  12.0000000  12.0000000   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           2           0           0           0           0           1           1           1           1           1
+ AtZEff=   4.5500000   3.6000000   3.6000000   3.6000000   3.6000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.4037610   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   7.0000000   6.0000000   6.0000000   6.0000000   6.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        11          12          13          14          15          16          17
+ IAtWgt=           1          12          16           1           1           1           1
+ AtmWgt=   1.0078250  12.0000000  15.9949146   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           0           0           1           1           1           1
+ AtZEff=   1.0000000   3.6000000   5.6000000   1.0000000   1.0000000   1.0000000   1.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   6.0000000   8.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:              13.2 elap:               0.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1593         calculate D2E/DX2 analytically  !
+ ! R2    R(2,3)                  1.4361         calculate D2E/DX2 analytically  !
+ ! R3    R(3,4)                  1.5242         calculate D2E/DX2 analytically  !
+ ! R4    R(3,5)                  1.5233         calculate D2E/DX2 analytically  !
+ ! R5    R(3,15)                 1.3429         calculate D2E/DX2 analytically  !
+ ! R6    R(4,6)                  1.0931         calculate D2E/DX2 analytically  !
+ ! R7    R(4,7)                  1.0917         calculate D2E/DX2 analytically  !
+ ! R8    R(4,8)                  1.0955         calculate D2E/DX2 analytically  !
+ ! R9    R(5,9)                  1.0933         calculate D2E/DX2 analytically  !
+ ! R10   R(5,10)                 1.0958         calculate D2E/DX2 analytically  !
+ ! R11   R(5,11)                 1.092          calculate D2E/DX2 analytically  !
+ ! R12   R(12,13)                1.3795         calculate D2E/DX2 analytically  !
+ ! R13   R(12,14)                1.0939         calculate D2E/DX2 analytically  !
+ ! R14   R(12,15)                1.3986         calculate D2E/DX2 analytically  !
+ ! R15   R(12,16)                1.0877         calculate D2E/DX2 analytically  !
+ ! R16   R(13,17)                0.9658         calculate D2E/DX2 analytically  !
+ ! A1    A(2,3,4)              114.0219         calculate D2E/DX2 analytically  !
+ ! A2    A(2,3,5)              114.7185         calculate D2E/DX2 analytically  !
+ ! A3    A(2,3,15)              99.1696         calculate D2E/DX2 analytically  !
+ ! A4    A(4,3,5)              115.7567         calculate D2E/DX2 analytically  !
+ ! A5    A(4,3,15)             104.1854         calculate D2E/DX2 analytically  !
+ ! A6    A(5,3,15)             106.572          calculate D2E/DX2 analytically  !
+ ! A7    A(3,4,6)              109.8419         calculate D2E/DX2 analytically  !
+ ! A8    A(3,4,7)              110.9789         calculate D2E/DX2 analytically  !
+ ! A9    A(3,4,8)              111.3648         calculate D2E/DX2 analytically  !
+ ! A10   A(6,4,7)              108.4059         calculate D2E/DX2 analytically  !
+ ! A11   A(6,4,8)              107.9394         calculate D2E/DX2 analytically  !
+ ! A12   A(7,4,8)              108.2062         calculate D2E/DX2 analytically  !
+ ! A13   A(3,5,9)              109.9065         calculate D2E/DX2 analytically  !
+ ! A14   A(3,5,10)             111.213          calculate D2E/DX2 analytically  !
+ ! A15   A(3,5,11)             111.6101         calculate D2E/DX2 analytically  !
+ ! A16   A(9,5,10)             107.7369         calculate D2E/DX2 analytically  !
+ ! A17   A(9,5,11)             108.4147         calculate D2E/DX2 analytically  !
+ ! A18   A(10,5,11)            107.8287         calculate D2E/DX2 analytically  !
+ ! A19   A(13,12,14)           115.9198         calculate D2E/DX2 analytically  !
+ ! A20   A(13,12,15)           105.3039         calculate D2E/DX2 analytically  !
+ ! A21   A(13,12,16)           110.405          calculate D2E/DX2 analytically  !
+ ! A22   A(14,12,15)           102.883          calculate D2E/DX2 analytically  !
+ ! A23   A(14,12,16)           114.283          calculate D2E/DX2 analytically  !
+ ! A24   A(15,12,16)           106.9309         calculate D2E/DX2 analytically  !
+ ! A25   A(12,13,17)           109.171          calculate D2E/DX2 analytically  !
+ ! A26   L(1,2,3,13,-1)        174.1317         calculate D2E/DX2 analytically  !
+ ! A27   L(3,15,12,6,-1)       185.1033         calculate D2E/DX2 analytically  !
+ ! A28   L(1,2,3,13,-2)        177.8936         calculate D2E/DX2 analytically  !
+ ! A29   L(3,15,12,6,-2)       160.9966         calculate D2E/DX2 analytically  !
+ ! D1    D(2,3,4,6)            170.7609         calculate D2E/DX2 analytically  !
+ ! D2    D(2,3,4,7)             50.9018         calculate D2E/DX2 analytically  !
+ ! D3    D(2,3,4,8)            -69.716          calculate D2E/DX2 analytically  !
+ ! D4    D(5,3,4,6)            -52.9073         calculate D2E/DX2 analytically  !
+ ! D5    D(5,3,4,7)           -172.7665         calculate D2E/DX2 analytically  !
+ ! D6    D(5,3,4,8)             66.6157         calculate D2E/DX2 analytically  !
+ ! D7    D(15,3,4,6)            63.7466         calculate D2E/DX2 analytically  !
+ ! D8    D(15,3,4,7)           -56.1126         calculate D2E/DX2 analytically  !
+ ! D9    D(15,3,4,8)          -176.7304         calculate D2E/DX2 analytically  !
+ ! D10   D(2,3,5,9)           -168.0097         calculate D2E/DX2 analytically  !
+ ! D11   D(2,3,5,10)            72.774          calculate D2E/DX2 analytically  !
+ ! D12   D(2,3,5,11)           -47.6907         calculate D2E/DX2 analytically  !
+ ! D13   D(4,3,5,9)             55.9613         calculate D2E/DX2 analytically  !
+ ! D14   D(4,3,5,10)           -63.2549         calculate D2E/DX2 analytically  !
+ ! D15   D(4,3,5,11)           176.2804         calculate D2E/DX2 analytically  !
+ ! D16   D(15,3,5,9)           -59.3454         calculate D2E/DX2 analytically  !
+ ! D17   D(15,3,5,10)         -178.5617         calculate D2E/DX2 analytically  !
+ ! D18   D(15,3,5,11)           60.9736         calculate D2E/DX2 analytically  !
+ ! D19   D(2,3,12,13)          -45.7421         calculate D2E/DX2 analytically  !
+ ! D20   D(2,3,12,14)           73.7036         calculate D2E/DX2 analytically  !
+ ! D21   D(2,3,12,16)         -161.5841         calculate D2E/DX2 analytically  !
+ ! D22   D(4,3,12,13)           69.5641         calculate D2E/DX2 analytically  !
+ ! D23   D(4,3,12,14)         -170.9903         calculate D2E/DX2 analytically  !
+ ! D24   D(4,3,12,16)          -46.278          calculate D2E/DX2 analytically  !
+ ! D25   D(5,3,12,13)         -163.8634         calculate D2E/DX2 analytically  !
+ ! D26   D(5,3,12,14)          -44.4178         calculate D2E/DX2 analytically  !
+ ! D27   D(5,3,12,16)           80.2946         calculate D2E/DX2 analytically  !
+ ! D28   D(14,12,13,17)        -44.8905         calculate D2E/DX2 analytically  !
+ ! D29   D(15,12,13,17)         68.0641         calculate D2E/DX2 analytically  !
+ ! D30   D(16,12,13,17)       -176.8528         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ Search for a saddle point of order  1.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.220288   -1.550157    0.103656
+      2          6           0       -1.501207   -0.641905    0.058124
+      3          6           0       -0.494536    0.379848   -0.013509
+      4          6           0       -0.213890    1.068746    1.316859
+      5          6           0       -0.603683    1.297832   -1.224247
+      6          1           0        0.666311    1.710292    1.224070
+      7          1           0       -0.025165    0.336346    2.104100
+      8          1           0       -1.056993    1.695472    1.627415
+      9          1           0        0.304645    1.898970   -1.318716
+     10          1           0       -1.450623    1.986018   -1.124973
+     11          1           0       -0.739861    0.731073   -2.147703
+     12          6           0        1.488104   -1.461591   -0.217717
+     13          8           0        1.061368   -2.302539    0.789136
+     14          1           0        1.402761   -1.852759   -1.235758
+     15          1           0        0.583065   -0.395292   -0.216477
+     16          1           0        2.465120   -1.048084    0.022153
+     17          1           0        0.217166   -2.697448    0.536026
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.159341   0.000000
+     3  C    2.591692   1.436140   0.000000
+     4  C    3.515131   2.483531   1.524212   0.000000
+     5  C    3.533805   2.492510   1.523316   2.581016   0.000000
+     6  H    4.496477   3.404467   2.156212   1.093136   2.788775
+     7  H    3.518413   2.705863   2.169441   1.091685   3.512412
+     8  H    3.769510   2.850146   2.177122   1.095470   2.914719
+     9  H    4.504986   3.407761   2.156382   2.811478   1.093321
+    10  H    3.821838   2.882405   2.174681   2.886770   1.095793
+    11  H    3.530480   2.707469   2.176769   3.520491   1.092030
+    12  C    3.723344   3.111905   2.713570   3.413841   3.605980
+    13  O    3.435873   3.139884   3.203167   3.642847   4.448458
+    14  H    3.874542   3.401959   3.174612   4.202928   3.735261
+    15  H    3.048768   2.116699   1.342856   2.264876   2.300139
+    16  H    4.712936   3.987233   3.286309   3.651620   4.058866
+    17  H    2.728443   2.721480   3.205973   3.870365   4.442366
+                    6          7          8          9         10
+     6  H    0.000000
+     7  H    1.772095   0.000000
+     8  H    1.769940   1.771757   0.000000
+     9  H    2.575299   3.777068   3.251947   0.000000
+    10  H    3.174183   3.896186   2.795532   1.768072   0.000000
+    11  H    3.782201   4.329484   3.909239   1.772623   1.768063
+    12  C    3.579796   3.303543   4.455231   3.729095   4.620091
+    13  O    4.055620   3.142196   4.601550   4.761129   5.325940
+    14  H    4.391861   4.240967   5.180550   3.910014   4.784379
+    15  H    2.552565   2.508050   3.234351   2.560486   3.260658
+    16  H    3.505561   3.528834   4.744392   3.892391   5.084753
+    17  H    4.483671   3.423665   4.702378   4.957296   5.241688
+                   11         12         13         14         15
+    11  H    0.000000
+    12  C    3.673751   0.000000
+    13  O    4.590452   1.379510   0.000000
+    14  H    3.478313   1.093939   2.102153   0.000000
+    15  H    2.597781   1.398603   2.208534   1.958327   0.000000
+    16  H    4.259762   1.087698   2.032841   1.832607   2.006293
+    17  H    4.457921   1.926331   0.965761   2.293110   2.449503
+                   16         17
+    16  H    0.000000
+    17  H    2.835095   0.000000
+ Stoichiometry    C5H10NO(2)
+ Framework group  C1[X(C5H10NO)]
+ Deg. of freedom    45
+ Full point group                 C1      NOp   1
+ RotChk:  IX=0 Diff= 9.57D-16
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.083056    2.287615   -0.039494
+      2          6           0        0.480209    1.199291    0.003997
+      3          6           0        0.827971   -0.194027    0.019008
+      4          6           0        1.039134   -0.765826    1.416032
+      5          6           0        1.856280   -0.605204   -1.026940
+      6          1           0        1.136922   -1.853188    1.361015
+      7          1           0        0.195815   -0.528089    2.067240
+      8          1           0        1.949997   -0.368005    1.876599
+      9          1           0        1.905874   -1.695476   -1.091740
+     10          1           0        2.855870   -0.240539   -0.765019
+     11          1           0        1.605021   -0.212024   -2.014264
+     12          6           0       -1.710047   -0.926764   -0.601494
+     13          8           0       -2.362197   -0.103135    0.292589
+     14          1           0       -1.824565   -0.670564   -1.658826
+     15          1           0       -0.346794   -0.712050   -0.374491
+     16          1           0       -1.909119   -1.970754   -0.370103
+     17          1           0       -2.214113    0.817641    0.041718
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           2.7213737           1.7880931           1.4598657
+ Leave Link  202 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:               0.3 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l301.exe)
+ Standard basis: 6-311G(2d,d,p) (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   193 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   186 symmetry adapted basis functions of A   symmetry.
+   186 basis functions,   304 primitive gaussians,   193 cartesian basis functions
+    28 alpha electrons       27 beta electrons
+       nuclear repulsion energy       292.2913579452 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   17 NActive=   17 NUniq=   17 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Jul  7 12:17:54 2020, MaxMem= 39321600000 cpu:               1.9 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   186 RedAO= T EigKep=  1.33D-03  NBF=   186
+ NBsUse=   186 1.00D-06 EigRej= -1.00D+00 NBFU=   186
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   193   193   193   193   193 MxSgAt=    17 MxSgA2=    17.
+ Leave Link  302 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               5.9 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l401.exe)
+ Initial guess from the checkpoint file:  "0_0xd628bc800d04214f0f9db0fec47002f2_geom_opt_freq.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5037
+ Leave Link  401 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               4.6 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 39321600000 LenX= 39321515670 LenY= 39321477980
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+
+ Cycle   1  Pass 1  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf= 970000000 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=         0 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -326.523681806275    
+ DIIS: error= 2.23D-08 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -326.523681806275     IErMin= 1 ErrMin= 2.23D-08
+ ErrMax= 2.23D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.15D-13 BMatP= 3.15D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.208 Goal=   None    Shift=    0.000
+ Gap=     0.209 Goal=   None    Shift=    0.000
+ RMSDP=2.98D-09 MaxDP=1.15D-07              OVMax= 2.12D-07
+
+ SCF Done:  E(UB3LYP) =  -326.523681806     A.U. after    1 cycles
+            NFock=  1  Conv=0.30D-08     -V/T= 2.0040
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7575 S= 0.5037
+ <L.S>=  0.00000000000    
+ KE= 3.252345051380D+02 PE=-1.345579858064D+03 EE= 4.015303131741D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7575,   after     0.7500
+ Leave Link  502 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:              17.0 elap:               0.5
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               0.1 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   186
+ NBasis=   186 NAE=    28 NBE=    27 NFC=     0 NFV=     0
+ NROrb=    186 NOA=    28 NOB=    27 NVA=   158 NVB=   159
+
+ **** Warning!!: The largest alpha MO coefficient is  0.10461312D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.10893525D+02
+
+ Leave Link  801 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               0.7 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1101.exe)
+ Using compressed storage, NAtomX=    17.
+ Will process     18 centers per pass.
+ Leave Link 1101 at Tue Jul  7 12:17:55 2020, MaxMem= 39321600000 cpu:               6.9 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Tue Jul  7 12:17:56 2020, MaxMem= 39321600000 cpu:               0.9 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=    17.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=   39321598504.
+ G2DrvN: will do    18 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=      3107 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Tue Jul  7 12:18:03 2020, MaxMem= 39321600000 cpu:             296.5 elap:               7.4
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l1002.exe)
+ Minotr:  UHF open shell wavefunction.
+          IDoAtm=11111111111111111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+         5053 words used for storage of precomputed grid.
+ Keep R1 and R2 ints in memory in canonical form, NReq=343229615.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  17391 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Two-electron integral symmetry not used.
+          MDV=   39321600000 using IRadAn=       1.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    54 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+     51 vectors produced by pass  0 Test12= 1.61D-14 1.85D-09 XBig12= 1.51D+02 7.55D+00.
+ AX will form    51 AO Fock derivatives at one time.
+     51 vectors produced by pass  1 Test12= 1.61D-14 1.85D-09 XBig12= 3.69D+01 9.64D-01.
+     51 vectors produced by pass  2 Test12= 1.61D-14 1.85D-09 XBig12= 1.01D+00 1.01D-01.
+     51 vectors produced by pass  3 Test12= 1.61D-14 1.85D-09 XBig12= 6.80D-03 1.31D-02.
+     51 vectors produced by pass  4 Test12= 1.61D-14 1.85D-09 XBig12= 5.48D-05 9.01D-04.
+     51 vectors produced by pass  5 Test12= 1.61D-14 1.85D-09 XBig12= 2.03D-07 4.51D-05.
+     28 vectors produced by pass  6 Test12= 1.61D-14 1.85D-09 XBig12= 4.99D-10 2.00D-06.
+      5 vectors produced by pass  7 Test12= 1.61D-14 1.85D-09 XBig12= 1.82D-12 1.29D-07.
+      2 vectors produced by pass  8 Test12= 1.61D-14 1.85D-09 XBig12= 6.76D-15 9.53D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 1.07D-14
+ Solved reduced A of dimension   341 with    54 vectors.
+ FullF1:  Do perturbations      1 to       3.
+ Isotropic polarizability for W=    0.000000       73.75 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Tue Jul  7 12:18:15 2020, MaxMem= 39321600000 cpu:             469.3 elap:              11.8
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 1 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A)
+ Beta  Orbitals:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ The electronic state is 2-A.
+ Alpha  occ. eigenvalues --  -19.15103 -14.30560 -10.23643 -10.22387 -10.20323
+ Alpha  occ. eigenvalues --  -10.18596 -10.18253  -1.06063  -0.91093  -0.82732
+ Alpha  occ. eigenvalues --   -0.71341  -0.69881  -0.65256  -0.54361  -0.50946
+ Alpha  occ. eigenvalues --   -0.48444  -0.46180  -0.44693  -0.42558  -0.41017
+ Alpha  occ. eigenvalues --   -0.40623  -0.38052  -0.37007  -0.36350  -0.35138
+ Alpha  occ. eigenvalues --   -0.32979  -0.31771  -0.19071
+ Alpha virt. eigenvalues --    0.01770   0.02844   0.04327   0.05097   0.07179
+ Alpha virt. eigenvalues --    0.07809   0.09334   0.10700   0.10948   0.13059
+ Alpha virt. eigenvalues --    0.13712   0.14204   0.17681   0.20870   0.22080
+ Alpha virt. eigenvalues --    0.23178   0.24266   0.26965   0.28772   0.30455
+ Alpha virt. eigenvalues --    0.34529   0.36354   0.38169   0.39652   0.42921
+ Alpha virt. eigenvalues --    0.44769   0.46613   0.49277   0.49612   0.51195
+ Alpha virt. eigenvalues --    0.51792   0.54082   0.55325   0.56146   0.56418
+ Alpha virt. eigenvalues --    0.58971   0.59388   0.60093   0.60827   0.62205
+ Alpha virt. eigenvalues --    0.63265   0.64941   0.70966   0.75030   0.76343
+ Alpha virt. eigenvalues --    0.81392   0.82834   0.84861   0.89529   0.90520
+ Alpha virt. eigenvalues --    0.91628   0.97524   0.99998   1.01649   1.06813
+ Alpha virt. eigenvalues --    1.14209   1.16737   1.19715   1.25024   1.26407
+ Alpha virt. eigenvalues --    1.28573   1.33196   1.35136   1.35994   1.37957
+ Alpha virt. eigenvalues --    1.39711   1.42882   1.43864   1.43947   1.45704
+ Alpha virt. eigenvalues --    1.48293   1.48913   1.51302   1.54363   1.56854
+ Alpha virt. eigenvalues --    1.57102   1.58706   1.60042   1.62095   1.64352
+ Alpha virt. eigenvalues --    1.65564   1.68323   1.69575   1.73919   1.74560
+ Alpha virt. eigenvalues --    1.82059   1.86383   1.89061   1.92090   1.95844
+ Alpha virt. eigenvalues --    1.97414   2.00684   2.04630   2.06328   2.07993
+ Alpha virt. eigenvalues --    2.09680   2.10564   2.13848   2.21155   2.25424
+ Alpha virt. eigenvalues --    2.29677   2.32610   2.32856   2.36789   2.39987
+ Alpha virt. eigenvalues --    2.40896   2.42775   2.45976   2.47608   2.48142
+ Alpha virt. eigenvalues --    2.49929   2.51808   2.53397   2.54880   2.57694
+ Alpha virt. eigenvalues --    2.58393   2.61718   2.63242   2.69651   2.75756
+ Alpha virt. eigenvalues --    2.80727   2.82288   2.84083   2.84725   2.90162
+ Alpha virt. eigenvalues --    2.93733   2.94864   3.00687   3.06684   3.07599
+ Alpha virt. eigenvalues --    3.11857   3.14058   3.31362   3.35519   3.48772
+ Alpha virt. eigenvalues --    3.67477   3.74159   3.76248   3.77333   3.79946
+ Alpha virt. eigenvalues --    3.81110   3.88020   3.90494   3.91548   3.94208
+ Alpha virt. eigenvalues --    4.09781   4.27576   4.52354   4.84499   5.21675
+ Alpha virt. eigenvalues --    5.62584  23.68105  23.76699  23.87901  23.91479
+ Alpha virt. eigenvalues --   24.39157  35.82494  49.84690
+  Beta  occ. eigenvalues --  -19.14756 -14.30316 -10.22745 -10.21631 -10.20419
+  Beta  occ. eigenvalues --  -10.18628 -10.18284  -1.05263  -0.90690  -0.81802
+  Beta  occ. eigenvalues --   -0.71251  -0.68115  -0.64633  -0.53499  -0.49796
+  Beta  occ. eigenvalues --   -0.47563  -0.45552  -0.44395  -0.41112  -0.40564
+  Beta  occ. eigenvalues --   -0.40463  -0.37928  -0.36199  -0.35804  -0.34118
+  Beta  occ. eigenvalues --   -0.32776  -0.29865
+  Beta virt. eigenvalues --   -0.09006   0.02118   0.02964   0.04844   0.05575
+  Beta virt. eigenvalues --    0.07483   0.07894   0.09490   0.11003   0.11242
+  Beta virt. eigenvalues --    0.13201   0.13780   0.14691   0.18218   0.21827
+  Beta virt. eigenvalues --    0.22475   0.23629   0.24788   0.27283   0.29278
+  Beta virt. eigenvalues --    0.31025   0.34916   0.36621   0.38645   0.39991
+  Beta virt. eigenvalues --    0.43072   0.45770   0.47107   0.49553   0.50037
+  Beta virt. eigenvalues --    0.51526   0.52524   0.54628   0.55720   0.56619
+  Beta virt. eigenvalues --    0.56706   0.59215   0.59593   0.60513   0.61472
+  Beta virt. eigenvalues --    0.62363   0.63492   0.65279   0.71335   0.75461
+  Beta virt. eigenvalues --    0.76516   0.81865   0.83269   0.85150   0.90102
+  Beta virt. eigenvalues --    0.91119   0.92226   0.98029   1.00741   1.02231
+  Beta virt. eigenvalues --    1.07433   1.14795   1.17553   1.20413   1.25277
+  Beta virt. eigenvalues --    1.26810   1.28762   1.33381   1.35638   1.36268
+  Beta virt. eigenvalues --    1.38443   1.40097   1.43712   1.44032   1.44517
+  Beta virt. eigenvalues --    1.46023   1.48476   1.49073   1.51548   1.54848
+  Beta virt. eigenvalues --    1.57328   1.57676   1.59190   1.60415   1.62342
+  Beta virt. eigenvalues --    1.64597   1.65868   1.68800   1.69687   1.74067
+  Beta virt. eigenvalues --    1.74701   1.82844   1.87274   1.89956   1.92725
+  Beta virt. eigenvalues --    1.96310   1.97774   2.01463   2.04941   2.06711
+  Beta virt. eigenvalues --    2.08540   2.10340   2.11244   2.14372   2.22602
+  Beta virt. eigenvalues --    2.25684   2.29983   2.32794   2.33247   2.37312
+  Beta virt. eigenvalues --    2.40345   2.41152   2.43595   2.46262   2.47785
+  Beta virt. eigenvalues --    2.48294   2.50314   2.52393   2.53605   2.55042
+  Beta virt. eigenvalues --    2.58020   2.58626   2.61928   2.63377   2.70200
+  Beta virt. eigenvalues --    2.76068   2.80794   2.82527   2.84560   2.84866
+  Beta virt. eigenvalues --    2.90448   2.94410   2.95119   3.01342   3.07288
+  Beta virt. eigenvalues --    3.07870   3.12312   3.14922   3.31993   3.37236
+  Beta virt. eigenvalues --    3.49303   3.68305   3.74281   3.76369   3.77986
+  Beta virt. eigenvalues --    3.80207   3.81315   3.88738   3.91059   3.92083
+  Beta virt. eigenvalues --    3.95210   4.10677   4.28097   4.52626   4.85878
+  Beta virt. eigenvalues --    5.22141   5.62988  23.68811  23.77697  23.87882
+  Beta virt. eigenvalues --   23.91447  24.39211  35.82750  49.85031
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.349238   1.005723  -0.103322   0.001274   0.000111  -0.000133
+     2  C    1.005723   4.883827   0.202403  -0.064848  -0.067021   0.008993
+     3  C   -0.103322   0.202403   5.637977   0.342987   0.354827  -0.039164
+     4  C    0.001274  -0.064848   0.342987   4.850181  -0.055489   0.404081
+     5  C    0.000111  -0.067021   0.354827  -0.055489   4.844811  -0.006747
+     6  H   -0.000133   0.008993  -0.039164   0.404081  -0.006747   0.574819
+     7  H    0.000226  -0.005510  -0.026256   0.399096   0.007904  -0.024011
+     8  H    0.000588  -0.007874  -0.035954   0.403544  -0.002686  -0.031024
+     9  H   -0.000157   0.008487  -0.038220  -0.005822   0.403183   0.005097
+    10  H    0.000604  -0.006686  -0.037262  -0.003336   0.405700  -0.001335
+    11  H    0.000822  -0.004352  -0.032100   0.007234   0.401831   0.000147
+    12  C    0.002323  -0.005089  -0.166720   0.003287   0.001537   0.003327
+    13  O   -0.003341   0.001725   0.012186  -0.002030   0.000568  -0.000384
+    14  H   -0.000189   0.000574   0.006340   0.000504   0.001223  -0.000171
+    15  H    0.002165  -0.039774   0.169461  -0.029190  -0.042389  -0.005846
+    16  H   -0.000040   0.001091   0.005156   0.000058   0.000199   0.000151
+    17  H    0.009265   0.007727  -0.002408   0.000228   0.000013   0.000111
+               7          8          9         10         11         12
+     1  N    0.000226   0.000588  -0.000157   0.000604   0.000822   0.002323
+     2  C   -0.005510  -0.007874   0.008487  -0.006686  -0.004352  -0.005089
+     3  C   -0.026256  -0.035954  -0.038220  -0.037262  -0.032100  -0.166720
+     4  C    0.399096   0.403544  -0.005822  -0.003336   0.007234   0.003287
+     5  C    0.007904  -0.002686   0.403183   0.405700   0.401831   0.001537
+     6  H   -0.024011  -0.031024   0.005097  -0.001335   0.000147   0.003327
+     7  H    0.546453  -0.026801   0.000067  -0.000335  -0.000350  -0.001114
+     8  H   -0.026801   0.567377  -0.001244   0.005094  -0.000387  -0.000765
+     9  H    0.000067  -0.001244   0.572881  -0.031239  -0.023360   0.002463
+    10  H   -0.000335   0.005094  -0.031239   0.566986  -0.028557  -0.000752
+    11  H   -0.000350  -0.000387  -0.023360  -0.028557   0.558068   0.001733
+    12  C   -0.001114  -0.000765   0.002463  -0.000752   0.001733   5.046149
+    13  O    0.008752  -0.000016  -0.000005  -0.000004  -0.000030   0.271788
+    14  H    0.000621  -0.000016  -0.000157  -0.000004   0.000477   0.383214
+    15  H   -0.009833   0.005349  -0.006273   0.005475  -0.003336   0.232083
+    16  H   -0.000535   0.000034   0.000033   0.000009  -0.000124   0.389975
+    17  H   -0.000513  -0.000066   0.000019  -0.000025  -0.000009  -0.037343
+              13         14         15         16         17
+     1  N   -0.003341  -0.000189   0.002165  -0.000040   0.009265
+     2  C    0.001725   0.000574  -0.039774   0.001091   0.007727
+     3  C    0.012186   0.006340   0.169461   0.005156  -0.002408
+     4  C   -0.002030   0.000504  -0.029190   0.000058   0.000228
+     5  C    0.000568   0.001223  -0.042389   0.000199   0.000013
+     6  H   -0.000384  -0.000171  -0.005846   0.000151   0.000111
+     7  H    0.008752   0.000621  -0.009833  -0.000535  -0.000513
+     8  H   -0.000016  -0.000016   0.005349   0.000034  -0.000066
+     9  H   -0.000005  -0.000157  -0.006273   0.000033   0.000019
+    10  H   -0.000004  -0.000004   0.005475   0.000009  -0.000025
+    11  H   -0.000030   0.000477  -0.003336  -0.000124  -0.000009
+    12  C    0.271788   0.383214   0.232083   0.389975  -0.037343
+    13  O    7.823072  -0.027341  -0.033363  -0.029899   0.318957
+    14  H   -0.027341   0.597024  -0.033520  -0.033259  -0.010448
+    15  H   -0.033363  -0.033520   0.650174  -0.022681  -0.004184
+    16  H   -0.029899  -0.033259  -0.022681   0.555063   0.007816
+    17  H    0.318957  -0.010448  -0.004184   0.007816   0.449360
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  N    0.134973  -0.006016  -0.012425   0.000387   0.000240   0.000036
+     2  C   -0.006016  -0.052886  -0.017321   0.003822  -0.001297   0.001125
+     3  C   -0.012425  -0.017321   0.735813  -0.034630  -0.018192  -0.008176
+     4  C    0.000387   0.003822  -0.034630  -0.015121  -0.000199   0.002913
+     5  C    0.000240  -0.001297  -0.018192  -0.000199  -0.021995  -0.000283
+     6  H    0.000036   0.001125  -0.008176   0.002913  -0.000283   0.008624
+     7  H    0.000017   0.000010  -0.001043   0.002237  -0.000208  -0.000009
+     8  H    0.000092  -0.003641  -0.006011   0.001860   0.001446  -0.005445
+     9  H    0.000031   0.001037  -0.005864   0.000367  -0.000731   0.001147
+    10  H    0.000109  -0.003679  -0.009546   0.000132   0.011124  -0.001008
+    11  H    0.000123   0.001491  -0.004739   0.000095   0.000030   0.000167
+    12  C    0.004625   0.008511  -0.175548   0.009039   0.001444   0.003346
+    13  O   -0.001647  -0.000516   0.020437  -0.001638  -0.000084  -0.000304
+    14  H   -0.000745  -0.000742   0.013110  -0.000413  -0.000413  -0.000149
+    15  H    0.002208   0.013538  -0.085852   0.010917   0.007760   0.002879
+    16  H   -0.000092  -0.000367   0.008325  -0.000690  -0.000142  -0.000475
+    17  H    0.001387  -0.000400  -0.003303   0.000257   0.000014   0.000052
+               7          8          9         10         11         12
+     1  N    0.000017   0.000092   0.000031   0.000109   0.000123   0.004625
+     2  C    0.000010  -0.003641   0.001037  -0.003679   0.001491   0.008511
+     3  C   -0.001043  -0.006011  -0.005864  -0.009546  -0.004739  -0.175548
+     4  C    0.002237   0.001860   0.000367   0.000132   0.000095   0.009039
+     5  C   -0.000208   0.001446  -0.000731   0.011124   0.000030   0.001444
+     6  H   -0.000009  -0.005445   0.001147  -0.001008   0.000167   0.003346
+     7  H    0.000948  -0.000106  -0.000036   0.000076  -0.000014  -0.000913
+     8  H   -0.000106   0.031969  -0.000799   0.002653  -0.000206  -0.001257
+     9  H   -0.000036  -0.000799   0.009039  -0.005012   0.001730   0.002337
+    10  H    0.000076   0.002653  -0.005012   0.029631  -0.003566  -0.000986
+    11  H   -0.000014  -0.000206   0.001730  -0.003566   0.004677   0.001815
+    12  C   -0.000913  -0.001257   0.002337  -0.000986   0.001815   0.676958
+    13  O   -0.000113   0.000172  -0.000049   0.000027  -0.000049  -0.090045
+    14  H   -0.000000   0.000058  -0.000302   0.000129  -0.000467  -0.021802
+    15  H    0.001583  -0.002648   0.002851  -0.002581   0.002093   0.090963
+    16  H    0.000042   0.000096  -0.000230   0.000052  -0.000088  -0.015087
+    17  H   -0.000019  -0.000055   0.000021  -0.000022   0.000036   0.002652
+              13         14         15         16         17
+     1  N   -0.001647  -0.000745   0.002208  -0.000092   0.001387
+     2  C   -0.000516  -0.000742   0.013538  -0.000367  -0.000400
+     3  C    0.020437   0.013110  -0.085852   0.008325  -0.003303
+     4  C   -0.001638  -0.000413   0.010917  -0.000690   0.000257
+     5  C   -0.000084  -0.000413   0.007760  -0.000142   0.000014
+     6  H   -0.000304  -0.000149   0.002879  -0.000475   0.000052
+     7  H   -0.000113  -0.000000   0.001583   0.000042  -0.000019
+     8  H    0.000172   0.000058  -0.002648   0.000096  -0.000055
+     9  H   -0.000049  -0.000302   0.002851  -0.000230   0.000021
+    10  H    0.000027   0.000129  -0.002581   0.000052  -0.000022
+    11  H   -0.000049  -0.000467   0.002093  -0.000088   0.000036
+    12  C   -0.090045  -0.021802   0.090963  -0.015087   0.002652
+    13  O    0.178380  -0.000262  -0.005068   0.000524   0.001154
+    14  H   -0.000262   0.009033  -0.003340   0.007298  -0.001395
+    15  H   -0.005068  -0.003340  -0.090422  -0.003245   0.001936
+    16  H    0.000524   0.007298  -0.003245  -0.003894  -0.000887
+    17  H    0.001154  -0.001395   0.001936  -0.000887  -0.002829
+ Mulliken charges and spin densities:
+               1          2
+     1  N   -0.265157   0.123304
+     2  C    0.080603  -0.057332
+     3  C   -0.249929   0.395034
+     4  C   -0.251757  -0.020664
+     5  C   -0.247575  -0.021486
+     6  H    0.112091   0.004441
+     7  H    0.132139   0.002452
+     8  H    0.124848   0.018177
+     9  H    0.114247   0.005536
+    10  H    0.125667   0.017533
+    11  H    0.122293   0.003127
+    12  C   -0.126095   0.496051
+    13  O   -0.340634   0.100920
+    14  H    0.115127  -0.000402
+    15  H    0.165681  -0.056428
+    16  H    0.126952  -0.008862
+    17  H    0.261498  -0.001402
+ Sum of Mulliken charges =  -0.00000   1.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  N   -0.265157   0.123304
+     2  C    0.080603  -0.057332
+     3  C   -0.084248   0.338606
+     4  C    0.117321   0.004406
+     5  C    0.114632   0.004710
+    12  C    0.115984   0.486788
+    13  O   -0.079136   0.099518
+ APT charges:
+               1
+     1  N   -0.368333
+     2  C    0.100968
+     3  C    0.180246
+     4  C    0.027378
+     5  C    0.042929
+     6  H   -0.006387
+     7  H    0.014230
+     8  H   -0.016142
+     9  H   -0.007566
+    10  H   -0.025656
+    11  H   -0.000635
+    12  C    0.584348
+    13  O   -0.610082
+    14  H   -0.078567
+    15  H   -0.112730
+    16  H   -0.017908
+    17  H    0.293905
+ Sum of APT charges =   0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.368333
+     2  C    0.100968
+     3  C    0.067517
+     4  C    0.019080
+     5  C    0.009072
+    12  C    0.487873
+    13  O   -0.316177
+ Electronic spatial extent (au):  <R**2>=            941.7428
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.9778    Y=             -3.2587    Z=             -1.0076  Tot=              3.5483
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -44.2587   YY=            -51.1196   ZZ=            -43.0441
+   XY=             -1.8018   XZ=              2.6070   YZ=              0.4877
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.8821   YY=             -4.9788   ZZ=              3.0967
+   XY=             -1.8018   XZ=              2.6070   YZ=              0.4877
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              1.5637  YYY=            -30.8656  ZZZ=             -0.3461  XYY=             -8.5191
+  XXY=              4.8569  XXZ=             -5.1576  XZZ=             -2.8192  YZZ=             -0.2041
+  YYZ=              0.9053  XYZ=             -0.7145
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -648.8149 YYYY=           -444.5250 ZZZZ=           -233.0740 XXXY=            -12.6068
+ XXXZ=             10.9457 YYYX=              0.7387 YYYZ=              1.5967 ZZZX=             -0.5557
+ ZZZY=             -0.1018 XXYY=           -156.2376 XXZZ=           -143.1281 YYZZ=           -105.9954
+ XXYZ=              1.8069 YYXZ=             -1.3227 ZZXY=              0.1278
+ N-N= 2.922913579452D+02 E-N=-1.345579863026D+03  KE= 3.252345051380D+02
+  Exact polarizability:  84.743   0.972  76.475   3.256   1.192  60.037
+ Approx polarizability: 113.984  -1.991 120.875   2.878   1.947  80.313
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  N(14)              0.00596       1.92546       0.68705       0.64226
+     2  C(13)             -0.01929     -21.68487      -7.73770      -7.23330
+     3  C(13)              0.14325     161.03790      57.46233      53.71646
+     4  C(13)             -0.01147     -12.89074      -4.59974      -4.29989
+     5  C(13)             -0.01200     -13.49082      -4.81386      -4.50005
+     6  H(1)               0.00155       6.92957       2.47264       2.31146
+     7  H(1)               0.00179       7.99504       2.85283       2.66686
+     8  H(1)               0.00867      38.74202      13.82412      12.92295
+     9  H(1)               0.00219       9.76672       3.48501       3.25783
+    10  H(1)               0.00903      40.34254      14.39522      13.45682
+    11  H(1)               0.00130       5.82313       2.07784       1.94239
+    12  C(13)              0.15165     170.47835      60.83091      56.86546
+    13  O(17)              0.01258      -7.62791      -2.72183      -2.54440
+    14  H(1)               0.00092       4.09931       1.46274       1.36738
+    15  H(1)              -0.02680    -119.80258     -42.74854     -39.96184
+    16  H(1)              -0.00150      -6.70878      -2.39386      -2.23781
+    17  H(1)              -0.00098      -4.39485      -1.56819      -1.46596
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        0.197112     -0.108893     -0.088219
+     2   Atom       -0.027449      0.041185     -0.013736
+     3   Atom        0.324435     -0.134926     -0.189509
+     4   Atom        0.001780     -0.006756      0.004976
+     5   Atom        0.010414     -0.006952     -0.003462
+     6   Atom       -0.001111      0.000560      0.000551
+     7   Atom       -0.003213     -0.005426      0.008639
+     8   Atom       -0.000038     -0.003516      0.003555
+     9   Atom        0.002880     -0.000577     -0.002303
+    10   Atom        0.005886     -0.003933     -0.001954
+    11   Atom        0.000678     -0.004982      0.004305
+    12   Atom        0.594867     -0.306410     -0.288457
+    13   Atom        0.518536     -0.282268     -0.236268
+    14   Atom       -0.007101     -0.030434      0.037535
+    15   Atom        0.148983     -0.068650     -0.080333
+    16   Atom       -0.005952      0.037262     -0.031310
+    17   Atom       -0.009435      0.027379     -0.017944
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.112246      0.090377      0.030305
+     2   Atom       -0.031692     -0.004684     -0.006093
+     3   Atom        0.278089      0.211627      0.100066
+     4   Atom       -0.000851      0.009049     -0.003195
+     5   Atom       -0.000824     -0.007153      0.001408
+     6   Atom       -0.002648      0.003803     -0.006149
+     7   Atom        0.001003      0.001117     -0.001132
+     8   Atom        0.000321      0.004929     -0.001442
+     9   Atom       -0.005079     -0.003486      0.004076
+    10   Atom       -0.000149     -0.003263      0.001131
+    11   Atom        0.001056     -0.005965      0.000248
+    12   Atom        0.153749      0.209768      0.031822
+    13   Atom        0.069941      0.246195      0.014645
+    14   Atom        0.006863      0.009479     -0.019440
+    15   Atom        0.072960      0.057941      0.019361
+    16   Atom        0.014718      0.006420     -0.018294
+    17   Atom       -0.005011      0.001108     -0.007790
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -0.1457    -5.618    -2.005    -1.874 -0.3063  0.9517 -0.0201
+     1 N(14)  Bbb    -0.1143    -4.408    -1.573    -1.470 -0.2573 -0.0625  0.9643
+              Bcc     0.2600    10.026     3.578     3.344  0.9165  0.3006  0.2640
+ 
+              Baa    -0.0414    -5.558    -1.983    -1.854  0.9022  0.3633  0.2326
+     2 C(13)  Bbb    -0.0124    -1.664    -0.594    -0.555 -0.2380 -0.0304  0.9708
+              Bcc     0.0538     7.221     2.577     2.409 -0.3597  0.9312 -0.0591
+ 
+              Baa    -0.2661   -35.708   -12.742   -11.911 -0.2361  0.8541 -0.4634
+     3 C(13)  Bbb    -0.2653   -35.606   -12.705   -11.877 -0.4517  0.3258  0.8306
+              Bcc     0.5314    71.314    25.447    23.788  0.8604  0.4054  0.3088
+ 
+              Baa    -0.0081    -1.082    -0.386    -0.361 -0.3231  0.8427  0.4307
+     4 C(13)  Bbb    -0.0050    -0.666    -0.237    -0.222  0.7091  0.5170 -0.4795
+              Bcc     0.0130     1.748     0.624     0.583  0.6268 -0.1505  0.7645
+ 
+              Baa    -0.0078    -1.043    -0.372    -0.348 -0.1903  0.7954 -0.5755
+     5 C(13)  Bbb    -0.0058    -0.772    -0.275    -0.257  0.3484  0.6028  0.7179
+              Bcc     0.0135     1.815     0.648     0.605  0.9178 -0.0639 -0.3918
+ 
+              Baa    -0.0058    -3.102    -1.107    -1.035 -0.2586  0.6129  0.7467
+     6 H(1)   Bbb    -0.0030    -1.599    -0.571    -0.534  0.8703  0.4833 -0.0952
+              Bcc     0.0088     4.702     1.678     1.568  0.4192 -0.6252  0.6584
+ 
+              Baa    -0.0060    -3.180    -1.135    -1.061 -0.3771  0.9207  0.1003
+     7 H(1)   Bbb    -0.0029    -1.525    -0.544    -0.509  0.9221  0.3834 -0.0519
+              Bcc     0.0088     4.705     1.679     1.569  0.0862 -0.0729  0.9936
+ 
+              Baa    -0.0046    -2.474    -0.883    -0.825 -0.5274  0.7239  0.4448
+     8 H(1)   Bbb    -0.0025    -1.314    -0.469    -0.438  0.6365  0.6834 -0.3576
+              Bcc     0.0071     3.787     1.351     1.263  0.5628 -0.0945  0.8212
+ 
+              Baa    -0.0057    -3.023    -1.079    -1.008 -0.1195 -0.6906  0.7133
+     9 H(1)   Bbb    -0.0033    -1.754    -0.626    -0.585  0.6922  0.4571  0.5585
+              Bcc     0.0090     4.777     1.705     1.593  0.7118 -0.5605 -0.4234
+ 
+              Baa    -0.0046    -2.475    -0.883    -0.825 -0.1549  0.8289 -0.5375
+    10 H(1)   Bbb    -0.0025    -1.309    -0.467    -0.437  0.3111  0.5573  0.7698
+              Bcc     0.0071     3.784     1.350     1.262  0.9377 -0.0480 -0.3442
+ 
+              Baa    -0.0055    -2.959    -1.056    -0.987 -0.4041  0.8749 -0.2668
+    11 H(1)   Bbb    -0.0032    -1.704    -0.608    -0.568  0.6929  0.4832  0.5352
+              Bcc     0.0087     4.663     1.664     1.555 -0.5972 -0.0315  0.8015
+ 
+              Baa    -0.3371   -45.238   -16.142   -15.090 -0.2659  0.4452  0.8550
+    12 C(13)  Bbb    -0.3303   -44.328   -15.817   -14.786 -0.0396  0.8812 -0.4711
+              Bcc     0.6675    89.566    31.959    29.876  0.9632  0.1591  0.2167
+ 
+              Baa    -0.3110    22.502     8.029     7.506 -0.2948  0.2473  0.9230
+    13 O(17)  Bbb    -0.2865    20.733     7.398     6.916 -0.0043  0.9656 -0.2601
+              Bcc     0.5975   -43.235   -15.427   -14.422  0.9556  0.0807  0.2836
+ 
+              Baa    -0.0383   -20.433    -7.291    -6.816 -0.2847  0.9194  0.2713
+    14 H(1)   Bbb    -0.0055    -2.937    -1.048    -0.980  0.9473  0.3132 -0.0672
+              Bcc     0.0438    23.370     8.339     7.795  0.1467 -0.2379  0.9602
+ 
+              Baa    -0.0950   -50.690   -18.088   -16.908 -0.0939 -0.4074  0.9084
+    15 H(1)   Bbb    -0.0902   -48.136   -17.176   -16.056 -0.3501  0.8677  0.3530
+              Bcc     0.1852    98.826    35.264    32.965  0.9320  0.2849  0.2241
+ 
+              Baa    -0.0390   -20.798    -7.421    -6.937 -0.3008  0.2770  0.9126
+    16 H(1)   Bbb    -0.0061    -3.256    -1.162    -1.086  0.9211 -0.1636  0.3533
+              Bcc     0.0451    24.054     8.583     8.024  0.2471  0.9468 -0.2060
+ 
+              Baa    -0.0193   -10.273    -3.665    -3.427 -0.0288  0.1617  0.9864
+    17 H(1)   Bbb    -0.0101    -5.391    -1.924    -1.798  0.9910  0.1339  0.0070
+              Bcc     0.0294    15.664     5.589     5.225 -0.1310  0.9777 -0.1641
+ 
+
+ ---------------------------------------------------------------------------------
+
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Tue Jul  7 12:18:15 2020, MaxMem= 39321600000 cpu:               7.1 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l701.exe)
+ ... and contract with generalized density number  0.
+ Compute integral second derivatives.
+ Leave Link  701 at Tue Jul  7 12:18:15 2020, MaxMem= 39321600000 cpu:               6.3 elap:               0.2
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Jul  7 12:18:15 2020, MaxMem= 39321600000 cpu:               0.6 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l703.exe)
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         0 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    100127 IOpCl=  1 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Tue Jul  7 12:18:27 2020, MaxMem= 39321600000 cpu:             452.3 elap:              11.3
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l716.exe)
+ Dipole        = 3.84677076D-01-1.28207860D+00-3.96427236D-01
+ Polarizability= 8.47434425D+01 9.71548231D-01 7.64749201D+01
+                 3.25634268D+00 1.19244954D+00 6.00374471D+01
+ Full mass-weighted force constant matrix:
+ Low frequencies ----1617.8276   -5.6232   -2.5889   -0.0007   -0.0006   -0.0004
+ Low frequencies ---    0.2814   56.9540   76.6820
+ ******    1 imaginary frequencies (negative Signs) ****** 
+ Diagonal vibrational polarizability:
+       77.0282676      10.4508905      12.5144046
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                      A                      A                      A
+ Frequencies --  -1617.8276                56.9527                76.6810
+ Red. masses --      1.1404                 3.5974                 5.6207
+ Frc consts  --      1.7586                 0.0069                 0.0195
+ IR Inten    --    175.5706                 3.8192                 4.9602
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00   0.00     0.11   0.08  -0.07     0.34   0.19   0.08
+     2   6     0.00   0.02   0.00     0.04   0.05  -0.08     0.11   0.11   0.04
+     3   6    -0.06  -0.04  -0.02    -0.03   0.03  -0.07    -0.04   0.07   0.03
+     4   6     0.01   0.00   0.01    -0.24  -0.00  -0.05     0.04   0.08   0.02
+     5   6     0.01   0.00   0.00     0.09   0.01   0.06    -0.16  -0.03  -0.05
+     6   1    -0.00   0.00  -0.00    -0.23   0.00  -0.06    -0.07   0.07   0.03
+     7   1     0.00  -0.00  -0.00    -0.35  -0.02  -0.18     0.14   0.18   0.10
+     8   1     0.00  -0.00   0.01    -0.32  -0.01   0.10     0.13  -0.00  -0.09
+     9   1    -0.00   0.00   0.00     0.04   0.01   0.03    -0.25  -0.04  -0.04
+    10   1     0.01   0.00  -0.01     0.07  -0.05   0.20    -0.11  -0.11  -0.15
+    11   1    -0.00  -0.00   0.00     0.24   0.05   0.03    -0.21  -0.03  -0.04
+    12   6    -0.08  -0.01  -0.01    -0.02   0.04  -0.06     0.01  -0.15   0.02
+    13   8     0.01  -0.00  -0.00     0.07  -0.18   0.21    -0.23  -0.20  -0.10
+    14   1     0.09   0.04   0.00    -0.18   0.27   0.01     0.03  -0.26  -0.01
+    15   1     0.91   0.30   0.24    -0.00   0.07  -0.18    -0.06   0.09   0.10
+    16   1     0.05  -0.01   0.03     0.07  -0.02  -0.26     0.18  -0.17   0.09
+    17   1    -0.01   0.00  -0.01    -0.06  -0.12   0.35    -0.40  -0.20  -0.17
+                      4                      5                      6
+                      A                      A                      A
+ Frequencies --    121.4038               182.1572               194.9796
+ Red. masses --      2.2071                 4.1869                 1.0843
+ Frc consts  --      0.0192                 0.0819                 0.0243
+ IR Inten    --      4.9786                 3.5846                 0.1072
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.05  -0.04  -0.03    -0.06   0.02   0.28     0.04   0.01   0.00
+     2   6     0.02  -0.01   0.00    -0.01   0.03  -0.06    -0.02  -0.02   0.00
+     3   6     0.03  -0.01   0.05    -0.03   0.02  -0.09    -0.02  -0.02   0.00
+     4   6     0.12   0.07   0.07    -0.09   0.21   0.00    -0.03  -0.01   0.00
+     5   6    -0.05  -0.09   0.00    -0.10  -0.20  -0.06    -0.01   0.04  -0.00
+     6   1     0.10   0.07   0.13    -0.05   0.20   0.17    -0.13  -0.02   0.02
+     7   1     0.18   0.13   0.12    -0.15   0.28  -0.10     0.02   0.07   0.03
+     8   1     0.17   0.09  -0.03    -0.14   0.31   0.01     0.03  -0.09  -0.03
+     9   1    -0.05  -0.09   0.09    -0.22  -0.22   0.09     0.42   0.03   0.36
+    10   1    -0.03  -0.06  -0.11    -0.05  -0.27  -0.16    -0.11   0.53  -0.28
+    11   1    -0.14  -0.17  -0.01    -0.11  -0.32  -0.11    -0.31  -0.40  -0.10
+    12   6     0.01   0.16  -0.14     0.06  -0.07  -0.06    -0.01  -0.01  -0.01
+    13   8    -0.07  -0.09   0.04     0.20   0.00  -0.03     0.03   0.00   0.00
+    14   1     0.17   0.52  -0.07    -0.00  -0.10  -0.06    -0.02   0.00  -0.01
+    15   1    -0.00   0.02   0.07     0.04  -0.03  -0.09    -0.01  -0.04  -0.01
+    16   1    -0.08   0.10  -0.51     0.04  -0.05   0.00    -0.04  -0.00  -0.02
+    17   1    -0.03  -0.03   0.30     0.27  -0.01  -0.04     0.04   0.00   0.00
+                      7                      8                      9
+                      A                      A                      A
+ Frequencies --    202.4056               209.9621               273.5060
+ Red. masses --      1.1609                 3.4237                 2.3572
+ Frc consts  --      0.0280                 0.0889                 0.1039
+ IR Inten    --      0.1836                 1.7958                 0.2316
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.05  -0.01   0.03     0.07   0.05  -0.16     0.13  -0.01   0.04
+     2   6    -0.00  -0.03  -0.02    -0.07   0.01   0.10    -0.12  -0.10  -0.03
+     3   6     0.00  -0.03  -0.02    -0.09   0.00   0.13    -0.11  -0.09  -0.03
+     4   6     0.02   0.03   0.01    -0.02  -0.08   0.08     0.08   0.09   0.02
+     5   6     0.03   0.00  -0.01    -0.23   0.07  -0.03     0.03   0.09   0.05
+     6   1     0.58   0.09  -0.00     0.27  -0.04  -0.02    -0.03   0.08   0.20
+     7   1    -0.23  -0.40  -0.16    -0.12  -0.36   0.05     0.25   0.29   0.16
+     8   1    -0.28   0.49   0.20    -0.15   0.11   0.19     0.22   0.10  -0.26
+     9   1     0.12   0.01   0.04    -0.34   0.07  -0.20     0.06   0.10  -0.16
+    10   1    -0.00   0.10  -0.03    -0.17  -0.05  -0.13    -0.02   0.04   0.31
+    11   1    -0.01  -0.06  -0.02    -0.34   0.23   0.06     0.22   0.29   0.09
+    12   6    -0.04   0.01   0.00     0.08  -0.04  -0.07    -0.13  -0.06  -0.07
+    13   8    -0.05   0.01  -0.00     0.20  -0.01  -0.01     0.05   0.01   0.01
+    14   1    -0.03   0.02   0.01     0.13   0.05  -0.05    -0.14   0.03  -0.05
+    15   1    -0.03  -0.04  -0.00     0.03  -0.06   0.06    -0.14  -0.23  -0.07
+    16   1    -0.07   0.01  -0.01    -0.01  -0.03  -0.13    -0.32  -0.03  -0.13
+    17   1    -0.03   0.01   0.01     0.28  -0.02   0.02     0.19  -0.00   0.05
+                     10                     11                     12
+                      A                      A                      A
+ Frequencies --    342.4680               431.9850               464.0768
+ Red. masses --      2.3374                 1.2060                 3.2721
+ Frc consts  --      0.1615                 0.1326                 0.4152
+ IR Inten    --      1.0482               117.2841                 5.4605
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.03   0.12  -0.01    -0.00   0.03   0.01     0.08   0.03   0.04
+     2   6    -0.07   0.10   0.00     0.00   0.03  -0.03    -0.24  -0.09  -0.11
+     3   6    -0.08   0.07  -0.01     0.01   0.02  -0.01    -0.09  -0.05  -0.04
+     4   6     0.12  -0.09  -0.11    -0.01  -0.02  -0.02    -0.02  -0.02  -0.05
+     5   6     0.00  -0.11   0.16     0.01  -0.00   0.00    -0.02  -0.01   0.02
+     6   1     0.29  -0.06  -0.35    -0.04  -0.02  -0.08    -0.02  -0.02  -0.07
+     7   1     0.20  -0.34   0.08    -0.03  -0.04  -0.03     0.01  -0.03  -0.00
+     8   1     0.15  -0.05  -0.20    -0.02  -0.06   0.02     0.01  -0.02  -0.11
+     9   1    -0.04  -0.13   0.43    -0.00  -0.00   0.02     0.02  -0.01   0.02
+    10   1    -0.02  -0.11   0.23     0.01  -0.01   0.01    -0.05   0.00   0.14
+    11   1     0.17  -0.33   0.03     0.03  -0.02  -0.01     0.09  -0.00   0.00
+    12   6    -0.04  -0.02  -0.04     0.01  -0.05   0.06     0.27   0.11   0.13
+    13   8     0.05  -0.00   0.00    -0.06  -0.00  -0.04    -0.03   0.01   0.00
+    14   1    -0.15  -0.06  -0.04     0.35   0.09   0.06     0.61   0.24   0.12
+    15   1    -0.07   0.03  -0.07     0.02  -0.09   0.14     0.13  -0.06   0.19
+    16   1    -0.01  -0.02   0.01    -0.28  -0.03  -0.11     0.23   0.08  -0.05
+    17   1    -0.01  -0.01  -0.05     0.72   0.01   0.44    -0.40   0.02  -0.14
+                     13                     14                     15
+                      A                      A                      A
+ Frequencies --    577.7580               594.4119               615.5216
+ Red. masses --      1.8475                 5.3559                 1.8418
+ Frc consts  --      0.3634                 1.1150                 0.4111
+ IR Inten    --     47.9659                 1.9388                31.7256
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.08  -0.03     0.06   0.07  -0.12    -0.03  -0.05  -0.03
+     2   6     0.09  -0.03   0.09    -0.29  -0.04   0.45     0.14   0.02   0.14
+     3   6    -0.12  -0.05  -0.05     0.11   0.02  -0.07    -0.07  -0.01  -0.05
+     4   6    -0.01   0.05  -0.08    -0.02   0.07  -0.07    -0.03   0.05  -0.11
+     5   6    -0.06   0.02   0.05     0.15  -0.11  -0.14    -0.03   0.01   0.03
+     6   1     0.09   0.05   0.04    -0.09   0.06   0.16     0.01   0.05  -0.03
+     7   1     0.06   0.07   0.02    -0.09   0.25  -0.22    -0.01   0.08  -0.09
+     8   1     0.02   0.19  -0.26    -0.07   0.11   0.01    -0.03   0.13  -0.17
+     9   1     0.05   0.03   0.06    -0.07  -0.14   0.08     0.03   0.01   0.07
+    10   1    -0.13   0.11   0.19     0.23  -0.27  -0.22    -0.07   0.06   0.14
+    11   1     0.04   0.02   0.03     0.18  -0.28  -0.21     0.07  -0.02  -0.01
+    12   6     0.09   0.07  -0.00    -0.01   0.01  -0.00     0.01  -0.06   0.06
+    13   8    -0.03  -0.01  -0.02    -0.03   0.00  -0.00     0.03   0.01   0.01
+    14   1    -0.19  -0.20  -0.04    -0.07  -0.03  -0.00     0.44   0.25   0.09
+    15   1    -0.04   0.20  -0.13     0.09   0.00  -0.09    -0.08  -0.14   0.13
+    16   1     0.53   0.05   0.26     0.04   0.01   0.05    -0.48  -0.04  -0.29
+    17   1     0.36   0.03   0.34     0.16   0.01   0.14    -0.31  -0.03  -0.32
+                     16                     17                     18
+                      A                      A                      A
+ Frequencies --    764.1286               962.2969               968.0013
+ Red. masses --      3.3871                 1.6903                 1.5548
+ Frc consts  --      1.1652                 0.9222                 0.8584
+ IR Inten    --      4.3441                 1.8298                 1.1161
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.08   0.16  -0.01     0.02  -0.07   0.00     0.02  -0.05   0.00
+     2   6     0.06   0.17   0.03     0.01  -0.05   0.00     0.01  -0.03   0.00
+     3   6    -0.17  -0.16  -0.07    -0.06   0.11  -0.07    -0.08   0.08   0.04
+     4   6    -0.01  -0.11   0.17     0.04  -0.01   0.12    -0.11   0.06   0.05
+     5   6     0.10  -0.09  -0.15    -0.04   0.07  -0.11     0.11  -0.01  -0.05
+     6   1     0.14  -0.11   0.46    -0.08  -0.01  -0.04     0.16   0.10  -0.40
+     7   1     0.10  -0.02   0.28    -0.04  -0.09   0.05     0.19  -0.31   0.56
+     8   1     0.02   0.14  -0.10     0.01  -0.15   0.29     0.13  -0.02  -0.35
+     9   1     0.40  -0.07  -0.30    -0.12   0.03   0.41    -0.07  -0.02  -0.09
+    10   1    -0.05   0.13   0.11    -0.10  -0.08   0.33     0.20  -0.10  -0.30
+    11   1     0.25   0.02  -0.15     0.52  -0.27  -0.38    -0.09  -0.03  -0.01
+    12   6     0.05   0.01   0.01    -0.01   0.00  -0.00    -0.00  -0.00   0.01
+    13   8     0.00   0.00   0.00     0.01  -0.00  -0.00     0.00  -0.00  -0.00
+    14   1     0.05   0.00   0.01     0.04   0.01  -0.00     0.05   0.03   0.01
+    15   1    -0.19  -0.09  -0.04    -0.06   0.07   0.04    -0.02   0.05  -0.05
+    16   1     0.01   0.01  -0.02     0.04  -0.01   0.00    -0.01  -0.01  -0.02
+    17   1    -0.03   0.00  -0.01     0.00  -0.00  -0.01     0.01  -0.01  -0.02
+                     19                     20                     21
+                      A                      A                      A
+ Frequencies --   1004.7852              1098.0136              1129.3888
+ Red. masses --      1.3170                 1.1868                 1.6227
+ Frc consts  --      0.7834                 0.8430                 1.2195
+ IR Inten    --      0.6368                73.6311                 7.1447
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.00   0.00     0.00  -0.00   0.00     0.01  -0.01   0.00
+     2   6     0.01   0.00  -0.03    -0.01  -0.01  -0.00    -0.03  -0.02  -0.01
+     3   6     0.02   0.00  -0.05     0.03   0.03   0.01     0.12   0.10   0.06
+     4   6    -0.03  -0.10   0.01    -0.01  -0.02  -0.01    -0.08  -0.06  -0.02
+     5   6     0.01   0.10   0.04    -0.02  -0.02  -0.01    -0.07  -0.06  -0.05
+     6   1     0.15  -0.11   0.47     0.05  -0.02   0.08     0.21  -0.04   0.23
+     7   1     0.09   0.17   0.06     0.03   0.04   0.03     0.14   0.10   0.19
+     8   1    -0.04   0.27  -0.30    -0.01   0.07  -0.09    -0.02   0.26  -0.41
+     9   1    -0.42   0.06   0.30     0.10  -0.01  -0.04     0.29  -0.03  -0.04
+    10   1     0.21  -0.25  -0.24    -0.06   0.06   0.07    -0.24   0.19   0.31
+    11   1    -0.10  -0.18  -0.04     0.04   0.04   0.00     0.22   0.10  -0.05
+    12   6     0.01  -0.01   0.02    -0.04  -0.07   0.00    -0.04   0.02  -0.01
+    13   8    -0.01   0.00  -0.00    -0.03   0.05   0.04     0.03  -0.02  -0.02
+    14   1    -0.00   0.04   0.03     0.02   0.34   0.11     0.17  -0.13  -0.07
+    15   1     0.06   0.00  -0.15    -0.06   0.15  -0.02     0.08   0.18   0.08
+    16   1    -0.07  -0.01  -0.04     0.54  -0.24  -0.34    -0.17   0.08   0.16
+    17   1     0.01  -0.00  -0.02     0.32  -0.13  -0.44    -0.12   0.05   0.17
+                     22                     23                     24
+                      A                      A                      A
+ Frequencies --   1137.0454              1150.7824              1185.4531
+ Red. masses --      1.2764                 4.6969                 3.2299
+ Frc consts  --      0.9723                 3.6648                 2.6743
+ IR Inten    --     18.3318                97.1903                 3.3994
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00   0.00     0.00   0.01   0.00    -0.01   0.00   0.01
+     2   6     0.01   0.00  -0.01    -0.00  -0.01  -0.00     0.02   0.01  -0.06
+     3   6    -0.04  -0.01   0.04    -0.02   0.01  -0.01    -0.11  -0.05   0.36
+     4   6     0.01  -0.01  -0.03     0.02  -0.01  -0.01     0.01   0.00  -0.15
+     5   6     0.04   0.02  -0.00     0.02  -0.01   0.02     0.07   0.04  -0.14
+     6   1    -0.03  -0.01   0.06    -0.02  -0.02   0.09    -0.07  -0.01   0.07
+     7   1    -0.02   0.05  -0.10    -0.00   0.03  -0.04    -0.06   0.22  -0.31
+     8   1    -0.03   0.02   0.04    -0.03   0.00   0.09    -0.10   0.18  -0.09
+     9   1    -0.06   0.01   0.01     0.01  -0.00  -0.06    -0.02   0.01   0.18
+    10   1     0.10  -0.08  -0.12     0.04  -0.00  -0.08     0.11  -0.20   0.04
+    11   1    -0.02  -0.05  -0.02    -0.05   0.01   0.04     0.30  -0.23  -0.30
+    12   6    -0.11   0.00  -0.06    -0.22   0.22   0.29     0.05   0.01   0.01
+    13   8     0.02   0.01   0.03     0.15  -0.19  -0.23    -0.00  -0.01  -0.01
+    14   1     0.71  -0.15  -0.17    -0.11   0.53   0.35    -0.41   0.04   0.06
+    15   1    -0.26  -0.06   0.16    -0.28   0.05  -0.00     0.03  -0.03   0.27
+    16   1     0.41  -0.01   0.25     0.27   0.09   0.10    -0.10   0.01  -0.09
+    17   1    -0.10   0.06   0.13     0.13  -0.18  -0.17     0.07  -0.04  -0.08
+                     25                     26                     27
+                      A                      A                      A
+ Frequencies --   1249.0746              1387.4803              1401.5073
+ Red. masses --      2.5195                 1.2454                 1.2002
+ Frc consts  --      2.3160                 1.4126                 1.3890
+ IR Inten    --      5.2118                33.4840                 6.6805
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.03  -0.07   0.00    -0.00   0.00  -0.00    -0.00  -0.00   0.00
+     2   6    -0.01  -0.04  -0.01     0.00   0.00  -0.00     0.00   0.00  -0.00
+     3   6    -0.18   0.25  -0.01    -0.00  -0.01   0.02    -0.00   0.01  -0.00
+     4   6     0.09  -0.09  -0.01     0.00   0.01  -0.00    -0.02   0.03  -0.09
+     5   6     0.08  -0.09   0.03    -0.01   0.00  -0.00     0.06  -0.02  -0.06
+     6   1    -0.15  -0.12   0.34    -0.00   0.00  -0.00     0.08   0.00   0.40
+     7   1    -0.03   0.22  -0.26    -0.01  -0.00  -0.01     0.23  -0.17   0.32
+     8   1    -0.15   0.17   0.24     0.01  -0.01   0.01    -0.10  -0.22   0.33
+     9   1     0.10  -0.06  -0.36     0.05   0.00  -0.00    -0.28  -0.04   0.25
+    10   1     0.05   0.18  -0.25     0.00  -0.03  -0.00    -0.12   0.17   0.32
+    11   1    -0.17   0.16   0.18     0.04  -0.01  -0.02    -0.33   0.15   0.12
+    12   6     0.04  -0.02  -0.00    -0.01  -0.10   0.03     0.00  -0.01  -0.00
+    13   8    -0.00   0.01   0.01     0.02   0.05  -0.06     0.00   0.01  -0.00
+    14   1    -0.04  -0.03  -0.00    -0.08   0.32   0.16    -0.06   0.01   0.01
+    15   1    -0.05   0.33  -0.06     0.04   0.01  -0.28    -0.01  -0.07   0.14
+    16   1    -0.19   0.00  -0.06     0.23  -0.20  -0.17     0.04  -0.02  -0.02
+    17   1    -0.02   0.02   0.04    -0.42   0.29   0.61    -0.03   0.02   0.04
+                     28                     29                     30
+                      A                      A                      A
+ Frequencies --   1413.8079              1420.6471              1453.6296
+ Red. masses --      1.1030                 1.2073                 1.0800
+ Frc consts  --      1.2990                 1.4356                 1.3445
+ IR Inten    --      1.2522                 0.4948                 1.6361
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.01  -0.00     0.00  -0.00   0.00     0.00   0.01  -0.00
+     2   6     0.01   0.00   0.01    -0.00   0.00   0.00    -0.02  -0.00  -0.00
+     3   6     0.00   0.05  -0.05    -0.00   0.00   0.00     0.02  -0.05  -0.03
+     4   6    -0.02  -0.03   0.01    -0.02   0.03  -0.08    -0.01   0.01   0.00
+     5   6    -0.00  -0.00   0.03    -0.07   0.03   0.06     0.01   0.02   0.02
+     6   1     0.05  -0.02  -0.04     0.07   0.01   0.37     0.04   0.01   0.04
+     7   1    -0.00   0.09  -0.00     0.21  -0.16   0.29    -0.03  -0.06  -0.00
+     8   1    -0.01   0.06  -0.09    -0.09  -0.22   0.32     0.04  -0.08  -0.03
+     9   1     0.00   0.01  -0.10     0.32   0.05  -0.26    -0.00   0.03  -0.07
+    10   1     0.02   0.03  -0.10     0.13  -0.20  -0.35     0.04  -0.07   0.00
+    11   1     0.06  -0.02   0.00     0.36  -0.16  -0.13    -0.04  -0.12  -0.03
+    12   6     0.00  -0.00  -0.02     0.01   0.00  -0.01     0.00  -0.00   0.03
+    13   8     0.01   0.01  -0.01    -0.01  -0.00   0.01     0.02   0.01  -0.01
+    14   1    -0.29   0.06   0.03    -0.01   0.01  -0.00    -0.06  -0.31  -0.05
+    15   1    -0.00  -0.48   0.75     0.05  -0.04  -0.04    -0.30   0.64   0.40
+    16   1     0.19  -0.05  -0.03    -0.03   0.02   0.03    -0.05  -0.10  -0.40
+    17   1    -0.07   0.05   0.12     0.03  -0.01  -0.03    -0.07   0.05   0.11
+                     31                     32                     33
+                      A                      A                      A
+ Frequencies --   1481.9425              1487.0125              1496.0713
+ Red. masses --      1.0480                 1.0458                 1.1044
+ Frc consts  --      1.3561                 1.3625                 1.4564
+ IR Inten    --      2.7113                 4.2152                 7.2457
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00  -0.00   0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+     2   6     0.00   0.00  -0.00     0.00   0.00   0.00    -0.01  -0.00  -0.00
+     3   6    -0.00   0.00  -0.01     0.01   0.00  -0.01     0.01  -0.01  -0.02
+     4   6     0.03   0.02  -0.00     0.02  -0.03  -0.01     0.01   0.02   0.00
+     5   6    -0.03  -0.02  -0.03    -0.01   0.03  -0.01     0.00   0.02  -0.00
+     6   1    -0.39  -0.04   0.14    -0.29  -0.03  -0.25    -0.19  -0.01   0.13
+     7   1    -0.08  -0.37   0.01     0.26   0.12   0.26    -0.10  -0.26  -0.03
+     8   1     0.01   0.18  -0.14    -0.29   0.41   0.21     0.06   0.03  -0.13
+     9   1     0.23  -0.03   0.44     0.26   0.03  -0.07     0.14   0.02  -0.02
+    10   1     0.09  -0.14  -0.22     0.05  -0.34   0.27     0.05  -0.20   0.12
+    11   1     0.11   0.46   0.14    -0.31  -0.17  -0.00    -0.17  -0.08   0.01
+    12   6    -0.01   0.02   0.01    -0.00   0.01   0.01     0.03  -0.06  -0.06
+    13   8     0.00   0.00  -0.00     0.00   0.00   0.00    -0.00  -0.00  -0.00
+    14   1    -0.01  -0.15  -0.03     0.01  -0.09  -0.02    -0.06   0.50   0.10
+    15   1     0.02  -0.07   0.04     0.03  -0.06  -0.02    -0.17   0.28   0.22
+    16   1     0.04  -0.03  -0.16     0.03  -0.02  -0.09    -0.11   0.11   0.52
+    17   1    -0.01   0.01   0.01    -0.01   0.00   0.01     0.02  -0.01  -0.02
+                     34                     35                     36
+                      A                      A                      A
+ Frequencies --   1498.3820              1507.7379              2280.9881
+ Red. masses --      1.0469                 1.0770                12.2842
+ Frc consts  --      1.3848                 1.4425                37.6567
+ IR Inten    --      7.1789                 6.0725                38.7709
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00   0.00    -0.00   0.01  -0.00     0.20  -0.55   0.02
+     2   6    -0.00  -0.00   0.00    -0.00  -0.00  -0.00    -0.26   0.74  -0.03
+     3   6    -0.03  -0.00  -0.01     0.02  -0.06  -0.01     0.04  -0.09   0.01
+     4   6    -0.03  -0.02   0.01     0.00  -0.02  -0.01    -0.00  -0.01   0.00
+     5   6    -0.02  -0.00  -0.03    -0.00  -0.02   0.01     0.00  -0.01  -0.01
+     6   1     0.45   0.04  -0.14    -0.12  -0.01  -0.27    -0.01  -0.01  -0.01
+     7   1     0.06   0.42  -0.06     0.24   0.18   0.22    -0.01   0.01   0.00
+     8   1     0.00  -0.23   0.15    -0.23   0.27   0.22     0.02   0.03  -0.02
+     9   1     0.33  -0.01   0.35    -0.27  -0.03   0.13    -0.01  -0.02   0.00
+    10   1     0.12  -0.31  -0.06    -0.04   0.32  -0.30     0.00   0.02   0.03
+    11   1    -0.10   0.32   0.13     0.34   0.19   0.00    -0.00   0.01  -0.01
+    12   6     0.01  -0.01  -0.01     0.01  -0.03  -0.02    -0.00   0.00   0.00
+    13   8     0.00  -0.00  -0.00     0.00  -0.00  -0.00     0.00  -0.00  -0.00
+    14   1    -0.02   0.08   0.02    -0.02   0.18   0.04     0.03   0.02   0.00
+    15   1    -0.06   0.10   0.06    -0.13   0.25   0.10    -0.15  -0.07  -0.05
+    16   1    -0.04   0.02   0.08    -0.06   0.03   0.17     0.01   0.00   0.01
+    17   1     0.01  -0.00  -0.00    -0.01   0.00   0.01     0.01  -0.02   0.01
+                     37                     38                     39
+                      A                      A                      A
+ Frequencies --   3015.0638              3018.8871              3030.1281
+ Red. masses --      1.0386                 1.0387                 1.0551
+ Frc consts  --      5.5629                 5.5774                 5.7077
+ IR Inten    --     20.6465                35.8236                30.5308
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00  -0.00    -0.00   0.00  -0.00    -0.00   0.00   0.00
+     2   6     0.00  -0.00   0.00     0.00  -0.00   0.00    -0.00  -0.00  -0.00
+     3   6    -0.00   0.00  -0.00    -0.00   0.00  -0.00     0.00   0.00   0.00
+     4   6     0.01  -0.00   0.02    -0.03   0.01  -0.04    -0.00   0.00   0.00
+     5   6    -0.05   0.00   0.01    -0.02   0.00   0.01     0.00   0.00   0.00
+     6   1    -0.01   0.20   0.02     0.03  -0.44  -0.03     0.00   0.00   0.00
+     7   1     0.13  -0.04  -0.09    -0.30   0.08   0.21     0.00  -0.00  -0.00
+     8   1    -0.26  -0.12  -0.12     0.59   0.27   0.29    -0.00  -0.00  -0.00
+     9   1     0.01  -0.44  -0.02     0.00  -0.19  -0.01     0.00  -0.01  -0.00
+    10   1     0.64   0.25   0.18     0.29   0.11   0.08    -0.01  -0.00  -0.00
+    11   1    -0.10   0.13  -0.33    -0.04   0.06  -0.15    -0.00   0.00  -0.01
+    12   6     0.00  -0.00  -0.00     0.00  -0.00  -0.00    -0.01  -0.01  -0.06
+    13   8    -0.00   0.00   0.00    -0.00   0.00   0.00    -0.00  -0.00  -0.00
+    14   1    -0.00   0.00  -0.00    -0.00  -0.00   0.00     0.08  -0.23   0.87
+    15   1     0.00   0.00   0.00     0.01   0.00   0.00    -0.01   0.00  -0.00
+    16   1    -0.00  -0.00   0.00    -0.00   0.00  -0.00     0.06   0.41  -0.11
+    17   1     0.00   0.00   0.00     0.00   0.00  -0.00     0.00  -0.01   0.00
+                     40                     41                     42
+                      A                      A                      A
+ Frequencies --   3074.8208              3079.5256              3103.8434
+ Red. masses --      1.0970                 1.0976                 1.1021
+ Frc consts  --      6.1108                 6.1331                 6.2556
+ IR Inten    --     13.6393                19.5316                18.2867
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7    -0.00   0.00  -0.00    -0.00   0.00   0.00    -0.00  -0.00   0.00
+     2   6     0.00  -0.00   0.00     0.00  -0.00  -0.00     0.00   0.00  -0.00
+     3   6    -0.00  -0.00   0.00    -0.00  -0.00  -0.00    -0.00   0.00  -0.00
+     4   6     0.01   0.01   0.00    -0.06  -0.07  -0.01     0.01  -0.00  -0.00
+     5   6    -0.05  -0.06  -0.04    -0.01  -0.01  -0.01    -0.02   0.07  -0.06
+     6   1     0.01  -0.10  -0.01    -0.08   0.70   0.04    -0.00   0.02   0.00
+     7   1    -0.02   0.01   0.02     0.25  -0.09  -0.21    -0.07   0.02   0.05
+     8   1    -0.07  -0.03  -0.03     0.50   0.21   0.25    -0.02  -0.01  -0.01
+     9   1    -0.04   0.68   0.03    -0.01   0.08   0.00     0.01  -0.54  -0.04
+    10   1     0.55   0.19   0.14     0.08   0.03   0.02     0.08   0.05   0.01
+    11   1     0.08  -0.15   0.34     0.02  -0.03   0.07     0.20  -0.29   0.75
+    12   6    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.00  -0.00   0.00
+    13   8     0.00  -0.00  -0.00     0.00  -0.00  -0.00     0.00   0.00   0.00
+    14   1     0.00  -0.00   0.02     0.00  -0.00   0.01     0.00  -0.00   0.00
+    15   1     0.00   0.00  -0.00     0.00   0.00   0.00     0.00   0.00   0.00
+    16   1     0.00   0.01  -0.00    -0.00  -0.01   0.00     0.00   0.01  -0.00
+    17   1    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.00  -0.00  -0.00
+                     43                     44                     45
+                      A                      A                      A
+ Frequencies --   3109.1728              3156.4352              3783.7315
+ Red. masses --      1.1019                 1.1101                 1.0664
+ Frc consts  --      6.2763                 6.5163                 8.9948
+ IR Inten    --     14.8224                18.5555                45.8419
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   7     0.00  -0.00  -0.00    -0.00  -0.00  -0.00     0.00  -0.00   0.00
+     2   6     0.00   0.00   0.00     0.00   0.00   0.00    -0.00   0.00  -0.00
+     3   6    -0.00   0.00   0.00     0.00   0.00  -0.00     0.00  -0.00   0.00
+     4   6    -0.06   0.05   0.04    -0.00  -0.00  -0.00    -0.00  -0.00  -0.00
+     5   6    -0.00   0.01  -0.00     0.00  -0.00   0.00    -0.00  -0.00  -0.00
+     6   1     0.03  -0.50  -0.03    -0.00   0.01   0.00     0.00   0.00   0.00
+     7   1     0.66  -0.18  -0.50     0.00  -0.00  -0.00     0.00   0.00   0.00
+     8   1     0.09   0.06   0.06     0.01   0.00   0.00    -0.00   0.00  -0.00
+     9   1     0.00  -0.06  -0.01    -0.00   0.01   0.00     0.00   0.00   0.00
+    10   1     0.00   0.00  -0.00    -0.00  -0.00  -0.00    -0.00   0.00   0.00
+    11   1     0.02  -0.02   0.06    -0.00   0.00  -0.01     0.00   0.00   0.00
+    12   6     0.00   0.00   0.00    -0.01  -0.08   0.05    -0.00  -0.00   0.00
+    13   8    -0.00  -0.00  -0.00     0.00   0.00  -0.00    -0.01  -0.06   0.02
+    14   1    -0.00   0.00  -0.00    -0.05   0.10  -0.40    -0.00   0.00  -0.00
+    15   1     0.00  -0.00   0.00    -0.00  -0.00   0.00    -0.00  -0.00  -0.00
+    16   1    -0.00  -0.00   0.00     0.16   0.87  -0.20     0.00   0.02  -0.00
+    17   1     0.00  -0.00   0.00    -0.01  -0.01   0.01     0.14   0.96  -0.25
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  7 and mass  14.00307
+ Atom     2 has atomic number  6 and mass  12.00000
+ Atom     3 has atomic number  6 and mass  12.00000
+ Atom     4 has atomic number  6 and mass  12.00000
+ Atom     5 has atomic number  6 and mass  12.00000
+ Atom     6 has atomic number  1 and mass   1.00783
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  1 and mass   1.00783
+ Atom     9 has atomic number  1 and mass   1.00783
+ Atom    10 has atomic number  1 and mass   1.00783
+ Atom    11 has atomic number  1 and mass   1.00783
+ Atom    12 has atomic number  6 and mass  12.00000
+ Atom    13 has atomic number  8 and mass  15.99491
+ Atom    14 has atomic number  1 and mass   1.00783
+ Atom    15 has atomic number  1 and mass   1.00783
+ Atom    16 has atomic number  1 and mass   1.00783
+ Atom    17 has atomic number  1 and mass   1.00783
+ Molecular mass:   100.07624 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   663.172881009.310541236.23784
+           X            0.99909  -0.04118   0.01132
+           Y            0.04112   0.99914   0.00503
+           Z           -0.01152  -0.00456   0.99992
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Warning -- assumption of classical behavior for rotation
+           may cause significant error
+ Rotational temperatures (Kelvin)      0.13061     0.08581     0.07006
+ Rotational constants (GHZ):           2.72137     1.78809     1.45987
+    1 imaginary frequencies ignored.
+ Zero-point vibrational energy     360040.4 (Joules/Mol)
+                                   86.05172 (Kcal/Mol)
+ Warning -- explicit consideration of  14 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:     81.94   110.33   174.67   262.08   280.53
+          (Kelvin)            291.22   302.09   393.51   492.74   621.53
+                              667.70   831.26   855.23   885.60  1099.41
+                             1384.53  1392.74  1445.66  1579.80  1624.94
+                             1635.95  1655.72  1705.60  1797.14  1996.27
+                             2016.46  2034.15  2043.99  2091.45  2132.18
+                             2139.48  2152.51  2155.84  2169.30  3281.83
+                             4338.00  4343.51  4359.68  4423.98  4430.75
+                             4465.74  4473.41  4541.41  5443.95
+ 
+ Zero-point correction=                           0.137132 (Hartree/Particle)
+ Thermal correction to Energy=                    0.146754
+ Thermal correction to Enthalpy=                  0.147698
+ Thermal correction to Gibbs Free Energy=         0.101942
+ Sum of electronic and zero-point Energies=           -326.386550
+ Sum of electronic and thermal Energies=              -326.376928
+ Sum of electronic and thermal Enthalpies=            -326.375984
+ Sum of electronic and thermal Free Energies=         -326.421740
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   92.089             32.595             96.301
+ Electronic               0.000              0.000              1.377
+ Translational            0.889              2.981             39.720
+ Rotational               0.889              2.981             28.205
+ Vibrational             90.312             26.633             26.998
+ Vibration     1          0.596              1.975              4.560
+ Vibration     2          0.599              1.965              3.974
+ Vibration     3          0.609              1.931              3.078
+ Vibration     4          0.630              1.864              2.306
+ Vibration     5          0.636              1.847              2.180
+ Vibration     6          0.639              1.836              2.111
+ Vibration     7          0.642              1.826              2.044
+ Vibration     8          0.676              1.722              1.574
+ Vibration     9          0.722              1.591              1.201
+ Vibration    10          0.793              1.401              0.852
+ Vibration    11          0.822              1.330              0.754
+ Vibration    12          0.934              1.079              0.490
+ Vibration    13          0.952              1.044              0.459
+ Vibration    14          0.975              0.999              0.424
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.128779D-46        -46.890155       -107.968571
+ Total V=0       0.153532D+17         16.186198         37.270098
+ Vib (Bot)       0.502508D-60        -60.298857       -138.843250
+ Vib (Bot)    1  0.362711D+01          0.559561          1.288436
+ Vib (Bot)    2  0.268707D+01          0.429278          0.988450
+ Vib (Bot)    3  0.168274D+01          0.226016          0.520421
+ Vib (Bot)    4  0.110180D+01          0.042102          0.096943
+ Vib (Bot)    5  0.102459D+01          0.010549          0.024289
+ Vib (Bot)    6  0.984216D+00         -0.006910         -0.015910
+ Vib (Bot)    7  0.945976D+00         -0.024120         -0.055538
+ Vib (Bot)    8  0.705338D+00         -0.151603         -0.349078
+ Vib (Bot)    9  0.541348D+00         -0.266523         -0.613693
+ Vib (Bot)   10  0.402719D+00         -0.394998         -0.909517
+ Vib (Bot)   11  0.365270D+00         -0.437387         -1.007120
+ Vib (Bot)   12  0.264339D+00         -0.577839         -1.330524
+ Vib (Bot)   13  0.252648D+00         -0.597484         -1.375758
+ Vib (Bot)   14  0.238710D+00         -0.622130         -1.432506
+ Vib (V=0)       0.599094D+03          2.777495          6.395418
+ Vib (V=0)    1  0.416141D+01          0.619241          1.425854
+ Vib (V=0)    2  0.323319D+01          0.509631          1.173469
+ Vib (V=0)    3  0.225545D+01          0.353233          0.813349
+ Vib (V=0)    4  0.170994D+01          0.232981          0.536459
+ Vib (V=0)    5  0.164008D+01          0.214864          0.494744
+ Vib (V=0)    6  0.160394D+01          0.205188          0.472462
+ Vib (V=0)    7  0.156999D+01          0.195896          0.451067
+ Vib (V=0)    8  0.136458D+01          0.135000          0.310848
+ Vib (V=0)    9  0.123692D+01          0.092343          0.212628
+ Vib (V=0)   10  0.114201D+01          0.057672          0.132794
+ Vib (V=0)   11  0.111921D+01          0.048912          0.112624
+ Vib (V=0)   12  0.106557D+01          0.027584          0.063515
+ Vib (V=0)   13  0.106021D+01          0.025390          0.058463
+ Vib (V=0)   14  0.105406D+01          0.022865          0.052649
+ Electronic      0.200000D+01          0.301030          0.693147
+ Translational   0.393505D+08          7.594950         17.488019
+ Rotational      0.325628D+06          5.512722         12.693512
+ 
+                                                  0xd628bc800d04214f0f9db0fec4700
+ 2f2
+                                                             IR Spectrum
+ 
+     3                  33333333                        2                    1111111111    111111 1                                  
+     7                  11100000                        2                    5444444443    211110 099      7   655   44  322211 1    
+     8                  50087311                        8                    0998852108    485329 066      6   197   63  471098 2 75 
+     4                  69405095                        1                    8867241427    951798 582      4   648   42  240252 1 77 
+ 
+     X                  XXXXXXXX                        X                    XXXXXXXXXX    XXXXXX XXX      X   XXX   XX  XXXXXX X XX 
+     X                  XXXXXXXX                        X                             X      XX X              X X    X              
+     X                  XXXX XXX                        X                             X      XX X              X X    X              
+     X                       XXX                        X                             X      X  X              X X    X              
+     X                       XX                         X                             X      X  X              X X    X              
+     X                        X                         X                             X      X  X                X    X              
+     X                                                  X                                    X  X                X    X              
+     X                                                                                       X  X                X    X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X  X                     X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                             X                        X              
+                                                                                                                      X              
+                                                                                                                      X              
+                                                                                                                      X              
+ 
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000000280   -0.000000685   -0.000000774
+      2        6           0.000000214    0.000000882   -0.000000728
+      3        6          -0.000003003    0.000000321    0.000001130
+      4        6           0.000000146   -0.000000480    0.000001677
+      5        6          -0.000000284    0.000001185   -0.000002249
+      6        1          -0.000000946    0.000000321    0.000000659
+      7        1          -0.000000168    0.000000621    0.000000361
+      8        1          -0.000000465   -0.000000712   -0.000000356
+      9        1          -0.000000499    0.000000574   -0.000001003
+     10        1           0.000000385   -0.000000930   -0.000001025
+     11        1           0.000000782    0.000000275   -0.000000772
+     12        6           0.000000386    0.000001032    0.000000137
+     13        8           0.000002389    0.000000394   -0.000000460
+     14        1           0.000000565    0.000000030    0.000000554
+     15        1          -0.000000213   -0.000002719    0.000002058
+     16        1           0.000000243    0.000000527    0.000000988
+     17        1           0.000000749   -0.000000634   -0.000000198
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000003003 RMS     0.000001012
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Leave Link  716 at Tue Jul  7 12:18:27 2020, MaxMem= 39321600000 cpu:               1.0 elap:               0.0
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000007192 RMS     0.000001420
+ Search for a saddle point.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Swapping is turned off.
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---   -0.05281   0.00136   0.00182   0.00216   0.00787
+     Eigenvalues ---    0.02055   0.02221   0.02853   0.03248   0.04199
+     Eigenvalues ---    0.04450   0.04533   0.04540   0.04562   0.04857
+     Eigenvalues ---    0.05039   0.06437   0.07164   0.08352   0.09460
+     Eigenvalues ---    0.10151   0.10577   0.11963   0.12324   0.13749
+     Eigenvalues ---    0.14489   0.14665   0.15294   0.15371   0.17088
+     Eigenvalues ---    0.17841   0.28547   0.28900   0.32691   0.32798
+     Eigenvalues ---    0.32831   0.33375   0.33496   0.34149   0.34268
+     Eigenvalues ---    0.34559   0.34960   0.41551   0.51593   1.18845
+ Eigenvectors required to have negative eigenvalues:
+                          R14       R5        D28       A20       D2
+   1                   -0.72350   0.62459  -0.10390   0.09099  -0.06083
+                          D13       D12       A22       A23       D4
+   1                   -0.06052   0.05970   0.05926  -0.05924   0.05786
+ Angle between quadratic step and forces=  59.06 degrees.
+ Linear search not attempted -- option 19 set.
+ Iteration  1 RMS(Cart)=  0.00013556 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000001 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 4.32D-04 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.19084   0.00000   0.00000  -0.00000  -0.00000   2.19084
+    R2        2.71391  -0.00000   0.00000   0.00000   0.00000   2.71391
+    R3        2.88034   0.00000   0.00000   0.00001   0.00001   2.88035
+    R4        2.87865   0.00000   0.00000   0.00002   0.00002   2.87867
+    R5        2.53763   0.00000   0.00000  -0.00002  -0.00002   2.53761
+    R6        2.06573  -0.00000   0.00000  -0.00000  -0.00000   2.06573
+    R7        2.06299  -0.00000   0.00000   0.00000   0.00000   2.06299
+    R8        2.07014  -0.00000   0.00000  -0.00000  -0.00000   2.07014
+    R9        2.06608   0.00000   0.00000   0.00000   0.00000   2.06608
+   R10        2.07075  -0.00000   0.00000  -0.00000  -0.00000   2.07075
+   R11        2.06364   0.00000   0.00000   0.00000   0.00000   2.06364
+   R12        2.60690  -0.00000   0.00000   0.00000   0.00000   2.60690
+   R13        2.06725  -0.00000   0.00000   0.00000   0.00000   2.06725
+   R14        2.64298   0.00000   0.00000   0.00001   0.00001   2.64299
+   R15        2.05545   0.00000   0.00000   0.00000   0.00000   2.05545
+   R16        1.82502   0.00000   0.00000  -0.00000  -0.00000   1.82502
+    A1        1.99006  -0.00000   0.00000   0.00001   0.00001   1.99006
+    A2        2.00221  -0.00000   0.00000  -0.00001  -0.00001   2.00220
+    A3        1.73084   0.00000   0.00000   0.00002   0.00002   1.73085
+    A4        2.02034   0.00000   0.00000   0.00001   0.00001   2.02035
+    A5        1.81838  -0.00000   0.00000   0.00000   0.00000   1.81838
+    A6        1.86003  -0.00000   0.00000  -0.00002  -0.00002   1.86001
+    A7        1.91710   0.00000   0.00000   0.00000   0.00000   1.91711
+    A8        1.93695   0.00000   0.00000   0.00001   0.00001   1.93695
+    A9        1.94368  -0.00000   0.00000   0.00000   0.00000   1.94368
+   A10        1.89204  -0.00000   0.00000  -0.00000  -0.00000   1.89204
+   A11        1.88390  -0.00000   0.00000  -0.00000  -0.00000   1.88390
+   A12        1.88855  -0.00000   0.00000  -0.00000  -0.00000   1.88855
+   A13        1.91823   0.00000   0.00000   0.00001   0.00001   1.91824
+   A14        1.94103   0.00000   0.00000   0.00001   0.00001   1.94104
+   A15        1.94796   0.00000   0.00000  -0.00000  -0.00000   1.94796
+   A16        1.88036  -0.00000   0.00000   0.00000   0.00000   1.88036
+   A17        1.89219  -0.00000   0.00000  -0.00001  -0.00001   1.89219
+   A18        1.88197  -0.00000   0.00000  -0.00000  -0.00000   1.88196
+   A19        2.02318  -0.00000   0.00000  -0.00000  -0.00000   2.02318
+   A20        1.83790   0.00000   0.00000   0.00003   0.00003   1.83793
+   A21        1.92693  -0.00000   0.00000  -0.00001  -0.00001   1.92693
+   A22        1.79565  -0.00000   0.00000   0.00000   0.00000   1.79565
+   A23        1.99461   0.00000   0.00000   0.00000   0.00000   1.99462
+   A24        1.86630  -0.00000   0.00000  -0.00002  -0.00002   1.86628
+   A25        1.90539   0.00000   0.00000  -0.00000  -0.00000   1.90539
+   A26        3.03917   0.00000   0.00000   0.00003   0.00003   3.03920
+   A27        3.23066  -0.00000   0.00000  -0.00000  -0.00000   3.23066
+   A28        3.10483  -0.00000   0.00000   0.00001   0.00001   3.10484
+   A29        2.80992   0.00001   0.00000   0.00024   0.00024   2.81017
+    D1        2.98034   0.00000   0.00000   0.00005   0.00005   2.98039
+    D2        0.88840   0.00000   0.00000   0.00005   0.00005   0.88845
+    D3       -1.21677   0.00000   0.00000   0.00005   0.00005  -1.21672
+    D4       -0.92341   0.00000   0.00000   0.00005   0.00005  -0.92336
+    D5       -3.01534   0.00000   0.00000   0.00005   0.00005  -3.01530
+    D6        1.16266   0.00000   0.00000   0.00005   0.00005   1.16271
+    D7        1.11259  -0.00000   0.00000   0.00003   0.00003   1.11261
+    D8       -0.97935  -0.00000   0.00000   0.00003   0.00003  -0.97932
+    D9       -3.08453  -0.00000   0.00000   0.00003   0.00003  -3.08450
+   D10       -2.93232   0.00000   0.00000  -0.00007  -0.00007  -2.93239
+   D11        1.27015  -0.00000   0.00000  -0.00008  -0.00008   1.27007
+   D12       -0.83236  -0.00000   0.00000  -0.00007  -0.00007  -0.83243
+   D13        0.97671  -0.00000   0.00000  -0.00007  -0.00007   0.97664
+   D14       -1.10401  -0.00000   0.00000  -0.00008  -0.00008  -1.10409
+   D15        3.07667  -0.00000   0.00000  -0.00008  -0.00008   3.07660
+   D16       -1.03577   0.00000   0.00000  -0.00007  -0.00007  -1.03584
+   D17       -3.11649  -0.00000   0.00000  -0.00008  -0.00008  -3.11656
+   D18        1.06419  -0.00000   0.00000  -0.00007  -0.00007   1.06412
+   D19       -0.79835  -0.00000   0.00000   0.00002   0.00002  -0.79833
+   D20        1.28637   0.00000   0.00000   0.00005   0.00005   1.28642
+   D21       -2.82017  -0.00000   0.00000  -0.00001  -0.00001  -2.82019
+   D22        1.21412  -0.00000   0.00000   0.00006   0.00006   1.21418
+   D23       -2.98434   0.00000   0.00000   0.00009   0.00009  -2.98425
+   D24       -0.80770  -0.00000   0.00000   0.00002   0.00002  -0.80768
+   D25       -2.85996  -0.00000   0.00000   0.00002   0.00002  -2.85994
+   D26       -0.77524   0.00000   0.00000   0.00005   0.00005  -0.77518
+   D27        1.40140  -0.00000   0.00000  -0.00001  -0.00001   1.40139
+   D28       -0.78349  -0.00000   0.00000   0.00004   0.00004  -0.78345
+   D29        1.18794   0.00000   0.00000   0.00005   0.00005   1.18800
+   D30       -3.08666   0.00000   0.00000   0.00005   0.00005  -3.08662
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000007     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000432     0.001800     YES
+ RMS     Displacement     0.000136     0.001200     YES
+ Predicted change in Energy=-1.243567D-09
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1593         -DE/DX =    0.0                 !
+ ! R2    R(2,3)                  1.4361         -DE/DX =    0.0                 !
+ ! R3    R(3,4)                  1.5242         -DE/DX =    0.0                 !
+ ! R4    R(3,5)                  1.5233         -DE/DX =    0.0                 !
+ ! R5    R(3,15)                 1.3429         -DE/DX =    0.0                 !
+ ! R6    R(4,6)                  1.0931         -DE/DX =    0.0                 !
+ ! R7    R(4,7)                  1.0917         -DE/DX =    0.0                 !
+ ! R8    R(4,8)                  1.0955         -DE/DX =    0.0                 !
+ ! R9    R(5,9)                  1.0933         -DE/DX =    0.0                 !
+ ! R10   R(5,10)                 1.0958         -DE/DX =    0.0                 !
+ ! R11   R(5,11)                 1.092          -DE/DX =    0.0                 !
+ ! R12   R(12,13)                1.3795         -DE/DX =    0.0                 !
+ ! R13   R(12,14)                1.0939         -DE/DX =    0.0                 !
+ ! R14   R(12,15)                1.3986         -DE/DX =    0.0                 !
+ ! R15   R(12,16)                1.0877         -DE/DX =    0.0                 !
+ ! R16   R(13,17)                0.9658         -DE/DX =    0.0                 !
+ ! A1    A(2,3,4)              114.0219         -DE/DX =    0.0                 !
+ ! A2    A(2,3,5)              114.7185         -DE/DX =    0.0                 !
+ ! A3    A(2,3,15)              99.1696         -DE/DX =    0.0                 !
+ ! A4    A(4,3,5)              115.7567         -DE/DX =    0.0                 !
+ ! A5    A(4,3,15)             104.1854         -DE/DX =    0.0                 !
+ ! A6    A(5,3,15)             106.572          -DE/DX =    0.0                 !
+ ! A7    A(3,4,6)              109.8419         -DE/DX =    0.0                 !
+ ! A8    A(3,4,7)              110.9789         -DE/DX =    0.0                 !
+ ! A9    A(3,4,8)              111.3648         -DE/DX =    0.0                 !
+ ! A10   A(6,4,7)              108.4059         -DE/DX =    0.0                 !
+ ! A11   A(6,4,8)              107.9394         -DE/DX =    0.0                 !
+ ! A12   A(7,4,8)              108.2062         -DE/DX =    0.0                 !
+ ! A13   A(3,5,9)              109.9065         -DE/DX =    0.0                 !
+ ! A14   A(3,5,10)             111.213          -DE/DX =    0.0                 !
+ ! A15   A(3,5,11)             111.6101         -DE/DX =    0.0                 !
+ ! A16   A(9,5,10)             107.7369         -DE/DX =    0.0                 !
+ ! A17   A(9,5,11)             108.4147         -DE/DX =    0.0                 !
+ ! A18   A(10,5,11)            107.8287         -DE/DX =    0.0                 !
+ ! A19   A(13,12,14)           115.9198         -DE/DX =    0.0                 !
+ ! A20   A(13,12,15)           105.3039         -DE/DX =    0.0                 !
+ ! A21   A(13,12,16)           110.405          -DE/DX =    0.0                 !
+ ! A22   A(14,12,15)           102.883          -DE/DX =    0.0                 !
+ ! A23   A(14,12,16)           114.283          -DE/DX =    0.0                 !
+ ! A24   A(15,12,16)           106.9309         -DE/DX =    0.0                 !
+ ! A25   A(12,13,17)           109.171          -DE/DX =    0.0                 !
+ ! A26   L(1,2,3,13,-1)        174.1317         -DE/DX =    0.0                 !
+ ! A27   L(3,15,12,6,-1)       185.1033         -DE/DX =    0.0                 !
+ ! A28   L(1,2,3,13,-2)        177.8936         -DE/DX =    0.0                 !
+ ! A29   L(3,15,12,6,-2)       160.9966         -DE/DX =    0.0                 !
+ ! D1    D(2,3,4,6)            170.7609         -DE/DX =    0.0                 !
+ ! D2    D(2,3,4,7)             50.9018         -DE/DX =    0.0                 !
+ ! D3    D(2,3,4,8)            -69.716          -DE/DX =    0.0                 !
+ ! D4    D(5,3,4,6)            -52.9073         -DE/DX =    0.0                 !
+ ! D5    D(5,3,4,7)           -172.7665         -DE/DX =    0.0                 !
+ ! D6    D(5,3,4,8)             66.6157         -DE/DX =    0.0                 !
+ ! D7    D(15,3,4,6)            63.7466         -DE/DX =    0.0                 !
+ ! D8    D(15,3,4,7)           -56.1126         -DE/DX =    0.0                 !
+ ! D9    D(15,3,4,8)          -176.7304         -DE/DX =    0.0                 !
+ ! D10   D(2,3,5,9)           -168.0097         -DE/DX =    0.0                 !
+ ! D11   D(2,3,5,10)            72.774          -DE/DX =    0.0                 !
+ ! D12   D(2,3,5,11)           -47.6907         -DE/DX =    0.0                 !
+ ! D13   D(4,3,5,9)             55.9613         -DE/DX =    0.0                 !
+ ! D14   D(4,3,5,10)           -63.2549         -DE/DX =    0.0                 !
+ ! D15   D(4,3,5,11)           176.2804         -DE/DX =    0.0                 !
+ ! D16   D(15,3,5,9)           -59.3454         -DE/DX =    0.0                 !
+ ! D17   D(15,3,5,10)         -178.5617         -DE/DX =    0.0                 !
+ ! D18   D(15,3,5,11)           60.9736         -DE/DX =    0.0                 !
+ ! D19   D(2,3,12,13)          -45.7421         -DE/DX =    0.0                 !
+ ! D20   D(2,3,12,14)           73.7036         -DE/DX =    0.0                 !
+ ! D21   D(2,3,12,16)         -161.5841         -DE/DX =    0.0                 !
+ ! D22   D(4,3,12,13)           69.5641         -DE/DX =    0.0                 !
+ ! D23   D(4,3,12,14)         -170.9903         -DE/DX =    0.0                 !
+ ! D24   D(4,3,12,16)          -46.278          -DE/DX =    0.0                 !
+ ! D25   D(5,3,12,13)         -163.8634         -DE/DX =    0.0                 !
+ ! D26   D(5,3,12,14)          -44.4178         -DE/DX =    0.0                 !
+ ! D27   D(5,3,12,16)           80.2946         -DE/DX =    0.0                 !
+ ! D28   D(14,12,13,17)        -44.8905         -DE/DX =    0.0                 !
+ ! D29   D(15,12,13,17)         68.0641         -DE/DX =    0.0                 !
+ ! D30   D(16,12,13,17)       -176.8528         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Jul  7 12:18:27 2020, MaxMem= 39321600000 cpu:               1.0 elap:               0.1
+ (Enter /home/gridsan/oscarwu/GRPAPI/Software/g16/l9999.exe)
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.139601D+01      0.354831D+01      0.118359D+02
+   x          0.921414D+00      0.234200D+01      0.781208D+01
+   y          0.931872D+00      0.236858D+01      0.790074D+01
+   z         -0.481110D+00     -0.122286D+01     -0.407902D+01
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.737519D+02      0.109289D+02      0.121601D+02
+   aniso      0.226579D+02      0.335756D+01      0.373579D+01
+   xx         0.798487D+02      0.118324D+02      0.131653D+02
+   yx        -0.441030D+01     -0.653540D+00     -0.727161D+00
+   yy         0.817053D+02      0.121075D+02      0.134714D+02
+   zx        -0.657969D+00     -0.975009D-01     -0.108484D+00
+   zy        -0.152496D+01     -0.225975D+00     -0.251431D+00
+   zz         0.597017D+02      0.884688D+01      0.984349D+01
+
+ ----------------------------------------------------------------------
+
+ Dipole orientation:
+     7         -1.74723650          0.45308322         -4.79225042
+     6         -1.44780026         -0.19180930         -2.72000156
+     6         -0.88380960         -0.76911255         -0.12887173
+     6          0.70749057         -3.14393731          0.22375850
+     6         -3.10178316         -0.46930405          1.68147009
+     1          1.31895371         -3.29247017          2.19131583
+     1          2.38399136         -3.09474348         -0.97742104
+     1         -0.37027300         -4.84960046         -0.23950405
+     1         -2.43146288         -0.54724565          3.63423079
+     1         -4.48602999         -1.98847881          1.42854975
+     1         -4.07662065          1.32735765          1.39809655
+     6          2.53447800          3.04278866          0.15416793
+     8          3.76586963          2.57101632         -2.09461336
+     1          1.39788102          4.76838015          0.21729606
+     1          0.71960959          1.13355555          0.36959282
+     1          3.82574049          2.82270356          1.73817763
+     1          2.61624532          2.86654181         -3.48088165
+
+ Electric dipole moment (dipole orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.139601D+01      0.354831D+01      0.118359D+02
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.139601D+01      0.354831D+01      0.118359D+02
+
+ Dipole polarizability, Alpha (dipole orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.737519D+02      0.109289D+02      0.121601D+02
+   aniso      0.226579D+02      0.335756D+01      0.373579D+01
+   xx         0.732974D+02      0.108616D+02      0.120851D+02
+   yx         0.122442D+02      0.181441D+01      0.201880D+01
+   yy         0.725605D+02      0.107524D+02      0.119636D+02
+   zx         0.216292D+01      0.320512D+00      0.356617D+00
+   zy        -0.378946D+01     -0.561540D+00     -0.624797D+00
+   zz         0.753979D+02      0.111728D+02      0.124314D+02
+
+ ----------------------------------------------------------------------
+
+ Test job not archived.
+ 1\1\GINC-D-9-16-1\Freq\UB3LYP\6-311G(2d,d,p)\C5H10N1O1(2)\OSCARWU\07-J
+ ul-2020\0\\#P Geom=AllCheck Guess=TCheck SCRF=Check Test GenChk UB3LYP
+ /6-311G(2d,d,p) Freq\\0xd628bc800d04214f0f9db0fec47002f2\\0,2\N,-2.220
+ 2876923,-1.5501565753,0.1036559546\C,-1.5012068224,-0.6419053456,0.058
+ 1241721\C,-0.4945356011,0.3798484731,-0.0135094585\C,-0.2138899047,1.0
+ 687455836,1.3168592617\C,-0.6036834219,1.297831931,-1.2242471143\H,0.6
+ 663114676,1.7102922089,1.2240699293\H,-0.0251647907,0.3363455457,2.104
+ 1002808\H,-1.0569933839,1.6954722525,1.6274151366\H,0.3046448608,1.898
+ 9700606,-1.3187162314\H,-1.4506227291,1.9860184815,-1.1249729362\H,-0.
+ 7398607902,0.7310731154,-2.1477026784\C,1.488103561,-1.4615914537,-0.2
+ 177171828\O,1.0613679078,-2.3025390672,0.7891357931\H,1.4027608339,-1.
+ 8527590104,-1.2357582018\H,0.5830653683,-0.3952918117,-0.2164769588\H,
+ 2.4651203266,-1.0480839174,0.0221525568\H,0.2171661904,-2.6974478709,0
+ .5360259171\\Version=ES64L-G16RevB.01\State=2-A\HF=-326.5236818\S2=0.7
+ 57508\S2-1=0.\S2A=0.750039\RMSD=2.983e-09\RMSF=1.012e-06\ZeroPoint=0.1
+ 371321\Thermal=0.1467539\Dipole=0.9214145,0.931872,-0.4811096\DipoleDe
+ riv=-0.452909,-0.0091937,0.0098982,-0.1977864,-0.3590449,0.0077704,0.0
+ 017206,-0.003562,-0.2930439,0.3018659,0.1326977,-0.0291064,0.3747732,0
+ .0678003,-0.007281,-0.0186786,-0.0019604,-0.0667615,0.06389,-0.2475017
+ ,0.0424668,-0.2206568,0.2724816,-0.012055,-0.0155832,0.0620048,0.20436
+ 72,0.0458408,0.0921939,0.0196112,0.003026,0.024997,0.0338946,-0.010986
+ ,0.0996501,0.0112958,0.0327116,0.0743269,-0.0496848,0.0026468,0.046124
+ 8,-0.0024156,0.0112383,-0.117338,0.0499515,-0.0540148,-0.1255041,0.001
+ 9505,-0.0882243,-0.0130979,-0.0140204,0.0398597,-0.0002247,0.0479526,0
+ .0742947,0.0019039,-0.0331671,0.0216746,0.0007083,0.0979889,-0.0169948
+ ,0.0488022,-0.0323131,-0.0377,0.0954664,0.0465487,0.0853138,-0.03643,-
+ 0.0693878,0.0294379,-0.0869313,0.0257054,-0.0669655,-0.1209058,0.02411
+ 32,-0.0738185,-0.0123814,0.0315688,-0.0187156,0.0287052,0.0566498,-0.0
+ 40427,0.1219542,0.0022842,0.1065194,-0.0692284,0.0335361,0.0134371,0.0
+ 378826,0.032686,0.0767263,-0.0107241,-0.0195536,-0.0096743,0.0124879,-
+ 0.0952953,-0.0287963,-0.0396384,-0.0911185,0.3985956,-0.0377502,-0.102
+ 8038,-0.3371415,0.8468681,-0.1994281,0.1744767,-0.3916257,0.5075809,-0
+ .2882428,-0.1364076,0.1871227,0.3175065,-0.9798464,0.2444469,-0.122180
+ 9,0.4418759,-0.5621569,-0.0577392,0.0549381,-0.0059061,0.0453949,-0.03
+ 95844,-0.0744471,0.0250381,-0.0346616,-0.1383774,-0.1053619,0.2069031,
+ -0.038537,0.0583553,-0.2278965,0.0388569,0.0332559,-0.0322618,-0.00493
+ 04,-0.1074581,-0.0484868,-0.0093524,0.0122656,0.0211333,-0.0011235,-0.
+ 0207936,-0.0288808,0.0326007,0.2168933,-0.0439101,-0.0458845,-0.100174
+ 3,0.4449085,-0.0126086,-0.0757355,0.0181639,0.2199118\Polar=79.8487394
+ ,-4.410304,81.705339,-0.657969,-1.5249571,59.7017313\Quadrupole=-3.303
+ 6757,1.6412986,1.6623771,-1.9855216,-1.4214386,1.4192766\PG=C01 [X(C5H
+ 10N1O1)]\NImag=1\\0.47342216,0.56917758,0.73021027,-0.02915134,-0.0360
+ 8913,0.02107125,-0.47218266,-0.54788335,0.02743797,0.65117365,-0.54376
+ 297,-0.72391269,0.03409406,0.66487068,0.91997500,0.02819739,0.03493252
+ ,-0.04107292,-0.03235688,-0.04423304,0.12579879,-0.01117042,-0.0313641
+ 1,0.00272714,-0.12474949,-0.07241233,0.00189167,0.26847762,-0.02140908
+ ,-0.00499840,0.00119575,-0.10870282,-0.16699272,0.01013460,0.13935032,
+ 0.43624783,0.00309015,0.00297459,0.02010691,-0.00139781,0.00420375,-0.
+ 07723397,0.03990222,-0.02671407,0.44104405,0.00181647,0.00192715,0.003
+ 04916,-0.01353992,-0.02212829,-0.02489321,-0.05996443,-0.01284221,-0.0
+ 1648371,0.54800243,-0.00070171,0.00151629,0.00220630,-0.00685026,-0.01
+ 779150,-0.02212885,-0.02054887,-0.09458305,-0.04478959,0.00055407,0.54
+ 316685,0.00386177,0.00462408,-0.00192436,-0.00737207,-0.00877608,0.003
+ 18189,-0.02012436,-0.03428552,-0.15817106,-0.01549955,-0.05340988,0.48
+ 331485,-0.00037507,0.00133974,-0.00333979,-0.00383659,-0.02353592,0.02
+ 389983,-0.05862037,-0.00010021,-0.01413705,0.00035703,0.00394160,-0.00
+ 356190,0.54929120,-0.00066023,0.00234942,-0.00147063,-0.00129091,-0.02
+ 220610,0.01942171,-0.00621315,-0.11207560,0.05854150,-0.00046700,0.011
+ 62768,-0.01160275,0.01878684,0.51860650,-0.00450814,-0.00455884,-0.000
+ 50678,0.00943261,0.01184515,-0.00186002,-0.01123223,0.04686877,-0.1447
+ 1665,-0.00531827,0.01841507,-0.02730254,0.00000133,0.05690031,0.503049
+ 83,0.00037801,0.00039422,-0.00010167,-0.00009770,-0.00097240,-0.000986
+ 58,-0.00361944,-0.00269390,0.00060112,-0.21686542,-0.12276584,0.019883
+ 10,0.00009817,0.00014062,0.00062119,0.23344779,-0.00014015,-0.00009729
+ ,0.00030481,-0.00114089,-0.00092241,-0.00318565,-0.01136462,-0.0109643
+ 9,0.00018974,-0.12201484,-0.13479267,0.01558667,0.00067064,0.00044921,
+ 0.00099779,0.13620732,0.14539872,-0.00051827,-0.00063182,0.00121374,-0
+ .00151238,-0.00275180,-0.00576670,-0.02305969,-0.01836370,0.00078979,0
+ .02154126,0.01691243,-0.04956759,-0.00072187,-0.00036400,0.00183013,-0
+ .02205173,-0.01344147,0.05385238,-0.00014214,-0.00024227,0.00024665,0.
+ 00038289,0.00093256,-0.00062399,-0.00257050,0.00367751,-0.00351838,-0.
+ 05551789,0.02997821,-0.03298093,0.00013875,-0.00091661,-0.00063645,0.0
+ 0578238,-0.01743606,0.01975456,0.05520999,0.00036658,-0.00001238,-0.00
+ 003110,-0.00049237,0.00103678,-0.00019921,-0.00276216,0.01202570,-0.01
+ 268965,0.03038693,-0.17131361,0.13076999,-0.00050924,-0.00154833,-0.00
+ 255850,0.00416863,-0.01185808,0.01171547,-0.03284940,0.18267046,-0.000
+ 26881,-0.00064803,0.00025302,0.00076058,0.00131551,0.00026050,-0.00383
+ 139,0.01843234,-0.02138680,-0.03246080,0.12750223,-0.18054589,-0.00125
+ 046,-0.00432960,-0.00393321,0.00017466,0.00091961,-0.00150872,0.036486
+ 07,-0.13867088,0.19990013,0.00001150,0.00073180,0.00003628,0.00100205,
+ -0.00077221,0.00001813,0.00607880,-0.00358862,-0.00134445,-0.20159026,
+ 0.11210078,0.05258595,0.00032745,-0.00030711,0.00049620,-0.01984941,0.
+ 01511217,0.00630256,-0.00418808,0.00195549,0.00099481,0.21676082,-0.00
+ 100450,-0.00075618,0.00026478,0.00207420,0.00175884,-0.00032799,0.0082
+ 6464,-0.01127152,-0.00732103,0.11368689,-0.12734239,-0.03687552,-0.000
+ 50191,0.00043592,0.00074896,-0.01492345,0.01186999,0.00572036,0.017120
+ 11,-0.01221880,-0.00643788,-0.12394897,0.13706889,-0.00123333,-0.00120
+ 743,0.00006256,0.00258855,0.00280230,0.00027609,0.01818620,-0.01874774
+ ,-0.01219702,0.05542421,-0.03844929,-0.06322035,0.00067549,-0.00051001
+ ,0.00183978,0.00261913,-0.00149192,-0.00147933,-0.01874200,0.01239145,
+ 0.00733604,-0.05852448,0.04580294,0.06997059,0.00064275,0.00051296,0.0
+ 0034343,0.00006973,0.00006066,-0.00079455,0.00343157,0.00252141,-0.000
+ 89152,0.00023066,0.00024784,-0.00005540,-0.22920224,-0.11913745,0.0169
+ 4647,0.00025513,0.00006382,0.00046587,0.00024469,0.00020807,0.00005932
+ ,-0.00013489,-0.00005069,0.00000706,0.24714740,-0.00034636,-0.00016799
+ ,-0.00045277,-0.00023105,-0.00204342,0.00419499,-0.01545927,-0.0139332
+ 8,0.00249880,0.00021663,0.00051806,-0.00128615,-0.11802193,-0.12210436
+ ,0.00979269,0.00025616,0.00057793,0.00043554,0.00024151,0.00000164,-0.
+ 00018840,0.00007376,0.00008817,-0.00001048,0.13030599,0.13366120,0.000
+ 57122,0.00027082,0.00093621,-0.00006720,0.00345069,-0.00467405,0.02070
+ 863,0.01518463,-0.00302003,0.00120964,0.00018952,0.00136444,0.01575607
+ ,0.00909875,-0.04919439,-0.00061158,-0.00036831,-0.00033668,-0.0002325
+ 2,-0.00009959,0.00036806,-0.00007145,-0.00003542,-0.00011128,-0.017447
+ 01,-0.01525659,0.05151390,0.00034701,0.00101356,0.00000230,0.00004784,
+ -0.00146668,-0.00026808,0.00015354,0.00223640,-0.00208526,0.00023640,-
+ 0.00023291,0.00003558,-0.20047206,0.12176201,0.02242894,-0.00017011,0.
+ 00007268,0.00004946,0.00015428,-0.00014350,-0.00012077,-0.00008327,-0.
+ 00001255,-0.00055291,-0.02081629,0.01697667,0.00331361,0.21555219,-0.0
+ 0126709,-0.00098542,-0.00001686,0.00261821,0.00219773,-0.00016977,0.01
+ 309400,-0.01644200,0.00284182,-0.00072647,0.00072327,-0.00092643,0.123
+ 33903,-0.14262525,-0.01942632,-0.00003219,0.00007773,0.00011073,-0.000
+ 22842,-0.00002118,-0.00003255,0.00005577,0.00052276,0.00069828,-0.0139
+ 3597,0.01209846,0.00173261,-0.13593671,0.15577335,0.00102870,0.0008771
+ 4,-0.00008924,-0.00242417,-0.00226808,0.00055589,-0.01838216,0.0188574
+ 7,-0.00098547,-0.00021825,0.00010795,0.00210480,0.01987768,-0.01711303
+ ,-0.04812610,-0.00005544,-0.00000283,-0.00014823,0.00033923,-0.0001120
+ 5,0.00019785,0.00046270,-0.00045125,-0.00036742,0.00127424,-0.00151269
+ ,-0.00096144,-0.02279447,0.01549499,0.05198281,-0.00009095,-0.00000987
+ ,-0.00013059,0.00038398,0.00040428,0.00062232,-0.00244209,-0.00106626,
+ -0.00197792,0.00045750,0.00024086,-0.00032731,-0.05109366,-0.01815848,
+ -0.02710185,0.00029782,0.00027021,0.00028319,0.00048465,0.00001203,-0.
+ 00025445,0.00009854,-0.00012715,-0.00043112,-0.00236654,-0.01343051,-0
+ .02349228,0.00370070,0.01337099,0.02206254,0.05043368,0.00029324,-0.00
+ 009250,-0.00014314,-0.00018991,0.00127248,0.00031482,0.00336084,0.0117
+ 7165,0.01910523,0.00002919,-0.00275560,0.00267084,-0.01841256,-0.12246
+ 605,-0.11914581,0.00024042,-0.00002225,-0.00004000,0.00026589,0.000626
+ 68,0.00110457,-0.00011320,-0.00000700,0.00020193,-0.00048232,-0.009083
+ 24,-0.01360128,-0.00351354,-0.01076023,-0.01625160,0.01883606,0.130875
+ 69,0.00052401,0.00069253,0.00032466,-0.00093107,-0.00146692,0.00025601
+ ,-0.00323712,-0.01295219,-0.02097578,-0.00007245,0.00477773,-0.0027740
+ 2,-0.02692801,-0.11656504,-0.23202531,0.00002078,0.00005233,0.00035372
+ ,-0.00020766,-0.00083944,-0.00126160,0.00013313,0.00001255,0.00025501,
+ -0.00011262,0.00211981,0.00369261,0.00007120,-0.00179616,-0.00238382,0
+ .03085608,0.12605075,0.25424837,-0.00041320,-0.00321789,0.00024540,0.0
+ 0519892,0.00916004,-0.00064561,-0.06963568,0.04605162,0.01276127,0.004
+ 87547,-0.00383471,-0.00280913,0.00510595,-0.00452318,-0.00008305,0.000
+ 10256,0.00014839,0.00035228,0.00002183,0.00019652,0.00073954,-0.000533
+ 07,-0.00025799,-0.00042794,0.00010148,0.00051120,-0.00026810,-0.000288
+ 96,-0.00007587,0.00064762,-0.00016859,0.00006513,-0.00026759,0.4460559
+ 2,0.00343317,0.00099130,0.00022322,-0.01158624,-0.00518705,0.00155176,
+ 0.08588217,-0.04851462,-0.01465588,-0.00788796,0.00605275,0.00259967,-
+ 0.00793598,0.00651371,0.00109477,-0.00012878,-0.00049935,-0.00011816,0
+ .00005792,0.00065870,0.00041179,0.00062125,0.00102820,0.00203781,-0.00
+ 013442,-0.00061117,0.00020591,0.00000409,0.00087021,-0.00179934,0.0003
+ 0938,-0.00017953,0.00003694,0.21609345,0.30026740,0.00156031,0.0049380
+ 9,-0.00101150,-0.00289503,-0.00612659,0.00129846,0.00073201,0.00282631
+ ,0.00467730,0.00268723,-0.00165536,0.00103912,0.00134490,-0.00062534,-
+ 0.00032739,-0.00031434,0.00023767,-0.00003173,-0.00002639,-0.00021772,
+ -0.00095630,-0.00065198,0.00012700,-0.00077776,-0.00016675,-0.00007161
+ ,0.00018148,0.00015413,-0.00088942,0.00054831,-0.00013751,-0.00005703,
+ -0.00003383,0.03483064,0.02290690,0.55396045,-0.00061841,0.00406429,-0
+ .00096633,-0.00182798,-0.00344214,0.00028489,0.00166144,-0.00111251,-0
+ .00036793,0.00097528,-0.00045274,0.00044368,0.00037326,-0.00005265,-0.
+ 00001067,-0.00007750,0.00034820,-0.00009062,-0.00034592,-0.00032118,-0
+ .00064589,-0.00013091,-0.00006362,-0.00045643,-0.00002330,0.00014566,0
+ .00000303,0.00008669,-0.00022108,0.00018628,-0.00007637,-0.00004061,0.
+ 00009208,-0.09769407,-0.06802828,0.04636186,0.48389615,0.00234507,0.00
+ 524843,-0.00008194,-0.00363360,-0.00631598,-0.00050019,-0.00992699,0.0
+ 1142194,0.00213012,0.00245869,-0.00117241,0.00004562,0.00255347,-0.001
+ 31510,-0.00168159,-0.00027214,0.00005224,0.00005355,-0.00009705,-0.000
+ 20614,-0.00007134,-0.00026521,-0.00071227,-0.00093570,-0.00041198,0.00
+ 019771,0.00010640,-0.00016055,-0.00055031,0.00090266,-0.00019675,0.000
+ 14501,0.00015879,-0.06787787,-0.12927971,0.11770466,0.25024287,0.25040
+ 924,-0.00203898,-0.00441182,0.00087024,0.00292409,0.00583484,0.0000158
+ 9,0.00380291,-0.00697738,-0.00119572,-0.00246866,0.00159397,-0.0008865
+ 4,-0.00158474,0.00075593,0.00103148,0.00027609,-0.00016954,0.00014460,
+ -0.00000578,0.00037791,0.00109129,0.00049566,0.00030229,0.00108698,0.0
+ 0031150,-0.00011276,-0.00016733,0.00006453,0.00049675,-0.00054660,0.00
+ 029117,-0.00012069,0.00006633,0.02704908,0.07957039,-0.19947844,0.0684
+ 3761,-0.09243807,0.30200780,-0.00062708,-0.00134425,-0.00010975,0.0006
+ 2559,0.00166136,-0.00004395,0.00448663,-0.00409639,-0.00108984,-0.0011
+ 2516,0.00054112,-0.00008240,-0.00080383,0.00054059,0.00052018,0.000123
+ 74,0.00006288,-0.00001907,0.00002755,-0.00006198,0.00005195,0.00025023
+ ,0.00011441,0.00031224,0.00007684,0.00002957,-0.00006546,0.00001046,0.
+ 00021881,-0.00039900,-0.00007764,0.00006985,-0.00021534,-0.04522749,-0
+ .02288606,-0.01772875,0.00400291,0.00163772,0.01147368,0.04208610,0.00
+ 029053,0.00093418,0.00003770,0.00004472,-0.00121245,0.00000991,-0.0028
+ 4933,0.00297121,0.00082115,0.00078345,-0.00048900,0.00005914,0.0005325
+ 0,-0.00039763,-0.00042527,-0.00010443,0.00016057,0.00000844,-0.0000866
+ 5,-0.00007163,0.00006842,-0.00010594,-0.00002622,-0.00010219,-0.000071
+ 62,-0.00009249,-0.00000751,-0.00004426,-0.00013220,0.00034370,0.000206
+ 82,-0.00005171,0.00026371,-0.02788747,-0.08426199,-0.10591130,-0.00029
+ 996,0.00860083,0.03182125,0.02185056,0.08280776,-0.00001793,0.00008367
+ ,0.00024816,0.00014176,-0.00026873,-0.00022764,0.00102568,-0.00015856,
+ 0.00009925,-0.00028629,0.00024915,0.00004903,0.00017914,-0.00015067,-0
+ .00012917,-0.00002171,0.00001322,0.00001787,-0.00006629,0.00012392,0.0
+ 0013917,0.00003631,0.00002891,0.00009165,-0.00004558,0.00000430,-0.000
+ 01012,-0.00005994,0.00004062,0.00006509,0.00003858,0.00000541,0.000106
+ 46,-0.02844861,-0.08810657,-0.26367466,0.00649960,0.00047085,-0.027756
+ 48,0.02191803,0.09180336,0.29244556,0.00949730,0.00850996,-0.00070865,
+ -0.04519381,-0.01264447,0.00591329,0.04685229,-0.03712728,-0.01290553,
+ -0.00709490,0.00751515,0.00583586,-0.01019729,0.01018995,-0.00184105,0
+ .00010683,-0.00101281,-0.00077058,0.00019083,-0.00002150,-0.00051379,0
+ .00168075,-0.00063342,0.00017069,0.00025159,-0.00126234,0.00072035,0.0
+ 0141142,-0.00051024,-0.00129141,0.00032270,-0.00036568,0.00031738,0.03
+ 232878,-0.07222827,0.00307912,0.00259763,0.01063170,-0.00619244,-0.006
+ 20857,0.00350555,-0.00061121,-0.01661994,-0.00606817,-0.01074620,0.000
+ 21794,0.01085994,0.02159153,0.00016430,-0.07429769,0.00540425,0.012699
+ 46,0.01559551,-0.01316578,-0.00896729,0.01756789,-0.01514260,0.0009580
+ 0,0.00039897,0.00064478,0.00082785,-0.00037846,0.00041803,0.00089889,-
+ 0.00143085,-0.00042088,-0.00234114,0.00023671,0.00092231,-0.00086933,-
+ 0.00049751,-0.00077591,0.00290020,-0.00064004,0.00075244,-0.00053440,-
+ 0.05389808,0.03720633,-0.00619738,0.00609082,-0.02883176,0.01500155,0.
+ 01115282,-0.00883960,-0.00144013,0.07508319,0.00896770,-0.00126792,-0.
+ 00124568,0.00042369,0.00509657,0.00186641,-0.00076361,-0.00792584,0.00
+ 375351,-0.02730969,0.01354532,-0.01136221,-0.00682312,-0.01027291,0.00
+ 815479,0.00043046,-0.00005828,0.00035324,0.00068593,0.00030652,0.00007
+ 258,0.00015448,-0.00093774,-0.00151402,-0.00266106,0.00011346,-0.00020
+ 199,0.00039739,-0.00027455,0.00185478,-0.00187829,-0.00028030,-0.00010
+ 213,0.00018799,-0.00558742,0.00338176,-0.02749970,-0.00529150,0.015564
+ 07,-0.00407805,0.00854243,-0.01060753,-0.00025862,0.00700249,-0.012405
+ 98,0.06886465,0.00002151,0.00019668,-0.00011495,-0.00018224,0.00001050
+ ,0.00019202,0.00130352,-0.00049061,0.00012469,-0.00063063,0.00016116,-
+ 0.00007842,-0.00046445,0.00015168,0.00032961,0.00009935,0.00032579,0.0
+ 0006178,-0.00009184,-0.00007159,0.00011088,0.00020893,0.00015269,0.000
+ 24852,0.00007529,0.00016349,-0.00008351,0.00005820,0.00010740,-0.00018
+ 030,0.00003992,-0.00006515,0.00000826,-0.26845250,-0.10757328,-0.06559
+ 522,-0.00903416,-0.00565563,0.00321429,0.00189784,0.00201020,0.0015097
+ 4,-0.00901089,-0.00101834,-0.00252078,0.28232129,-0.00036812,0.0000109
+ 9,0.00001806,0.00094766,-0.00005518,-0.00024729,-0.00359100,0.00190730
+ ,0.00053173,0.00065183,-0.00023040,0.00000032,0.00068295,-0.00037321,-
+ 0.00031308,-0.00001033,-0.00023477,-0.00009966,0.00003198,-0.00003499,
+ -0.00011546,-0.00012982,-0.00022761,-0.00029601,-0.00001621,-0.0001326
+ 2,0.00008248,-0.00002547,-0.00018431,0.00025667,-0.00002396,0.00002372
+ ,0.00002694,-0.08549364,-0.06818982,-0.02039955,-0.02480201,-0.0135429
+ 4,-0.00105631,-0.01137709,-0.00122346,-0.00329803,0.01271168,0.0010852
+ 2,0.00217675,0.11228207,0.08177228,0.00016278,0.00020316,0.00013549,-0
+ .00001046,-0.00024827,-0.00007142,-0.00118821,0.00103641,0.00031232,0.
+ 00011908,-0.00005435,0.00004819,0.00018249,-0.00025088,-0.00015482,-0.
+ 00000191,-0.00007160,0.00002263,0.00008631,0.00000668,-0.00007118,-0.0
+ 0004771,-0.00005686,-0.00010008,-0.00001294,0.00005904,0.00003210,0.00
+ 001888,-0.00003379,0.00010687,0.00001307,-0.00003090,0.00006533,-0.071
+ 11515,-0.02831474,-0.07218307,0.02967261,0.01455295,0.00560430,-0.0243
+ 4316,-0.00763091,-0.00211207,0.00240903,-0.00192051,-0.00005492,0.0614
+ 3461,0.01860888,0.07170449,-0.00051679,-0.00380623,0.00053474,0.002725
+ 73,0.00403732,-0.00040670,0.00032702,-0.00060736,-0.00028005,-0.000622
+ 63,0.00010622,0.00024554,-0.00062624,0.00015509,-0.00004482,-0.0000122
+ 1,-0.00017273,-0.00006673,0.00021855,-0.00006132,-0.00003143,0.0000908
+ 2,0.00011128,0.00013611,0.00001613,-0.00016918,0.00005654,0.00007196,0
+ .00012982,-0.00013378,0.00009635,0.00002236,-0.00005106,-0.01137735,-0
+ .00801215,-0.00323423,-0.38376476,-0.18137175,-0.10605000,0.00048188,0
+ .00222534,-0.00179129,-0.00091471,0.00124329,-0.00018953,0.00184086,-0
+ .00147055,0.00262067,0.39196538,-0.00017780,0.00050818,-0.00027706,0.0
+ 0058599,-0.00119287,0.00026738,0.00083752,-0.00197430,-0.00036766,-0.0
+ 0022358,0.00003152,-0.00022671,-0.00039691,0.00027180,0.00048790,0.000
+ 09712,0.00016003,0.00002624,-0.00007076,-0.00015285,-0.00015924,0.0000
+ 1091,0.00021010,0.00015721,0.00008319,0.00010310,-0.00008378,-0.000031
+ 72,0.00021331,-0.00022989,0.00000239,-0.00004956,-0.00003792,-0.025159
+ 66,-0.01686536,-0.00658933,-0.16205506,-0.09414879,-0.03046832,0.00188
+ 609,0.00132382,0.00059927,-0.00234117,0.00093013,0.00026166,-0.0006870
+ 7,-0.00037021,0.00414567,0.18764052,0.11100196,0.00000839,-0.00080386,
+ -0.00104114,0.00058494,0.00072679,0.00002680,0.00000456,-0.00009062,0.
+ 00016255,0.00012530,-0.00010482,0.00011314,-0.00012019,0.00010895,0.00
+ 009470,0.00000716,0.00007624,-0.00007180,-0.00017899,-0.00003984,-0.00
+ 003683,0.00001609,0.00001216,-0.00000440,0.00000503,-0.00001174,-0.000
+ 01087,0.00001736,0.00002072,-0.00007501,-0.00003363,0.00003902,-0.0001
+ 0212,0.03302677,0.01897377,0.00426928,-0.14415227,-0.05598082,-0.07780
+ 975,0.00127821,-0.00055205,0.00090653,-0.00061356,0.00100797,0.0001824
+ 6,0.00133878,0.00412356,-0.00328415,0.10868605,0.03249458,0.07668061\\
+ 0.00000028,0.00000068,0.00000077,-0.00000021,-0.00000088,0.00000073,0.
+ 00000300,-0.00000032,-0.00000113,-0.00000015,0.00000048,-0.00000168,0.
+ 00000028,-0.00000118,0.00000225,0.00000095,-0.00000032,-0.00000066,0.0
+ 0000017,-0.00000062,-0.00000036,0.00000047,0.00000071,0.00000036,0.000
+ 00050,-0.00000057,0.00000100,-0.00000039,0.00000093,0.00000102,-0.0000
+ 0078,-0.00000027,0.00000077,-0.00000039,-0.00000103,-0.00000014,-0.000
+ 00239,-0.00000039,0.00000046,-0.00000057,-0.00000003,-0.00000055,0.000
+ 00021,0.00000272,-0.00000206,-0.00000024,-0.00000053,-0.00000099,-0.00
+ 000075,0.00000063,0.00000020\\\@
+
+
+ SOME PEOPLE TRY TO PULL THE WOOL OVER YOUR EYES
+ USING THE WRONG YARN.
+ Job cpu time:       0 days  0 hours 21 minutes 38.7 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes 33.0 seconds.
+ File lengths (MBytes):  RWF=    121 Int=      0 D2E=      0 Chk=      5 Scr=      1
+ Normal termination of Gaussian 16 at Tue Jul  7 12:18:27 2020.


### PR DESCRIPTION
In certain gaussian jobs, frequencies are printed more than once. Previously the parser will erroneously record the duplicated frequencies. Now only the last frequencies output by Gaussian is recorded. A test is also added.