### PR TITLE
Troubleshoot Molpro memory

### DIFF
--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -360,9 +360,14 @@ def determine_ess_status(output_path: str,
                     # e.g.: `insufficient memory available - require              228765625  have
                     #        62928590
                     #        the request was for real words`
-                    # add_mem = (float(line.split()[-2]) - float(prev_line.split()[0])) / 1e6
                     keywords = ['Memory']
                     error = f'Additional memory required: {float(line.split()[-2]) / 1e6} MW'
+                    break
+                elif 'Insufficient memory to allocate' in line or 'The problem occurs in memory' in line:
+                    # e.g.: `Insufficient memory to allocate a new array of length 321843600 8-byte words
+                    #        The problem occurs in memory`
+                    keywords = ['Memory']
+                    error = f'Additional memory required'
                     break
                 elif 'Basis library exhausted' in line:
                     # e.g.:

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -989,9 +989,14 @@ def trsh_ess_job(label: str,
             # job_status standardizes the format to be:  `'Additional memory required: {0} MW'`
             # The number is the ADDITIONAL memory required in GB
             ess_trsh_methods.append('memory')
-            add_mem = float(job_status['error'].split()[-2])  # parse Molpro's requirement in MW
-            add_mem = int(np.ceil(add_mem / 100.0)) * 100  # round up to the next hundred
-            memory = memory_gb + add_mem / 128. + 5  # convert MW to GB, add 5 extra GB (be conservative)
+            add_mem_str = job_status['error'].split()[-2]  # parse Molpro's requirement in MW
+            if all(c.isdigit() or c == '.' for c in add_mem_str):
+                add_mem = float(add_mem_str)
+                add_mem = int(np.ceil(add_mem / 100.0)) * 100  # round up to the next hundred
+                memory = memory_gb + add_mem / 128. + 5  # convert MW to GB, add 5 extra GB (be conservative)
+            else:
+                # The required memory is not specified
+                memory = memory_gb * 3  # convert MW to GB, add 5 extra GB (be conservative)
             logger.info(f'Troubleshooting {job_type} job in {software} for {label} using memory: {memory:.2f} GB '
                         f'instead of {memory_gb} GB')
         elif 'shift' not in ess_trsh_methods:

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -346,6 +346,16 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('memory', ess_trsh_methods)
         self.assertAlmostEqual(memory, 222.15625)
 
+        path = os.path.join(self.base_path['molpro'], 'insufficient_memory_2.out')
+        status, keywords, error, line = trsh.determine_ess_status(output_path=path, species_label='TS', job_type='sp')
+        job_status = {'keywords': keywords, 'error': error}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        self.assertIn('memory', ess_trsh_methods)
+        self.assertEqual(memory, 96.0)
+
         # test orca
         # orca: test 1
         # Test troubleshooting insufficient memory issue

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -261,7 +261,7 @@ class TestTrsh(unittest.TestCase):
     def test_trsh_ess_job(self):
         """Test the trsh_ess_job() function"""
 
-        # test gaussian
+        # Test Gaussian
         label = 'ethanol'
         level_of_theory = {'method': 'ccsd', 'basis': 'vdz'}
         server = 'server1'
@@ -273,7 +273,7 @@ class TestTrsh(unittest.TestCase):
         ess_trsh_methods = ['change_node', 'int=(Acc2E=14)']
         cpu_cores = 8
 
-        # gaussian: test 1
+        # Gaussian: test 1
         job_status = {'keywords': ['CheckFile']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -285,7 +285,7 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(memory, 16)
         self.assertFalse(couldnt_trsh)
 
-        # gaussian: test 2
+        # Gaussian: test 2
         job_status = {'keywords': ['InternalCoordinateError']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -295,7 +295,7 @@ class TestTrsh(unittest.TestCase):
         self.assertFalse(remove_checkfile)
         self.assertEqual(trsh_keyword, 'opt=(cartesian,nosymm)')
 
-        # gaussian: test 3
+        # Gaussian: test 3
         job_status = {'keywords': ['tmp']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -306,18 +306,18 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(level_of_theory.simple(), 'cbs-qb3')
         self.assertEqual(job_type, 'composite')
 
-        # test qchem
+        # Test Q-Chem
         software = 'qchem'
         ess_trsh_methods = ['change_node']
         job_status = {'keywords': ['MaxOptCycles', 'Unconverged']}
-        # qchem: test 1
+        # Q-Chem: test 1
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
                                                                        job_type, software, fine, memory_gb,
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
         self.assertIn('max_cycles', ess_trsh_methods)
 
-        # qchem: test 2
+        # Q-Chem: test 2
         job_status = {'keywords': ['SCF']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -325,10 +325,10 @@ class TestTrsh(unittest.TestCase):
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
         self.assertIn('DIIS_GDM', ess_trsh_methods)
 
-        # test molpro
+        # Test Molpro
         software = 'molpro'
 
-        # molpro: test
+        # Molpro: test
         path = os.path.join(self.base_path['molpro'], 'insufficient_memory.out')
         label = 'TS'
         level_of_theory = {'method': 'mrci', 'basis': 'aug-cc-pV(T+d)Z'}
@@ -356,8 +356,8 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('memory', ess_trsh_methods)
         self.assertEqual(memory, 96.0)
 
-        # test orca
-        # orca: test 1
+        # Test Orca
+        # Orca: test 1
         # Test troubleshooting insufficient memory issue
         # Automatically increase memory provided not exceeding maximum available memory
         label = 'test'
@@ -382,7 +382,7 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(cpu_cores, 32)
         self.assertAlmostEqual(memory, 327)
 
-        # orca: test 2
+        # Orca: test 2
         # Test troubleshooting insufficient memory issue
         # Automatically reduce cpu cores to ensure enough memory per core when maximum available memory is limited
         label = 'test'
@@ -408,7 +408,7 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(cpu_cores, 22)
         self.assertAlmostEqual(memory, 227)
 
-        # orca: test 3
+        # Orca: test 3
         # Test troubleshooting insufficient memory issue
         # Stop troubleshooting when ARC determined there is not enough computational resource to accomplish the job
         label = 'test'
@@ -434,7 +434,7 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(couldnt_trsh, True)
         self.assertLess(cpu_cores, 1)  # can't really run job with less than 1 cpu ^o^
 
-        # orca: test 4
+        # Orca: test 4
         # Test troubleshooting too many cpu cores
         # Automatically reduce cpu cores
         label = 'test'

--- a/arc/testing/trsh/molpro/insufficient_memory_2.out
+++ b/arc/testing/trsh/molpro/insufficient_memory_2.out
@@ -1,0 +1,512 @@
+Nodes     nprocs
+ c-16-9-3     8
+ GA implementation: MPI file
+ GA implementation (serial work in mppx): MPI file
+
+ Using customized tuning parameters: mindgm=1; mindgv=20; mindgc=4; mindgr=1; noblas=0; minvec=7
+ default implementation of scratch files=sf  
+
+
+ Variables initialized (1013), CPU time= 0.01 sec
+ ***,2,3_hydroperoxy_1,4_dioxane
+ memory,224,m;
+ file,1,file1.int                                                                !allocate permanent integral file
+ file,2,file2.wfu                                                                !allocate permanent wave-function (dump) file
+ 
+ geometry={angstrom;
+ O      -0.52199800   -1.31106100    0.39946900
+ C       0.76511800   -0.98131700   -0.01404400
+ O       1.68062700   -1.74554400    0.77406800
+ O       1.84661600   -2.94850400    0.25089200
+ C       1.06978700    0.50012600    0.19456400
+ O       1.09364900    0.73062300    1.63209800
+ O       1.71767900    1.86290700    1.89806200
+ O       0.11215200    1.28347400   -0.42424900
+ C      -1.23490800    0.94188400   -0.04848200
+ C      -1.48862800   -0.52483700   -0.30526700
+ H       0.92876500   -1.23870600   -1.06572300
+ H       2.04230600    0.78761600   -0.19706400
+ H      -1.87680800    1.56985800   -0.66186700
+ H      -1.39121000    1.18095000    1.00462000
+ H      -1.43079500   -0.74456600   -1.37708300
+ H      -2.46223500   -0.83067000    0.07108700}
+ 
+ basis=cc-pvtz-f12
+ 
+ 
+ 
+ int;
+ {hf;
+ maxit,1000;
+ wf,spin=2,charge=0;}
+ 
+ uccsd(t)-f12;
+ 
+ 
+ 
+ Commands initialized (815), CPU time= 0.02 sec, 669 directives.
+ Default parameters read. Elapsed time= 0.79 sec
+
+ Checking input...
+ Passed
+1
+
+
+                                         ***  PROGRAM SYSTEM MOLPRO  ***
+                                       Copyright, TTI GmbH Stuttgart, 2015
+                                    Version 2021.3 linked Nov 22 2021 23:03:34
+
+
+ **********************************************************************************************************************************
+ LABEL *   2,3_hydroperoxy_1,4_dioxane                                                   
+  64 bit mpp version                                                                     DATE: 28-Oct-22          TIME: 09:08:50  
+ **********************************************************************************************************************************
+
+ SHA1:             8b8f1fffdd8ed686b3bdbdb000c23abeeca3c440
+ **********************************************************************************************************************************
+
+ Memory per process:       224 MW
+ Total memory per node:   1792 MW
+
+ GA preallocation disabled
+ GA check disabled
+
+ Variable memory set to 224.0 MW
+
+
+
+ Permanent file  1  file1.int        assigned.  Implementation=df  
+ Permanent file  2  file2.wfu        assigned.  Implementation=df    Size= 27.23 MB
+
+
+ PROGRAM * RESTART 
+
+
+ Reading variables from file 2
+
+ _FNUC           =      0.00000000
+ _BASIS          =    CC-PVTZ-F12
+ _NELEC          =     64.00000000
+ _PROGRAM        =    CCSD(T)-F12
+ _DMX_SCF        =     -0.96004302
+ _DMY_SCF        =     -0.48786540
+ _DMZ_SCF        =      0.03239633
+ _HOMO           =     32.10000000
+ _EHOMO          =     -0.41362846
+ _LUMO           =     33.10000000
+ _ELUMO          =      0.04228831
+ _EMP2           =   -457.34032001
+ _EMP2_SING      =     -1.06089440
+ _EMP2_TRIP      =     -0.62442422
+ _EMP2_SINGLES   =      0.00000000
+ _EMP2_SCS       =   -457.31660529
+ _ECSING(1:2)    =     -1.26119170    -1.23759734
+ _ECTRIP(1:2)    =     -0.57418322    -0.57234760
+ _EF12           =     -0.14665913
+ _EF12_SING      =     -0.13011706
+ _EF12_TRIP      =     -0.01654208
+ _EF12_RHFRELAX  =     -0.00423572
+ _EF12_SINGLES   =     -0.00423572
+ _EF12_SCS       =     -0.16643331
+ _EF12_STRONG    =     -0.14665913
+ _EF12_CLOSE     =      0.00000000
+ _EF12_WEAK      =      0.00000000
+ _EF12_DIST      =      0.00000000
+ _EF12S          =     -0.14570707
+ _EF12S_SING     =     -0.12988209
+ _EF12S_TRIP     =     -0.01582499
+ _EF12S_SCS      =     -0.16570516
+ _EF12S_STRONG   =     -0.14570707
+ _EF12S_CLOSE    =      0.00000000
+ _EF12S_WEAK     =      0.00000000
+ _EF12S_DIST     =      0.00000000
+ _EF12D          =     -0.15579051
+ _EF12D_SING     =     -0.13880643
+ _EF12D_TRIP     =     -0.01698408
+ _EF12D_SCS      =     -0.17713559
+ _EF12D_STRONG   =     -0.15579051
+ _EF12D_CLOSE    =      0.00000000
+ _EF12D_WEAK     =      0.00000000
+ _EF12D_DIST     =      0.00000000
+ _ENERGC(1:2)    =   -457.49037496  -457.46494498
+ _ENERG_CC(1:2)  =      0.00000000     0.00000000
+ _ENERG_CV(1:2)  =      0.00000000     0.00000000
+ _ENERG_VV(1:2)  =     -1.83537357    -1.80994360
+ _ENERGR         =   -455.65500139
+ _ENERGT(1:3)    =   -457.53869685  -457.54141607  -457.53752348
+ _ENERGY(1:2)    =   -457.56412683  -457.53869685
+ _ENERGY_METHOD  =    CCSD(T)-F12
+ _ENERGY_BASIS   =    cc-pVTZ-F12
+ _ENUC           =    423.55136240
+ _IPROC_MPP      =      0.00000000
+ _IPROC_MPPX     =      0.00000000
+ _ORBITAL        =   2102.20000000
+ _ECDIAG(1:2)    =     -0.16391902    -0.16105126
+ _EPDIAG(1:2)    =     -0.16391902    -0.16105126
+ _STATUS         =      1.00000000
+ _T1DIAG         =      0.01229091
+ _D1DIAG         =      0.03616631
+ _D2DIAG         =      0.17429381
+ !DFBASIS_MP2    =    CC-PVTZ-F12-MP2FIT
+ !DFBASIS_F12K   =    VTZ-F12-JKFIT
+ !RIBASIS_MP2    =    CC-PVTZ-F12_OPT
+ !RIBASIS_EXCH   =     
+ _DATE           =    26-Oct-22
+ _METHODC        =    CCSD-F12a
+ _METHODC        =    CCSD-F12b
+ _METHODT        =    CCSD(T)-F12b
+ _METHODT        =    CCSD[T]-F12b
+ _METHODT        =    CCSD-T-F12b
+ _OUTPUT         =    /state/partition1/slurm_tmp/20495513.4294967291.0/molpro/alongd/a10142-20495513/input.out
+ _PGROUP         =    C1  
+ _TIME           =    23:53:03
+ _ANSATZ         =    F12/3C(FIX)
+ _SVDDEL         =      0.00000000
+ _SYM_CATION     =      1.00000000
+
+ Geometry written to block  1 of record 702
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1       2       11.50       500      702   
+                                          VAR     GEOM   
+
+              2      14       27.23       500      610      700     1000      520     2100     7360     7350      701     1001   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    EF12     GEOM     BASIS   
+                                         2101      702     1002     2102   
+                                          RHF     GEOM     BASIS     RHF  
+
+ PROGRAMS   *        TOTAL   RESTART
+ CPU TIMES  *         0.27      0.03
+ REAL TIME  *         1.27 SEC
+ DISK USED  *        38.73 MB (local),      309.87 MB (total)
+ **********************************************************************************************************************************
+
+ Geometry recognized as XYZ
+
+ SETTING BASIS          =    CC-PVTZ-F12
+
+
+ Using spherical harmonics
+
+ Library entry O      S cc-pVTZ-F12          selected for orbital group  1
+ Library entry O      P cc-pVTZ-F12          selected for orbital group  1
+ Library entry O      D cc-pVTZ-F12          selected for orbital group  1
+ Library entry O      F cc-pVTZ-F12          selected for orbital group  1
+ Library entry C      S cc-pVTZ-F12          selected for orbital group  2
+ Library entry C      P cc-pVTZ-F12          selected for orbital group  2
+ Library entry C      D cc-pVTZ-F12          selected for orbital group  2
+ Library entry C      F cc-pVTZ-F12          selected for orbital group  2
+ Library entry H      S cc-pVTZ-F12          selected for orbital group  7
+ Library entry H      P cc-pVTZ-F12          selected for orbital group  7
+ Library entry H      D cc-pVTZ-F12          selected for orbital group  7
+
+
+ PROGRAM * SEWARD (Integral evaluation for generally contracted gaussian basis sets)     Author: Roland Lindh, 1990
+
+ Geometry written to block  1 of record 703
+
+
+ Point group  C1  
+
+
+
+ ATOMIC COORDINATES
+
+ NR  ATOM    CHARGE       X              Y              Z
+
+   1  O       8.00   -0.986433258   -2.477546223    0.754887005
+   2  C       6.00    1.445863473   -1.854420371   -0.026539314
+   3  O       8.00    3.175924748   -3.298600098    1.462776522
+   4  O       8.00    3.489598497   -5.571865037    0.474117167
+   5  C       6.00    2.021604442    0.945101168    0.367672674
+   6  O       8.00    2.066697086    1.380677370    3.084218229
+   7  O       8.00    3.245942880    3.520384026    3.586817348
+   8  O       8.00    0.211936564    2.425414348   -0.801714419
+   9  C       6.00   -2.333637909    1.779902801   -0.091617702
+  10  C       6.00   -2.813099221   -0.991798190   -0.576871025
+  11  H       1.00    1.755111484   -2.340815089   -2.013924595
+  12  H       1.00    3.859399003    1.488378531   -0.372396989
+  13  H       1.00   -3.546653109    2.966601675   -1.250747361
+  14  H       1.00   -2.629005882    2.231672067    1.898456659
+  15  H       1.00   -2.703810690   -1.407025822   -2.602309721
+  16  H       1.00   -4.652949804   -1.569738800    0.134334961
+
+ Bond lengths in Bohr (Angstrom)
+
+  1- 2  2.629635014   1-10  2.705131274   2- 3  2.701264288   2- 5  2.885169250   2-11  2.069278717
+       ( 1.391542922)       ( 1.431493823)       ( 1.429447502)       ( 1.526765817)       ( 1.095015140)
+
+  3- 4  2.498714074   5- 6  2.751614022   5- 8  2.614132956   5-12  2.054347159   6- 7  2.494307737
+       ( 1.322262545)       ( 1.456091434)       ( 1.383339586)       ( 1.087113700)       ( 1.319930811)
+
+  8- 9  2.720454356   9-10  2.854414182   9-13  2.055052714   9-14  2.061973247  10-15  2.070449198
+       ( 1.439602449)       ( 1.510490936)       ( 1.087487063)       ( 1.091149252)       ( 1.095634532)
+
+ 10-16  2.055451160
+       ( 1.087697912)
+
+ Bond angles
+
+  1- 2- 3  107.57030189   1- 2- 5  111.95652036   1- 2-11  111.58825038   1-10- 9  109.64555301
+
+  1-10-15  109.62201771   1-10-16  106.23970165   2- 1-10  110.37374791   2- 3- 4  110.40452535
+
+  2- 5- 6  106.96347573   2- 5- 8  110.49953419   2- 5-12  112.69944589   3- 2- 5  108.39841278
+
+  3- 2-11  107.94700649   5- 2-11  109.23730790   5- 6- 7  110.02756434   5- 8- 9  113.36786144
+
+  6- 5- 8  111.30521424   6- 5-12  107.40546285   8- 5-12  107.96213161   8- 9-10  110.07227406
+
+  8- 9-13  105.54951373   8- 9-14  109.50989553   9-10-15  110.62053157   9-10-16  111.38037507
+
+ 10- 9-13  111.44986278  10- 9-14  110.65615372  13- 9-14  109.46930450  15-10-16  109.22910850
+
+ NUCLEAR CHARGE:                   78
+ NUMBER OF PRIMITIVE AOS:         846
+ NUMBER OF SYMMETRY AOS:          750
+ NUMBER OF CONTRACTIONS:          638   (  638A   )
+ NUMBER OF INNER CORE ORBITALS:     0   (    0A   )
+ NUMBER OF OUTER CORE ORBITALS:    10   (   10A   )
+ NUMBER OF VALENCE ORBITALS:       46   (   46A   )
+
+ MOLECULE CHANGED: INITIALIZING OCCUPATION AND DUMP RECORDS
+
+
+ NUCLEAR REPULSION ENERGY  595.56444026
+
+
+ Eigenvalues of metric
+
+         1 0.134E-04 0.227E-04 0.341E-04 0.473E-04 0.642E-04 0.954E-04 0.958E-04 0.109E-03
+
+
+ Contracted 2-electron integrals neglected if value below      1.0D-12
+ AO integral compression algorithm  1   Integral accuracy      1.0D-12
+
+     67682.173 MB (compressed) written to integral file ( 38.3%)
+
+     Node minimum: 7728.792 MB, node maximum: 9443.475 MB
+
+
+ NUMBER OF SORTED TWO-ELECTRON INTEGRALS: 2597023520.     BUFFER LENGTH:  32768
+ NUMBER OF SEGMENTS:  82  SEGMENT LENGTH:   31996696      RECORD LENGTH: 262144
+
+ Memory used in sort:      32.29 MW
+
+ SORT1 READ 22078984307. AND WROTE  2068173544. INTEGRALS IN  11880 RECORDS. CPU TIME:  1058.61 SEC, REAL TIME:  1188.09 SEC
+ SORT2 READ 16542230169. AND WROTE 20775678561. INTEGRALS IN 235864 RECORDS. CPU TIME:    57.93 SEC, REAL TIME:  1318.34 SEC
+
+ Node minimum:  2596870640.  Node maximum:  2597049001. integrals
+
+ OPERATOR DM      FOR CENTER  0  COORDINATES:    0.000000    0.000000    0.000000
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      19       43.44       500      702      610      703      900      950      970     1003      129      960   
+                                          VAR     GEOM    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS    
+                                         1100     1400     1410     1200     1210     1080     1600     1650     1700   
+                                           S        T        V       H0       H01     AOSYM     SMH    MOLCAS    OPER   
+
+              2      16       31.45       500      610      700     1000      520     2100     7360     7350      701     1001   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    EF12     GEOM     BASIS   
+                                         2101      702     1002     2102      703     1003   
+                                          RHF     GEOM     BASIS     RHF     GEOM     BASIS   
+
+ PROGRAMS   *        TOTAL       INT   RESTART
+ CPU TIMES  *      1242.77   1242.39      0.03
+ REAL TIME  *      2694.33 SEC
+ DISK USED  *        75.03 MB (local),      248.40 GB (total)
+ GA USED    *         0.00 MB       (max)       0.00 MB       (current)
+ **********************************************************************************************************************************
+
+
+ Program * Restricted Hartree-Fock
+
+ Orbital guess generated from atomic densities. Full valence occupancy:   56
+
+ Initial alpha occupancy:  40
+ Initial beta  occupancy:  38
+
+ NELEC=   78   SYM=1   MS2= 2   THRE=1.0D-08   THRD=3.2D-06   THRG=3.2D-06  HFMA2=F  DIIS_START=2   DIIS_MAX=10   DIIS_INCORE=F
+
+ Level shifts:    0.00 (CLOSED)    0.00 (OPEN)    0.30 (GAP_MIN)
+
+ ITER           ETOT              DE          GRAD        DDIFF     DIIS  NEXP   TIME(IT)  TIME(TOT)  DIAG
+   1     -603.85191443    -603.85191443     0.00D+00     0.26D-01     0     0      45.83     84.42    start
+   2     -604.00165333      -0.14973889     0.30D-02     0.30D-02     1     0      44.54    128.96    diag2
+   3     -604.08646796      -0.08481464     0.22D-02     0.15D-02     2     0      44.88    173.84    diag2
+   4     -604.09945818      -0.01299022     0.42D-03     0.42D-03     3     0      44.60    218.44    diag2
+   5     -604.10676993      -0.00731175     0.31D-03     0.26D-03     4     0      45.17    263.61    diag2
+   6     -604.11212710      -0.00535718     0.19D-03     0.21D-03     5     0      44.25    307.86    diag2
+   7     -604.11636670      -0.00423960     0.14D-03     0.33D-03     6     0      41.82    349.68    diag2
+   8     -604.11654577      -0.00017907     0.50D-04     0.71D-04     7     0      40.69    390.37    diag2
+   9     -604.11658044      -0.00003467     0.20D-04     0.35D-04     8     0      40.48    430.85    diag2
+  10     -604.11658546      -0.00000502     0.78D-05     0.98D-05     9     0      41.21    472.06    diag2/orth
+  11     -604.11658902      -0.00000356     0.40D-05     0.63D-05     9     0      41.20    513.26    diag2
+  12     -604.11659236      -0.00000334     0.31D-05     0.50D-05     9     0      40.35    553.61    diag2
+  13     -604.11659702      -0.00000465     0.29D-05     0.74D-05     9     0      41.05    594.66    diag2
+  14     -604.11660792      -0.00001091     0.28D-05     0.20D-04     9     0      40.27    634.93    diag2
+  15     -604.11662311      -0.00001519     0.23D-05     0.43D-04     9     0      40.63    675.56    diag2
+  16     -604.11662606      -0.00000294     0.13D-05     0.19D-04     9     0      40.40    715.96    diag2
+  17     -604.11662670      -0.00000065     0.64D-06     0.11D-04     9     0      40.70    756.66    diag2
+  18     -604.11662674      -0.00000004     0.32D-06     0.25D-05     9     0      39.96    796.62    diag2
+  19     -604.11662675      -0.00000000     0.13D-06     0.56D-06     9     0      41.27    837.89    diag2
+  20     -604.11662675      -0.00000000     0.67D-07     0.76D-07     0     0      40.20    878.09    diag/orth
+
+ Final alpha occupancy:  40
+ Final beta  occupancy:  38
+
+ !RHF STATE 1.1 Energy               -604.116626746536
+  RHF One-electron energy           -2013.534462838620
+  RHF Two-electron energy             813.853395835240
+  RHF Kinetic energy                  603.570296294287
+  RHF Nuclear energy                  595.564440256844
+  RHF Virial quotient                  -1.000905164578
+
+ !RHF STATE 1.1 Dipole moment          -0.96693663     0.32240197    -1.18479820
+ Dipole moment /Debye                  -2.45770778     0.81946407    -3.01145665
+
+ Orbital energies:
+
+           1.1          2.1          3.1          4.1          5.1          6.1          7.1          8.1          9.1         10.1
+    -20.671944   -20.667606   -20.667181   -20.660840   -20.599152   -20.594425   -11.373765   -11.372088   -11.307844   -11.304358
+
+          11.1         12.1         13.1         14.1         15.1         16.1         17.1         18.1         19.1         20.1
+     -1.560896    -1.549200    -1.443472    -1.403685    -1.201458    -1.158774    -1.054875    -0.965848    -0.923159    -0.830201
+
+          21.1         22.1         23.1         24.1         25.1         26.1         27.1         28.1         29.1         30.1
+     -0.767593    -0.734790    -0.732553    -0.723241    -0.713621    -0.666022    -0.657611    -0.619979    -0.616506    -0.605228
+
+          31.1         32.1         33.1         34.1         35.1         36.1         37.1         38.1         39.1         40.1
+     -0.589745    -0.582928    -0.563824    -0.517846    -0.509906    -0.493170    -0.479648    -0.438715    -0.593285    -0.587049
+
+          41.1         42.1
+      0.037636     0.045509
+
+
+ HOMO     40.1    -0.587049 =     -15.9744eV
+ LUMO     41.1     0.037636 =       1.0241eV
+ LUMO-HOMO         0.624686 =      16.9986eV
+
+ Orbitals saved in record  2103.2
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      19       43.44       500      702      610      703      900      950      970     1003      129      960   
+                                          VAR     GEOM    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS    
+                                         1100     1400     1410     1200     1210     1080     1600     1650     1700   
+                                           S        T        V       H0       H01     AOSYM     SMH    MOLCAS    OPER   
+
+              2      17       44.01       500      610      700     1000      520     2100     7360     7350      701     1001   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    EF12     GEOM     BASIS   
+                                         2101      702     1002     2102      703     1003     2103   
+                                          RHF     GEOM     BASIS     RHF     GEOM     BASIS     RHF  
+
+ PROGRAMS   *        TOTAL    HF-SCF       INT   RESTART
+ CPU TIMES  *      2121.23    878.41   1242.39      0.03
+ REAL TIME  *      9776.68 SEC
+ DISK USED  *       143.57 MB (local),      248.93 GB (total)
+ GA USED    *         0.00 MB       (max)       0.00 MB       (current)
+ **********************************************************************************************************************************
+
+
+ PROGRAM * CCSD (Unrestricted open-shell coupled cluster)     Authors: C. Hampel, H.-J. Werner, 1991, M. Deegan, P.J. Knowles, 1992
+
+                           UCCSD-F12 implementation by G. Knizia and H.-J. Werner, 2008
+
+                   Density fitting integral evaluation by F.R. Manby, 2003,2007, G. Knizia, 2010
+
+
+ Basis set VTZ-F12/JKFIT generated.      Number of basis functions:   1316 
+ Basis set CC-PVTZ-F12/OPTRI generated.  Number of basis functions:   996 
+ Basis set CC-PVTZ-F12/MP2FIT generated. Number of basis functions:   1336 
+
+ Convergence thresholds:  THRVAR = 1.00D-08  THRDEN = 1.00D-06
+
+ CCSD(T)     terms to be evaluated (factor= 1.000)
+
+
+ Number of core orbitals:          10 (  10 )
+ Number of closed-shell orbitals:  28 (  28 )
+ Number of active  orbitals:        2 (   2 )
+ Number of external orbitals:     598 ( 598 )
+ = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+ Memory manager status, default implementation STACK
+ Heap status:    39 entries, memory used=58500 doubles
+                           Type               Address    Size  Rank Bounds
+ - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                           double            A2FBDF80     900     1  1:900
+                           double            A2FBC350     900     1  1:900
+                           double            A2FBA720     900     1  1:900
+                           double            A2FB8AF0     900     1  1:900
+                           double            A2FB6EC0     900     1  1:900
+                           double            A2FB5290     900     1  1:900
+                           integer           A2FB1A40    1800     1  1:1800
+                           integer           A2FAE1F0    1800     1  1:1800
+                           integer           A2FAC5C0     900     1  1:900
+                           integer           A2FAA990     900     1  1:900
+                           integer           A2FA8D60     900     1  1:900
+                           integer           A2FA7130     900     1  1:900
+                           integer           A2FA5500     900     1  1:900
+                           integer           A2FA38D0     900     1  1:900
+                           integer           A2FA1CA0     900     1  1:900
+                           integer           A2FA0070     900     1  1:900
+                           integer           A2F9E440     900     1  1:900
+                           integer           A2F9C810     900     1  1:900
+                           integer           A2F9ABE0     900     1  1:900
+                           integer           A2E50F80     900     1  1:900
+                           integer           A2E4F350     900     1  1:900
+                           integer           A2E4D720     900     1  1:900
+                           integer           A2E4BAF0     900     1  1:900
+                           integer           A2E49EC0     900     1  1:900
+                           integer           A2E48290     900     1  1:900
+                           integer           A2E46660     900     1  1:900
+                           integer           A2E44A30     900     1  1:900
+                           integer           A2E42E00     900     1  1:900
+                           integer           A2E411D0     900     1  1:900
+                           integer           A2E3F5A0     900     1  1:900
+                           integer           A2E3D970     900     1  1:900
+                           integer           A2DE5750     900     1  1:900
+                           integer           A2DE3B20     900     1  1:900
+                           integer           A2E34CC0    4500     2  1:5  1:900
+                           integer           A2E2C010    4500     2  1:5  1:900
+                           integer           A2E23360    4500     2  1:5  1:900
+                           integer           A2E1A6B0    4500     2  1:5  1:900
+                           integer           A2E11A00    4500     2  1:5  1:900
+                           integer           A2E08D50    4500     2  1:5  1:900
+ = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+ Stack status: Remaining memory=223231216 doubles (768784 currently used, 224000000 maximum used), Entries=22
+                           Type        Depth            Address      Size  Rank Bounds
+ - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                          integer        900           386BF310       900     1  1:900
+                          integer       1800           386BD6F0       900     1  1:900
+                          integer       2700           386BBAD0       900     1  1:900
+                          integer       3600           386B9EB0       900     1  1:900
+                          integer       4500           386B8290       900     1  1:900
+                          integer       5400           386B6670       900     1  1:900
+                          integer       6300           386B4A50       900     1  1:900
+                          double       24240           386919B0     17940     1  1:17940
+                          double       42180           3866E910     17940     1  1:17940
+                          double       42778           3866D660       598     1  1:598
+                          double       43376           3866C3B0       598     1  1:598
+                          double       43406           3866C2C0        30     1  1:30
+                          double       43436           3866C1D0        30     1  1:30
+                          double      401040           383B1AB0    357604     1  1:357604
+                          double      758644           380F7390    357604     1  1:357604
+                          double      759544           380F5770       900     1  1:900
+                          double      760444           380F3B50       900     1  1:900
+                          double      767884           380E52D0      7440     1  1:7440
+                          double      767944           380E50F0        60     1  1:60
+                          integer     767984           380E4FB0        40     1  1:40
+                          integer     768384           380E4330       400     1  1:400
+                          double      768784           380E36B0       400     1  1:400
+ = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+ ? Error
+ ? Insufficient memory to allocate a new array of length 321843600 8-byte words
+ ? The problem occurs in memory
+
+ GLOBAL ERROR fehler on processor   0                                         

--- a/functional/functional_test.py
+++ b/functional/functional_test.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 """
-This module contains functional tests for ARC
+This module that contains functional tests for ARC
 """
 
 from encodings import utf_8
@@ -19,6 +19,7 @@ from arc.species import ARCSpecies
 
 settings['ts_adapters'] = ['xtb-gsm']
 
+
 class TestFunctional(unittest.TestCase):
     """
     Contains functional tests for ARC.
@@ -32,16 +33,17 @@ class TestFunctional(unittest.TestCase):
         cls.has_settings = False
         
         cls.job_types = {'conformers': True,
-                    'opt': True,
-                    'fine_grid': False,
-                    'freq': True,
-                    'sp': True,
-                    'rotors': False,
-                    'irc': False,
-                    }
+                         'opt': True,
+                         'fine_grid': False,
+                         'freq': True,
+                         'sp': True,
+                         'rotors': False,
+                         'irc': False,
+                         }
 
-        cls.species_list_1 = [ARCSpecies(label= "2-propanol", smiles="CC(O)C"), ARCSpecies(label= "1-propanol", smiles="CCCO"), ARCSpecies(label= "NN", smiles="NN")]
-
+        cls.species_list_1 = [ARCSpecies(label="2-propanol", smiles="CC(O)C"),
+                              ARCSpecies(label="1-propanol", smiles="CCCO"),
+                              ARCSpecies(label="NN", smiles="NN")]
         cls.arc_object_1 = ARC(project='FunctionalThermoTest',
                                project_directory=os.path.join(ARC_PATH, "functional", "test", "thermo"),
                                species=cls.species_list_1,
@@ -54,7 +56,6 @@ class TestFunctional(unittest.TestCase):
                                )
 
         cls.species_list_2 = [ARCSpecies(label= "iC3H7", smiles="C[CH]C"), ARCSpecies(label= "nC3H7", smiles="CC[CH2]")]
-
         with open(os.path.join(ARC_PATH, "functional", "ts_guess.xyz"), 'r') as f:
             cls.ts_guess = f.read()
 
@@ -65,7 +66,7 @@ class TestFunctional(unittest.TestCase):
                                job_types=cls.job_types,
                                conformer_level='gfn2',
                                level_of_theory='gfn2',
-                               ts_guess_level = 'gfn2',
+                               ts_guess_level='gfn2',
                                freq_scale_factor=1.0,
                                bac_type = None,
                                verbose=1,
@@ -93,10 +94,11 @@ class TestFunctional(unittest.TestCase):
             self.assertTrue(ter)
         self.assertTrue(os.path.exists(os.path.join(ARC_PATH, "functional", "test", "kinetic", "output", "RMG libraries", "kinetics")))
         has_content = False
-        with open(file = os.path.join(ARC_PATH, "functional", "test", "kinetic", "output", "RMG libraries", "kinetics", "reactions.py"), mode='r') as f:
+        with open(file=os.path.join(ARC_PATH, "functional", "test", "kinetic", "output", "RMG libraries", "kinetics", "reactions.py"), mode='r') as f:
             for line in f.readlines():
                 if "Arrhenius" in line:
                     has_content = True
+                    break
         self.assertTrue(has_content)
     
     @classmethod
@@ -105,8 +107,8 @@ class TestFunctional(unittest.TestCase):
         A function that is run ONCE after all unit tests in this class.
         Delete all project directories created during these unit tests.
         """
-        shutil.rmtree(os.path.join(ARC_PATH, 'functional', 'test', 'kinetic'), ignore_errors=True)
-        shutil.rmtree(os.path.join(ARC_PATH, 'functional', 'test', 'thermo'), ignore_errors=True)
+        for folder in ['thermo', 'kinetic']:
+            shutil.rmtree(os.path.join(ARC_PATH, 'functional', 'test', folder), ignore_errors=True)
 
  
 if __name__ == '__main__':


### PR DESCRIPTION
ARC troubleshoots issues with insufficient memory in Molpro only if an estimate of the additional required memory is given by Molpro. Here we tell ARC to request x3 the amount of memory for a Molpro job that crashed due to insufficient memory if an estimate is not provided. A test was added.