### PR TITLE
added save_atom_labels option to ARCSpecies

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -307,6 +307,7 @@ class ARCSpecies(object):
                  run_time: Optional[datetime.timedelta] = None,
                  rxn_label: Optional[str] = None,
                  rxn_index: Optional[int] = None,
+                 save_atom_labels = False,
                  smiles: str = '',
                  species_dict: Optional[dict] = None,
                  ts_methods: Optional[List[str]] = None,
@@ -344,6 +345,7 @@ class ARCSpecies(object):
         self.yml_path = None
         self.fragments = fragments
         self.original_label = None
+        self.save_atom_labels = save_atom_labels
 
         if species_dict is not None:
             # Reading from a dictionary (it's possible that the dict contain only a 'yml_path' argument, check first)
@@ -450,7 +452,7 @@ class ARCSpecies(object):
             # Perceive molecule from xyz coordinates. This also populates the .mol attribute of the Species.
             # It overrides self.mol generated from adjlist or smiles so xyz and mol will have the same atom order.
             if self.final_xyz or self.initial_xyz or self.most_stable_conformer or self.conformers:
-                self.mol_from_xyz(get_cheap=False)
+                self.mol_from_xyz(get_cheap=False,save_atom_labels=self.save_atom_labels)
             if not self.is_ts:
                 # We don't care about BACs in TSs
                 if self.mol is None:
@@ -1379,7 +1381,7 @@ class ARCSpecies(object):
     def mol_from_xyz(self,
                      xyz: dict = None,
                      get_cheap: bool = False,
-                     ) -> None:
+                     save_atom_labels=False) -> None:
         """
         Make sure atom order in self.mol corresponds to xyz.
         Important for TS discovery and for identifying rotor indices.
@@ -1399,9 +1401,14 @@ class ARCSpecies(object):
                 raise SpeciesError(f'The number of atoms in the molecule and in the cartesian coordinates is different.'
                                    f'\nGot:\n{self.mol.copy(deep=True).to_adjacency_list()}\nand:\n{xyz}')
             # self.mol should have come from another source, e.g., SMILES or yml
-            perceived_mol = molecules_from_xyz(xyz=xyz,
-                                               multiplicity=self.multiplicity,
-                                               charge=self.charge)[1]
+            if not save_atom_labels:
+                perceived_mol = molecules_from_xyz(xyz=xyz,
+                                                    multiplicity=self.multiplicity,
+                                                    charge=self.charge)[1]
+            
+            else:
+                perceived_mol = None
+
             if perceived_mol is not None:
                 allow_nonisomorphic_2d = (self.charge is not None and self.charge) \
                                          or self.mol.has_charge() or perceived_mol.has_charge() \
@@ -1806,7 +1813,8 @@ class ARCSpecies(object):
                           multiplicity=mol1.multiplicity,
                           charge=mol1.get_net_charge(),
                           compute_thermo=False,
-                          e0_only=True)
+                          e0_only=True,
+                          save_atom_labels=True)
         spc1.generate_conformers()
         spc1.rotors_dict = None
         spc2 = ARCSpecies(label=label2,
@@ -1815,7 +1823,8 @@ class ARCSpecies(object):
                           multiplicity=mol2.multiplicity,
                           charge=mol2.get_net_charge(),
                           compute_thermo=False,
-                          e0_only=True)
+                          e0_only=True,
+                          save_atom_labels=True)
         spc2.generate_conformers()
         spc2.rotors_dict = None
 

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1381,7 +1381,7 @@ class ARCSpecies(object):
     def mol_from_xyz(self,
                      xyz: dict = None,
                      get_cheap: bool = False,
-                     save_atom_labels=False) -> None:
+                     save_atom_labels: bool =False) -> None:
         """
         Make sure atom order in self.mol corresponds to xyz.
         Important for TS discovery and for identifying rotor indices.

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -1309,6 +1309,7 @@ H       1.11582953    0.94384729   -0.10134685"""
                                                                       charge=spc.charge)[1]))
         self.assertTrue(any(spc.mol.to_smiles() == 'CO[NH]' for spc in spc_list))
 
+
     def test_net_charged_species(self):
         """Test that we can define, process, and manipulate ions"""
         nh4 = ARCSpecies(label='NH4', smiles='[NH4+]', charge=1)
@@ -1725,7 +1726,7 @@ class TestTSGuess(unittest.TestCase):
         mol_graph_1 = MolGraph(symbols=xyz_arb['symbols'], coords=xyz_arb['coords'])
         self.assertEqual(mol_graph_1.get_formula(), 'CH3NO2')
 
-    @work_in_progress
+
     def test_gcn(self):
         """
         Test that ARC can call the GNN to make TS guesses for further optimization.


### PR DESCRIPTION
I added the option to save the labels of the atoms by bypassing the regeneration of the molecule object in percived_mol in mol_from_xyz.