### PR TITLE
remove deprecated warn keyword

### DIFF
--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -6,7 +6,7 @@ import matplotlib
 # Force matplotlib to not use any Xwindows backend.
 # This must be called before pylab, matplotlib.pyplot, or matplotlib.backends is imported.
 # Do not warn if the backend has already been set, e.g., when running from an IPython notebook.
-matplotlib.use('Agg', warn=False, force=False)
+matplotlib.use('Agg', force=False)
 import matplotlib.pyplot as plt
 import numpy as np
 import os


### PR DESCRIPTION
Fix for #421 . Doesn't seem like we need it: https://matplotlib.org/3.2.1/api/api_changes.html.

This is the same fix as was done on RMG-Py earlier today: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2012