### PR TITLE
Add commit strings

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -24,6 +24,7 @@ import pandas as pd
 import qcelemental as qcel
 
 from arkane.ess import ess_factory, GaussianLog, MolproLog, OrcaLog, QChemLog, TeraChemLog
+import rmgpy
 from rmgpy.molecule.element import get_element
 from rmgpy.qm.qmdata import QMData
 from rmgpy.qm.symmetry import PointGroupCalculator
@@ -34,7 +35,12 @@ from arc.imports import settings
 
 logger = logging.getLogger('arc')
 
-arc_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))  # absolute path to the ARC folder
+# absolute path to the ARC folder
+arc_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+# absolute path to RMG-Py folder
+RMG_PATH = os.path.abspath(os.path.dirname(os.path.dirname(rmgpy.__file__)))
+# absolute path to RMG-database folder
+RMG_DATABASE_PATH = os.path.abspath(os.path.dirname(rmgpy.settings['database.directory']))
 
 VERSION = '1.1.0'
 
@@ -265,16 +271,20 @@ def log_header(project: str,
     logger.log(level, '###############################################################')
     logger.log(level, '')
 
-    # Extract HEAD git commit from ARC
-    head, date = get_git_commit()
-    branch_name = get_git_branch()
-    if head != '' and date != '':
-        logger.log(level, 'The current git HEAD for ARC is:')
-        logger.log(level, f'    {head}\n    {date}')
-    if branch_name and branch_name != 'master':
-        logger.log(level, f'    (running on the {branch_name} branch)\n')
-    else:
-        logger.log(level, '\n')
+
+    paths_dict = {'ARC': arc_path, 'RMG-Py': RMG_PATH, 'RMG-database': RMG_DATABASE_PATH}
+    for repo, path in paths_dict.items():
+        # Extract HEAD git commit
+        head, date = get_git_commit(path)
+        branch_name = get_git_branch(path)
+        if head != '' and date != '':
+            logger.log(level, f'The current git HEAD for {repo} is:')
+            logger.log(level, f'    {head}\n    {date}')
+        if branch_name and branch_name != 'master':
+            logger.log(level, f'    (running on the {branch_name} branch)\n')
+        else:
+            logger.log(level, '\n')
+
     logger.info(f'Starting project {project}')
 
 

--- a/arc/common.py
+++ b/arc/common.py
@@ -36,7 +36,7 @@ from arc.imports import settings
 logger = logging.getLogger('arc')
 
 # absolute path to the ARC folder
-arc_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+ARC_PATH = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 # absolute path to RMG-Py folder
 RMG_PATH = os.path.abspath(os.path.dirname(os.path.dirname(rmgpy.__file__)))
 # absolute path to RMG-database folder
@@ -46,7 +46,7 @@ VERSION = '1.1.0'
 
 # define default values for using the optional GCN to predict TS guesses
 # default assumption is that TS-GCN is installed in the same parent folder as the ARC repository
-TS_GCN_PATH = os.path.join(os.path.dirname(arc_path), 'TS-GCN')
+TS_GCN_PATH = os.path.join(os.path.dirname(ARC_PATH), 'TS-GCN')
 # default environment name for this repo is `ts_gcn`
 TS_GCN_PYTHON = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))),
                              'ts_gcn', 'bin', 'python')
