### PR TITLE
Changed the conversion of MB to Bytes to 1E6

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -763,7 +763,7 @@ class JobAdapter(ABC):
             self.submit_script_memory = math.ceil(total_submit_script_memory)  # in MB
         if cluster_software in ['pbs']:
             # In PBS, "#PBS -l select=1:ncpus=8:mem=12000000" specifies the memory for all cores to be 12 MB.
-            self.submit_script_memory = math.ceil(total_submit_script_memory) * 1E3  # in Bytes
+            self.submit_script_memory = math.ceil(total_submit_script_memory) * 1E6  # in Bytes
         elif cluster_software in ['slurm']:
             # In Slurm, "#SBATCH --mem-per-cpu=2000" specifies the memory **per cpu/thread** to be 2000 MB.
             self.submit_script_memory = math.ceil(total_submit_script_memory / self.cpu_cores)  # in MB

--- a/arc/job/adapter_test.py
+++ b/arc/job/adapter_test.py
@@ -334,7 +334,7 @@ class TestJobAdapter(unittest.TestCase):
         self.job_4.server = 'server3'
         self.job_4.cpu_cores = None
         self.job_4.set_cpu_and_mem()
-        expected_memory = math.ceil(14 * 1024 * 1.1) * 1000
+        expected_memory = math.ceil(14 * 1024 * 1.1) * 1E6
         self.assertEqual(self.job_4.submit_script_memory, expected_memory)
         self.job_4.server = 'local'
 


### PR DESCRIPTION
Originally in the code, the memory for PBS was being converted by multiplying by 1E3. This has been corrected now to 1E6