### PR TITLE
save non standard object to yaml.

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -420,6 +420,9 @@ def to_yaml(py_content: Union[list, dict]) -> str:
     Returns: str
         The corresponding YAML representation.
     """
+    if not isinstance(py_content, (list, dict)):
+        logger.warning(f"Type of output data is not a list or dictionary. Trying to convert {type(py_content)} to list:")
+        py_content = list(py_content)
     yaml.add_representer(str, string_representer)
     yaml_str = yaml.dump(data=py_content)
     return yaml_str

--- a/arc/commonTest.py
+++ b/arc/commonTest.py
@@ -68,6 +68,18 @@ class TestCommon(unittest.TestCase):
         with self.assertRaises(InputError):
             common.read_yaml_file('nopath')
 
+    def test_to_yaml(self):
+        """test the to_yaml() function"""
+        content_1 = [1, 2, 3]
+        expected_1 = "- 1\n- 2\n- 3\n"
+        content_2 = {"a": 1, "b" : 2, "c" :3}
+        expected_2 = "a: 1\nb: 2\nc: 3\n"
+        content_3 = content_2.values()
+        expected_3 = expected_1
+        self.assertEqual(common.to_yaml(content_1), expected_1)
+        self.assertEqual(common.to_yaml(content_2), expected_2)
+        self.assertEqual(common.to_yaml(content_3), expected_3)
+
     def test_get_git_commit(self):
         """Test the get_git_commit() function"""
         git_commit = common.get_git_commit()


### PR DESCRIPTION
Solves the error:
`can't pickle dict_values objects`
(and hopefully other similar errors).
Also added a unit test to the `to_yaml()` function.