### PR TITLE
Troubleshoot job memory issues from server-generated log

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -893,12 +893,6 @@ class JobAdapter(ABC):
                                                       'time limit.'
                         self.job_status[1]['line'] = line
                         break
-                    if 'memory exceeded' in line:
-                        self.job_status[1]['status'] = 'errored'
-                        self.job_status[1]['keywords'] = ['Memory']
-                        self.job_status[1]['error'] = 'Insufficient job memory.'
-                        self.job_status[1]['line'] = line
-                        break
         elif self.job_status[0] == 'running':
             self.job_status[1]['status'] = 'running'
 
@@ -986,6 +980,7 @@ class JobAdapter(ABC):
             status, keywords, error, line = determine_ess_status(output_path=self.local_path_to_output_file,
                                                                  species_label=self.species_label,
                                                                  job_type=self.job_type,
+                                                                 job_log=self.additional_job_info,
                                                                  software=self.job_adapter,
                                                                  )
             if status != 'done' and self.final_time is not None \
@@ -995,6 +990,7 @@ class JobAdapter(ABC):
                 status, keywords, error, line = determine_ess_status(output_path=self.local_path_to_output_file,
                                                                      species_label=self.species_label,
                                                                      job_type=self.job_type,
+                                                                     job_log=self.additional_job_info,
                                                                      software=self.job_adapter,
                                                                      )
         else:

--- a/arc/job/trshTest.py
+++ b/arc/job/trshTest.py
@@ -458,6 +458,33 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('cpu', ess_trsh_methods)
         self.assertEqual(cpu_cores, 10)
 
+    def test_determine_job_log_memory_issues(self):
+        """Test the determine_job_log_memory_issues() function."""
+        job_log_path_1 = os.path.join(ARC_PATH, 'arc', 'testing', 'job_log', 'no_issues.log')
+        keywords, error, line = trsh.determine_job_log_memory_issues(job_log=job_log_path_1)
+        self.assertEqual(keywords, [])
+        self.assertEqual(error, '')
+        self.assertEqual(line, '')
+
+        job_log_path_2 = os.path.join(ARC_PATH, 'arc', 'testing', 'job_log', 'memory_exceeded.log')
+        keywords, error, line = trsh.determine_job_log_memory_issues(job_log=job_log_path_2)
+        self.assertEqual(keywords, ['Memory'])
+        self.assertEqual(error, 'Insufficient job memory.')
+        self.assertEqual(line, '\tMEMORY EXCEEDED\n')
+
+        job_log_path_3 = os.path.join(ARC_PATH, 'arc', 'testing', 'job_log', 'using_to_few.log')
+        keywords, error, line = trsh.determine_job_log_memory_issues(job_log=job_log_path_3)
+        self.assertEqual(keywords, ['Memory'])
+        self.assertIn('Memory requested is too high, used only', error)
+        self.assertEqual(line, '\tJob Is Wasting Memory using less than 20 percent of requested Memory\n')
+
+        with open(job_log_path_3, 'r') as f:
+            job_log_content = f.read()
+        keywords, error, line = trsh.determine_job_log_memory_issues(job_log=job_log_content)
+        self.assertEqual(keywords, ['Memory'])
+        self.assertIn('Memory requested is too high, used only', error)
+        self.assertEqual(line, '\tJob Is Wasting Memory using less than 20 percent of requested Memory')
+
     def test_trsh_negative_freq(self):
         """Test troubleshooting a negative frequency"""
         gaussian_neg_freq_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'Gaussian_neg_freq.out')

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -887,9 +887,25 @@ class Scheduler(object):
                 if job_name in self.running_jobs[label]:
                     self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
 
+        if job.job_status[1]['status'] == 'errored' and job.job_status[1]['keywords'] == ['memory']:
+            original_mem = job.job_memory_gb
+            if job.job_status[1]['error'] == 'Insufficient job memory.':
+                job.job_memory_gb *= 3
+                logger.warning(f'Job {job.job_name} errored because of insufficient memory. '
+                               f'Was {original_mem} GB, rerunning job with {job.job_memory_gb} GB.')
+                self._run_a_job(job=job, label=label)
+            elif 'Memory requested is too high' in job.job_status[1]['error']:
+                used_mem = None
+                if 'used only' in job.job_status[1]['error']:
+                    used_mem = int(job.job_status[1]['error'][-2])
+                logger.warning(f'Job {job.job_name} errored because the requested memory is too high. '
+                               f'Was {original_mem} GB, rerunning job with {job.job_memory_gb} GB.')
+                job.job_memory_gb = used_mem * 4.5 if used_mem is not None else job.job_memory_gb * 0.5
+                self._run_a_job(job=job, label=label)
+
         if not os.path.isfile(job.local_path_to_output_file) and not job.execution_type == 'incore':
             job.rename_output_file()
