### PR TITLE
Fixed issue 506, cyclic scisson

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1693,7 +1693,8 @@ class ARCSpecies(object):
             indices (tuple): The atom indices between which to cut (1-indexed, atoms must be bonded).
 
         Returns: list
-            The scission-resulting species.
+            The scission-resulting species, a list of either one or two species, if the scissored location is linear,
+            or one if the scission is in a cycle.
         """
         if any([i < 1 for i in indices]):
             raise SpeciesError(f'Scissors indices must be larger than 0 (1-indexed). Got: {indices}.')

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1742,7 +1742,16 @@ class ARCSpecies(object):
             logger.warning(f'Scissors were requested to remove a non-single bond in {self.label}.')
         mol_copy.remove_bond(bond)
         mol_splits = mol_copy.split()
-        if len(mol_splits) == 2:
+        if len(mol_splits) == 1: # If cutting leads to only one split, then the split is cyclic.
+            spc1 = ARCSpecies(label=self.label + '_BDE_' + str(indices[0] + 1) + '_' + str(indices[1] + 1) + '_cyclic',
+                    mol=mol_splits[0],
+                    multiplicity=mol_splits[0].multiplicity,
+                    charge=mol_splits[0].get_net_charge(),
+                    compute_thermo=False,
+                    e0_only=True)
+            spc1.generate_conformers()
+            return [spc1]
+        elif len(mol_splits) == 2:
             mol1, mol2 = mol_splits
         else:
             logger.warning(f'Could not split {self.label} between indices {indices}.')

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -1733,7 +1733,6 @@ class TestTSGuess(unittest.TestCase):
         mol_graph_1 = MolGraph(symbols=xyz_arb['symbols'], coords=xyz_arb['coords'])
         self.assertEqual(mol_graph_1.get_formula(), 'CH3NO2')
 
-    @work_in_progress
     def test_gcn(self):
         """
         Test that ARC can call the GNN to make TS guesses for further optimization.

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -1309,6 +1309,14 @@ H       1.11582953    0.94384729   -0.10134685"""
                                                                       charge=spc.charge)[1]))
         self.assertTrue(any(spc.mol.to_smiles() == 'CO[NH]' for spc in spc_list))
 
+        cycle = ARCSpecies(label="cycle",smiles= "C(1)CC(1)")
+        cycle.bdes = [(1, 2)]
+        cycle.final_xyz = cycle.get_xyz()
+        cycle_scissors = cycle.scissors()
+        cycle_scissors[0].mol.update()
+        self.assertTrue(cycle_scissors[0].mol.is_isomorphic(ARCSpecies(label="check",smiles ="[CH2+]C[CH2+]").mol))
+        self.assertEqual(len(cycle_scissors), 1)
+
     def test_net_charged_species(self):
         """Test that we can define, process, and manipulate ions"""
         nh4 = ARCSpecies(label='NH4', smiles='[NH4+]', charge=1)


### PR DESCRIPTION
Added the option of exiting with one species, if mol_splits has only one item in it, due to scission of a cyclic molecule. In addition, added a test.