### PR TITLE
Fix cairo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - rmg
   - conda-forge
+  - anaconda
 dependencies:
   - cairo
   - cairocffi

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
   - conda-forge
   - anaconda
 dependencies:
-  - cairo
-  - cairocffi
+  - anaconda::cairo
+  - conda-forge::cairocffi
   - rmg::cantera >=2.3.0
   - conda-forge::cclib >=1.7.0
   - rmg::chemprop


### PR DESCRIPTION
Cairo was not working for a while in atlas, the reason might be that it cannot be found by mamba/conda, if channels are not specified.