### PR TITLE
Tests: Removed WIP decorator from GCN test

### DIFF
--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -1725,7 +1725,6 @@ class TestTSGuess(unittest.TestCase):
         mol_graph_1 = MolGraph(symbols=xyz_arb['symbols'], coords=xyz_arb['coords'])
         self.assertEqual(mol_graph_1.get_formula(), 'CH3NO2')
 
-    @work_in_progress
     def test_gcn(self):
         """
         Test that ARC can call the GNN to make TS guesses for further optimization.


### PR DESCRIPTION
Now that GCN can again be installed automatically, see https://github.com/ReactionMechanismGenerator/TS-GCN/pull/9