### PR TITLE
add clean and PHONY to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 #
 ################################################################################
 
+.PHONY : clean gcn gcn-cpu test test-unittests
+
 test test-unittests:
 	nosetests --nocapture --nologcapture --all-modules --verbose --with-coverage --cover-inclusive --cover-package=arc --cover-erase --cover-html --exe --cover-html-dir=testing/coverage
 
@@ -12,3 +14,9 @@ gcn:
 
 gcn-cpu:
 	bash devtools/install_gcn_cpu.sh
+
+clean:
+	find -type d -name __pycache__ -exec rm -rf {} +
+	rm -rf testing
+	rm -rf arc/testing/gcn_tst
+	rm -f .coverage


### PR DESCRIPTION
I am terrible at this and royally broke something when rebasing, so this is a new PR attempting to be the old PR (#452)...
`make clean` now available to wipe out items created locally during testing, `__pycache__ `folders; `PHONY` added to protect arguments
`make clean` deletes the folders it does to clean up from failed tests since these would otherwise persist - if tests run successfully and folders aren't present, `make clean` will silently do nothing (`-f` option)