-        if not os.path.exists(job.local_path_to_output_file) and not job.execution_type == 'incore':
+        if not os.path.isfile(job.local_path_to_output_file) and not job.execution_type == 'incore':
             if 'restart_due_to_file_not_found' in job.ess_trsh_methods:
                 job.job_status[0] = 'errored'
                 job.job_status[1]['status'] = 'errored'

--- a/arc/testing/job_log/memory_exceeded.log
+++ b/arc/testing/job_log/memory_exceeded.log
@@ -1,0 +1,100 @@
+000 (143499.000.000) 11/12 02:01:47 Job submitted from host: <192.114.101.132:9618?addrs=192.114.101.132-9618+[2001-bf8-900-d-2--84]-9618&noUDP&sock=2301880_cbdb_3>
+...
+001 (143499.000.000) 11/12 02:01:49 Job executing on host: <192.114.101.223:9618?addrs=192.114.101.223-9618&noUDP&sock=9582_0892_3>
+...
+006 (143499.000.000) 11/12 02:01:57 Image size of job updated: 177408
+	105  -  MemoryUsage of job (MB)
+	106776  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:06:57 Image size of job updated: 9595520
+	1725  -  MemoryUsage of job (MB)
+	1766240  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:11:58 Image size of job updated: 9596104
+	2002  -  MemoryUsage of job (MB)
+	2049716  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:16:59 Image size of job updated: 9596104
+	2015  -  MemoryUsage of job (MB)
+	2062560  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:21:59 Image size of job updated: 9596104
+	2015  -  MemoryUsage of job (MB)
+	2062624  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:26:59 Image size of job updated: 9598108
+	3377  -  MemoryUsage of job (MB)
+	3457344  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:32:00 Image size of job updated: 9609512
+	3620  -  MemoryUsage of job (MB)
+	3705964  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:37:01 Image size of job updated: 9609512
+	3635  -  MemoryUsage of job (MB)
+	3721784  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:42:01 Image size of job updated: 9621868
+	3647  -  MemoryUsage of job (MB)
+	3734448  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:47:02 Image size of job updated: 9621868
+	3648  -  MemoryUsage of job (MB)
+	3734960  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:52:03 Image size of job updated: 9621868
+	3649  -  MemoryUsage of job (MB)
+	3735560  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 02:57:03 Image size of job updated: 9621868
+	3669  -  MemoryUsage of job (MB)
+	3756332  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 03:02:03 Image size of job updated: 9621868
+	3674  -  MemoryUsage of job (MB)
+	3762040  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:02:15 Image size of job updated: 9622292
+	3675  -  MemoryUsage of job (MB)
+	3763060  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:07:16 Image size of job updated: 9622292
+	3676  -  MemoryUsage of job (MB)
+	3763492  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:12:16 Image size of job updated: 9622292
+	3676  -  MemoryUsage of job (MB)
+	3764076  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:17:17 Image size of job updated: 9622292
+	3702  -  MemoryUsage of job (MB)
+	3790364  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:22:18 Image size of job updated: 9622292
+	3845  -  MemoryUsage of job (MB)
+	3936512  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:37:20 Image size of job updated: 9622292
+	6811  -  MemoryUsage of job (MB)
+	6974344  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 05:42:20 Image size of job updated: 9622292
+	6812  -  MemoryUsage of job (MB)
+	6975072  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 06:07:23 Image size of job updated: 10405800
+	7665  -  MemoryUsage of job (MB)
+	7847980  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 06:12:24 Image size of job updated: 10412200
+	7665  -  MemoryUsage of job (MB)
+	7847980  -  ResidentSetSize of job (KB)
+...
+006 (143499.000.000) 11/12 06:17:24 Image size of job updated: 10420908
+	8128  -  MemoryUsage of job (MB)
+	8322944  -  ResidentSetSize of job (KB)
+...
+012 (143499.000.000) 11/12 06:17:24 Job was held.
+	MEMORY EXCEEDED
+	Code 26 Subcode 0
+...

