### PR TITLE
set uno_cutoff=15 in align for atom mapping

### DIFF
--- a/arc/species/mapping.py
+++ b/arc/species/mapping.py
@@ -85,7 +85,7 @@ def map_general_rxn(rxn: 'ARCReaction',
                             )
     if qcmol_1 is None or qcmol_2 is None:
         return None
-    data = qcmol_2.align(ref_mol=qcmol_1, verbose=0)[1]
+    data = qcmol_2.align(ref_mol=qcmol_1, verbose=0, uno_cutoff=15)[1]
     atom_map = data['mill'].atommap.tolist()
     return atom_map
 
@@ -334,7 +334,7 @@ def map_two_species(spc_1: Union[ARCSpecies, Species, Molecule],
     if len(qcmol_1.symbols) != len(qcmol_2.symbols):
         raise ValueError(f'The number of atoms in spc1 ({spc_1.number_of_atoms}) must be equal '
                          f'to the number of atoms in spc1 ({spc_2.number_of_atoms}).')
-    data = qcmol_2.align(ref_mol=qcmol_1, verbose=0)
+    data = qcmol_2.align(ref_mol=qcmol_1, verbose=0, uno_cutoff=15)
     atom_map = data[1]['mill'].atommap.tolist()
     if map_type == 'dict':  # ** Todo: test
         atom_map = {key: val for key, val in enumerate(atom_map)}


### PR DESCRIPTION
Add optional argument `uno_cutoff=15` as suggested in https://github.com/MolSSI/QCElemental/issues/270

Unable to test locally due to unmet dependencies (Gaussian, KinBot:

```
$ nosetests mappingTest.py:TestMapping.test_map_two_species
E
======================================================================
ERROR: Failure: NameError (name 'ReactionGenerator' is not defined)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/site-packages/nose/loader.py", line 417, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/home/fuller/miniconda3/envs/arc_env/lib/python3.7/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/__init__.py", line 2, in <module>
    import arc.main
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/main.py", line 39, in <module>
    from arc.job.ssh import SSHClient
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/job/__init__.py", line 2, in <module>
    import arc.job.adapters
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/job/adapters/__init__.py", line 7, in <module>
    import arc.job.adapters.ts
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/job/adapters/ts/__init__.py", line 3, in <module>
    import arc.job.adapters.ts.kinbot_ts
  File "/home/fuller/Dropbox/Documents/Technion/Code/ARC/arc/job/adapters/ts/kinbot_ts.py", line 387, in <module>
    ) -> ReactionGenerator:
NameError: name 'ReactionGenerator' is not defined
```
...
```
root: DEBUG: Did not find Gaussian on path, checking if it exists in a declared GAUSS_EXEDIR, g09root or g03root...
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```