### PR TITLE
Replace ":" in folder name when creating folders in the scale.py script

### DIFF
--- a/arc/utils/scale.py
+++ b/arc/utils/scale.py
@@ -362,4 +362,5 @@ def rename_level(level: str) -> str:
     level = level.replace(')', 'b')
     level = level.replace(')', 'b')
     level = level.replace(' ', '_')
+    level = level.replace(':', '..')
     return level

--- a/arc/utils/scale_test.py
+++ b/arc/utils/scale_test.py
@@ -112,10 +112,13 @@ class TestScale(unittest.TestCase):
         """Test the scale rename_level() function"""
         level1 = 'b3lyp/6-311+G**'
         level2 = 'wb97xd/6-311+G(2d,2p)'
+        level3 = 'wb97xd/aug-ccpZQZ, solvation_method: SMD, solvent: DMSO, software: gaussian'
         renamed_level1 = rename_level(level1)
         renamed_level2 = rename_level(level2)
+        renamed_level3 = rename_level(level3)
         self.assertEqual(renamed_level1, 'b3lyp_6-311pGss')
         self.assertEqual(renamed_level2, 'wb97xd_6-311pGb2d,2pb')
+        self.assertEqual(renamed_level3, 'wb97xd_aug-ccpZQZ,_solvation_method.._SMD,_solvent.._DMSO,_software.._gaussian')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This creates a folder for a "sub" ARC job to compute freq scale factors for new levels of theory.
When we use solvation the `__str()__` method of the `Level` class outputs `:` chars.
Here we replace them with `..` when we use the level of theory string representation to name folders.
A test was added