@@ -272,7 +272,7 @@ def log_header(project: str,
     logger.log(level, '')
 
 
-    paths_dict = {'ARC': arc_path, 'RMG-Py': RMG_PATH, 'RMG-database': RMG_DATABASE_PATH}
+    paths_dict = {'ARC': ARC_PATH, 'RMG-Py': RMG_PATH, 'RMG-database': RMG_DATABASE_PATH}
     for repo, path in paths_dict.items():
         # Extract HEAD git commit
         head, date = get_git_commit(path)
@@ -316,7 +316,7 @@ def get_git_commit(path: Optional[str] = None) -> Tuple[str, str]:
     Returns: tuple
         The git HEAD commit hash and the git HEAD commit date, each as a string.
     """
-    path = path or arc_path
+    path = path or ARC_PATH
     head, date = '', ''
     if os.path.exists(os.path.join(path, '.git')):
         try:
@@ -337,7 +337,7 @@ def get_git_branch(path: Optional[str] = None) -> str:
     Returns: str
         The git branch name.
     """
-    path = path or arc_path
+    path = path or ARC_PATH
     if os.path.exists(os.path.join(path, '.git')):
         try:
             branch_list = subprocess.check_output(['git', 'branch'], cwd=path).splitlines()
@@ -595,7 +595,7 @@ def determine_symmetry(xyz: dict) -> Tuple[int, int]:
     # coords is an N x 3 numpy.ndarray of atomic coordinates in the same order as `atom_numbers`
     coords = np.array(xyz['coords'], np.float64)
     unique_id = '0'  # Just some name that the SYMMETRY code gives to one of its jobs
-    scr_dir = os.path.join(arc_path, 'scratch')  # Scratch directory that the SYMMETRY code writes its files in
+    scr_dir = os.path.join(ARC_PATH, 'scratch')  # Scratch directory that the SYMMETRY code writes its files in
     if not os.path.exists(scr_dir):
         os.makedirs(scr_dir)
     symmetry = optical_isomers = 1

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -47,7 +47,7 @@ class TestCommon(unittest.TestCase):
 
     def test_read_yaml_file(self):
         """Test the read_yaml_file() function"""
-        restart_path = os.path.join(common.arc_path, 'arc', 'testing', 'restart', '1_restart_thermo', 'restart.yml')
+        restart_path = os.path.join(common.ARC_PATH, 'arc', 'testing', 'restart', '1_restart_thermo', 'restart.yml')
         input_dict = common.read_yaml_file(restart_path)
         self.assertIsInstance(input_dict, dict)
         self.assertTrue('reactions' in input_dict)
@@ -367,9 +367,9 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
 
     def test_determine_ess(self):
         """Test the determine_ess function"""
-        gaussian = os.path.join(common.arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
-        qchem = os.path.join(common.arc_path, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
-        molpro = os.path.join(common.arc_path, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
+        gaussian = os.path.join(common.ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        qchem = os.path.join(common.ARC_PATH, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
+        molpro = os.path.join(common.ARC_PATH, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
 
         self.assertEqual(common.determine_ess(gaussian), 'gaussian')
         self.assertEqual(common.determine_ess(qchem), 'qchem')
@@ -510,7 +510,7 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
 
     def test_globalize_paths(self):
         """Test modifying a file's contents to correct absolute file paths"""
-        project_directory = os.path.join(common.arc_path, 'arc', 'testing', 'restart', '4_globalized_paths')
+        project_directory = os.path.join(common.ARC_PATH, 'arc', 'testing', 'restart', '4_globalized_paths')
         restart_path = os.path.join(project_directory, 'restart_paths.yml')
         common.globalize_paths(file_path=restart_path, project_directory=project_directory)
         globalized_restart_path = os.path.join(project_directory, 'restart_paths_globalized.yml')
@@ -653,7 +653,7 @@ H       1.98414750   -0.79355889   -0.24492049"""  # colliding atoms
         """
         A function that is run ONCE after all unit tests in this class.
         """
-        globalized_restart_path = os.path.join(common.arc_path, 'arc', 'testing', 'restart', '4_globalized_paths',
+        globalized_restart_path = os.path.join(common.ARC_PATH, 'arc', 'testing', 'restart', '4_globalized_paths',
                                                'restart_paths_globalized.yml')
         os.remove(path=globalized_restart_path)
 

--- a/arc/job/job.py
+++ b/arc/job/job.py
@@ -10,7 +10,7 @@ import shutil
 from pprint import pformat
 from typing import Dict, Optional, Union
 
-from arc.common import arc_path, get_logger
+from arc.common import ARC_PATH, get_logger
 from arc.exceptions import JobError, InputError
 from arc.imports import settings, input_files, submit_scripts
 from arc.job.local import (get_last_modified_time,
@@ -424,7 +424,7 @@ class Job(object):
         """
         Used as the entry number in the database, as well as the job name on the server.
         """
-        csv_path = os.path.join(arc_path, 'initiated_jobs.csv')
+        csv_path = os.path.join(ARC_PATH, 'initiated_jobs.csv')
         if not os.path.isfile(csv_path):
             # check file, make index file and write headers if file doesn't exists
             with open(csv_path, 'w') as f:
@@ -445,7 +445,7 @@ class Job(object):
         """
         Write an initiated ARCJob into the initiated_jobs.csv file.
         """
-        csv_path = os.path.join(arc_path, 'initiated_jobs.csv')
+        csv_path = os.path.join(ARC_PATH, 'initiated_jobs.csv')
         if self.conformer < 0:  # this is not a conformer search job
             conformer = '-'
         else:
@@ -463,7 +463,7 @@ class Job(object):
         """
         if self.job_status[0] != 'done' or self.job_status[1]['status'] != 'done':
             self.determine_job_status()
-        csv_path = os.path.join(arc_path, 'completed_jobs.csv')
+        csv_path = os.path.join(ARC_PATH, 'completed_jobs.csv')
         if not os.path.isfile(csv_path):
             # check file, make index file and write headers if file doesn't exists
             with open(csv_path, 'w') as f:
@@ -473,7 +473,7 @@ class Job(object):
                        'final_time', 'run_time', 'job_status_(server)', 'job_status_(ESS)',
                        'ESS troubleshooting methods used', 'comments']
                 writer.writerow(row)
-        csv_path = os.path.join(arc_path, 'completed_jobs.csv')
+        csv_path = os.path.join(ARC_PATH, 'completed_jobs.csv')
         if self.conformer < 0:  # this is not a conformer search job
             conformer = '-'
         else:
@@ -1590,19 +1590,19 @@ end
                                                     'local': self.conformers,
                                                     'remote': os.path.join(self.remote_path, 'coords.yml')})
             self.additional_files_to_upload.append({'name': 'acpype.py', 'source': 'path', 'make_x': False,
-                                                    'local': os.path.join(arc_path, 'arc', 'scripts', 'conformers',
+                                                    'local': os.path.join(ARC_PATH, 'arc', 'scripts', 'conformers',
                                                                           'acpype.py'),
                                                     'remote': os.path.join(self.remote_path, 'acpype.py')})
             self.additional_files_to_upload.append({'name': 'mdconf.py', 'source': 'path', 'make_x': False,
-                                                    'local': os.path.join(arc_path, 'arc', 'scripts', 'conformers',
+                                                    'local': os.path.join(ARC_PATH, 'arc', 'scripts', 'conformers',
                                                                           'mdconf.py'),
                                                     'remote': os.path.join(self.remote_path, 'mdconf.py')})
             self.additional_files_to_upload.append({'name': 'M00.tleap', 'source': 'path', 'make_x': False,
-                                                    'local': os.path.join(arc_path, 'arc', 'scripts', 'conformers',
+                                                    'local': os.path.join(ARC_PATH, 'arc', 'scripts', 'conformers',
                                                                           'M00.tleap'),
                                                     'remote': os.path.join(self.remote_path, 'M00.tleap')})
             self.additional_files_to_upload.append({'name': 'mdp.mdp', 'source': 'path', 'make_x': False,
-                                                    'local': os.path.join(arc_path, 'arc', 'scripts', 'conformers',
+                                                    'local': os.path.join(ARC_PATH, 'arc', 'scripts', 'conformers',
                                                                           'mdp.mdp'),
                                                     'remote': os.path.join(self.remote_path, 'mdp.mdp')})
             if self.software == 'terachem':

--- a/arc/job/jobTest.py
+++ b/arc/job/jobTest.py
@@ -13,7 +13,7 @@ import unittest
 
 from arc.job.job import Job
 from arc.level import Level
-from arc.common import arc_path
+from arc.common import ARC_PATH
 
 
 class TestJob(unittest.TestCase):
@@ -40,7 +40,7 @@ class TestJob(unittest.TestCase):
                        fine=True,
                        job_num=100,
                        testing=True,
-                       project_directory=os.path.join(arc_path, 'Projects', 'project_test'),
+                       project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'),
                        initial_time=datetime.datetime(2019, 3, 15, 19, 53, 7, 0),
                        final_time='2019-3-15 19:53:08',
                        )
@@ -75,7 +75,7 @@ class TestJob(unittest.TestCase):
                          'total_job_memory_gb': 14,
                          'multiplicity': 1,
                          'project': 'arc_project_for_testing_delete_after_usage3',
-                         'project_directory': os.path.join(arc_path, 'Projects', 'project_test'),
+                         'project_directory': os.path.join(ARC_PATH, 'Projects', 'project_test'),
                          'server': 'server1',
                          'max_job_time': 120,
                          'scan_res': 8.0,
@@ -104,60 +104,60 @@ class TestJob(unittest.TestCase):
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'b3lyp', 'basis': '6-311++G(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'gaussian')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'ccsd(t)', 'basis': 'avtz'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'molpro')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'wb97xd2', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'terachem')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'wb97x-d3', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'qchem')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'b97', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'gaussian')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'm062x', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'gaussian')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='opt', level={'method': 'm06-2x', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'qchem')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='scan', level={'method': 'm062x', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'gaussian')
 
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='scan', level={'method': 'm06-2x', 'basis': '6-311++g(d,p)'},
                    multiplicity=1, testing=True,
-                   project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True, job_num=100)
+                   project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True, job_num=100)
         self.assertEqual(job0.software, 'qchem')
         job0 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc', xyz=self.xyz_c,
                    job_type='sp', level={'method': 'dlpno-ccsd(t)', 'basis': 'aug-cc-pvtz',
                                          'auxiliary_basis': 'aug-cc-pvtz/c'}, multiplicity=1,
-                   testing=True, project_directory=os.path.join(arc_path, 'Projects', 'project_test'), fine=True,
+                   testing=True, project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'), fine=True,
                    job_num=100)
         self.assertEqual(job0.software, 'orca')
 
@@ -171,14 +171,14 @@ class TestJob(unittest.TestCase):
         job2 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc',
                    xyz=self.xyz_c, job_type='onedmin',
                    level={'method': 'b3lyp', 'basis': '6-31+g(d)'}, multiplicity=1,
-                   testing=True, project_directory=os.path.join(arc_path, 'Projects', 'project_test'),
+                   testing=True, project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'),
                    fine=True, job_num=100)
         self.assertEqual(job2.bath_gas, 'N2')
 
         job2 = Job(project='project_test', ess_settings=self.ess_settings, species_name='tst_spc',
                    xyz=self.xyz_c, job_type='onedmin',
                    level={'method': 'b3lyp', 'basis': '6-31+g(d)'}, multiplicity=1,
-                   testing=True, project_directory=os.path.join(arc_path, 'Projects', 'project_test'),
+                   testing=True, project_directory=os.path.join(ARC_PATH, 'Projects', 'project_test'),
                    fine=True, job_num=100, bath_gas='Ar')
         self.assertEqual(job2.bath_gas, 'Ar')
 
@@ -371,7 +371,7 @@ class TestJob(unittest.TestCase):
         """
         projects = ['arc_project_for_testing_delete_after_usage3']
         for project in projects:
-            project_directory = os.path.join(arc_path, 'Projects', project)
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
 

--- a/arc/job/localTest.py
+++ b/arc/job/localTest.py
@@ -11,7 +11,7 @@ import shutil
 import unittest
 
 import arc.job.local as local
-from arc.common import arc_path
+from arc.common import ARC_PATH
 
 
 class TestLocal(unittest.TestCase):
@@ -33,22 +33,22 @@ class TestLocal(unittest.TestCase):
 
     def test_get_last_modified_time(self):
         """Test the get_last_modified_time() function"""
-        path = os.path.join(arc_path, 'ARC.py')
+        path = os.path.join(ARC_PATH, 'ARC.py')
         t = local.get_last_modified_time(path)
         self.assertIsInstance(t, datetime.datetime)
 
     def test_rename_output(self):
         """Test the rename_output() function"""
-        path1 = os.path.join(arc_path, 'scratch', 'input.log')
-        path2 = os.path.join(arc_path, 'scratch', 'output.out')
-        if not os.path.exists(os.path.join(arc_path, 'scratch')):
-            os.makedirs(os.path.join(arc_path, 'scratch'))
+        path1 = os.path.join(ARC_PATH, 'scratch', 'input.log')
+        path2 = os.path.join(ARC_PATH, 'scratch', 'output.out')
+        if not os.path.exists(os.path.join(ARC_PATH, 'scratch')):
+            os.makedirs(os.path.join(ARC_PATH, 'scratch'))
         with open(path1, 'w'):
             pass
         local.rename_output(local_file_path=path2, software='gaussian')
         self.assertFalse(os.path.isfile(path1))
         self.assertTrue(os.path.isfile(path2))
-        shutil.rmtree(os.path.join(arc_path, 'scratch'), ignore_errors=True)
+        shutil.rmtree(os.path.join(ARC_PATH, 'scratch'), ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -9,7 +9,7 @@ import os
 import unittest
 
 import arc.job.trsh as trsh
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.imports import settings
 from arc.parser import parse_1d_scan_energies
 
@@ -28,7 +28,7 @@ class TestTrsh(unittest.TestCase):
         A method that is run before all unit tests in this class.
         """
         cls.maxDiff = None
-        path = os.path.join(arc_path, 'arc', 'testing', 'trsh')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'trsh')
         cls.base_path = {ess: os.path.join(path, ess) for ess in supported_ess}
 
     def test_determine_ess_status(self):
@@ -502,7 +502,7 @@ class TestTrsh(unittest.TestCase):
 
     def test_trsh_negative_freq(self):
         """Test troubleshooting a negative frequency"""
-        gaussian_neg_freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'Gaussian_neg_freq.out')
+        gaussian_neg_freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'Gaussian_neg_freq.out')
         current_neg_freqs_trshed, conformers, output_errors, output_warnings = \
             trsh.trsh_negative_freq(label='2-methoxy_n-methylaniline', log_file=gaussian_neg_freq_path)
         expected_current_neg_freqs_trshed = [-18.07]
