### PR TITLE
Process BDEs for cyclic structures

### DIFF
--- a/arc/processor.py
+++ b/arc/processor.py
@@ -338,20 +338,24 @@ def process_bdes(label: str,
                      f'for this species.')
         return bde_report
     for bde_indices in source.bdes:
-        found_a_label = False
+        found_a_label, cyclic = False, False
         # Index 0 of the tuple:
         if source.mol.atoms[bde_indices[0] - 1].is_hydrogen():
             e1 = species_dict['H'].e0
         else:
             bde_label = f'{label}_BDE_{bde_indices[0]}_{bde_indices[1]}_A'
-            if bde_label not in species_dict.keys():
+            bde_cyclic_label = f'{label}_BDE_{bde_indices[0]}_{bde_indices[1]}_cyclic'
+            cyclic = bde_cyclic_label in species_dict.keys()
+            if not cyclic and bde_label not in species_dict.keys():
                 logger.error(f'Could not find BDE species {bde_label} for generating a BDE report for {label}. '
                              f'Not generating a BDE report for this species.')
                 return dict()
             found_a_label = True
-            e1 = species_dict[bde_label].e0
+            e1 = species_dict[bde_cyclic_label if cyclic else bde_label].e0
         # Index 1 of the tuple:
-        if source.mol.atoms[bde_indices[1] - 1].is_hydrogen():
+        if cyclic:
+            e2 = 0
+        elif source.mol.atoms[bde_indices[1] - 1].is_hydrogen():
             e2 = species_dict['H'].e0
         else:
             letter = 'B' if found_a_label else 'A'

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1778,7 +1778,8 @@ class ARCSpecies(object):
             atom.label = str(index)
 
     def scissors(self,
-                sort_atom_labels: bool = False) -> list:
+                 sort_atom_labels: bool = False,
+                 ) -> list:
         """
         Cut chemical bonds to create new species from the original one according to the .bdes attribute,
         preserving the 3D geometry other than the scissioned bond.

--- a/arc/species/speciesTest.py
+++ b/arc/species/speciesTest.py
@@ -2061,6 +2061,38 @@ H       1.11582953    0.94384729   -0.10134685"""
                     if atom.radical_electrons:
                         self.assertEqual(i, 6)
 
+        dioxane = ARCSpecies(label="1_4_dioxane",
+                             smiles="O1CCOCC1",
+                             bdes=['all_h', (1, 2), (2, 3)],
+                             xyz="""C       0.76422800    1.11776800    0.30323800
+                                    C       1.35370300   -0.27043400    0.14047400
+                                    O       0.40406000   -1.25943500    0.47642000
+                                    C      -0.76422800   -1.11776800   -0.30323800
+                                    C      -1.35370300    0.27043300   -0.14047400
+                                    O      -0.40406000    1.25943500   -0.47642000
+                                    H       1.46830100    1.87912700   -0.03427600
+                                    H       0.53133100    1.29562500    1.36278900
+                                    H       1.68661400   -0.40822800   -0.89814000
+                                    H       2.20781000   -0.40849000    0.80435700
+                                    H      -1.46830100   -1.87912700    0.03427600
+                                    H      -0.53133100   -1.29562500   -1.36278900
+                                    H      -2.20781000    0.40849000   -0.80435700
+                                    H      -1.68661400    0.40822800    0.89814000""")
+        dioxane.final_xyz = dioxane.get_xyz()
+        species = dioxane.scissors()
+        self.assertEqual(sorted([spc.label for spc in species]),
+                         ['1_4_dioxane_BDE_1_2_cyclic',
+                          '1_4_dioxane_BDE_1_7_A',
+                          '1_4_dioxane_BDE_1_8_A',
+                          '1_4_dioxane_BDE_2_10_A',
+                          '1_4_dioxane_BDE_2_3_cyclic',
+                          '1_4_dioxane_BDE_2_9_A',
+                          '1_4_dioxane_BDE_4_11_A',
+                          '1_4_dioxane_BDE_4_12_A',
+                          '1_4_dioxane_BDE_5_13_A',
+                          '1_4_dioxane_BDE_5_14_A',
+                          'H'])
+
     def test_net_charged_species(self):
         """Test that we can define, process, and manipulate ions"""
         nh4 = ARCSpecies(label='NH4', smiles='[NH4+]', charge=1)


### PR DESCRIPTION
The `scissors()` function performs well for cyclic species, but the BDEs processor was not set up properly.
Here we fix that.
Also added a test for `scissors()` for a cyclic species