### PR TITLE
Refactored generate_resonance_structures()

### DIFF
--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 from rmgpy.molecule.molecule import Molecule
+from rmgpy.species import Species
 
 import arc.common as common
 from arc.exceptions import InputError, SettingsError
@@ -1072,6 +1073,21 @@ class TestCommon(unittest.TestCase):
         representation = common.rmg_mol_to_dict_repr(mol)
         new_mol = common.rmg_mol_from_dict_repr(representation, is_ts=False)
         self.assertEqual(new_mol.to_smiles(), 'CC')
+
+    def test_generate_resonance_structures(self):
+        """Test the generate_resonance_structures() function."""
+        mol = Molecule(smiles='[N-]=[N+]=O')
+        mol_list = common.generate_resonance_structures(mol)
+        self.assertEqual(len(mol_list), 2)
+        self.assertIsInstance(mol_list[0], Molecule)
+        self.assertIsInstance(mol_list[1], Molecule)
+
+        spc = Species(smiles='[N-]=[N+]=O')
+        result = common.generate_resonance_structures(spc)
+        self.assertIsNone(result)
+        self.assertEqual(len(spc.molecule), 2)
+        self.assertIsInstance(spc.molecule[0], Molecule)
+        self.assertIsInstance(spc.molecule[1], Molecule)
 
     def test_calc_rmsd(self):
         """Test compute the root-mean-square deviation between two matrices."""

--- a/arc/rmgdb.py
+++ b/arc/rmgdb.py
@@ -11,7 +11,7 @@ from rmgpy.data.rmg import RMGDatabase
 from rmgpy.exceptions import KineticsError
 from rmgpy.reaction import same_species_lists, Reaction
 
-from arc.common import get_logger
+from arc.common import get_logger, generate_resonance_structures
 from arc.exceptions import InputError
 
 if TYPE_CHECKING:
@@ -201,7 +201,7 @@ def determine_reaction_family(rmgdb: RMGDatabase,
         - Whether the family is its own reverse. ``True`` if it is.
     """
     for rmg_spc in reaction.reactants + reaction.products:
-        rmg_spc.generate_resonance_structures(keep_isomorphic=False, filter_structures=True, save_order=True)
+        generate_resonance_structures(rmg_spc)
     fam_list = loop_families(rmgdb=rmgdb, reaction=reaction)
     families = [fam_l[0] for fam_l in fam_list]
     if len(set(families)) == 1:
@@ -229,7 +229,7 @@ def loop_families(rmgdb: RMGDatabase,
     """
     reaction = reaction.copy()  # Use a copy to avoid changing atom order in the molecules by RMG.
     for spc in reaction.reactants + reaction.products:
-        spc.generate_resonance_structures(save_order=True)
+        generate_resonance_structures(spc)
     fam_list = list()
     for family in rmgdb.kinetics.families.values():
         family.save_order = True

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -21,7 +21,13 @@ from rmgpy.quantity import ArrayQuantity
 from rmgpy.species import Species
 from rmgpy.statmech import Conformer
 
-from arc.common import almost_equal_lists, calc_rmsd, get_atom_radius, get_logger, is_str_float
+from arc.common import (almost_equal_lists,
+                        calc_rmsd,
+                        get_atom_radius,
+                        get_logger,
+                        generate_resonance_structures,
+                        is_str_float,
+                        )
 from arc.exceptions import ConverterError, InputError, SanitizationError, SpeciesError
 from arc.species.xyz_to_2d import MolGraph
 from arc.species.xyz_to_smiles import xyz_to_smiles
@@ -1449,7 +1455,7 @@ def set_radicals_by_map(mol, radical_map):
         atom.radical_electrons = radical_map.atoms[i].radical_electrons
 
 
-def order_atoms_in_mol_list(ref_mol, mol_list):
+def order_atoms_in_mol_list(ref_mol, mol_list) -> bool:
     """
     Order the atoms in all molecules of ``mol_list`` by the atom order in ``ref_mol``.
 
@@ -1457,12 +1463,11 @@ def order_atoms_in_mol_list(ref_mol, mol_list):
         ref_mol (Molecule): The reference Molecule object.
         mol_list (list): Entries are Molecule objects whose atoms will be reordered according to the reference.
 
+    Raises:
+        TypeError: If ``ref_mol`` or the entries in ``mol_list`` have a wrong type.
+
     Returns:
         bool: Whether the reordering was successful, ``True`` if it was.
-
-    Raises:
-        SanitizationError: If atoms could not be re-ordered.
-        TypeError: If ``ref_mol`` or the entries in ``mol_list`` have a wrong type.
     """
     if not isinstance(ref_mol, Molecule):
         raise TypeError(f'expected mol to be a Molecule instance, got {ref_mol} which is a {type(ref_mol)}.')
@@ -1753,20 +1758,8 @@ def check_isomorphism(mol1, mol2, filter_structures=True, convert_to_single_bond
     spc2 = Species(molecule=[mol2_copy])
 
     if not convert_to_single_bonds:
-        try:
-            spc1.generate_resonance_structures(keep_isomorphic=False,
-                                               filter_structures=filter_structures,
-                                               save_order=True,
-                                               )
-        except (AtomTypeError, ValueError):
-            pass
-        try:
-            spc2.generate_resonance_structures(keep_isomorphic=False,
-                                               filter_structures=filter_structures,
-                                               save_order=True,
-                                               )
-        except (AtomTypeError, ValueError):
-            pass
+        generate_resonance_structures(spc1, filter_structures=filter_structures)
+        generate_resonance_structures(spc2, filter_structures=filter_structures)
 
     for molecule1 in spc1.molecule:
         for molecule2 in spc2.molecule:

--- a/arc/species/mapping.py
+++ b/arc/species/mapping.py
@@ -21,7 +21,7 @@ from rmgpy.molecule import Molecule
 from rmgpy.species import Species
 
 import arc.rmgdb as rmgdb
-from arc.common import convert_list_index_0_to_1, extremum_list, logger
+from arc.common import convert_list_index_0_to_1, extremum_list, generate_resonance_structures, logger
 from arc.exceptions import SpeciesError
 from arc.species import ARCSpecies
 from arc.species.conformers import determine_chirality
@@ -522,8 +522,8 @@ def get_atom_indices_of_labeled_atoms_in_an_rmg_reaction(arc_reaction: 'ARCReact
     if not hasattr(rmg_reaction, 'labeled_atoms') or not rmg_reaction.labeled_atoms:
         return None, None
 
-    for mol in rmg_reaction.reactants + rmg_reaction.products:
-        mol.generate_resonance_structures(save_order=True)
+    for spc in rmg_reaction.reactants + rmg_reaction.products:
+        generate_resonance_structures(spc)
 
     r_map, p_map = map_arc_rmg_species(arc_reaction=arc_reaction, rmg_reaction=rmg_reaction)
 
@@ -584,9 +584,9 @@ def map_arc_rmg_species(arc_reaction: 'ARCReaction',
                 if not isinstance(rmg_spc, Species):
                     raise ValueError(f'Expected an RMG object instances of Molecule or Species, '
                                      f'got {rmg_obj} which is a {type(rmg_obj)}.')
-                rmg_spc.generate_resonance_structures(save_order=True)
+                generate_resonance_structures(rmg_spc)
                 rmg_spc_based_on_arc_spc = Species(molecule=arc_spc.mol_list)
-                rmg_spc_based_on_arc_spc.generate_resonance_structures(save_order=True)
+                generate_resonance_structures(rmg_spc_based_on_arc_spc)
                 if rmg_spc.is_isomorphic(rmg_spc_based_on_arc_spc, save_order=True):
                     if i in spc_map.keys() and concatenate:
                         spc_map[i].append(j)

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import rmgpy.molecule.element as elements
 from arkane.common import ArkaneSpecies, symbol_by_number
 from arkane.statmech import is_linear
-from rmgpy.exceptions import AtomTypeError, ILPSolutionError, InvalidAdjacencyListError, ResonanceError
+from rmgpy.exceptions import AtomTypeError, InvalidAdjacencyListError
 from rmgpy.molecule.molecule import Atom, Molecule
 from rmgpy.molecule.resonance import generate_kekule_structure
 from rmgpy.reaction import Reaction
@@ -24,6 +24,7 @@ from arc.common import (convert_list_index_0_to_1,
                         determine_top_group_indices,
                         get_logger,
                         get_single_bond_length,
+                        generate_resonance_structures,
                         rmg_mol_from_dict_repr,
                         rmg_mol_to_dict_repr,
                         timedelta_from_str,
@@ -901,13 +902,8 @@ class ARCSpecies(object):
             if not self.is_ts:
                 mol_copy = self.mol.copy(deep=True)
                 mol_copy.reactive = True
-                try:
-                    self.mol_list = mol_copy.generate_resonance_structures(keep_isomorphic=False,
-                                                                           filter_structures=True,
-                                                                           save_order=True,
-                                                                           )
-                except (AtomTypeError, ValueError, ILPSolutionError, ResonanceError) as e:
-                    logger.warning(f'Could not generate resonance structures for species {self.label}. Got: {e}')
+                self.mol_list = generate_resonance_structures(mol_copy)
+                if self.mol_list is None:
                     self.mol_list = [self.mol]
             else:
                 self.mol_list = [self.mol]


### PR DESCRIPTION
There are 5 exceptions to be caught when calling generate_resonance_structures() for RMG Species or Molecules. Instead of catching them all around ARC with try-except blocks (also the current behavior was inconsistent), we now added a single wrapper function to be used all around ARC. A test was added, and the original behavior was preserved.