@@ -542,7 +542,7 @@ class TestTrsh(unittest.TestCase):
 
     def test_scan_quality_check(self):
         """Test scan quality check for 1D rotor"""
-        log_file = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
+        log_file = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
         # Case 1: non-smooth scan which troubleshot once
         case1 = {'label': 'CH2OOH',
                  'pivots': [1, 2],
@@ -567,7 +567,7 @@ class TestTrsh(unittest.TestCase):
         self.assertIn([2, 1, 4, 5], actions['freeze'])
 
         # Case 2: Lower conformer
-        log_file = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'COCCOO.out')
+        log_file = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'COCCOO.out')
         case2 = {'label': 'COCCOO',
                  'pivots': [2, 5],
                  'energies': parse_1d_scan_energies(log_file)[0],
@@ -609,7 +609,7 @@ class TestTrsh(unittest.TestCase):
                  'scan': [4, 1, 2, 3],
                  'scan_list': [[4, 1, 2, 3], [1, 2, 3, 6]],
                  'methods': {'freeze': [[5, 1, 2, 3], [2, 1, 4, 5]]},
-                 'log_file': os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out'),
+                 'log_file': os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out'),
                 }
         scan_trsh, scan_res = trsh.trsh_scan_job(**case)
         self.assertEqual(scan_trsh, 'D 5 4 1 2 F\nD 1 2 3 6 F\nB 2 3 F\n')

--- a/arc/level.py
+++ b/arc/level.py
@@ -12,7 +12,7 @@ from arkane.encorr.bac import BAC
 from arkane.encorr.corr import assign_frequency_scale_factor
 from arkane.modelchem import METHODS_THAT_REQUIRE_SOFTWARE, LevelOfTheory, standardize_name
 
-from arc.common import arc_path, get_logger, get_ordered_intersection_of_two_lists, read_yaml_file
+from arc.common import ARC_PATH, get_logger, get_ordered_intersection_of_two_lists, read_yaml_file
 from arc.imports import settings
 
 
@@ -527,7 +527,7 @@ class Level(object):
         if self.compatible_ess is None:
             # Don't append if the user already specified a restricted list.
             self.compatible_ess = list()
-            ess_methods = read_yaml_file(path=os.path.join(arc_path, 'data', 'ess_methods.yml'))
+            ess_methods = read_yaml_file(path=os.path.join(ARC_PATH, 'data', 'ess_methods.yml'))
             ess_methods = {ess: [method.lower() for method in methods] for ess, methods in ess_methods.items()}
             if self.method in ess_methods['gaussian']:
                 self.compatible_ess.append('gaussian')

--- a/arc/levelTest.py
+++ b/arc/levelTest.py
@@ -10,7 +10,7 @@ import unittest
 
 from arkane.modelchem import LevelOfTheory
 
-from arc.common import arc_path, read_yaml_file
+from arc.common import ARC_PATH, read_yaml_file
 from arc.level import Level
 
 
@@ -142,7 +142,7 @@ class TestLevel(unittest.TestCase):
 
     def test_ess_methods_yml(self):
         """Test reading the ess_methods.yml file"""
-        ess_methods = read_yaml_file(path=os.path.join(arc_path, 'data', 'ess_methods.yml'))
+        ess_methods = read_yaml_file(path=os.path.join(ARC_PATH, 'data', 'ess_methods.yml'))
         self.assertIsInstance(ess_methods, dict)
         for ess, methods in ess_methods.items():
             self.assertIsInstance(ess, str)

--- a/arc/main.py
+++ b/arc/main.py
@@ -23,7 +23,7 @@ from rmgpy.species import Species
 
 import arc.rmgdb as rmgdb
 from arc.common import (VERSION,
-                        arc_path,
+                        ARC_PATH,
                         check_ess_settings,
                         get_logger,
                         globalize_path,
@@ -260,7 +260,7 @@ class ARC(object):
         self.__version__ = VERSION
         self.verbose = verbose
         self.project_directory = project_directory if project_directory is not None \
-            else os.path.join(arc_path, 'Projects', self.project)
+            else os.path.join(ARC_PATH, 'Projects', self.project)
         if not os.path.exists(self.project_directory):
             os.makedirs(self.project_directory)
         self.output = output
@@ -339,11 +339,11 @@ class ARC(object):
                 for rotor_num, rotor_dict in spc.rotors_dict.items():
                     if rotor_dict['scan_path'] and not os.path.isfile(rotor_dict['scan_path']) and rotor_dict['success']:
                         # try correcting relative paths
-                        if os.path.isfile(os.path.join(arc_path, rotor_dict['scan_path'])):
-                            spc.rotors_dict[rotor_num]['scan_path'] = os.path.join(arc_path, rotor_dict['scan_path'])
-                        elif os.path.isfile(os.path.join(arc_path, 'Projects', rotor_dict['scan_path'])):
+                        if os.path.isfile(os.path.join(ARC_PATH, rotor_dict['scan_path'])):
+                            spc.rotors_dict[rotor_num]['scan_path'] = os.path.join(ARC_PATH, rotor_dict['scan_path'])
+                        elif os.path.isfile(os.path.join(ARC_PATH, 'Projects', rotor_dict['scan_path'])):
                             spc.rotors_dict[rotor_num]['scan_path'] = \
-                                os.path.join(arc_path, 'Projects', rotor_dict['scan_path'])
+                                os.path.join(ARC_PATH, 'Projects', rotor_dict['scan_path'])
                         else:
                             raise SpeciesError(f'Could not find rotor scan output file for rotor {rotor_num} of '
                                                f'species {spc.label}: {rotor_dict["scan_path"]}')
@@ -1105,10 +1105,10 @@ class ARC(object):
                         if key in ['geo', 'freq', 'sp', 'composite']:
                             if val and not os.path.isfile(val):
                                 # try correcting relative paths
-                                if os.path.isfile(os.path.join(arc_path, val)):
-                                    self.output[label]['paths'][key] = os.path.join(arc_path, val)
-                                elif os.path.isfile(os.path.join(arc_path, 'Projects', val)):
-                                    self.output[label]['paths'][key] = os.path.join(arc_path, 'Projects', val)
+                                if os.path.isfile(os.path.join(ARC_PATH, val)):
+                                    self.output[label]['paths'][key] = os.path.join(ARC_PATH, val)
+                                elif os.path.isfile(os.path.join(ARC_PATH, 'Projects', val)):
+                                    self.output[label]['paths'][key] = os.path.join(ARC_PATH, 'Projects', val)
                                 elif os.path.isfile(os.path.join(globalize_path(
                                         string=val, project_directory=self.project_directory))):
                                     self.output[label]['paths'][key] = globalize_path(

--- a/arc/mainTest.py
+++ b/arc/mainTest.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import unittest
 
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.main import ARC, process_adaptive_levels
@@ -174,7 +174,7 @@ class TestARC(unittest.TestCase):
                                      'rotors_dict': {},
                                      'xyzs': []}],
                         'three_params': False,
