### PR TITLE
Pass the sp_level to Scheduler in arc/utils/scale.py

### DIFF
--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -103,7 +103,7 @@ def determine_scaling_factors(levels: List[Union[Level, dict, str]],
         ess_settings = check_ess_settings(ess_settings or global_ess_settings)
 
         Scheduler(project=project, project_directory=project_directory, species_list=species_list,
-                  composite_method=composite_method, opt_level=freq_level, freq_level=freq_level,
+                  composite_method=composite_method, opt_level=freq_level, freq_level=freq_level, sp_level=freq_level,
                   ess_settings=ess_settings, job_types=job_types, allow_nonisomorphic_2d=True)
 
         zpe_dict = dict()


### PR DESCRIPTION
Problem: I tried obtaining a frequency scaling factor for a level of theory not currently in the RMG-database. Due to a bug, ARC was initally giving the following error:
```
Running job freq_a13985 for C2H2
Traceback (most recent call last):
  File "../../ARC.py", line 69, in <module>
    main()
  File "../../ARC.py", line 64, in main
    arc_object = ARC(**input_dict)
  File "/Users/kevin/Documents/RMG/ARC/arc/main.py", line 414, in __init__
    self.check_freq_scaling_factor()
  File "/Users/kevin/Documents/RMG/ARC/arc/main.py", line 832, in check_freq_scaling_factor
    init_log=False)[0]
  File "/Users/kevin/Documents/RMG/ARC/arc/utils/scale.py", line 107, in determine_scaling_factors
    ess_settings=ess_settings, job_types=job_types, allow_nonisomorphic_2d=True)
  File "/Users/kevin/Documents/RMG/ARC/arc/scheduler.py", line 471, in __init__
    self.schedule_jobs()
  File "/Users/kevin/Documents/RMG/ARC/arc/scheduler.py", line 542, in schedule_jobs
    self.spawn_post_opt_jobs(label=label, job_name=job_name)
  File "/Users/kevin/Documents/RMG/ARC/arc/scheduler.py", line 1358, in spawn_post_opt_jobs
    self.run_sp_job(label)
  File "/Users/kevin/Documents/RMG/ARC/arc/scheduler.py", line 1110, in run_sp_job
    if 'mrci' in level.method:
AttributeError: 'NoneType' object has no attribute 'method'
```

The problem was that line 107 of `ARC/arc/utils/scale.py`, did not pass an `sp_level` to `Scheduler` so `self.sp_level` was initialized to `None`, which ultimately caused the error of `AttributeError: 'NoneType' object has no attribute 'method'`. **This PR fixes the issue and thus allows ARC to automatically obtain the frequency scaling factor for a new level of theory.** Note that the true problem is likely caused by Scheduler not recognizing the frequency scale factor job type and continuing to spawn a single point job. 