### PR TITLE
zmat map_index_to_int

### DIFF
--- a/arc/species/zmat.py
+++ b/arc/species/zmat.py
@@ -2036,6 +2036,22 @@ def remove_1st_atom(zmat: dict) -> dict:
                            up_param(coords[2], increment=-1) if i >= 4 else None))
     new_coords = tuple(new_coords)
     new_vars = {up_param(key, increment=-1): val for key, val in zmat['vars'].items() if key not in removed_vars}
-    val_0 = zmat['map'][0]
-    new_map = {key - 1: val - 1 if val > val_0 else val for key, val in zmat['map'].items() if key != 0}
+    val_0 = map_index_to_int(zmat['map'][0])
+    new_map = {key - 1: map_index_to_int(val) - 1 if map_index_to_int(val) > val_0 else val for key, val in zmat['map'].items() if key != 0}
     return {'symbols': new_symbols, 'coords': new_coords, 'vars': new_vars, 'map': new_map}
+
+
+def map_index_to_int(index: Union[int, str]) -> int:
+    """
+    Convert a zmat map value, e.g., 1 or 'X15', into an int, e.g., 1 or 15.
+
+    Args:
+        index (Union[int, str]): The map index.
+
+    Returns: int
+    """
+    if isinstance(index, int):
+        return index
+    if isinstance(index, str) and all(char.isdigit() for char in index[1:]):
+        return int(index[1:])
+    raise TypeError(f'Expected either an int or a string on the format "X15", got {index}')

--- a/arc/species/zmatTest.py
+++ b/arc/species/zmatTest.py
@@ -1658,6 +1658,14 @@ class TestZMat(unittest.TestCase):
             for coord1, coord2 in zip(coords1, coords2):
                 self.assertAlmostEqual(coord1, coord2)
 
+    def test_map_index_to_int(self):
+        """Test the map_index_to_int() function."""
+        self.assertEqual(zmat.map_index_to_int(9), 9)
+        self.assertEqual(zmat.map_index_to_int('X2'), 2)
+        self.assertIsInstance(zmat.map_index_to_int('X13'), int)
+        self.assertEqual(zmat.map_index_to_int('X5486'), 5486)
+        with self.assertRaises(TypeError):
+            zmat.map_index_to_int('XY5486')
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
The `remove_1st_atom()` function in zmat assumes that an index of the zmat mat is an integer, where in fact it could also be a string representing a dummy atom (e.g., `X7`). Here we add a function that returns the index in the corresponding integer form.
A test was added.