### PR TITLE
Added an option to use external submit scrips

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -658,7 +658,7 @@ def sort_two_lists_by_the_first(list1: List[Union[float, int, None]],
     """
     Sort two lists in increasing order by the values of the first list.
     Ignoring None entries from list1 and their respective entries in list2.
-    The function was written in this format rather the more pytonic ``zip(*sorted(zip(list1, list2)))`` style
+    The function was written in this format rather the more pythonic ``zip(*sorted(zip(list1, list2)))`` style
     to accommodate for dictionaries as entries of list2, otherwise a
     ``TypeError: '<' not supported between instances of 'dict' and 'dict'`` error is raised.
 

--- a/arc/main.py
+++ b/arc/main.py
@@ -140,6 +140,8 @@ class ARC(object):
         output (dict, optional): Output dictionary with status and final QM file paths for all species.
                                  Only used for restarting.
         running_jobs (dict, optional): A dictionary of jobs submitted in a precious ARC instance, used for restarting.
+        external_submit_scripts (str, optional): A path to a YAML file with relevant submit scripts. If given, these
+                                                 scripts will be used instead the ones available in ARC.
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -204,6 +206,8 @@ class ARC(object):
                           jobs without fine=True
         three_params (bool): Compute rate coefficients using the modified three-parameter Arrhenius equation
                              format (``True``) or classical two-parameter Arrhenius equation format (``False``).
+        external_submit_scripts (str): A path to a YAML file with relevant submit scripts. If given, these
+                                       scripts will be used instead the ones available in ARC.
     """
 
     def __init__(self,
@@ -222,6 +226,7 @@ class ARC(object):
                  dont_gen_confs: List[str] = None,
                  e_confs: float = 5.0,
                  ess_settings: Dict[str, Union[str, List[str]]] = None,
+                 external_submit_scripts: Optional[str] = None,
                  freq_level: Optional[Union[str, dict, Level]] = None,
                  freq_scale_factor: Optional[float] = None,
                  irc_level: Optional[Union[str, dict, Level]] = None,
@@ -299,6 +304,7 @@ class ARC(object):
         self.bac_type = bac_type
         self.arkane_level_of_theory = Level(repr=arkane_level_of_theory) if arkane_level_of_theory is not None else None
         self.freq_scale_factor = freq_scale_factor
+        self.external_submit_scripts = external_submit_scripts
 
         # attributes related to level of theory specifications
         self.level_of_theory = level_of_theory
@@ -445,6 +451,8 @@ class ARC(object):
             restart_dict['dont_gen_confs'] = self.dont_gen_confs
         restart_dict['e_confs'] = self.e_confs
         restart_dict['ess_settings'] = self.ess_settings
+        if self.external_submit_scripts is not None:
+            restart_dict['external_submit_scripts'] = self.external_submit_scripts
         if self.freq_level is not None:
             restart_dict['freq_level'] = self.freq_level.as_dict() \
                 if not isinstance(self.freq_level, (dict, str)) else self.freq_level
@@ -556,6 +564,7 @@ class ARC(object):
                                    e_confs=self.e_confs,
                                    dont_gen_confs=self.dont_gen_confs,
                                    fine_only=self.fine_only,
+                                   external_submit_scripts=self.external_submit_scripts,
                                    )
 
         save_yaml_file(path=os.path.join(self.project_directory, 'output', 'status.yml'), content=self.scheduler.output)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -135,7 +135,9 @@ class Scheduler(object):
         n_confs (int, optional): The number of lowest force field conformers to consider.
         e_confs (float, optional): The energy threshold in kJ/mol above the lowest energy conformer below which
                                    force field conformers are considered.
-        fine_only (bool): If ``True`` ARC will not run optimization jobs without fine=True
+        fine_only (bool): If ``True`` ARC will not run optimization jobs without setting ``fine=True``.
+        external_submit_scripts (str, optional): A path to a YAML file with relevant submit scripts. If given, these
+                                                 scripts will be used instead the ones available in ARC.
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -185,7 +187,9 @@ class Scheduler(object):
                                 values are dictionaries with job type tuples as keys and levels of theory
                                 as values. 'inf' is accepted an max_num_atoms rmg_database
                                 (RMGDatabase, optional): The RMG database object.
-        fine_only (bool): If ``True`` ARC will not run optimization jobs without fine=True
+        fine_only (bool): If ``True`` ARC will not run optimization jobs without setting ``fine=True``.
+        external_submit_scripts (str): A path to a YAML file with relevant submit scripts. If given, these
+                                       scripts will be used instead the ones available in ARC.
     """
 
     def __init__(self,
@@ -216,6 +220,7 @@ class Scheduler(object):
                  n_confs: Optional[int] = 10,
                  e_confs: Optional[float] = 5,
                  fine_only: Optional[bool] = False,
+                 external_submit_scripts: Optional[str] = None,
                  ) -> None:
 
         self.project = project
@@ -240,6 +245,7 @@ class Scheduler(object):
         self.dont_gen_confs = dont_gen_confs or list()
         self.job_types = job_types if job_types is not None else default_job_types
         self.fine_only = fine_only
+        self.external_submit_scripts = external_submit_scripts
         self.output = dict()
 
         self.species_dict = dict()
@@ -790,6 +796,7 @@ class Scheduler(object):
                   rotor_index=rotor_index,
                   cpu_cores=cpu_cores,
                   irc_direction=irc_direction,
+                  external_submit_scripts=self.external_submit_scripts,
                   )
         if job.software is not None:
             if conformer < 0:

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -864,4 +864,15 @@ all reactions in the same ARC project.
 Advanced: to recompute the rate coefficient in the modified three-parameter Arrhenius equation format, simply change
 ``three_params`` to ``True`` in the ARC project's restart.yml file, and then restart ARC.
 
+Use external submit scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes it is desired to use submit scripts stored outside of the ARC repository
+(e.g., when ARC is installed for a group of users on a server, and each user would like to customize
+the scripts used by ARC).
+It is possible to do so by passing a YAML file containing the desired scripts into
+the ``external_submit_scripts`` argument.
+Note that the structure of the YAML file must be identical to that in ARC's submit scripts file
+(e.g., nested dictionaries). An example is available under the examples directory in ARC.
+
 .. include:: links.txt

--- a/examples/external_submit_scripts/readme.md
+++ b/examples/external_submit_scripts/readme.md
@@ -1,0 +1,10 @@
+## External submit scripts example
+
+Sometimes it is desired to use submit scripts stored outside of the ARC repository
+(e.g., when ARC is installed for a group of users on a server, and each user would like to customize
+the scripts used by ARC).
+It is possible to do so by passing a YAML file containing the desired scripts into
+the ``external_submit_scripts`` argument.
+Note that the structure of the YAML file must be identical to that in ARC's submit scripts file
+(e.g., nested dictionaries). 
+This folder includes an example for how such YAML should be set up.

--- a/examples/external_submit_scripts/submit.yml
+++ b/examples/external_submit_scripts/submit.yml
@@ -1,0 +1,392 @@
+c3ddb:
+  gaussian: |+
+    #!/bin/bash -l
+    #SBATCH -p defq
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH -n {cpus}
+    #SBATCH --time={t_max}
+    #SBATCH --mem-per-cpu={memory}
+
+    module add c3ddb/gaussian/09.d01
+    which g09
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    SubmitDir=`pwd`
+
+    GAUSS_SCRDIR=/scratch/users/{un}/g09/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    export GAUSS_SCRDIR
+
+    mkdir -p $GAUSS_SCRDIR
+    mkdir -p $WorkDir
+
+    cd $WorkDir
+    . $g09root/g09/bsd/g09.profile
+
+    cp "$SubmitDir/input.gjf" .
+    cp "$SubmitDir/check.chk" .
+
+    g09 < input.gjf > input.log
+    formchk  check.chk check.fchk
+    cp * "$SubmitDir/"
+
+    rm -rf $GAUSS_SCRDIR
+    rm -rf $WorkDir
+
+  orca: |+
+    #!/bin/bash -l
+    #SBATCH -p defq
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH -n {cpus}
+    #SBATCH --time={t_max}
+    #SBATCH --mem-per-cpu={memory}
+
+    module add c3ddb/orca/4.1.2
+    module add c3ddb/openmpi/3.1.3
+    which orca
+
+    export ORCA_DIR=/cm/shared/modulefiles/c3ddb/orca/4.1.2/
+    export OMPI_DIR=/cm/shared/modulefiles/c3ddb/openmpi/3.1.3/
+    export PATH=$PATH:$ORCA_DIR
+    export PATH=$PATH:$OMPI_DIR
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+
+    WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    SubmitDir=`pwd`
+
+    mkdir -p $WorkDir
+    cd $WorkDir
+
+    cp "$SubmitDir/input.inp" .
+
+    ${ORCA_DIR}/orca input.inp > input.log
+    cp * "$SubmitDir/"
+
+    rm -rf $WorkDir
+
+pharos:
+  gaussian: |+
+    #!/bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -l h_vmem={memory}M
+    #$ -pe singlenode {cpus}
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    echo "Running on node:"
+    hostname
+
+    g16root=/opt
+    GAUSS_SCRDIR=/scratch/{un}/{name}
+    export g16root GAUSS_SCRDIR
+    . $g16root/g16/bsd/g16.profile
+    mkdir -p /scratch/{un}/{name}
+
+    g16 input.gjf
+
+    rm -r /scratch/{un}/{name}
+
+  gaussian03_pharos: |+
+    #!/bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -l h_vmem={memory}M
+    #$ -pe singlenode {cpus}
+    #$ -l h=!node60.cluster
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    echo "Running on node:"
+    hostname
+
+    g03root=/opt
+    GAUSS_SCRDIR=/scratch/{un}/{name}
+    export g03root GAUSS_SCRDIR
+    . $g03root/g03/bsd/g03.profile
+    mkdir -p /scratch/{un}/{name}
+
+    g03 input.gjf
+
+    rm -r /scratch/{un}/{name}
+
+  molpro: |+
+    #! /bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -pe singlenode {cpus}
+    #$ -l h=!node60.cluster
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    export PATH=/opt/molpro2012/molprop_2012_1_Linux_x86_64_i8/bin:$PATH
+
+    sdir=/scratch/{un}
+    mkdir -p /scratch/{un}/qlscratch
+
+    molpro -d $sdir -n {cpus} input.in
+
+  onedmin: |+
+    #! /bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -pe singlenode {cpus}
+    #$ -l h=!node60.cluster
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    WorkDir=`pwd`
+    cd
+    sdir=/scratch/{un}
+    mkdir -p /scratch/{un}/onedmin
+    cd $WorkDir
+
+    ~/auto1dmin/exe/auto1dmin.x < input.in > output.out
+
+  orca: |+
+    #!/bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -l h_vmem={memory}M
+    #$ -pe singlenode {cpus}
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    echo "Running on node:"
+    hostname
+
+    export PATH=/opt/orca/:$PATH
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/:/usr/local/etc
+
+    WorkDir=/scratch/{un}/{name}
+    SubmitDir=`pwd`
+
+    mkdir -p $WorkDir
+    cd $WorkDir
+
+    cp "$SubmitDir/input.in" .
+
+    /opt/orca/orca input.in > input.log
+    cp * "$SubmitDir/"
+
+    rm -rf $WorkDir
+
+  qchem: |+
+    #!/bin/bash -l
+
+    #$ -N {name}
+    #$ -l long{architecture}
+    #$ -l h_rt={t_max}
+    #$ -pe singlenode {cpus}
+    #$ -l h=!node60.cluster
+    #$ -cwd
+    #$ -o out.txt
+    #$ -e err.txt
+
+    echo "Running on node:"
+    hostname
+
+    source /opt/qchem/qcenv.sh
+
+    export QC=/opt/qchem
+    export QCSCRATCH=/scratch/{un}/{name}
+    export QCLOCALSCR=/scratch/{un}/{name}/qlscratch
+    . $QC/qcenv.sh
+
+    mkdir -p /scratch/{un}/{name}/qlscratch
+
+    qchem -nt {cpus} input.in output.out
+
+    rm -r /scratch/{un}/{name}
+
+rmg:
+  gaussian: |+
+    #!/bin/bash -l
+    #SBATCH -p long
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH -n {cpus}
+    #SBATCH --time={t_max}
+    #SBATCH --mem-per-cpu={memory}
+
+    export g16root=/opt
+    which g16
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    WorkDir=/scratch/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    SubmitDir=`pwd`
+
+    GAUSS_SCRDIR=/scratch/{un}/g16/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    export GAUSS_SCRDIR
+
+    mkdir -p $GAUSS_SCRDIR
+    mkdir -p $WorkDir
+
+    cd $WorkDir
+    . $g16root/g16/bsd/g16.profile
+
+    cp "$SubmitDir/input.gjf" .
+    cp "$SubmitDir/check.chk" .
+
+    g16 < input.gjf > input.log
+    formchk check.chk check.fchk
+    cp * "$SubmitDir/"
+
+    rm -rf $GAUSS_SCRDIR
+    rm -rf $WorkDir
+
+  gromacs: |+
+    #!/bin/bash -l
+    #SBATCH -p long
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH --time={t_max}
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    python mdconf.py -s {size}
+
+  molpro: |+
+    #!/bin/bash -l
+    #SBATCH -p long
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH -n {cpus}
+    #SBATCH --time={t_max}
+    #SBATCH --mem-per-cpu={memory}
+
+    export PATH=/opt/molpro/molprop_2015_1_linux_x86_64_i8/bin:$PATH
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    sdir=/scratch/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    SubmitDir=`pwd`
+
+    mkdir -p $sdir
+    cd $sdir
+
+    cp "$SubmitDir/input.in" .
+
+    molpro -n {cpus} -d $sdir input.in
+
+    cp input.* "$SubmitDir/"
+    cp geometry*.* "$SubmitDir/"
+
+    rm -rf $sdir
+
+  orca: |+
+    #!/bin/bash -l
+    #SBATCH -p normal
+    #SBATCH -J {name}
+    #SBATCH -N 1
+    #SBATCH -n {cpus}
+    #SBATCH --time={t_max}
+    #SBATCH --mem-per-cpu={memory}
+
+    export PATH=/opt/orca_4_2_1_linux_x86-64_openmpi314/:/opt/openmpi-3.1.4/bin/:$PATH
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/openmpi-3.1.4/lib/:/opt/openmpi-3.1.4/etc
+    which orca
+
+    export ORCA_DIR=/cm/shared/modulefiles/c3ddb/orca/4.1.2/
+    export OMPI_DIR=/cm/shared/modulefiles/c3ddb/openmpi/3.1.3/
+    export PATH=$PATH:$ORCA_DIR
+    export PATH=$PATH:$OMPI_DIR
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    WorkDir=/scratch/users/{un}/$SLURM_JOB_NAME-$SLURM_JOB_ID
+    SubmitDir=`pwd`
+
+    mkdir -p $WorkDir
+    cd $WorkDir
+
+    cp "$SubmitDir/input.inp" .
+
+    ${ORCA_DIR}/orca input.inp > input.log
+    cp * "$SubmitDir/"
+
+    rm -rf $WorkDir
+
+  terachem: |+
+    #!/bin/bash -l
+    #SBATCH -J {name}
+    #SBATCH -e err.txt
+    #SBATCH -o out.txt
+    #SBATCH -t {t_max}
+    #SBATCH --cpus-per-task=1
+    #SBATCH --ntasks-per-node=4
+    #SBATCH --gres=gpu:2
+    #SBATCH --mem-per-cpu={memory}
+
+    echo "============================================================"
+    echo "Job ID : $SLURM_JOB_ID"
+    echo "Job Name : $SLURM_JOB_NAME"
+    echo "Starting on : $(date)"
+    echo "Running on node : $SLURMD_NODENAME"
+    echo "Current directory : $(pwd)"
+    echo "============================================================"
+
+    module load cuda92/toolkit
+    module load medsci
+    module load terachem
+
+    terachem input.in > output.out
+
+...


### PR DESCRIPTION
Sometimes it's desired to use submit scripts stored outside of the ARC repository (e.g., when ARC is installed for a group of users on a server, and each user would like to customize the scripts used by ARC).
It is now possible to do so by passing a YAML file containing the desired scripts into the ``external_submit_scripts`` argument.
Documentation and an example were added.