### PR TITLE
Improved support for diatomic conformers

### DIFF
--- a/arc/job/adapters/ts/heuristicsTest.py
+++ b/arc/job/adapters/ts/heuristicsTest.py
@@ -1003,6 +1003,42 @@ class TestHeuristicsAdapter(unittest.TestCase):
                                                         (-0.24126731380591912, -1.1854584049033523, 0.25056549328076716),
                                                         (-0.24126731380591912, -2.3138262157211655, -0.9993080355777685))}))
 
+        # HO2 + H2NN(T) <=> O2 + N2H3
+        ho2_xyz = """O 0.0553530 -0.6124600 0.0000000
+                     O 0.0553530 0.7190720 0.0000000
+                     H -0.8856540 -0.8528960 0.0000000"""  # tmp
+        ho2 = ARCSpecies(label='HO2', smiles='O[O]', xyz=ho2_xyz)  # tmp
+        h2nnt = ARCSpecies(label='H2NN(T)', smiles='[N]N', xyz="""N       1.25464159   -0.04494405   -0.06271952
+                                                                  N      -0.11832785   -0.00810069    0.29783210
+                                                                  H      -0.59897890   -0.78596704   -0.15190060
+                                                                  H      -0.53733484    0.83901179   -0.08321197""")
+        o2 = ARCSpecies(label='O2', smiles='[O][O]', xyz="""O	0.0000000	0.0000000	0.6029240
+                                                            O	0.0000000	0.0000000	-0.6029240""")
+        n2h3 = ARCSpecies(label='N2H3', smiles='N[NH]')
+        rxn17 = ARCReaction(r_species=[ho2, h2nnt], p_species=[o2, n2h3])
+        rxn17.determine_family(rmg_database=self.rmgdb)
+        self.assertEqual(rxn17.family.label, 'H_Abstraction')
+        heuristics_16 = HeuristicsAdapter(job_type='tsg',
+                                          reactions=[rxn17],
+                                          testing=True,
+                                          project='test',
+                                          project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'heuristics'),
+                                          dihedral_increment=60,
+                                          )
+        heuristics_16.execute_incore()
+        self.assertEqual(len(rxn17.ts_species.ts_guesses), 6)
+        self.assertTrue(rxn17.ts_species.ts_guesses[0].success)
+        self.assertTrue(almost_equal_coords(rxn17.ts_species.ts_guesses[0].initial_xyz,
+                                            {'symbols': ('O', 'O', 'H', 'N', 'N', 'H', 'H'),
+                                             'isotopes': (16, 16, 1, 14, 14, 1, 1),
+                                             'coords': ((0.013593215731698737, -1.347070871626458, 0.36164270540431365),
+                                                        (0.013593215731698737, -1.347070871626458, -0.9698892962207406),
+                                                        (0.013593215731698737, -0.21786249639185695, 0.6501658548665676),
+                                                        (0.013593215731698737, 0.9780697857982745, 0.9557375776492565),
+                                                        (0.013593215731698737, 1.793420788206805, -0.26034039898121963),
+                                                        (0.0829706072265909, 2.768175658285228, 0.033768621055696224),
+                                                        (-0.9057700201426672, 1.6996105936782921, -0.6927116617671318))}))
+
     def test_keeping_atom_order_in_ts(self):
         """Test that the generated TS has the same atom order as in the reactants"""
         # reactant_reversed, products_reversed = False, False

