### PR TITLE
Allow heuristics TS generation for reactions with isomorphic reactants or products

### DIFF
--- a/arc/job/adapters/ts/heuristics.py
+++ b/arc/job/adapters/ts/heuristics.py
@@ -249,7 +249,7 @@ class HeuristicsAdapter(JobAdapter):
                                             multiplicity=rxn.multiplicity,
                                             )
             rxn.arc_species_from_rmg_reaction()
-            reactants, products = rxn.get_reactants_and_products(arc=True)
+            reactants, products = rxn.get_reactants_and_products(arc=True, return_copies=True)
             reactant_mol_combinations = list(itertools.product(*list(reactant.mol_list for reactant in reactants)))
             product_mol_combinations = list(itertools.product(*list(product.mol_list for product in products)))
             reaction_list = list()
@@ -905,8 +905,9 @@ def h_abstraction(arc_reaction: 'ARCReaction',
             products_reversed = True
             break
 
-    arc_reactant = arc_reaction.r_species[int(reactants_reversed)]  # Get R(*1)-H(*2).
-    arc_product = arc_reaction.p_species[int(not products_reversed)]  # Get R(*3)-H(*2).
+    arc_reactants, arc_products = arc_reaction.get_reactants_and_products(arc=True, return_copies=False)
+    arc_reactant = arc_reactants[int(reactants_reversed)]  # Get R(*1)-H(*2).
+    arc_product = arc_products[int(not products_reversed)]  # Get R(*3)-H(*2).
 
     if any([is_linear(coordinates=np.array(arc_reactant.get_xyz()['coords'])),
             is_linear(coordinates=np.array(arc_product.get_xyz()['coords']))]) and is_angle_linear(a2):

--- a/arc/job/adapters/ts/heuristics_test.py
+++ b/arc/job/adapters/ts/heuristics_test.py
@@ -795,6 +795,25 @@ class TestHeuristicsAdapter(unittest.TestCase):
         self.assertEqual(rxn1.ts_species.multiplicity, 2)
         self.assertEqual(len(rxn1.ts_species.ts_guesses), 6)
 
+        # H2NN(T) + N2H4 <=> N2H3 + N2H3
+        h2nn = ARCSpecies(label='H2NN(T)', smiles='[N]N')
+        n2h2 = ARCSpecies(label='N2H4', smiles='NN')
+        n2h3 = ARCSpecies(label='N2H3', smiles='[NH]N')
+        rxn1 = ARCReaction(r_species=[h2nn, n2h2], p_species=[n2h3, n2h3])
+        rxn1.determine_family(rmg_database=self.rmgdb)
+        self.assertEqual(rxn1.family.label, 'H_Abstraction')
+        heuristics_1 = HeuristicsAdapter(job_type='tsg',
+                                         reactions=[rxn1],
+                                         testing=True,
+                                         project='test',
+                                         project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'heuristics'),
+                                         dihedral_increment=60,
+                                         )
+        heuristics_1.execute_incore()
+        self.assertTrue(rxn1.ts_species.is_ts)
+        self.assertEqual(rxn1.ts_species.charge, 0)
+        self.assertEqual(len(rxn1.ts_species.ts_guesses), 6)
+
     def test_keeping_atom_order_in_ts(self):
         """Test that the generated TS has the same atom order as in the reactants"""
         # reactant_reversed, products_reversed = False, False

--- a/arc/job/adapters/ts/heuristics_test.py
+++ b/arc/job/adapters/ts/heuristics_test.py
@@ -1018,6 +1018,31 @@ class TestHeuristicsAdapter(unittest.TestCase):
                               )
         self.assertTrue(_check_r_n_p_symbols_between_rmg_and_arc_rxns(rxn_1, rmg_reactions))
 