--- a/arc/testing/job_log/no_issues.log
+++ b/arc/testing/job_log/no_issues.log
@@ -1,0 +1,23 @@
+000 (143546.000.000) 11/12 06:18:39 Job submitted from host: <192.114.101.132:9618?addrs=192.114.101.132-9618+[2001-bf8-900-d-2--84]-9618&noUDP&sock=2301880_cbdb_3>
+...
+001 (143546.000.000) 11/12 06:18:59 Job executing on host: <192.114.101.221:9618?addrs=192.114.101.221-9618&noUDP&sock=9509_f628_3>
+...
+006 (143546.000.000) 11/12 06:19:07 Image size of job updated: 1719600
+	0  -  MemoryUsage of job (MB)
+	0  -  ResidentSetSize of job (KB)
+...
+005 (143546.000.000) 11/12 06:19:07 Job terminated.
+	(1) Normal termination (return value 0)
+		Usr 0 00:00:09, Sys 0 00:00:02  -  Run Remote Usage
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Run Local Usage
+		Usr 0 00:00:09, Sys 0 00:00:02  -  Total Remote Usage
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Total Local Usage
+	0  -  Run Bytes Sent By Job
+	0  -  Run Bytes Received By Job
+	0  -  Total Bytes Sent By Job
+	0  -  Total Bytes Received By Job
+	Partitionable Resources :    Usage  Request Allocated 
+	   Cpus                 :        0       10        10 
+	   Disk (KB)            :        1        1    683744 
+	   Memory (MB)          :        0    39424     39424 
+...

--- a/arc/testing/job_log/using_to_few.log
+++ b/arc/testing/job_log/using_to_few.log
@@ -1,0 +1,53 @@
+000 (70293.000.000) 10/05 15:47:13 Job submitted from host: <192.114.101.132:9618?addrs=192.114.101.132-9618+[2001-bf8-900-d-2--84]-9618&noUDP&sock=231514_ed0c_3>
+...
+001 (70293.000.000) 10/05 15:47:15 Job executing on host: <192.114.101.8:9618?addrs=192.114.101.8-9618&noUDP&sock=2591_c9f9_3>
+...
+006 (70293.000.000) 10/05 15:47:24 Image size of job updated: 471192
+	279  -  MemoryUsage of job (MB)
+	285276  -  ResidentSetSize of job (KB)
+...
+006 (70293.000.000) 10/05 15:52:25 Image size of job updated: 67192164
+	1759  -  MemoryUsage of job (MB)
+	1800784  -  ResidentSetSize of job (KB)
+...
+...
+006 (81248.000.000) 10/13 15:43:43 Image size of job updated: 68806844
+	2122  -  MemoryUsage of job (MB)
+	2172708  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 15:48:43 Image size of job updated: 70044348
+	2171  -  MemoryUsage of job (MB)
+	2222492  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 15:53:43 Image size of job updated: 71455676
+	2284  -  MemoryUsage of job (MB)
+	2338408  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 15:58:44 Image size of job updated: 71765436
+	2340  -  MemoryUsage of job (MB)
+	2395860  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 16:03:45 Image size of job updated: 71765436
+	2411  -  MemoryUsage of job (MB)
+	2468500  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 16:08:45 Image size of job updated: 71765436
+	3162  -  MemoryUsage of job (MB)
+	3237720  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 16:13:45 Image size of job updated: 73736636
+	3162  -  MemoryUsage of job (MB)
+	3237780  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 16:18:46 Image size of job updated: 74170300
+	3162  -  MemoryUsage of job (MB)
+	3237780  -  ResidentSetSize of job (KB)
+...
+006 (81248.000.000) 10/13 16:23:33 Image size of job updated: 75888060
+	3162  -  MemoryUsage of job (MB)
+	3237780  -  ResidentSetSize of job (KB)
+...
+012 (81248.000.000) 10/13 16:23:33 Job was held.
+	Job Is Wasting Memory using less than 20 percent of requested Memory
+	Code 26 Subcode 0
+...


### PR DESCRIPTION
Here we add the ability to read a server-generated job log file (not the ESS log file).
The specific implementation is based on HTCondor `job.log` and can be extended.
A test was added