--- a/arc/reactionTest.py
+++ b/arc/reactionTest.py
@@ -229,8 +229,8 @@ class TestARCReaction(unittest.TestCase):
                                          {'arkane_file': None,
                                           'bond_corrections': {'H-O': 1},
                                           'charge': 0,
-                                          'cheap_conformer': 'O       0.48890387    0.00000000    0.00000000\n'
-                                                             'H      -0.48890387    0.00000000    0.00000000',
+                                          'cheap_conformer': 'O       0.00000000    0.00000000    0.61310000\n'
+                                                             'H       0.00000000    0.00000000   -0.61310000',
                                           'compute_thermo': True,
                                           'consider_all_diastereomers': True,
                                           'force_field': 'MMFF94s',

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -50,7 +50,6 @@ from arc.species.species import (ARCSpecies,
 from arc.species.converter import (check_isomorphism,
                                    compare_confs,
                                    molecules_from_xyz,
-                                   str_to_xyz,
                                    xyz_to_coords_list,
                                    xyz_to_str,
                                    )
@@ -405,19 +404,7 @@ class Scheduler(object):
                     species.initial_xyz = species.conformers[0]
                 if species.label not in self.running_jobs:
                     self.running_jobs[species.label] = list()  # initialize before running the first job
-                if species.number_of_atoms == 1:
-                    logger.debug(f'Species {species.label} is monoatomic')
-                    if not species.initial_xyz:
-                        # generate a simple "Symbol   0.0   0.0   0.0" coords in a dictionary format
-                        if species.mol is not None:
-                            symbol = species.mol.atoms[0].symbol
-                        else:
-                            symbol = species.label
-                            logger.warning(f'Could not determine element of monoatomic species {species.label}. '
-                                           f'Assuming element is {symbol}')
-                        monoatomic_xyz_dict = str_to_xyz(f'{symbol}   0.0   0.0   0.0')
-                        species.initial_xyz = monoatomic_xyz_dict
-                        species.final_xyz = monoatomic_xyz_dict
+                if species.is_monoatomic():
                     if not self.output[species.label]['job_types']['sp'] \
                             and not self.output[species.label]['job_types']['composite'] \
                             and 'sp' not in list(self.job_dict[species.label].keys()) \

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -204,13 +204,19 @@ def generate_conformers(mol_list: Union[List[Molecule], Molecule],
                                  f'got {type(mol)}')
     mol_list = [update_mol(mol) for mol in mol_list]
 
-    # a quick bypass for mono-atomic species:
+    # A quick bypass for monoatomic and diatomic species:
+    confs = None
     if len(mol_list[0].atoms) == 1:
         confs = [generate_monoatomic_conformer(symbol=mol_list[0].atoms[0].element.symbol)]
-        if not return_all_conformers:
-            return confs
-        else:
+    elif len(mol_list[0].atoms) == 2:
+        confs = [generate_diatomic_conformer(symbol_1=mol_list[0].atoms[0].element.symbol,
+                                             symbol_2=mol_list[0].atoms[1].element.symbol,
+                                             multiplicity=multiplicity,
+                                             )]
+    if confs is not None:
+        if return_all_conformers:
             return confs, confs
+        return confs
 
     if xyzs is not None and any([not isinstance(xyz, dict) for xyz in xyzs]):
         raise TypeError(f"xyz entries of xyzs must be dictionaries, e.g.:\n\n"

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -54,9 +54,10 @@ from rmgpy.molecule.converter import to_ob_mol
 from rmgpy.molecule.molecule import Atom, Bond, Molecule
 from rmgpy.molecule.element import C as C_ELEMENT, H as H_ELEMENT, F as F_ELEMENT, Cl as Cl_ELEMENT, I as I_ELEMENT
 
-from arc.common import (logger,
-                        convert_list_index_0_to_1,
+from arc.common import (convert_list_index_0_to_1,
                         determine_top_group_indices,
+                        get_single_bond_length,
+                        logger,
                         )
 from arc.exceptions import ConformerError, InputError
 import arc.plotter
@@ -1680,7 +1681,7 @@ def update_mol(mol):
     return mol
 
 
-def generate_monoatomic_conformer(symbol):
+def generate_monoatomic_conformer(symbol: str) -> dict:
     """
     Generate a conformer for a monoatomic species.
 
@@ -1697,6 +1698,78 @@ def generate_monoatomic_conformer(symbol):
             'FF energy': 0.0,
             'chirality': None,
             'source': 'monoatomic species',
+            'torsion_dihedrals': None,
+            }
+    return conf
+
+
+def generate_diatomic_conformer(symbol_1: str,
+                                symbol_2: str,
+                                multiplicity: Optional[int] = None,
+                                ) -> dict:
+    """
+    Generate a conformer for a diatomic species.
+    Data from CCCBDB.
+
+    Args:
+        symbol_1 (str): The atomic symbol of atom 1.
+        symbol_2 (str): The atomic symbol of atom 2.
+        multiplicity (int, optional): The diatomic species multiplicity
+
+    Returns:
+        dict: The diatomic conformer.
+    """
+    r = None
+    if multiplicity is not None:
+        if symbol_1 == symbol_2:
+            if symbol_1 == 'H' and multiplicity == 1:
+                r = 0.3710
+            if symbol_1 == 'O' and multiplicity == 3:
+                r = 0.6029
+            elif symbol_1 == 'O' and multiplicity == 1:
+                r = 0.6088
+            elif symbol_1 == 'S' and multiplicity == 3:
+                r = 0.9492
+            elif symbol_1 == 'S' and multiplicity == 1:
+                r = 0.9655
+            elif symbol_1 == 'N' and multiplicity == 1:
+                r = 0.5491
+            elif symbol_1 == 'N' and multiplicity == 3:
+                r = 0.6059
+        else:
+            symbols = [symbol_1, symbol_2]
+            if 'O' in symbols and 'H' in symbols and multiplicity == 2:
+                r = 0.6131
+            elif 'N' in symbols and 'H' in symbols and multiplicity == 3:
+                r = 0.5197
+            elif 'N' in symbols and 'H' in symbols and multiplicity == 1:
+                r = 0.5165
+            elif 'C' in symbols and 'O' in symbols and multiplicity == 1:
+                r = 0.5647
+            elif 'C' in symbols and 'S' in symbols and multiplicity == 1:
+                r = 0.7752
+            elif 'C' in symbols and 'H' in symbols and multiplicity == 2:
+                r = 0.5585
+            elif 'C' in symbols and 'H' in symbols and multiplicity == 4:
+                r = 0.5456
+            elif 'N' in symbols and 'O' in symbols and multiplicity == 2:
+                r = 0.5740
+            elif 'S' in symbols and 'O' in symbols and multiplicity == 3:
+                r = 0.7414
+            elif 'S' in symbols and 'O' in symbols and multiplicity == 1:
+                r = 0.7498
+            elif 'S' in symbols and 'H' in symbols and multiplicity == 1:
+                r = 0.6690
+    if r is None:
+        r = get_single_bond_length(symbol_1, symbol_2) * 0.5
+    conf = {'xyz': {'symbols': (symbol_1, symbol_2),
+                    'isotopes': (converter.get_most_common_isotope_for_element(symbol_1),
+                                 converter.get_most_common_isotope_for_element(symbol_2)),
+                    'coords': ((0.0, 0.0, r), (0.0, 0.0, -1 * r))},
+            'index': 0,
+            'FF energy': 0.0,
+            'chirality': None,
+            'source': 'diatomic species',
             'torsion_dihedrals': None,
             }
     return conf

--- a/arc/species/conformersTest.py
+++ b/arc/species/conformersTest.py
@@ -2447,6 +2447,62 @@ Cl      2.38846685    0.24054066    0.55443324
                          'source': 'monoatomic species', 'torsion_dihedrals': None}
         self.assertEqual(conf, expected_conf)
 
+    def test_generate_diatomic_conformer(self):
+        """Test generating a diatomic conformer"""
+        conf = conformers.generate_diatomic_conformer('O', 'O')
+        expected_conf = {'xyz': {'symbols': ('O', 'O'), 'isotopes': (16, 16),
+                                 'coords': ((0.0, 0.0, 0.74), (0.0, 0.0, -0.74))},
+                         'index': 0, 'FF energy': 0.0, 'chirality': None,
+                         'source': 'diatomic species', 'torsion_dihedrals': None}
+        self.assertEqual(conf, expected_conf)
+
+        conf = conformers.generate_diatomic_conformer('O', 'O', multiplicity=3)
+        expected_conf = {'xyz': {'symbols': ('O', 'O'), 'isotopes': (16, 16),
+                                 'coords': ((0.0, 0.0, 0.6029), (0.0, 0.0, -0.6029))},
+                         'index': 0, 'FF energy': 0.0, 'chirality': None,
+                         'source': 'diatomic species', 'torsion_dihedrals': None}
+        self.assertEqual(conf, expected_conf)
+
+        conf = conformers.generate_diatomic_conformer('O', 'O', multiplicity=1)
+        expected_coords = ((0.0, 0.0, 0.6088), (0.0, 0.0, -0.6088))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('N', 'N', multiplicity=1)
+        expected_coords = ((0.0, 0.0, 0.5491), (0.0, 0.0, -0.5491))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('C', 'O', multiplicity=1)
+        expected_coords = ((0.0, 0.0, 0.5647), (0.0, 0.0, -0.5647))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('O', 'C', multiplicity=1)
+        expected_coords = ((0.0, 0.0, 0.5647), (0.0, 0.0, -0.5647))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('O', 'S', multiplicity=1)
+        expected_coords = ((0.0, 0.0, 0.7498), (0.0, 0.0, -0.7498))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('O', 'S', multiplicity=3)
+        expected_coords = ((0.0, 0.0, 0.7414), (0.0, 0.0, -0.7414))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('O', 'N', multiplicity=2)
+        expected_coords = ((0.0, 0.0, 0.5740), (0.0, 0.0, -0.5740))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('N', 'S', multiplicity=2)
+        expected_coords = ((0.0, 0.0, 1.25), (0.0, 0.0, -1.25))
+        self.assertEqual(conf['xyz']['coords'], expected_coords)
+
+        conf = conformers.generate_diatomic_conformer('O', 'H', multiplicity=2)
+        expected_xyz = {'symbols': ('O', 'H'), 'isotopes': (16, 1), 'coords': ((0.0, 0.0, 0.6131), (0.0, 0.0, -0.6131))}
+        self.assertEqual(conf['xyz'], expected_xyz)
+
+        conf = conformers.generate_diatomic_conformer('H', 'O', multiplicity=2)
+        expected_xyz = {'symbols': ('H', 'O'), 'isotopes': (1, 16), 'coords': ((0.0, 0.0, 0.6131), (0.0, 0.0, -0.6131))}
+        self.assertEqual(conf['xyz'], expected_xyz)
+
     def test_determine_smallest_atom_index_in_scan(self):
         """Test determine_smallest_atom_index_in_scan()"""
         xyz_0 = """O                  2.26520400   -1.90260200   -2.47777200

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -929,6 +929,20 @@ class ARCSpecies(object):
             return len(xyz['symbols']) == 1
         return None
 
+    def is_diatomic(self) -> Optional[bool]:
+        """
+        Determine whether the species is diatomic.
+
+        Returns:
+            Optional[bool]: Whether the species is diatomic.
+        """
+        if self.mol is not None and len(self.mol.atoms):
+            return len(self.mol.atoms) == 2
+        xyz = self.get_xyz()
+        if xyz is not None:
+            return len(xyz['symbols']) == 2
+        return None
+
     def is_isomorphic(self, other: Union['ARCSpecies', Species, Molecule]) -> Optional[bool]:
         """
         Determine whether the species is isomorphic with ``other``.

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1403,7 +1403,7 @@ class ARCSpecies(object):
                               f'optimization: {self.chosen_ts_method}\n'
 
     def mol_from_xyz(self,
-                     xyz: dict = None,
+                     xyz: Optional[dict] = None,
                      get_cheap: bool = False,
                      ) -> None:
         """
@@ -1418,7 +1418,14 @@ class ARCSpecies(object):
             get_cheap (bool, optional): Whether to generate conformers if the species has no xyz data.
         """
         if xyz is None:
-            xyz = self.get_xyz(generate=get_cheap)
+            xyz = self.get_xyz(generate=get_cheap, return_format='dict')
+        if xyz is None:
+            return None
+
+        if len(xyz['symbols']) == 2 and xyz['symbols'][0] == xyz['symbols'][1] \
+                and xyz['symbols'][0] in ['O', 'S'] and self.multiplicity == 3:
+            # Hard-coded for triplet O2 and S2: Don't perceive mol.
+            return None
 
         if self.mol is not None:
             if len(self.mol.atoms) != len(xyz['symbols']):

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -2379,11 +2379,11 @@ def check_label(label: str,
                 verbose: bool = False,
                 ) -> Tuple[str, Optional[str]]:
     """
-    Check whether a species (or reaction) label is illegal, modify it if needed.
+    Check whether a species (or reaction) label is legal, modify it if needed.
 
     Args:
         label (str): A label.
-        is_ts (bool, optional): Whether the species label belongs to a TS.
+        is_ts (bool, optional): Whether the species label belongs to a transition state.
         verbose (bool, optional): Whether to log errors.
 
     Raises:

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -2366,6 +2366,29 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         self.assertTrue(colliding_atoms(str_to_xyz(xyz_3)))
         self.assertTrue(colliding_atoms(str_to_xyz(xyz_4)))
 
+    def test_correct_representation_of_o2_and_s2(self):
+        """Test that ARC represents O2 and S2 correctly."""
+        o2 = ARCSpecies(label='O2', smiles='[O][O]', xyz="""O   0.0000000   0.0000000   0.6029240
+                                                            O   0.0000000   0.0000000  -0.6029240""")
+        for mol in o2.mol_list:
+            print(f'mol lost')
+            print(mol.to_smiles())
+        self.assertEqual(o2.multiplicity, 3)
+        self.assertEqual(o2.mol.to_smiles(), '[O][O]')
+        self.assertEqual(o2.mol.to_adjacency_list(), """multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+""")
+
+        s2 = ARCSpecies(label='S2', smiles='[S][S]', xyz="""S   0.0000000   0.0000000   0.9496880
+                                                            S   0.0000000   0.0000000  -0.9496880""")
+        self.assertEqual(s2.multiplicity, 3)
+        self.assertEqual(s2.mol.to_smiles(), '[S][S]')
+        self.assertEqual(s2.mol.to_adjacency_list(), """multiplicity 3
+1 S u1 p2 c0 {2,S}
+2 S u1 p2 c0 {1,S}
+""")
+
     @classmethod
     def tearDownClass(cls):
         """

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -60,7 +60,7 @@ class TestARCSpecies(unittest.TestCase):
 
         # Method 2: ARCSpecies object by XYZ (also give SMILES for thermo BAC)
         oh_xyz = """O       0.00000000    0.00000000   -0.12002167
-        H       0.00000000    0.00000000    0.85098324"""
+                    H       0.00000000    0.00000000    0.85098324"""
         cls.spc2 = ARCSpecies(label='OH', xyz=oh_xyz, smiles='[OH]', multiplicity=2, charge=0)
 
         # Method 3: ARCSpecies object by SMILES
@@ -190,6 +190,17 @@ class TestARCSpecies(unittest.TestCase):
         self.assertFalse(self.spc3.is_monoatomic())
         n_rad = ARCSpecies(label='N', smiles='[N]')
         self.assertTrue(n_rad.is_monoatomic())
+
+    def test_is_diatomic(self):
+        """Test the is_diatomic() method."""
+        self.assertFalse(self.spc1.is_diatomic())
+        self.assertTrue(self.spc2.is_diatomic())
+        self.assertFalse(self.spc3.is_diatomic())
+        self.assertFalse(self.spc4.is_diatomic())
+        n_rad = ARCSpecies(label='N', smiles='[N]')
+        self.assertFalse(n_rad.is_diatomic())
+        n2 = ARCSpecies(label='N2', smiles='N#N')
+        self.assertTrue(n2.is_diatomic())
 
     def test_is_isomorphic(self):
         """Test the is_isomorphic() method."""


### PR DESCRIPTION
RDKit cannot generate conformers for triplet O2. Plus, ARC has a problem perceiving a Molecule representation for O2. This PR solves both issues, and adds capabilities to cheaply generate reasonable xyz guesses for any diatomic species. Tests were added.
