### PR TITLE
Misc. scan fixes

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1076,8 +1076,9 @@ class ARCSpecies(object):
                 for vals2 in vals1:
                     for val in vals2:
                         if val not in all_pivots:
-                            raise SpeciesError('The pivots {0} do not represent a rotor in species {1}. Valid rotors '
-                                               'are: {2}'.format(val, self.label, all_pivots))
+                            raise SpeciesError(f'The pivots {val} do not represent a rotor in species {self.label}. '
+                                               f'Valid rotor pivots are: {all_pivots}\n\n'
+                                               f'Species coordinates:\n{xyz_to_str(self.get_xyz())}')
             # Modify self.rotors_dict to remove respective 1D rotors dicts and add ND rotors dicts
             rotor_indices_to_del = list()
             for key, vals in directed_rotors.items():

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -312,7 +312,7 @@ an ND scan. Values are nested lists. Each value is a list where the entries are 
 or lists of pivot lists (e.g., ``[[1, 5], [6, 8]]``), or a mix (e.g., ``[[4, 8], [[6, 9], [3, 4]]``). The requested
 directed scan type will be executed separately for each list entry. A list entry that contains only two pivots
 will result in a 1D scan, while a list entry with N pivots will consider all of them, and will result in an ND scan
-(if ``_diagonal`` is not specified).
+(if ``_diagonal`` is not specified). Note that indices are 1-indexed.
 
 ARC will generate geometries using the ``rotor_scan_resolution`` argument in ``settings.py``.
 


### PR DESCRIPTION
- Minor: Print the species xyz if requested pivots are illegal
- Docs: Mention that pivot indices are 1-indexed 