-                        'project_directory': os.path.join(arc_path, 'Projects',
+                        'project_directory': os.path.join(ARC_PATH, 'Projects',
                                                           'arc_project_for_testing_delete_after_usage_test_from_dict'),
                         }
         arc1 = ARC(project='wrong', freq_scale_factor=0.95)
@@ -196,7 +196,7 @@ class TestARC(unittest.TestCase):
         """Test the from_dict() method of ARC"""
         restart_dict = {'specific_job_type': 'bde',
                         'project': 'unit_test_specific_job',
-                        'project_directory': os.path.join(arc_path, 'Projects', 'unit_test_specific_job'),
+                        'project_directory': os.path.join(ARC_PATH, 'Projects', 'unit_test_specific_job'),
                         }
         arc1 = ARC(**restart_dict)
         job_type_expected = {'conformers': False, 'opt': True, 'freq': True, 'sp': True, 'rotors': False,
@@ -427,7 +427,7 @@ class TestARC(unittest.TestCase):
         projects = ['arc_project_for_testing_delete_after_usage_test_from_dict',
                     'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong']
         for project in projects:
-            project_directory = os.path.join(arc_path, 'Projects', project)
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
 
 

--- a/arc/parserTest.py
+++ b/arc/parserTest.py
@@ -10,7 +10,7 @@ import os
 import unittest
 
 import arc.parser as parser
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.species import ARCSpecies
 from arc.species.converter import xyz_to_str
 
@@ -29,17 +29,17 @@ class TestParser(unittest.TestCase):
 
     def test_parse_frequencies(self):
         """Test frequency parsing"""
-        no3_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'NO3_freq_QChem_fails_on_cclib.out')
-        c2h6_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
-        so2oo_path = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
-        ch2o_path_molpro = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
-        ch2o_path_terachem = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CH2O_freq_terachem.dat')
-        ch2o_path_terachem_output = os.path.join(arc_path, 'arc', 'testing', 'freq',
+        no3_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'NO3_freq_QChem_fails_on_cclib.out')
+        c2h6_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
+        so2oo_path = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        ch2o_path_molpro = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
+        ch2o_path_terachem = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CH2O_freq_terachem.dat')
+        ch2o_path_terachem_output = os.path.join(ARC_PATH, 'arc', 'testing', 'freq',
                                                  'formaldehyde_freq_terachem_output.out')
-        ncc_path_terachem_output = os.path.join(arc_path, 'arc', 'testing', 'freq',
+        ncc_path_terachem_output = os.path.join(ARC_PATH, 'arc', 'testing', 'freq',
                                                 'ethylamine_freq_terachem_output.out')
-        orca_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'orca_example_freq.log')
-        dual_freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'dual_freq_output.out')
+        orca_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'orca_example_freq.log')
+        dual_freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'dual_freq_output.out')
 
         no3_freqs = parser.parse_frequencies(path=no3_path, software='QChem')
         c2h6_freqs = parser.parse_frequencies(path=c2h6_path, software='QChem')
@@ -89,7 +89,7 @@ class TestParser(unittest.TestCase):
 
     def test_parse_normal_displacement_modes(self):
         """Test parsing frequencies and normal displacement modes"""
-        freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'Gaussian_neg_freq.out')
+        freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'Gaussian_neg_freq.out')
         freqs, normal_disp_modes = parser.parse_normal_displacement_modes(path=freq_path)
         expected_freqs = np.array([-18.0696, 127.6948, 174.9499, 207.585, 228.8421, 281.2939, 292.4101,
                                    308.0345, 375.4493, 486.8396, 498.6986, 537.6196, 564.0223, 615.3762,
@@ -107,7 +107,7 @@ class TestParser(unittest.TestCase):
              [0.3, 0.03, 0.41], [0.0, 0.0, -0.15], [0.0, -0.0, 0.01], [0.0, -0.0, 0.21], [0.0, -0.0, 0.19]], np.float64)
         np.testing.assert_almost_equal(normal_disp_modes[0], expected_normal_disp_modes_0)
 
-        freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CHO_neg_freq.out')
+        freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CHO_neg_freq.out')
         freqs, normal_disp_modes = parser.parse_normal_displacement_modes(path=freq_path)
         expected_freqs = np.array([-1612.8294, 840.8655, 1883.4822, 3498.091], np.float64)
         np.testing.assert_almost_equal(freqs, expected_freqs)
@@ -118,7 +118,7 @@ class TestParser(unittest.TestCase):
              [[0.0, -0.0, 0.02], [-0.0, 0.0, -0.11], [0.0, -0.0, 0.99]]], np.float64)
         np.testing.assert_almost_equal(normal_disp_modes, expected_normal_disp_modes)
 
-        freq_path = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CH3OO_freq_gaussian.out')
+        freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CH3OO_freq_gaussian.out')
         freqs, normal_disp_modes = parser.parse_normal_displacement_modes(path=freq_path)
         expected_freqs = np.array([136.4446, 494.1267, 915.7812, 1131.4603, 1159.9315, 1225.148, 1446.5652,
                                    1474.8065, 1485.6423, 3046.2186, 3134.8026, 3147.5619], np.float64)
