### PR TITLE
Update rdkit version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.15.4
 cclib>=1.6
 py3Dmol==0.8.0
 ase>=3.15.0
-rdkit>=2019.09.1
+rdkit>=2019.09.2.0
 openbabel
 pyyaml
 pandas>=1.01


### PR DESCRIPTION
After moving ARC to GitHub actions, the `gh-pages.yml` failed to deploy as seen [here](https://github.com/ReactionMechanismGenerator/ARC/actions/runs/545610642). 

The [error](https://github.com/ReactionMechanismGenerator/ARC/runs/1849515778?check_suite_focus=true#step:7:20) was
```
ERROR: Could not find a version that satisfies the requirement rdkit>=2019.09.1
ERROR: No matching distribution found for rdkit>=2019.09.1
Error: Process completed with exit code 1.
```

Since `environment.yml` requires version 2019.09.2.0, this PR updates `requirements.txt` to require the same version for rdkit.