### PR TITLE
BugFix: Consider the migrating H atom when atom mapping intra-H migration reactions

### DIFF
--- a/arc/species/converterTest.py
+++ b/arc/species/converterTest.py
@@ -4119,7 +4119,7 @@ H      -0.81291200   -0.46933500   -0.31111876"""
         new_xyz = converter.modify_coords(coords=xyz1, indices=indices, new_value=new_val,
                                           modification_type=modification_type, mol=mol1)
         self.assertTrue(almost_equal_coords_lists(new_xyz, expected_xyz))
-        self.assertEqual(converter.get_zmat_param_value(coords=new_xyz, indices=indices, mol=mol1), new_val)
+        self.assertAlmostEqual(converter.get_zmat_param_value(coords=new_xyz, indices=indices, mol=mol1), new_val, 5)
 
         indices, new_val = [1, 0], -1.5
         expected_xyz = {'symbols': ('O', 'C', 'C', 'O', 'H', 'H', 'H', 'H'), 'isotopes': (16, 12, 12, 16, 1, 1, 1, 1),
@@ -4436,7 +4436,7 @@ H      -0.81291200   -0.46933500   -0.31111876"""
         # test TSs
         indices = [19, 10, 4, 2]
         fragments = [[46, 47, 48, 49, 50, 51, 52], [f + 1 for f in range(45)]]
-        self.assertAlmostEqual(calculate_dihedral_angle(coords=xyz5, torsion=indices, index=1), 56.83358841)
+        self.assertAlmostEqual(calculate_dihedral_angle(coords=xyz5, torsion=indices, index=1), 56.83358841, 3)
         new_xyz = converter.modify_coords(coords=xyz5,
                                           indices=indices,
                                           new_value=300,
@@ -4445,11 +4445,11 @@ H      -0.81291200   -0.46933500   -0.31111876"""
                                           index=1,
                                           fragments=fragments,
                                           )
-        self.assertAlmostEqual(calculate_dihedral_angle(coords=new_xyz, torsion=indices, index=1), 300, places=4)
+        self.assertAlmostEqual(calculate_dihedral_angle(coords=new_xyz, torsion=indices, index=1), 300, places=3)
 
         indices = [1, 2, 3, 5]
         fragments = [[f + 1 for f in range(23)], [24, 25, 26, 27, 28]]
-        self.assertAlmostEqual(calculate_dihedral_angle(coords=xyz6, torsion=indices, index=1), 62.30597206)
+        self.assertAlmostEqual(calculate_dihedral_angle(coords=xyz6, torsion=indices, index=1), 62.30597206, 3)
         new_xyz = converter.modify_coords(coords=xyz6,
                                           indices=indices,
                                           new_value=200,
@@ -4458,7 +4458,7 @@ H      -0.81291200   -0.46933500   -0.31111876"""
                                           index=1,
                                           fragments=fragments,
                                           )
-        self.assertAlmostEqual(calculate_dihedral_angle(coords=new_xyz, torsion=indices, index=1), 200, places=4)
+        self.assertAlmostEqual(calculate_dihedral_angle(coords=new_xyz, torsion=indices, index=1), 200, places=3)
 
 
     def test_compare_zmats(self):
@@ -4512,7 +4512,7 @@ H      -0.81291200   -0.46933500   -0.31111876"""
                             (-0.6300326, 0.6300326, -0.6300326),
                             (0.6300326, -0.6300326, -0.6300326))}
         self.assertFalse(converter.compare_confs(ch4_1, ch4_3))
-        self.assertAlmostEqual(converter.compare_confs(ch4_1, ch4_3, rmsd_score=True), 0.0004480326076878692)
+        self.assertAlmostEqual(converter.compare_confs(ch4_1, ch4_3, rmsd_score=True), 0.00044803, 5)
 
 
         occco_1 = {'symbols': ('O', 'C', 'C', 'C', 'O', 'H', 'H', 'H', 'H', 'H', 'H', 'H', 'H'),
@@ -4549,7 +4549,7 @@ H      -0.81291200   -0.46933500   -0.31111876"""
                               (1.0743805139106757, -1.9882575918786236, 1.2595102280098387),
                               (0.35195568839394714, -2.3791987519096245, -0.81652943836054))}
         self.assertFalse(converter.compare_confs(occco_1, occco_2))