@@ -200,17 +200,17 @@ class TestParser(unittest.TestCase):
 
     def test_parse_xyz_from_file(self):
         """Test parsing xyz from a file"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'CH3C(O)O.gjf')
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'CH3C(O)O.xyz')
-        path3 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'AIBN.gjf')
-        path4 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'molpro.in')
-        path5 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'qchem.in')
-        path6 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'qchem_output.out')
-        path7 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'TS.gjf')
-        path8 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'formaldehyde_coords.xyz')
-        path9 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'optim_traj_terachem.xyz')  # test trajectories
-        path10 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'ethane_minimize_terachem_output.out')
-        path11 = os.path.join(arc_path, 'arc', 'testing', 'orca_example_opt.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'CH3C(O)O.gjf')
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'CH3C(O)O.xyz')
+        path3 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'AIBN.gjf')
+        path4 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'molpro.in')
+        path5 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'qchem.in')
+        path6 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'qchem_output.out')
+        path7 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'TS.gjf')
+        path8 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'formaldehyde_coords.xyz')
+        path9 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'optim_traj_terachem.xyz')  # test trajectories
+        path10 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'ethane_minimize_terachem_output.out')
+        path11 = os.path.join(ARC_PATH, 'arc', 'testing', 'orca_example_opt.log')
 
         xyz1 = parser.parse_xyz_from_file(path1)
         xyz2 = parser.parse_xyz_from_file(path2)
@@ -265,26 +265,26 @@ H      -0.59436200   -0.94730400    0.00000000"""
     def test_parse_geometry(self):
         """Test parse_geometry()"""
         # Test parsing xyz from a Gaussina file with more than 50 atoms where the iop(2/9=2000) keyword is not specified
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'Gaussian_large.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'Gaussian_large.log')
         xyz = parser.parse_geometry(path=path1)
         self.assertIsInstance(xyz, dict)
         self.assertEqual(len(xyz['symbols']), 53)
 
     def test_parse_trajectory(self):
         """Test parsing trajectories"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'scan_optim.xyz')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'scan_optim.xyz')
         trajectory = parser.parse_trajectory(path)
         self.assertEqual(len(trajectory), 46)
         self.assertIsInstance(trajectory[0], dict)
         self.assertEqual(len(trajectory[0]['symbols']), 9)
 
-        path = os.path.join(arc_path, 'arc', 'testing', 'irc', 'cyano_irc_1.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'irc', 'cyano_irc_1.out')
         trajectory = parser.parse_trajectory(path)
         self.assertEqual(len(trajectory), 58)
         self.assertIsInstance(trajectory[0], dict)
         self.assertEqual(len(trajectory[0]['symbols']), 16)
 
-        path = os.path.join(arc_path, 'arc', 'testing', 'irc', 'irc_failed.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'irc', 'irc_failed.out')
         trajectory = parser.parse_trajectory(path)
         self.assertEqual(len(trajectory), 21)
         self.assertIsInstance(trajectory[0], dict)
@@ -292,7 +292,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_1d_scan_coords(self):
         """Test parsing the optimized coordinates of a torsion scan at each optimization point"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
         traj = parser.parse_1d_scan_coords(path)
         self.assertEqual(len(traj), 37)
         self.assertEqual(traj[10], {'coords': ((-0.715582, -0.140909, 0.383809),
@@ -304,34 +304,34 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_t1(self):
         """Test T1 diagnostic parsing"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'sp', 'mehylamine_CCSD(T).out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'sp', 'mehylamine_CCSD(T).out')
         t1 = parser.parse_t1(path)
         self.assertEqual(t1, 0.0086766)
 
     def test_parse_e_elect(self):
         """Test parsing E0 from an sp job output file"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'sp', 'mehylamine_CCSD(T).out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'sp', 'mehylamine_CCSD(T).out')
         e_elect = parser.parse_e_elect(path)
         self.assertAlmostEqual(e_elect, -251377.49160993524)
 
-        path = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         e_elect = parser.parse_e_elect(path, zpe_scale_factor=0.99)
         self.assertAlmostEqual(e_elect, -1833127.0939478774)
 
-        path = os.path.join(arc_path, 'arc', 'testing', 'sp', 'formaldehyde_sp_terachem_output.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'sp', 'formaldehyde_sp_terachem_output.out')
         e_elect = parser.parse_e_elect(path)
         self.assertAlmostEqual(e_elect, -300621.95378630824)
 
-        path = os.path.join(arc_path, 'arc', 'testing', 'sp', 'formaldehyde_sp_terachem_results.dat')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'sp', 'formaldehyde_sp_terachem_results.dat')
         e_elect = parser.parse_e_elect(path)
         self.assertAlmostEqual(e_elect, -300621.95378630824)
 
     def test_parse_zpe(self):
         """Test the parse_zpe() function for parsing zero point energies"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
-        path3 = os.path.join(arc_path, 'arc', 'testing', 'freq', 'NO3_freq_QChem_fails_on_cclib.out')
-        path4 = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
+        path3 = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'NO3_freq_QChem_fails_on_cclib.out')
+        path4 = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         zpe1, zpe2, zpe3, zpe4 = parser.parse_zpe(path1), parser.parse_zpe(path2), parser.parse_zpe(path3), \
             parser.parse_zpe(path4)
         self.assertAlmostEqual(zpe1, 198.08311200000, 5)
@@ -341,7 +341,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_1d_scan_energies(self):
         """Test parsing a 1D scan output file"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'sBuOH.out')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'sBuOH.out')
         energies, angles = parser.parse_1d_scan_energies(path=path1)
         expected_energies = np.array([1.57530564e-05, 3.98826556e-01, 1.60839959e+00, 3.49030801e+00,
                                       5.74358812e+00, 8.01124810e+00, 9.87649510e+00, 1.10079306e+01,
@@ -362,14 +362,14 @@ H      -0.59436200   -0.94730400    0.00000000"""
         np.testing.assert_almost_equal(energies, expected_energies)
         np.testing.assert_almost_equal(angles, expected_angles)
 
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'scan_1d_curvilinear_error.out')
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'scan_1d_curvilinear_error.out')
         energies_2, angles_2 = parser.parse_1d_scan_energies(path=path2)
         self.assertEqual(energies_2, None)
         self.assertEqual(angles_2, None)
 
     def test_parse_nd_scan_energies(self):
         """Test parsing an ND scan output file"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'scan_2D_relaxed_OCdOO.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'scan_2D_relaxed_OCdOO.log')
         results = parser.parse_nd_scan_energies(path=path1, software='gaussian')
         self.assertEqual(results[0]['directed_scan_type'], 'ess_gaussian')
         self.assertEqual(results[0]['scans'], [(4, 1, 2, 5), (4, 1, 3, 6)])
@@ -379,37 +379,37 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_dipole_moment(self):
         """Test parsing the dipole moment from an opt job output file"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         dm1 = parser.parse_dipole_moment(path1)
         self.assertEqual(dm1, 0.63)
 
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'N2H4_opt_QChem.out')
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'N2H4_opt_QChem.out')
         dm2 = parser.parse_dipole_moment(path2)
         self.assertEqual(dm2, 2.0664)
 
-        path3 = os.path.join(arc_path, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
+        path3 = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CH2O_freq_molpro.out')
         dm3 = parser.parse_dipole_moment(path3)
         self.assertAlmostEqual(dm3, 2.8840, 4)
 
-        path4 = os.path.join(arc_path, 'arc', 'testing', 'orca_example_opt.log')
+        path4 = os.path.join(ARC_PATH, 'arc', 'testing', 'orca_example_opt.log')
         dm4 = parser.parse_dipole_moment(path4)
         self.assertEqual(dm4, 2.11328)
 
-        path5 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'ethane_minimize_terachem_output.out')
+        path5 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'ethane_minimize_terachem_output.out')
         dm5 = parser.parse_dipole_moment(path5)
         self.assertAlmostEqual(dm5, 0.000179036, 4)
 
     def test_parse_polarizability(self):
         """Test parsing the polarizability moment from a freq job output file"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         polar1 = parser.parse_polarizability(path1)
         self.assertAlmostEqual(polar1, 3.99506, 4)
 
     def test_process_conformers_file(self):
         """Test processing ARC conformer files"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'conformers_before_optimization.txt')
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'conformers_after_optimization.txt')
-        path3 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'conformers_file.txt')
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'conformers_before_optimization.txt')
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'conformers_after_optimization.txt')
+        path3 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'conformers_file.txt')
 
         xyzs, energies = parser.process_conformers_file(path1)
         self.assertEqual(len(xyzs), 3)
@@ -448,7 +448,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_str_blocks(self):
         """Test parsing str blocks"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
         str_blks = parser.parse_str_blocks(
             path, 'Initial Parameters', '--------', regex=False, tail_count=3)
         desire_str_lists = [
@@ -469,7 +469,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_scan_args(self):
         """Test parsing scan arguments"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
         scan_args = parser.parse_scan_args(path)
         self.assertEqual(scan_args['scan'], [4, 1, 2, 3])
         self.assertEqual(scan_args['freeze'], [[1, 2, 3, 6], [2, 3]])
@@ -479,7 +479,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_ic_info(self):
         """Test parsing internal coordinates information"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH2OOH.out')
         ic_info = parser.parse_ic_info(path)
         expected_labels = ['R1', 'R2', 'R3', 'R4', 'R5', 'A1', 'A2',
                            'A3', 'A4', 'A5', 'D1', 'D2', 'D3', 'D4']
@@ -515,7 +515,7 @@ H      -0.59436200   -0.94730400    0.00000000"""
 
     def test_parse_conformers(self):
         """Test parsing internal coordinates of all intermediate conformers in a scan job"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
         scan_conformers = parser.parse_scan_conformers(path)
         expected_labels = ['R1', 'R2', 'R3', 'A1', 'A2', 'D1']
         expected_types = ['R', 'R', 'R', 'A', 'A', 'D']

--- a/arc/plotterTest.py
+++ b/arc/plotterTest.py
@@ -10,7 +10,7 @@ import shutil
 import unittest
 
 import arc.plotter as plotter
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.species.converter import str_to_xyz
 from arc.species.species import ARCSpecies
 
@@ -32,7 +32,7 @@ H      -1.16115119    0.31478894    0.81506145
 H      -1.16115119    0.31478894   -0.81506145""")
         spc.opt_level = 'opt/level'
         project = 'arc_project_for_testing_delete_after_usage'
-        project_directory = os.path.join(arc_path, 'Projects', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
         xyz_path = os.path.join(project_directory, 'output', 'Species', spc.label, 'geometry', 'methylamine.xyz')
         gjf_path = os.path.join(project_directory, 'output', 'Species', spc.label, 'geometry', 'methylamine.gjf')
         plotter.save_geo(species=spc, project_directory=project_directory)
@@ -69,7 +69,7 @@ H      -1.16115119    0.31478894   -0.81506145
     def test_save_conformers_file(self):
         """test the save_conformers_file function"""
         project = 'arc_project_for_testing_delete_after_usage'
-        project_directory = os.path.join(arc_path, 'Projects', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
         label = 'butanol'
         spc1 = ARCSpecies(label=label, smiles='CCCCO')
         spc1.generate_conformers(n_confs=3)
@@ -88,7 +88,7 @@ H      -1.16115119    0.31478894   -0.81506145
         angles = [0, 90, 180, 270, 360]
         energies = [0, 10, 0, 10, 0]
         pivots = [1, 2]
-        path = os.path.join(arc_path, 'Projects', project, 'rotors', '{0}_directed_scan.txt'.format(pivots))
+        path = os.path.join(ARC_PATH, 'Projects', project, 'rotors', '{0}_directed_scan.txt'.format(pivots))
         plotter.save_rotor_text_file(angles, energies, path)
         self.assertTrue(os.path.isfile(path))
         with open(path, 'r') as f:
@@ -97,7 +97,7 @@ H      -1.16115119    0.31478894   -0.81506145
 
     def test_log_bde_report(self):
         """Test the log_bde_report() function"""
-        path = os.path.join(arc_path, 'arc', 'testing', 'bde_report_test.txt')
+        path = os.path.join(ARC_PATH, 'arc', 'testing', 'bde_report_test.txt')
         bde_report = {'aniline': {(1, 2): 431.43, (5, 8): 465.36, (6, 9): 458.70, (3, 10): 463.16, (4, 11): 463.16,
                                   (7, 12): 458.70, (1, 13): 372.31, (1, 14): 372.31, (5, 6): 'N/A'}}
         xyz = """N       2.28116100   -0.20275000   -0.29653100
@@ -163,9 +163,9 @@ H      -1.16115119    0.31478894   -0.81506145
     def tearDownClass(cls):
         """A function that is run ONCE after all unit tests in this class."""
         project = 'arc_project_for_testing_delete_after_usage'
-        project_directory = os.path.join(arc_path, 'Projects', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
         shutil.rmtree(project_directory, ignore_errors=True)
-        os.remove(os.path.join(arc_path, 'arc', 'testing', 'bde_report_test.txt'))
+        os.remove(os.path.join(ARC_PATH, 'arc', 'testing', 'bde_report_test.txt'))
 
 
 if __name__ == '__main__':

--- a/arc/restartTest.py
+++ b/arc/restartTest.py
@@ -15,7 +15,7 @@ from rmgpy.data.rmg import RMGDatabase
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.species import Species
 
-from arc.common import arc_path, read_yaml_file
+from arc.common import ARC_PATH, read_yaml_file
 from arc.main import ARC
 
 
@@ -37,10 +37,10 @@ class TestARC(unittest.TestCase):
         Test restarting ARC through the ARC class in main.py via the input_dict argument of the API
         Rather than through ARC.py. Check that all files are in place and the log file content.
         """
-        restart_path = os.path.join(arc_path, 'arc', 'testing', 'restart', '1_restart_thermo', 'restart.yml')
+        restart_path = os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '1_restart_thermo', 'restart.yml')
         input_dict = read_yaml_file(path=restart_path)
         project = 'arc_project_for_testing_delete_after_usage_restart_thermo'
-        project_directory = os.path.join(arc_path, 'Projects', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
         input_dict['project'], input_dict['project_directory'] = project, project_directory
         arc1 = ARC(**input_dict)
         arc1.execute()
@@ -160,10 +160,10 @@ class TestARC(unittest.TestCase):
 
     def test_restart_rate(self):
         """Test restarting ARC and attaining reaction a rate coefficient"""
-        restart_path = os.path.join(arc_path, 'arc', 'testing', 'restart', '2_restart_rate', 'restart.yml')
+        restart_path = os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '2_restart_rate', 'restart.yml')
         input_dict = read_yaml_file(path=restart_path)
         project = 'arc_project_for_testing_delete_after_usage_restart_rate'
-        project_directory = os.path.join(arc_path, 'Projects', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
         input_dict['project'], input_dict['project_directory'] = project, project_directory
         arc1 = ARC(**input_dict)
         arc1.execute()
@@ -180,12 +180,12 @@ class TestARC(unittest.TestCase):
 
     def test_restart_bde(self):
         """Test restarting ARC and attaining reaction a rate coefficient"""
-        restart_path = os.path.join(arc_path, 'arc', 'testing', 'restart', '3_restart_bde', 'restart.yml')
+        restart_path = os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '3_restart_bde', 'restart.yml')
         input_dict = read_yaml_file(path=restart_path)
         arc1 = ARC(**input_dict)
         arc1.execute()
 
-        report_path = os.path.join(arc_path, 'Projects', 'test_restart_bde', 'output', 'BDE_report.txt')
+        report_path = os.path.join(ARC_PATH, 'Projects', 'test_restart_bde', 'output', 'BDE_report.txt')
         with open(report_path, 'r') as f:
             lines = f.readlines()
         self.assertIn(' BDE report for anilino_radical:\n', lines)
@@ -195,7 +195,7 @@ class TestARC(unittest.TestCase):
 
     def test_globalize_paths(self):
         """Test modifying a YAML file's contents to correct absolute file paths"""
-        project_directory = os.path.join(arc_path, 'arc', 'testing', 'restart', '4_globalized_paths')
+        project_directory = os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '4_globalized_paths')
         restart_path = os.path.join(project_directory, 'restart_paths.yml')
         input_dict = read_yaml_file(path=restart_path, project_directory=project_directory)
         input_dict['project_directory'] = project_directory
@@ -218,11 +218,11 @@ class TestARC(unittest.TestCase):
                     'test_restart_bde',
                     ]
         for project in projects:
-            project_directory = os.path.join(arc_path, 'Projects', project)
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
 
         for file_name in ['arc.log', 'restart_paths_globalized.yml']:
-            os.remove(os.path.join(arc_path, 'arc', 'testing', 'restart', '4_globalized_paths', file_name))
+            os.remove(os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '4_globalized_paths', file_name))
 
 
 if __name__ == '__main__':

--- a/arc/schedulerTest.py
+++ b/arc/schedulerTest.py
@@ -11,7 +11,7 @@ import shutil
 
 import arc.rmgdb as rmgdb
 import arc.parser as parser
-from arc.common import arc_path, almost_equal_coords_lists
+from arc.common import ARC_PATH, almost_equal_coords_lists
 from arc.job.job import Job
 from arc.level import Level
 from arc.plotter import save_conformers_file
@@ -34,7 +34,7 @@ class TestScheduler(unittest.TestCase):
         """
         cls.maxDiff = None
         cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1'], 'qchem': ['server1']}
-        cls.project_directory = os.path.join(arc_path, 'Projects', 'arc_project_for_testing_delete_after_usage3')
+        cls.project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_for_testing_delete_after_usage3')
         cls.spc1 = ARCSpecies(label='methylamine', smiles='CN')
         cls.spc2 = ARCSpecies(label='C2H6', smiles='CC')
         xyz1 = """C       1.11424367   -0.01231165   -0.11493630
@@ -85,9 +85,9 @@ H      -1.82570782    0.42754384   -0.56130718"""
     def test_conformers(self):
         """Test the parse_conformer_energy() and determine_most_stable_conformer() methods"""
         label = 'methylamine'
-        self.job1.local_path_to_output_file = os.path.join(arc_path, 'arc', 'testing', 'methylamine_conformer_0.out')
+        self.job1.local_path_to_output_file = os.path.join(ARC_PATH, 'arc', 'testing', 'methylamine_conformer_0.out')
         self.job1.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
-        self.job2.local_path_to_output_file = os.path.join(arc_path, 'arc', 'testing', 'methylamine_conformer_1.out')
+        self.job2.local_path_to_output_file = os.path.join(ARC_PATH, 'arc', 'testing', 'methylamine_conformer_1.out')
         self.job2.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
         self.sched1.job_dict[label] = dict()
         self.sched1.job_dict[label]['conformers'] = dict()
@@ -148,7 +148,7 @@ H      -1.82570782    0.42754384   -0.56130718"""
     def test_check_negative_freq(self):
         """Test the check_negative_freq() method"""
         label = 'C2H6'
-        self.job3.local_path_to_output_file = os.path.join(arc_path, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
+        self.job3.local_path_to_output_file = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'C2H6_freq_QChem.out')
         self.job3.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
         vibfreqs = parser.parse_frequencies(path=self.job3.local_path_to_output_file, software=self.job3.software)
         self.assertTrue(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=vibfreqs))
@@ -277,7 +277,7 @@ H      -1.82570782    0.42754384   -0.56130718"""
         """
         projects = ['arc_project_for_testing_delete_after_usage3']
         for project in projects:
-            project_directory = os.path.join(arc_path, 'Projects', project)
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
 
 

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -14,7 +14,7 @@ from rmgpy.reaction import Reaction
 from rmgpy.species import Species
 from rmgpy.transport import TransportData
 
-from arc.common import almost_equal_coords_lists, arc_path
+from arc.common import almost_equal_coords_lists, ARC_PATH
 from arc.exceptions import SpeciesError
 from arc.level import Level
 from arc.plotter import save_conformers_file
@@ -81,7 +81,7 @@ class TestARCSpecies(unittest.TestCase):
         H       1.4015274689    -0.6230592706    -0.8487058662"""
         cls.spc6 = ARCSpecies(label='N3', xyz=n3_xyz, multiplicity=1, smiles='NNN')
 
-        xyz1 = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'AIBN.gjf')
+        xyz1 = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'AIBN.gjf')
         cls.spc7 = ARCSpecies(label='AIBN', smiles='N#CC(C)(C)N=NC(C)(C)C#N', xyz=xyz1)
 
         hso3_xyz = """S      -0.12383700    0.10918200   -0.21334200
@@ -129,7 +129,7 @@ class TestARCSpecies(unittest.TestCase):
                                (-2.339586, -0.300928, 0.289904),
                                (-1.2713739999999998, -1.271158, -0.51544))}
 
-        n4h6_yml_path = os.path.join(arc_path, 'arc', 'testing', 'yml_testing', 'N4H6.yml')
+        n4h6_yml_path = os.path.join(ARC_PATH, 'arc', 'testing', 'yml_testing', 'N4H6.yml')
         n4h6 = ARCSpecies(yml_path=n4h6_yml_path)
         self.assertEqual(n4h6.mol.to_adjacency_list(), n4h6_adj_list)
         self.assertEqual(n4h6.charge, 0)
@@ -565,18 +565,18 @@ H      -1.67091600   -1.35164600   -0.93286400"""
 
     def test_determine_rotor_type(self):
         """Test that we correctly determine whether a rotor is FreeRotor or HinderedRotor"""
-        free_path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH3C(O)O_FreeRotor.out')
-        hindered_path = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
+        free_path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH3C(O)O_FreeRotor.out')
+        hindered_path = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'H2O2.out')
         self.assertEqual(determine_rotor_type(free_path), 'FreeRotor')
         self.assertEqual(determine_rotor_type(hindered_path), 'HinderedRotor')
 
     def test_rotor_symmetry(self):
         """Test that ARC automatically determines a correct rotor symmetry"""
-        path1 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'OOC1CCOCO1.out')  # symmetry = 1; min at -10 o
-        path2 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'H2O2.out')  # symmetry = 1
-        path3 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'N2O3.out')  # symmetry = 2
-        path4 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'sBuOH.out')  # symmetry = 3
-        path5 = os.path.join(arc_path, 'arc', 'testing', 'rotor_scans', 'CH3C(O)O_FreeRotor.out')  # symmetry = 6
+        path1 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'OOC1CCOCO1.out')  # symmetry = 1; min at -10 o
+        path2 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'H2O2.out')  # symmetry = 1
+        path3 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'N2O3.out')  # symmetry = 2
+        path4 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'sBuOH.out')  # symmetry = 3
+        path5 = os.path.join(ARC_PATH, 'arc', 'testing', 'rotor_scans', 'CH3C(O)O_FreeRotor.out')  # symmetry = 6
 
         sym1, e1, _ = determine_rotor_symmetry(label='label', pivots=[3, 4], rotor_path=path1)
         sym2, e2, _ = determine_rotor_symmetry(label='label', pivots=[3, 4], rotor_path=path2)
@@ -705,7 +705,7 @@ H    2.9757   -2.2266    0.5368"""
         self.assertEqual(len(spc2.conformer_energies), 1)
         self.assertEqual(spc2.multiplicity, 1)
 
-        xyz_path = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'CH3C(O)O.xyz')
+        xyz_path = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'CH3C(O)O.xyz')
         expected_xyz3 = """O      -0.53466300   -1.24850800   -0.02156300
 O      -0.79314200    1.04818800    0.18134200
 C      -0.02397300    0.01171700   -0.37827400
@@ -725,7 +725,7 @@ H      -1.69944700    0.93441600   -0.11271200"""
         self.assertEqual(len(spc3.conformer_energies), 1)
         self.assertEqual(spc3.multiplicity, 1)
 
