### PR TITLE
BugFix: Make ess server name check non case-sensitive

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -176,7 +176,7 @@ def check_ess_settings(ess_settings: Optional[dict] = None) -> dict:
             raise SettingsError(f'Recognized ESS software are Gaussian, QChem, Molpro, Orca, TeraChem, Psi4, '
                                 f'or OneDMin. Got: {ess}')
         for server in server_list:
-            if not isinstance(server, bool) and server.lower() not in list(servers.keys()):
+            if not isinstance(server, bool) and server.lower() not in [s.lower() for s in servers.keys()]:
                 server_names = [name for name in servers.keys()]
                 raise SettingsError(f'Recognized servers are {server_names}. Got: {server}')
     logger.info(f'\nUsing the following ESS settings:\n{pprint.pformat(settings_dict)}\n')


### PR DESCRIPTION
ARC requires users to specify servers on which the ESS are installed, e.g.:
```python

global_ess_settings = {
    'gaussian': ['local', 'server2'],
    'molpro': ['local', 'server2'],
    'onedmin': 'server1',
    'orca': 'local',
    'qchem': 'server1',
    'terachem': 'server1',
}
```
ARC checks that each server name is well-defined, yet this check so far was done in a clumsy was, calling `.lower()` for the values in the `ess_settings`, but comparing to server names from the `servers` dict without calling `.lower()` as well.
It is now fixed.

Fixes #473 