-        self.assertAlmostEqual(converter.compare_confs(occco_1, occco_2, rmsd_score=True), 1.0094079844245747)
+        self.assertAlmostEqual(converter.compare_confs(occco_1, occco_2, rmsd_score=True), 1.00940798, 5)
 
         occco_3 = {'symbols': ('O', 'C', 'C', 'C', 'O', 'H', 'H', 'H', 'H', 'H', 'H', 'H', 'H'),
                    'isotopes': (16, 12, 12, 12, 16, 1, 1, 1, 1, 1, 1, 1, 1),

--- a/arc/species/mapping.py
+++ b/arc/species/mapping.py
@@ -480,6 +480,7 @@ def map_intra_h_migration(rxn: 'ARCReaction',
 def check_family_for_mapping_function(rxn: 'ARCReaction',
                                       family: str,
                                       db: Optional['RMGDatabase'] = None,
+                                      verbose: bool = True,
                                       ) -> bool:
     """
     Check that the actual reaction family and the desired reaction family are the same.
@@ -488,6 +489,7 @@ def check_family_for_mapping_function(rxn: 'ARCReaction',
         rxn (ARCReaction): An ARCReaction object instance.
         family (str): The desired reaction family to check for.
         db (RMGDatabase, optional): The RMG database instance.
+        verbose (bool): Whether to print a warning if the reaction does not match the family.
 
     Returns:
         bool: Whether the reaction family and the desired ``family`` are consistent.
@@ -495,6 +497,8 @@ def check_family_for_mapping_function(rxn: 'ARCReaction',
     if rxn.family is None:
         rmgdb.determine_family(reaction=rxn, db=db)
     if rxn.family is None or rxn.family.label != family:
+        if verbose:
+            logger.warning(f'Reaction {rxn} does not belong to family {family}.')
         return False
     return True
 

--- a/arc/species/mapping.py
+++ b/arc/species/mapping.py
@@ -445,10 +445,14 @@ def map_intra_h_migration(rxn: 'ARCReaction',
     map_ = map_two_species(spc_r_dot, spc_p_dot, backend=backend)
 
     new_map = list()
-    for i, entry in enumerate(map_):
-        if i == r_h_index:
-            new_map.append(p_h_index)
-        new_map.append(entry if entry < p_h_index else entry + 1)
+    if r_h_index == len(map_):
+        new_map = map_ + [p_h_index]
+    else:
+        for i, entry in enumerate(map_):
+            if i == r_h_index:
+                new_map.append(p_h_index)
+            new_map.append(entry if entry < p_h_index else entry + 1)
+
     return new_map
 
 

--- a/arc/species/mappingTest.py
+++ b/arc/species/mappingTest.py
@@ -1356,10 +1356,10 @@ class TestMapping(unittest.TestCase):
         new_dihedrals_2 = [calculate_dihedral_angle(coords=spc2.get_xyz(),
                                                     torsion=[atom_map[t] for t in rotor_dict['torsion']])
                            for rotor_dict in spc1.rotors_dict.values()]
-        self.assertAlmostEqual(original_dihedrals_1[2], 67.81049913527622)
-        self.assertAlmostEqual(original_dihedrals_2[2], 174.65228274664804)
-        self.assertAlmostEqual(new_dihedrals_1[2], 121.23139159126627)
-        self.assertAlmostEqual(new_dihedrals_2[2], 121.23139016907017)
+        self.assertAlmostEqual(original_dihedrals_1[2], 67.810499, 4)
+        self.assertAlmostEqual(original_dihedrals_2[2], 174.652282, 4)
+        self.assertAlmostEqual(new_dihedrals_1[2], 121.231392, 4)
+        self.assertAlmostEqual(new_dihedrals_2[2], 121.231390, 4)
 
     def test_get_backbone_dihedral_deviation_score(self):
         """Test the get_backbone_dihedral_deviation_score function."""
@@ -1368,7 +1368,7 @@ class TestMapping(unittest.TestCase):
         fingerprint_1, fingerprint_2 = mapping.fingerprint(self.spc1), mapping.fingerprint(self.spc2)
         backbone_map = mapping.identify_superimposable_candidates(fingerprint_1, fingerprint_2)[0]
         score = mapping.get_backbone_dihedral_deviation_score(spc_1=self.spc1, spc_2=self.spc2, backbone_map=backbone_map)
-        self.assertAlmostEqual(score, 106.8417836)
+        self.assertAlmostEqual(score, 106.8417836, 4)
 
     def test_get_backbone_dihedral_angles(self):
         """Test the get_backbone_dihedral_angles function."""
@@ -1377,8 +1377,8 @@ class TestMapping(unittest.TestCase):
         torsions = mapping.get_backbone_dihedral_angles(self.spc1, self.spc2, backbone_map={0: 0, 3: 1, 5: 3, 6: 4, 4: 2})
         self.assertEqual(torsions[0]['torsion 1'], [0, 3, 5, 6])
         self.assertEqual(torsions[0]['torsion 2'], [0, 1, 3, 4])
-        self.assertAlmostEqual(torsions[0]['angle 1'], 67.81049913527622)
-        self.assertAlmostEqual(torsions[0]['angle 2'], 174.65228274664804)
+        self.assertAlmostEqual(torsions[0]['angle 1'], 67.810499, 4)
+        self.assertAlmostEqual(torsions[0]['angle 2'], 174.652283, 4)
 
     def test_map_lists(self):
         """Test the map_lists function."""

--- a/arc/species/mappingTest.py
+++ b/arc/species/mappingTest.py
@@ -761,6 +761,25 @@ class TestMapping(unittest.TestCase):
         self.assertIn(atom_map[7], [3, 4, 5, 8])
         self.assertIn(atom_map[8], [3, 4, 5, 8])
 
+        # CH2OH <=> CH3O
+        ch2oh_xyz = """C      -0.45684508   -0.05786787   -0.03035793
+                       O       0.82884092   -0.36979664    0.26059161
+                       H      -0.64552049    0.90546331   -0.47022606
+                       H      -1.17752551   -0.82040960    0.21231033
+                       H       0.92128715   -1.25559200    0.65522542"""
+        ch2oh = ARCSpecies(label='reactant', smiles='[CH2]O', xyz=ch2oh_xyz)
+        ch3o_xyz = """C       0.03807240    0.00035621   -0.00484242
+                      O       1.35198769    0.01264937   -0.17195885
+                      H      -0.33965241   -0.14992727    1.02079480
+                      H      -0.51702680    0.90828035   -0.29592912
+                      H      -0.53338088   -0.77135867   -0.54806440"""
+        ch3o = ARCSpecies(label='product', smiles='C[O]', xyz=ch3o_xyz)
+        rxn_1 = ARCReaction(label='reactant <=> product', ts_label='TS1', r_species=[ch2oh], p_species=[ch3o])
+        atom_map_1 = rxn_1.atom_map
+        self.assertEqual(atom_map_1[:2], [0, 1])
+        for index in [2, 3, 4]:
+            self.assertIn(atom_map_1[index], [2, 3, 4])
+
     def test_map_isomerization_reaction(self):
         """Test the map_isomerization_reaction() function."""
         reactant_xyz = """C  -1.3087    0.0068    0.0318
@@ -784,11 +803,11 @@ class TestMapping(unittest.TestCase):
                          H  -1.4329   -0.1554    0.9349"""
         product = ARCSpecies(label='product', smiles='[N-]=[N+]=C(N=O)C', xyz=product_xyz)
         rxn_1 = ARCReaction(label='reactant <=> product', ts_label='TS0', r_species=[reactant], p_species=[product])
-        atom_map = mapping.map_isomerization_reaction(rxn_1)
-        self.assertEqual(atom_map[:6], [0, 1, 2, 3, 4, 5])
-        self.assertIn(atom_map[6], [6, 8])
-        self.assertIn(atom_map[7], [6, 7])
-        self.assertIn(atom_map[8], [7, 8])
+        atom_map_1 = mapping.map_isomerization_reaction(rxn_1)
+        self.assertEqual(atom_map_1[:6], [0, 1, 2, 3, 4, 5])
+        self.assertIn(atom_map_1[6], [6, 8])
+        self.assertIn(atom_map_1[7], [6, 7])
+        self.assertIn(atom_map_1[8], [7, 8])
 
     def test_get_atom_indices_of_labeled_atoms_in_an_rmg_reaction(self):
         """Test the get_atom_indices_of_labeled_atoms_in_an_rmg_reaction() function."""


### PR DESCRIPTION
Previously, if a H atom in an intra-H migration reaction was the last atom in the reactant, it wasn't included in the atom map.
A fix was added along with a test. Additional minor changes were added as well.