-        conformers_path = os.path.join(arc_path, 'arc', 'testing', 'xyz', 'conformers_file.txt')
+        conformers_path = os.path.join(ARC_PATH, 'arc', 'testing', 'xyz', 'conformers_file.txt')
         spc4 = ARCSpecies(label='test_spc3', xyz=conformers_path)
         self.assertEqual(len(spc4.conformers), 4)
         self.assertEqual(len(spc4.conformer_energies), 4)
@@ -782,7 +782,7 @@ H      -1.69944700    0.93441600   -0.11271200"""
 
     def test_append_conformers(self):
         """Test that ARC correctly parses its own conformer files"""
-        project_directory = os.path.join(arc_path, 'Projects', 'arc_project_for_testing_delete_after_usage4')
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_for_testing_delete_after_usage4')
         xyzs = [{'symbols': ('O', 'C', 'C', 'H', 'H', 'H'), 'isotopes': (16, 12, 12, 1, 1, 1),
                  'coords': ((1.090687, 0.265168, -0.167063), (2.922041, -1.183357, -0.388849),
                             (2.276555, -0.003739, 0.085435), (2.365448, -1.88781, -0.999146),
@@ -882,11 +882,11 @@ H       1.32129900    0.71837500    0.38017700
     def test_set_transport_data(self):
         """Test the set_transport_data method"""
         self.assertIsInstance(self.spc1.transport_data, TransportData)
-        lj_path = os.path.join(arc_path, 'arc', 'testing', 'NH3_oneDMin.dat')
-        opt_path = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        lj_path = os.path.join(ARC_PATH, 'arc', 'testing', 'NH3_oneDMin.dat')
+        opt_path = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         bath_gas = 'N2'
         opt_level = Level(repr='CBS-QB3')
-        freq_path = os.path.join(arc_path, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
+        freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'composite', 'SO2OO_CBS-QB3.log')
         freq_level = Level(repr='CBS-QB3')
         self.spc1.set_transport_data(lj_path, opt_path, bath_gas, opt_level, freq_path, freq_level)
         self.assertIsInstance(self.spc1.transport_data, TransportData)
@@ -1367,7 +1367,7 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         """
         projects = ['arc_project_for_testing_delete_after_usage4']
         for project in projects:
