### PR TITLE
Add the scf=xqc keyword to a Gaussian input file only if allowed

### DIFF
--- a/arc/job/adapters/gaussian.py
+++ b/arc/job/adapters/gaussian.py
@@ -297,8 +297,8 @@ class GaussianAdapter(JobAdapter):
 
         if self.level.method[:2] == 'ro':
             self.add_to_args(val='use=L506')
-        else:
-            # xqc will do qc (quadratic convergence) if the job fails w/o it, so use by default
+        elif 'no_xqc' not in self.args['trsh']:
+            # xqc will do qc (quadratic convergence) if the job fails w/o it, so use it by default.
             self.add_to_args(val='scf=xqc')
 
         if self.level.method == 'cbs-qb3-paraskevas':

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -105,7 +105,10 @@ def determine_ess_status(output_path: str,
                         keywords = ['GL401']
                     elif 'l502.exe' in line:
                         keywords = ['SCF', 'GL502']
-                        error = 'Unconverged SCF.'
+                        error = 'Unconverged SCF'
+                    elif 'l508.exe' in line:
+                        keywords = ['no_xqc', 'GL508']
+                        error = 'Unconverged'
                     elif 'l716.exe' in line:
                         keywords = ['ZMat', 'GL716']
                         error = 'Angle in z-matrix outside the allowed range 0 < x < 180.'


### PR DESCRIPTION
Don't use this keyword if 'no_xqc' was passed in args['trsh']