### PR TITLE
Don't initialize `directed_scan_type` in the rotor_dict to 'ess'

### DIFF
--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1566,7 +1566,7 @@ def find_internal_rotors(mol):
                         rotor['trsh_counter'] = 0
                         rotor['trsh_methods'] = list()
                         rotor['scan_path'] = ''
-                        rotor['directed_scan_type'] = 'ess'  # default to 'ess', changed in initialize_directed_rotors()
+                        rotor['directed_scan_type'] = ''
                         rotor['directed_scan'] = dict()
                         rotor['dimensions'] = 1
                         rotor['original_dihedrals'] = list()


### PR DESCRIPTION
It causes ARC to think each scan job is a directed job.

It is unclear what triggered this bug now, will be rewritten in the upcoming changes to ARC Job module.

Fixes #471 