-            project_directory = os.path.join(arc_path, 'Projects', project)
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
 
 
@@ -1436,7 +1436,7 @@ class TestTSGuess(unittest.TestCase):
         Test that ARC can call the GNN to make TS guesses for further optimization.
         """
         # create temporary project directory to delete afterwards
-        project_dir = os.path.join(arc_path, 'arc', 'testing', 'gcn_tst')
+        project_dir = os.path.join(ARC_PATH, 'arc', 'testing', 'gcn_tst')
 
         r_xyz = """C  -1.3087    0.0068    0.0318
         C  0.1715   -0.0344    0.0210

--- a/arc/ts/atst.py
+++ b/arc/ts/atst.py
@@ -4,7 +4,7 @@ A module for calling AutoTST
 
 import os
 
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.exceptions import TSError
 from arc.species.converter import str_to_xyz
 
@@ -27,8 +27,8 @@ def autotst(reaction_label=None, rmg_reaction=None, reaction_family=None):
         TSError: if neither ``rmg_reaction`` nor ``reaction_family`` were specified.
     """
     xyz_str = ''
-    xyz_path = os.path.join(arc_path, 'arc', 'ts', 'auto_tst.xyz')
-    run_autotst_path = os.path.join(arc_path, 'arc', 'ts', 'run_autotst.py')
+    xyz_path = os.path.join(ARC_PATH, 'arc', 'ts', 'auto_tst.xyz')
+    run_autotst_path = os.path.join(ARC_PATH, 'arc', 'ts', 'run_autotst.py')
 
     reaction_family = str('H_Abstraction') if reaction_family is None else str(reaction_family)
 

--- a/arc/ts/run_autotst.py
+++ b/arc/ts/run_autotst.py
@@ -26,7 +26,7 @@ except ImportError:
     except ImportError:
         has_auto_tst = False
 
-from arc.common import arc_path, get_logger
+from arc.common import ARC_PATH, get_logger
 from arc.exceptions import TSError
 from arc.species.converter import xyz_from_data, xyz_to_str
 
@@ -78,7 +78,7 @@ def main(reaction_label=None, reaction_family=None):
             numbers = reaction.ts.ase_ts.get_atomic_numbers()
             xyz_guess = xyz_to_str(xyz_dict=xyz_from_data(coords=positions, numbers=numbers))
 
-            xyz_path = os.path.join(arc_path, 'arc', 'ts', 'auto_tst.xyz')
+            xyz_path = os.path.join(ARC_PATH, 'arc', 'ts', 'auto_tst.xyz')
 
             with open(xyz_path, 'w') as f:
                 f.write(xyz_guess)

--- a/arc/utils/delete.py
+++ b/arc/utils/delete.py
@@ -13,7 +13,7 @@ import argparse
 import csv
 import os
 
-from arc.common import arc_path
+from arc.common import ARC_PATH
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.job.local import delete_all_local_arc_jobs
@@ -66,7 +66,7 @@ def main():
 
     server_list = args.server if args.server else [server for server in servers.keys()]
 
-    csv_path = os.path.join(arc_path, 'initiated_jobs.csv')
+    csv_path = os.path.join(ARC_PATH, 'initiated_jobs.csv')
 
     project, jobs = None, list()
     if args.project:

--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -221,9 +221,9 @@ def summarize_results(lambda_zpes: list,
 
     with open(info_file_path, 'w') as f:
         f.write(HEADER)
-        arkane_text = '\n\n\nYou may copy-paste the following harmonic frequencies scaling factor/s to Arkane\n' \
-                      '(paste in the `freq_dict` under assign_frequency_scale_factor() in arkane/statmech.py):\n'
-        arkane_formats = list()
+        database_text = '\n\n\nYou may copy-paste the following harmonic frequencies scaling factor/s to RMG-database\n' \
+                      '(paste in the `freq_dict` in RMG-database/input/quantum_corrections/data.py):\n'
+        database_formats = list()
         harmonic_freq_scaling_factors = list()
         for lambda_zpe, level, zpe_dict, execution_time\
                 in zip(lambda_zpes, levels, zpe_dicts, times):
@@ -241,12 +241,12 @@ def summarize_results(lambda_zpes: list,
             text += f'(execution time: {execution_time})\n'
             logger.info(text)
             f.write(text)
-            arkane_formats.append(f"                 '{level}': {harmonic_freq_scaling_factor:.3f},  # [4]\n")
-        logger.info(arkane_text)
-        f.write(arkane_text)
-        for arkane_format in arkane_formats:
-            logger.info(arkane_format)
-            f.write(arkane_format)
+            database_formats.append(f"             '{level}': {harmonic_freq_scaling_factor:.3f},  # [4]\n")
+        logger.info(database_text)
+        f.write(database_text)
+        for database_format in database_formats:
+            logger.info(database_format)
+            f.write(database_format)
         overall_time_text = f'\n\nScaling factors calculation for {len(levels)} levels of theory completed ' \
                             f'(elapsed time: {overall_time}).\n'
         logger.info(overall_time_text)

--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -10,7 +10,7 @@ import time
 from typing import List, Optional, Union
 import shutil
 
-from arc.common import (arc_path,
+from arc.common import (ARC_PATH,
                         check_ess_settings,
                         get_logger,
                         initialize_job_types,
@@ -86,7 +86,7 @@ def determine_scaling_factors(levels: List[Union[Level, dict, str]],
         logger.info(f'\nComputing scaling factors at the {level} level of theory...\n\n')
         renamed_level = rename_level(str(level))
         project = 'scaling_' + renamed_level
-        project_directory = os.path.join(arc_path, 'Projects', 'scaling_factors', project)
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'scaling_factors', project)
         if os.path.isdir(project_directory):
             shutil.rmtree(project_directory)
 
@@ -208,7 +208,7 @@ def summarize_results(lambda_zpes: list,
         overall_time (str): A string-format of the overall calculation execution time.
         base_path (str, optional): The path to the scaling factors base folder.
     """
