### PR TITLE
BugFix: Opt IRC results using freq level if using a composite method

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2576,7 +2576,7 @@ class Scheduler(object):
         self.initialize_output_dict(label=irc_spc.label)
         self.run_job(label=irc_spc.label,
                      xyz=self.species_dict[irc_spc.label].get_xyz(),
-                     level_of_theory=self.opt_level,
+                     level_of_theory=self.opt_level if not self.composite_method else self.freq_level,
                      job_type='opt',
                      fine=False,
                      )


### PR DESCRIPTION
When we use a composite method (e.g., CBS-QB3), `opt_level` is `None`. Then we cannot optimize at the `opt_level` a species that results from an IRC run. Luckily, a `freq_level` is already defined at the appropriate LOT, and it's recommended to use this level (that corresponds to the opt step of the composite method) for further optimizations. Note that we don't want to use the composite method here since it'll spawn an actual freq computation and higher level sp.
Here we fix this bug by passing the `freq_level` when needed.