### PR TITLE
Store xyz in job adapter as_dict() as a string, not as a numpy array

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -36,6 +36,7 @@ from arc.job.local import (change_mode,
 from arc.job.trsh import trsh_job_on_server
 from arc.job.ssh import SSHClient
 from arc.job.trsh import determine_ess_status
+from arc.species.converter import xyz_to_str
 from arc.species.vectors import calculate_dihedral_angle
 
 if TYPE_CHECKING:
@@ -822,7 +823,7 @@ class JobAdapter(ABC):
         if self.tsg:
             job_dict['tsg'] = self.tsg
         if self.xyz:
-            job_dict['xyz'] = self.xyz
+            job_dict['xyz'] = xyz_to_str(self.xyz)
         return job_dict
 
     def format_max_job_time(self, time_format: str) -> str:


### PR DESCRIPTION
`job_dict` is used to "dump" the description of an ARC job in a YAML file, usually to create the restart file. Since YAML doesn't work well with numpy arrays, the xyz must be converted into a string format first. This is the case throughout ARC, but this line seems to be an exception and this PR fixes that.