-    base_path = base_path or os.path.join(arc_path, 'Projects', 'scaling_factors')
+    base_path = base_path or os.path.join(ARC_PATH, 'Projects', 'scaling_factors')
     if not os.path.exists(base_path):
         os.makedirs(base_path)
     i, success = 0, False

--- a/arc/utils/scaleTest.py
+++ b/arc/utils/scaleTest.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import unittest
 
-from arc.common import almost_equal_coords_lists, arc_path
+from arc.common import almost_equal_coords_lists, ARC_PATH
 from arc.utils.scale import (calculate_truhlar_scaling_factors,
                              get_species_list,
                              rename_level,
@@ -68,7 +68,7 @@ class TestScale(unittest.TestCase):
         levels_of_theory = ['level1', 'level2']
         times = ['3', '5']
         overall_time = '8.5'
-        base_path = os.path.join(arc_path, 'Projects', 'scaling_factors_arc_testing_delete_after_usage')
+        base_path = os.path.join(ARC_PATH, 'Projects', 'scaling_factors_arc_testing_delete_after_usage')
 
         summarize_results(lambda_zpes=lambda_zpes,
                           levels=levels_of_theory,
@@ -119,7 +119,7 @@ class TestScale(unittest.TestCase):
         A function that is run ONCE after all unit tests in this class.
         Delete all directories created during these unit tests
         """
-        path = os.path.join(arc_path, 'Projects', 'scaling_factors_arc_testing_delete_after_usage')
+        path = os.path.join(ARC_PATH, 'Projects', 'scaling_factors_arc_testing_delete_after_usage')
         shutil.rmtree(path, ignore_errors=True)
 
 

--- a/arc/utils/scaleTest.py
+++ b/arc/utils/scaleTest.py
@@ -89,8 +89,8 @@ class TestScale(unittest.TestCase):
         self.assertIn('Scale Factor for Fundamental Frequencies = 0.955\n', lines)
         self.assertIn('Scale Factor for Harmonic Frequencies    = 0.994\n', lines)
         self.assertIn('Scaling factors calculation for 2 levels of theory completed (elapsed time: 8.5).\n', lines)
-        self.assertIn('You may copy-paste the following harmonic frequencies scaling factor/s to Arkane\n', lines)
-        self.assertIn("                 'level1': 0.963,  # [4]\n", lines)
+        self.assertIn('You may copy-paste the following harmonic frequencies scaling factor/s to RMG-database\n', lines)
+        self.assertIn("             'level1': 0.963,  # [4]\n", lines)
 
     def test_get_species_list(self):
         """Test the scale get_species_list() function"""


### PR DESCRIPTION
ARC currently logs the git commit string for the ARC repository. Since ARC relies on code from RMG-Py and RMG-database, this PR allows ARC to log the git commit strings for these repos as well. I think it would be particularly informative when using ARC to run Arkane with specified AECs + BACs to obtain thermo or rates so that the `arc.log` records the commit hash of all repositories involved in the calculation.

Within `common.py`, should we rename `arc_path` to `ARC_PATH` to indicate the variable is constant and keep it consistent with PEP 8?

This PR also includes a minor change for updating the message printed after obtaining a frequency factor for a new LoT. Previously, users were directed to `RMG-Py/arkane/statmech.py`; the message now points users to `RMG-database/input/quantum_corrections/data.py`

Happy to hear any feedback :) 