### PR TITLE
Parse xTB freqs from an auxiliary file if needed

### DIFF
--- a/arc/job/adapters/xtbTest.py
+++ b/arc/job/adapters/xtbTest.py
@@ -137,6 +137,13 @@ H      -0.20775137    1.01509427    0.05730382""")],
                                 project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_xTBAdapter_11'),
                                 species=[ARCSpecies(label='TS', is_ts=True, xyz=cls.ts_xyz)],
                                 )
+        cls.job_12 = xTBAdapter(execution_type='incore',
+                                job_type='freq',
+                                project='test_12',
+                                level=Level(method='gfn2'),
+                                project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_xTBAdapter_12'),
+                                species=[ARCSpecies(label='H2', smiles='[H][H]')],
+                                )
 
     def test_write_input_file(self):
         """Test writing Gaussian input files"""
@@ -270,6 +277,11 @@ $end"""
         for freq, expected_freq in zip(parse_frequencies(self.job_11.local_path_to_output_file)[:5], expected_freqs):
             self.assertAlmostEqual(freq, expected_freq, places=0)
 
+        self.job_12.execute_incore()
+        expected_freqs = [4225.72]
+        for freq, expected_freq in zip(parse_frequencies(self.job_12.local_path_to_output_file), expected_freqs):
+            self.assertAlmostEqual(freq, expected_freq, places=0)
+
     def test_scan(self):
         """Test running a 1D scan calculation using xTB."""
         self.job_8.execute()
@@ -281,7 +293,7 @@ $end"""
         A function that is run ONCE after all unit tests in this class.
         Delete all project directories created during these unit tests
         """
-        for i in range(15):
+        for i in range(20):
             path = os.path.join(ARC_PATH, 'arc', 'testing', f'test_xTBAdapter_{i}')
             shutil.rmtree(path, ignore_errors=True)
 

--- a/arc/parserTest.py
+++ b/arc/parserTest.py
@@ -43,6 +43,7 @@ class TestParser(unittest.TestCase):
         co2_xtb_freqs_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'CO2_xtb.out')
         ts_xtb_freqs_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'TS_NH2+N2H3_xtb.out')
         yml_freqs_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'output.yml')
+        vibspectrum_path = os.path.join(ARC_PATH, 'arc', 'testing', 'freq', 'vibspectrum')
 
         no3_freqs = parser.parse_frequencies(path=no3_path, software='QChem')
         c2h6_freqs = parser.parse_frequencies(path=c2h6_path, software='QChem')
@@ -56,6 +57,7 @@ class TestParser(unittest.TestCase):
         co2_xtb_freqs = parser.parse_frequencies(path=co2_xtb_freqs_path)
         ts_xtb_freqs = parser.parse_frequencies(path=ts_xtb_freqs_path)
         yml_freqs = parser.parse_frequencies(path=yml_freqs_path)
+        vibspectrum_freqs = parser.parse_frequencies(path=vibspectrum_path, software='xTB')
 
         np.testing.assert_almost_equal(no3_freqs,
                                        np.array([-390.08, -389.96, 822.75, 1113.23, 1115.24, 1195.35], np.float64))
@@ -107,6 +109,7 @@ class TestParser(unittest.TestCase):
                                                  3085.8337759988153, 3128.1504569691283, 3135.666024988286,
                                                  3230.936983192379, 3235.2332367908975, 3922.9230982968807],
                                                 np.float64))
+        np.testing.assert_almost_equal(vibspectrum_freqs, np.array([4225.72], np.float64))
 
     def test_parse_normal_mode_displacement(self):
         """Test parsing frequencies and normal mode displacements"""

--- a/arc/testing/freq/vibspectrum
+++ b/arc/testing/freq/vibspectrum
@@ -1,0 +1,10 @@
+$vibrational spectrum
+#  mode     symmetry     wave number   IR intensity    selection rules
+#                         cm**(-1)        (amu)          IR     RAMAN
+     1                       0.00         0.00000        -       - 
+     2                       0.00         0.00000        -       - 
+     3                       0.00         0.00000        -       - 
+     4                       0.00         0.00000        -       - 
+     5                       0.00         0.00000        -       - 
+     6        a           4225.72         0.00000       YES     YES
+$end


### PR DESCRIPTION
Solves an issue where xTB save frequencies in a vibspectrum file instead of the primary output file