+        rxn_2 = ARCReaction(reactants=['H2N2(T)', 'N2H4'], products=['N2H3', 'N2H3'],
+                            r_species=[ARCSpecies(label='H2N2(T)', smiles='[N]N'), ARCSpecies(label='N2H4', smiles='NN')],
+                            p_species=[ARCSpecies(label='N2H3', smiles='[NH]N')])
+        rxn_2.determine_family(rmg_database=self.rmgdb, save_order=True)
+        self.assertEqual(rxn_2.family.label, 'H_Abstraction')
+        reactants, products = rxn_2.get_reactants_and_products(arc=False)
+        reactant_labels = [atom.label for atom in reactants[0].molecule[0].atoms if atom.label] \
+                          + [atom.label for atom in reactants[1].molecule[0].atoms if atom.label]
+        product_labels = [atom.label for atom in products[0].molecule[0].atoms if atom.label] \
+                          + [atom.label for atom in products[1].molecule[0].atoms if atom.label]
+        self.assertEqual(reactant_labels, list())
+        self.assertEqual(product_labels, list())
+        rmg_reactions = react(reactants=list(reactants),
+                              products=list(products),
+                              family=rxn_2.family,
+                              arc_reaction=rxn_2,
+                              )
+        reactant_labels = [atom.label for atom in rmg_reactions[0].reactants[0].molecule[0].atoms if atom.label] \
+                          + [atom.label for atom in rmg_reactions[0].reactants[1].molecule[0].atoms if atom.label]
+        product_labels = [atom.label for atom in rmg_reactions[0].products[0].molecule[0].atoms if atom.label] \
+                         + [atom.label for atom in rmg_reactions[0].products[1].molecule[0].atoms if atom.label]
+        for label in ['*1', '*2', '*3']:
+            self.assertIn(label, reactant_labels)
+            self.assertIn(label, product_labels)
+
     def test_generate_the_two_constrained_zmats(self):
         """Test the generate_the_two_constrained_zmats() function."""
         zmat_1, zmat_2 = generate_the_two_constrained_zmats(xyz_1=self.ccooh_xyz,

--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -741,6 +741,7 @@ class ARCReaction(object):
 
     def get_reactants_and_products(self,
                                    arc: bool = True,
+                                   return_copies: bool = True,
                                    ) -> Tuple[List[Union[ARCSpecies, Species]], List[Union[ARCSpecies, Species]]]:
         """
         Get a list of reactant and product species including duplicate species, if any.
@@ -748,6 +749,7 @@ class ARCReaction(object):
 
         Args:
             arc (bool, optional): Whether to return the species as ARCSpecies (``True``) or as RMG Species (``False``).
+            return_copies (bool, optional): Whether to return unique object instances using the copy() method.
 
         Returns:
             Tuple[List[Union[ARCSpecies, Species]], List[Union[ARCSpecies, Species]]]:
@@ -756,16 +758,20 @@ class ARCReaction(object):
         reactants, products = list(), list()
         for r_spc in self.r_species:
             if arc:
-                reactants.extend([r_spc] * self.get_species_count(species=r_spc, well=0))
+                for i in range(self.get_species_count(species=r_spc, well=0)):
+                    reactants.append(r_spc.copy() if return_copies else r_spc)
             else:
-                reactants.extend([Species(label=r_spc.label, molecule=[r_spc.mol])] *
-                                 self.get_species_count(species=r_spc, well=0))
+                for i in range(self.get_species_count(species=r_spc, well=0)):
+                    reactants.append(Species(label=r_spc.label, molecule=[r_spc.mol.copy(deep=True) if return_copies
+                                                                          else r_spc.mol]))
         for p_spc in self.p_species:
             if arc:
-                products.extend([p_spc] * self.get_species_count(species=p_spc, well=1))
+                for i in range(self.get_species_count(species=p_spc, well=1)):
+                    products.append(p_spc.copy() if return_copies else p_spc)
             else:
-                products.extend([Species(label=p_spc.label, molecule=[p_spc.mol])] *
-                                self.get_species_count(species=p_spc, well=1))
+                for i in range(self.get_species_count(species=p_spc, well=1)):
+                    products.append(Species(label=p_spc.label, molecule=[p_spc.mol.copy(deep=True) if return_copies
+                                                                          else p_spc.mol]))
         return reactants, products
 
     def get_expected_changing_bonds(self,

--- a/arc/reaction_test.py
+++ b/arc/reaction_test.py
@@ -608,6 +608,12 @@ class TestARCReaction(unittest.TestCase):
         self.assertEqual(rxn1.get_species_count(label=spc2.label, well=0), 1)
         self.assertEqual(rxn1.get_species_count(label=spc2.label, well=1), 2)
 
+        h2nn = ARCSpecies(label='H2NN(T)', smiles='[N]N')
+        n2h2 = ARCSpecies(label='N2H4', smiles='NN')
+        n2h3 = ARCSpecies(label='N2H3', smiles='[NH]N')
+        rxn2 = ARCReaction(r_species=[h2nn, n2h2], p_species=[n2h3, n2h3])
+        self.assertEqual(rxn2.get_species_count(label=n2h3.label, well=1), 2)
+
     def test_get_reactants_and_products(self):
         """Test getting reactants and products"""
         self.rxn1.arc_species_from_rmg_reaction()
@@ -637,6 +643,19 @@ class TestARCReaction(unittest.TestCase):
         self.assertEqual(len(reactants), 2)
         self.assertEqual(len(products), 2)
         self.assertNotEqual(products[0].label, products[1].label)
+
+        h2nn = ARCSpecies(label='H2NN(T)', smiles='[N]N')
+        n2h2 = ARCSpecies(label='N2H4', smiles='NN')
+        n2h3 = ARCSpecies(label='N2H3', smiles='[NH]N')
+        rxn1 = ARCReaction(r_species=[h2nn, n2h2], p_species=[n2h3, n2h3])
+        reactants, products = rxn1.get_reactants_and_products(arc=True, return_copies=False)
+        self.assertEqual(len(reactants), 2)
+        self.assertEqual(len(products), 2)
+        self.assertIs(products[0], products[1])
+        reactants, products = rxn1.get_reactants_and_products(arc=True, return_copies=True)
+        self.assertEqual(len(reactants), 2)
+        self.assertEqual(len(products), 2)
+        self.assertIsNot(products[0], products[1])
 
     def test_get_expected_changing_bonds(self):
         """Test the get_expected_changing_bonds() method."""

--- a/arc/species/mapping.py
+++ b/arc/species/mapping.py
@@ -592,7 +592,7 @@ def map_arc_rmg_species(arc_reaction: 'ARCReaction',
                         spc_map[i].append(j)
                     elif concatenate:
                         spc_map[i] = [j]
-                    else:
+                    elif i not in spc_map.keys() and j not in spc_map.values():
                         spc_map[i] = j
                         break
     if not r_map or not p_map:

--- a/arc/species/mapping_test.py
+++ b/arc/species/mapping_test.py
@@ -1031,6 +1031,19 @@ class TestMapping(unittest.TestCase):
         self.assertEqual(r_map, {0: 0, 1: 1})
         self.assertEqual(p_map, {0: 1, 1: 0})
 
+        rmg_reaction = Reaction(reactants=[Species(smiles='[N]N'), Species(smiles='NN')],
+                                products=[Species(smiles='[NH]N'), Species(smiles='[NH]N')])
+        arc_reaction = ARCReaction(r_species=[ARCSpecies(label='H2NN(T)', smiles='[N]N'),
+                                              ARCSpecies(label='N2H4', smiles='NN')],
+                                   p_species=[ARCSpecies(label='N2H3', smiles='[NH]N'),
+                                              ARCSpecies(label='N2H3', smiles='[NH]N')])
+        r_map, p_map = mapping.map_arc_rmg_species(rmg_reaction=rmg_reaction,
+                                                   arc_reaction=arc_reaction,
+                                                   concatenate=False,
+                                                   )
+        self.assertEqual(r_map, {0: 0, 1: 1})
+        self.assertEqual(p_map, {0: 0, 1: 1})
+
     def test_find_equivalent_atoms_in_reactants_and_products(self):
         """Test the find_equivalent_atoms_in_reactants_and_products() function"""
         equivalence_map_1 = mapping.find_equivalent_atoms_in_reactants(arc_reaction=self.rxn_2a)


### PR DESCRIPTION
This PR solves a bug where ARC got stuck when a reaction had two identical reactants or two identical products.
The issue was traced to the function `mapping.map_arc_rmg_species()`, where a very simple fix was added

Tests were added to `Reaction.get_reactants_and_products()`, `mapping.map_arc_rmg_species()`, `heuristics.react()`, and `heuristics_for_h_abstraction`