### PR TITLE
Insufficient mem molpro

### DIFF
--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -320,8 +320,14 @@ ${self.species[0].occ}wf,spin=${input_dict['spin']},charge=${input_dict['charge'
         Set the input_file_memory attribute.
         """
         # Molpro's memory is per cpu core and in MW (mega word; 1 MW ~= 8 MB; 1 GB = 128 MW)
-        self.input_file_memory = math.ceil(self.job_memory_gb * 128 / self.cpu_cores)
-
+        #self.input_file_memory = math.ceil(self.job_memory_gb * 128 / self.cpu_cores)
+        # https://www.molpro.net/pipermail/molpro-user/2010-April/003723.html
+        # In the link, they describe the conversion of 100,000,000 Words (100Mword) is equivalent to
+        # 800,000,000 bytes (800 mb). 
+        # Formula - (100,000,000 [Words]/( 800,000,000 [Bytes] / (job mem in gb * 1000,000,000 [Bytes])))/ 1000,000 [Words -> MegaWords] 
+        # The division by 1E6 is for converting into MWords
+        self.input_file_memory = math.ceil((1E8/(8E8 /(self.job_memory_gb * 1E9)))/1E6)
+        
     def execute_incore(self):
         """
         Execute a job incore.

--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -320,7 +320,6 @@ ${self.species[0].occ}wf,spin=${input_dict['spin']},charge=${input_dict['charge'
         Set the input_file_memory attribute.
         """
         # Molpro's memory is per cpu core and in MW (mega word; 1 MW ~= 8 MB; 1 GB = 128 MW)
-        #self.input_file_memory = math.ceil(self.job_memory_gb * 128 / self.cpu_cores)
         # https://www.molpro.net/pipermail/molpro-user/2010-April/003723.html
         # In the link, they describe the conversion of 100,000,000 Words (100Mword) is equivalent to
         # 800,000,000 bytes (800 mb). 

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -40,13 +40,13 @@ class TestMolproAdapter(unittest.TestCase):
         """Test assigning number of cpu's and memory"""
         self.job_1.cpu_cores = 48
         self.job_1.input_file_memory = None
-        self.job_1.submit_script_memory = None
+        self.job_1.submit_script_memory = 14
         self.job_1.set_cpu_and_mem()
         self.assertEqual(self.job_1.cpu_cores, 48)
 
     def test_set_input_file_memory(self):
         """Test setting the input_file_memory argument"""
-        expected_memory = math.ceil(14 * 128 / 48)
+        expected_memory = math.ceil((1E8/(8E8 /(14 * 1E9)))/1E6)
         self.assertEqual(self.job_1.input_file_memory, expected_memory)
 
     def test_write_input_file(self):
@@ -55,7 +55,7 @@ class TestMolproAdapter(unittest.TestCase):
         with open(os.path.join(self.job_1.local_path, input_filenames[self.job_1.job_adapter]), 'r') as f:
             content_1 = f.read()
         job_1_expected_input_file = """***,spc1
-memory,38,m;
+memory,1750,m;
 file,1,file1.int    !allocate permanent integral file
 file,2,file2.wfu    !allocate permanent wave-function (dump) file
 

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -359,7 +359,6 @@ def determine_ess_status(output_path: str,
                     keywords = ['IGNORE_ERROR in the ORBITAL directive']
                     error = 'Unconverged'
                     break
-
                 elif 'A further' in line and 'Mwords of memory are needed' in line and 'Increase memory to' in line:
                     # e.g.: `A further 246.03 Mwords of memory are needed for the triples to run.
                     # Increase memory to 996.31 Mwords.` (w/o the line break)

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -344,6 +344,19 @@ class TestTrsh(unittest.TestCase):
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
         self.assertIn('memory', ess_trsh_methods)
         self.assertEqual(memory, 96.0)
+        
+        # Molpro: Insuffienct Memory 3 Test
+        path = os.path.join(self.base_path['molpro'], 'insufficient_memory_3.out')
+        status, keywords, error, line = trsh.determine_ess_status(output_path=path,
+                                                                  species_label='TS',
+                                                                  job_type='sp')
+        job_status = {'keywords': keywords, 'error': error}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        self.assertIn('memory', ess_trsh_methods)
+        self.assertEqual(memory, 62.0)
 
         # Test Orca
         # Orca: test 1

--- a/arc/testing/trsh/molpro/insufficient_memory_3.out
+++ b/arc/testing/trsh/molpro/insufficient_memory_3.out
@@ -1,0 +1,619 @@
+
+ Working directory              : /gtmp/calvin.p/scratch/molpro/313795.zeus-master/molpro.1zPAnXaz57/
+ Global scratch directory       : /gtmp/calvin.p/scratch/molpro/313795.zeus-master/molpro.1zPAnXaz57/
+ Wavefunction directory         : /home/calvin.p/wfu/
+ Main file repository           : /gtmp/calvin.p/scratch/molpro/313795.zeus-master/molpro.1zPAnXaz57/
+
+ id        : dana
+
+ Nodes     nprocs
+ n035         1
+ GA implementation: MPI file
+ GA implementation (serial work in mppx): MPI file
+
+ Using customized tuning parameters: mindgm=1; mindgv=20; mindgc=4; mindgr=1; noblas=0; minvec=7
+ default implementation of scratch files=df  
+
+
+ Variables initialized (1025), CPU time= 0.00 sec
+ ***,DMF_rad_on_methyl
+ memory,1000,m;
+ file,1,file1.int                                                                !allocate permanent integral file
+ file,2,file2.wfu                                                                !allocate permanent wave-function (dump) file
+ 
+ geometry={angstrom;
+ C      -2.10714600    1.24844900    0.32354700
+ C      -1.03500900    0.22991700    0.36805400
+ C      -0.97884000   -1.03439400   -0.43828800
+ C       0.50608200   -1.26344000   -0.50929300
+ C       1.13266500   -0.22234600    0.04183100
+ C       2.56724200    0.09360300    0.23628500
+ O       0.25451400    0.73290900    0.52090200
+ H      -3.08293100    0.77492100    0.43101700
+ H      -1.98761200    1.97675800    1.12579000
+ H      -2.10875500    1.80017800   -0.62816500
+ H      -1.52417300   -1.85838400    0.03478600
+ H      -1.42868400   -0.90773400   -1.43760400
+ H       0.99137100   -2.11859500   -0.94935400
+ H       2.82187700    1.03630100   -0.25070100
+ H       2.79604700    0.19906300    1.29798700
+ H       3.18729200   -0.69683600   -0.18108200}
+ 
+ basis=cc-pvtz-f12
+ 
+ 
+ 
+ int;
+ {hf;
+ maxit,1000;
+ wf,spin=1,charge=0;}
+ 
+ uccsd(t)-f12;
+ 
+ 
+ 
+ Commands initialized (840), CPU time= 0.01 sec, 684 directives.
+ Default parameters read. Elapsed time= 0.13 sec
+
+ Checking input...
+ Passed
+1
+
+
+                                         ***  PROGRAM SYSTEM MOLPRO  ***
+                                       Copyright, TTI GmbH Stuttgart, 2015
+                                    Version 2022.3 linked Wed Nov 30 13:40:34 2022
+
+
+ **********************************************************************************************************************************
+ LABEL *   DMF_rahyl                                                                     
+  (16 PROC) 64 bit serial version                                                        DATE: 02-Feb-23          TIME: 14:52:04  
+ **********************************************************************************************************************************
+
+ SHA1:             e31ec9a5ea85254ab76f59d122cbdd51c71cf98b
+ **********************************************************************************************************************************
+
+ Memory per process:      1000 MW
+ Total memory per node:   1000 MW
+
+ GA preallocation disabled
+ GA check disabled
+
+ Variable memory set to 1000.0 MW
+
+
+
+ Permanent file  1  file1.int        assigned.  Implementation=df  
+ Permanent file  2  file2.wfu        assigned.  Implementation=df    Size= 19.53 MB
+
+
+ PROGRAM * RESTART 
+
+
+ Reading variables from file 2
+
+ _FNUC           =      0.00000000
+ _BASIS          =    CC-PVTZ-F12
+ _NELEC          =      1.00000000
+ _PROGRAM        =    UCCSD(T)-F12
+ _NCEN           =      1.00000000
+ _DMX_SCF        =      0.00000000
+ _DMY_SCF        =      0.00000000
+ _DMZ_SCF        =      0.00000000
+ _HOMO           =      1.10000000
+ _EHOMO          =     -0.49994557
+ _LUMO           =      2.10000000
+ _ELUMO          =      0.26739009
+ _EMP2           =     -0.49994621
+ _EMP2_SING      =      0.00000000
+ _EMP2_TRIP      =      0.00000000
+ _EMP2_SINGLES   =     -0.00000000
+ _EMP2_SCS       =     -0.49994621
+ _ECSING(1:2)    =      0.00000000     0.00000000
+ _ECTRIP(1:2)    =      0.00000000     0.00000000
+ _ECTRIPAB(1:2)  =      0.00000000     0.00000000
+ _ECTRIPAA(1:2)  =      0.00000000     0.00000000
+ _ECTRIPBB(1:2)  =      0.00000000     0.00000000
+ _ECSINGLES      =     -0.00000000
+ _EF12           =      0.00000000
+ _EF12_SING      =      0.00000000
+ _EF12_TRIP      =      0.00000000
+ _ECSING_F12(1:2)=      0.00000000     0.00000000
+ _ECTRIP_F12(1:2)=      0.00000000     0.00000000
+ _ECTRIPAB_F12(1:2)   =      0.00000000     0.00000000
+ _ECTRIPAA_F12(1:2)   =      0.00000000     0.00000000
+ _ECTRIPBB_F12(1:2)   =      0.00000000     0.00000000
+ _EF12_RHFRELAX  =     -0.00000064
+ _EF12_CONVSUPPRS=      0.00000000
+ _EF12_CONVSUPPRT=      0.00000000
+ _EF12_SINGLES   =     -0.00000064
+ _EF12_SCS       =      0.00000000
+ _EF12S          =      0.00000000
+ _EF12S_SING     =      0.00000000
+ _EF12S_TRIP     =      0.00000000
+ _EF12S_SCS      =      0.00000000
+ _EF12D          =      0.00000000
+ _EF12D_SING     =      0.00000000
+ _EF12D_TRIP     =      0.00000000
+ _EF12D_SCS      =      0.00000000
+ _EF12F          =      0.00000000
+ _EF12F_SING     =      0.00000000
+ _EF12F_TRIP     =      0.00000000
+ _EF12F_SCS      =      0.00000000
+ _ENERGC(1:2)    =     -0.49994621    -0.49994621
+ _ENERG_CC(1:2)  =      0.00000000     0.00000000
+ _ENERG_CV(1:2)  =      0.00000000     0.00000000
+ _ENERG_VV(1:2)  =     -0.00000000    -0.00000000
+ _ENERGR         =     -0.49994621
+ _ENERGT(1:6)    =     -0.49994621    -0.49994621    -0.49994621    -0.49994621    -0.49994621    -0.49994621
+ _ENERGY(1:2)    =     -0.49994621    -0.49994621
+ _ENERGY_METHOD  =    UCCSD(T)-F12
+ _ENERGY_BASIS   =    cc-pVTZ-F12
+ _ENUC           =      0.00000000
+ _IPROC_MPP      =      0.00000000
+ _IPROC_MPPX     =      0.00000000
+ _ORBITAL        =   2100.20000000
+ _ECDIAG(1:2)    =      0.00000000     0.00000000
+ _EPDIAG(1:2)    =      0.00000000     0.00000000
+ _STATUS         =      1.00000000
+ _T1DIAG         =      0.00000000
+ _D1DIAG         =      0.00000000
+ _D2DIAG         =      0.00000000
+ !DFBASIS_MP2    =    CC-PVTZ-F12-MP2FIT
+ !DFBASIS_F12K   =    VTZ-F12-JKFIT
+ !RIBASIS_MP2    =    CC-PVTZ-F12_OPT
+ !RIBASIS_EXCH   =     
+ _DATE           =    25-Jan-23
+ _METHODC        =    UCCSD-F12a
+ _METHODC        =    UCCSD-F12b
+ _METHODT        =    UCCSD(T)-F12a
+ _METHODT        =    UCCSD[T]-F12a
+ _METHODT        =    UCCSD-T-F12a
+ _METHODT        =    UCCSD(T)-F12b
+ _METHODT        =    UCCSD[T]-F12b
+ _METHODT        =    UCCSD-T-F12b
+ _OUTPUT         =    /tmp/calvin.p/scratch/molpro/299041.zeus-master/input.out
+ _PGROUP         =    D2h 
+ _TIME           =    09:44:41
+ _ANSATZ         =    F12/3C(FIX)
+ _SVDDEL         =      0.00000000
+ _SYM_CATION     =      1.00000000
+
+ Geometry written to block  1 of record 700
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1       2       11.47       500      700   
+                                          VAR     GEOM   
+
+              2      11       19.53       500      610      700     1000      520     2100     7360      701     1001     2101   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    GEOM     BASIS     RHF  
+                                         7350   
+                                         EF12   
+
+ PROGRAMS   *        TOTAL   RESTART
+ CPU TIMES  *         0.18      0.04
+ REAL TIME  *         0.49 SEC
+ DISK USED  *        31.00 MB
+ **********************************************************************************************************************************
+
+ Geometry recognized as XYZ
+
+ SETTING BASIS          =    CC-PVTZ-F12
+
+
+ Using spherical harmonics
+
+ Library entry C      S cc-pVTZ-F12          selected for orbital group  1
+ Library entry C      P cc-pVTZ-F12          selected for orbital group  1
+ Library entry C      D cc-pVTZ-F12          selected for orbital group  1
+ Library entry C      F cc-pVTZ-F12          selected for orbital group  1
+ Library entry O      S cc-pVTZ-F12          selected for orbital group  2
+ Library entry O      P cc-pVTZ-F12          selected for orbital group  2
+ Library entry O      D cc-pVTZ-F12          selected for orbital group  2
+ Library entry O      F cc-pVTZ-F12          selected for orbital group  2
+ Library entry H      S cc-pVTZ-F12          selected for orbital group  3
+ Library entry H      P cc-pVTZ-F12          selected for orbital group  3
+ Library entry H      D cc-pVTZ-F12          selected for orbital group  3
+
+
+ PROGRAM * SEWARD (Integral evaluation for generally contracted gaussian basis sets)     Author: Roland Lindh, 1990
+
+ Geometry written to block  1 of record 701
+
+
+ Point group  C1  
+
+
+
+ ATOMIC COORDINATES
+
+ NR  ATOM    CHARGE       X              Y              Z
+
+   1  C       6.00   -3.981928845    2.359226691    0.611415218
+   2  C       6.00   -1.955883547    0.434480161    0.695521259
+   3  C       6.00   -1.849739520   -1.954721365   -0.828244284
+   4  C       6.00    0.956356377   -2.387555575   -0.962424287
+   5  C       6.00    2.140426641   -0.420173045    0.079049134
+   6  C       6.00    4.851384276    0.176884034    0.446513937
+   7  O       8.00    0.480961755    1.384997284    0.984362118
+   8  H       1.00   -5.825895251    1.464388458    0.814504085
+   9  H       1.00   -3.756042322    3.735531235    2.127434774
+  10  H       1.00   -3.984969414    3.401843396   -1.187059811
+  11  H       1.00   -2.880269537   -3.511836794    0.065736013
+  12  H       1.00   -2.699821479   -1.715368654   -2.716677836
+  13  H       1.00    1.873419678   -4.003564319   -1.794019055
+  14  H       1.00    5.332574687    1.958325073   -0.473756229
+  15  H       1.00    5.283763062    0.376174552    2.452839943
+  16  H       1.00    6.023108959   -1.316829194   -0.342195386
+
+ Bond lengths in Bohr (Angstrom)
+
+  1- 2  2.795815190   1- 8  2.059658384   1- 9  2.059988886   1-10  2.078838924   2- 3  2.835738337
+       ( 1.479481685)       ( 1.089924279)       ( 1.090099173)       ( 1.100074184)       ( 1.500608104)
+
+  2- 7  2.631563578   3- 4  2.842450335   3-11  2.070217705   3-12  2.084732678   4- 5  2.521365364
+       ( 1.392563475)       ( 1.504159940)       ( 1.095512031)       ( 1.103193024)       ( 1.334249091)
+
+  4-13  2.035691337   5- 6  2.800142645   5- 7  2.613820044   6-14  2.062031417   6-15  2.062040777
+       ( 1.077241464)       ( 1.481771675)       ( 1.383174001)       ( 1.091180034)       ( 1.091184987)
+
+  6-16  2.055767579
+       ( 1.087865354)
+
+ Bond angles
+
+  1-2-3  126.22742713   1-2-7  115.19426684   2-1-8  110.28662321   2-1-9  110.99902873
+
+  2- 1-10  111.86146253   2- 3- 4  100.98864478   2- 3-11  112.52199441   2- 3-12  112.00892791
+
+  2- 7- 5  107.48373486   3- 2- 7  109.18620546   3- 4- 5  108.98325377   3- 4-13  125.79565500
+
+  4- 3-11  113.40779077   4- 3-12  112.16483014   4- 5- 6  132.47269204   4- 5- 7  112.56929336
+
+  5- 4-13  125.21171112   5- 6-14  110.58319343   5- 6-15  110.56678019   5- 6-16  110.27586786
+
+  6- 5- 7  114.95773861   8- 1- 9  108.41354181   8- 1-10  107.57136719   9- 1-10  107.56333661
+
+ 11- 3-12  105.93479102  14- 6-15  107.56616705  14- 6-16  108.87441776  15- 6-16  108.90501847
+
+ NUCLEAR CHARGE:                   53
+ NUMBER OF PRIMITIVE AOS:         693
+ NUMBER OF SYMMETRY AOS:          621
+ NUMBER OF CONTRACTIONS:          533   (  533A   )
+ NUMBER OF INNER CORE ORBITALS:     0   (    0A   )
+ NUMBER OF OUTER CORE ORBITALS:     7   (    7A   )
+ NUMBER OF VALENCE ORBITALS:       37   (   37A   )
+
+ MOLECULE CHANGED: INITIALIZING OCCUPATION AND DUMP RECORDS
+
+
+ NUCLEAR REPULSION ENERGY  298.69463471
+
+
+ Eigenvalues of metric
+
+         1 0.143E-04 0.231E-04 0.295E-04 0.362E-04 0.374E-04 0.543E-04 0.677E-04 0.718E-04
+
+
+ Contracted 2-electron integrals neglected if value below      1.0D-12
+ AO integral compression algorithm  1   Integral accuracy      1.0D-12
+
+     36414.947 MB (compressed) written to integral file ( 42.2%)
+
+
+ NUMBER OF SORTED TWO-ELECTRON INTEGRALS:10126281516.     BUFFER LENGTH:  32768
+ NUMBER OF SEGMENTS: 159  SEGMENT LENGTH:   63999810      RECORD LENGTH: 262144
+
+ Memory used in sort:      64.29 MW
+
+ SORT1 READ 10793992478. AND WROTE  8589676652. INTEGRALS IN  49236 RECORDS. CPU TIME:   159.24 SEC, REAL TIME:   387.76 SEC
+ SORT2 READ  8589676652. AND WROTE 10126281516. INTEGRALS IN 138912 RECORDS. CPU TIME:   150.60 SEC, REAL TIME:   324.00 SEC
+
+ FILE SIZES:   FILE 1: 36455.8 MBYTE,  FILE 4:103255.4 MBYTE,   TOTAL: 139711.2 MBYTE
+
+ OPERATOR DM      FOR CENTER  0  COORDINATES:    0.000000    0.000000    0.000000
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      20    32486.87       500      700      610      701      900      950      970     1002      129      960   
+                                          VAR     GEOM    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS    
+                                         1100     1400     1410     1200     1210     1080     1600     1650     1300     1700   
+                                           S        T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
+
+              2      13       19.63       500      610      700     1000      520     2100     7360      701     1001     2101   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    GEOM     BASIS     RHF  
+                                         7350      701(1)  1002   
+                                         EF12     GEOM     BASIS   
+
+ PROGRAMS   *        TOTAL       INT   RESTART
+ CPU TIMES  *      3328.82   3328.60      0.04
+ REAL TIME  *      1214.44 SEC
+ DISK USED  *       130.14 GB
+ **********************************************************************************************************************************
+
+
+ Program * Restricted Hartree-Fock
+
+ Orbital guess generated from atomic densities. Full valence occupancy:   44
+
+ Initial alpha occupancy:  27
+ Initial beta  occupancy:  26
+
+ NELEC=   53   SYM=1   MS2= 1   THRE=1.0D-08   THRD=3.2D-06   THRG=3.2D-06  HFMA2=F  DIIS_START=2   DIIS_MAX=10   DIIS_INCORE=F
+
+ Level shifts:    0.00 (CLOSED)    0.00 (OPEN)    0.30 (GAP_MIN)
+
+ ITER           ETOT              DE          GRAD        DDIFF     DIIS  NEXP   TIME(IT)  TIME(TOT)  DIAG
+   1     -307.27499039    -307.27499039     0.00D+00     0.27D-01     0     0    2484.44   5210.58    start
+   2     -307.36131742      -0.08632702     0.21D-02     0.24D-02     1     0    2391.93   7602.51    diag2
+   3     -307.37326704      -0.01194963     0.75D-03     0.78D-03     2     0    2414.37  10016.88    diag2
+   4     -307.37655022      -0.00328318     0.30D-03     0.40D-03     3     0    2184.59  12201.47    diag2
+   5     -307.37711032      -0.00056010     0.10D-03     0.15D-03     4     0    2123.89  14325.36    diag2
+   6     -307.37728341      -0.00017309     0.45D-04     0.84D-04     5     0    2270.61  16595.97    diag2
+   7     -307.37731859      -0.00003518     0.21D-04     0.43D-04     6     0    2207.30  18803.27    diag2
+   8     -307.37732237      -0.00000378     0.78D-05     0.14D-04     7     0    2076.45  20879.72    fixocc
+   9     -307.37732292      -0.00000056     0.31D-05     0.62D-05     8     0    2091.83  22971.55    diag2
+  10     -307.37732297      -0.00000005     0.84D-06     0.22D-05     9     0    2155.96  25127.51    diag2/orth
+  11     -307.37732298      -0.00000000     0.32D-06     0.61D-06     9     0    2051.99  27179.50    diag2
+  12     -307.37732298      -0.00000000     0.13D-06     0.17D-06     0     0    2069.36  29248.86    diag
+
+ Final alpha occupancy:  27
+ Final beta  occupancy:  26
+
+ !RHF STATE 1.1 Energy               -307.377322975725
+  RHF One-electron energy           -1008.861082037535
+  RHF Two-electron energy             402.789124349213
+  RHF Kinetic energy                  307.134621134865
+  RHF Nuclear energy                  298.694634712597
+  RHF Virial quotient                  -1.000790213230
+
+ !RHF STATE 1.1 Dipole moment           0.02147375    -0.24024810    -0.26240307
+ Dipole moment /Debye                   0.05458082    -0.61064977    -0.66696207
+
+ Orbital energies:
+
+           1.1          2.1          3.1          4.1          5.1          6.1          7.1          8.1          9.1         10.1
+    -20.578091   -11.288247   -11.264777   -11.229646   -11.227789   -11.218809   -11.210199    -1.415036    -1.070639    -1.051266
+
+          11.1         12.1         13.1         14.1         15.1         16.1         17.1         18.1         19.1         20.1
+     -0.981148    -0.889100    -0.790422    -0.738837    -0.654934    -0.636060    -0.601116    -0.575629    -0.570469    -0.553738
+
+          21.1         22.1         23.1         24.1         25.1         26.1         27.1         28.1         29.1
+     -0.540464    -0.533368    -0.520995    -0.517837    -0.485355    -0.333149    -0.328644     0.043250     0.047648
+
+
+ HOMO     27.1    -0.328644 =      -8.9429eV
+ LUMO     28.1     0.043250 =       1.1769eV
+ LUMO-HOMO         0.371893 =      10.1197eV
+
+ Orbitals saved in record  2102.2
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      20    32486.87       500      700      610      701      900      950      970     1002      129      960   
+                                          VAR     GEOM    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS    
+                                         1100     1400     1410     1200     1210     1080     1600     1650     1300     1700   
+                                           S        T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
+
+              2      14       28.42       500      610      700     1000      520     2100     7360      701     1001     2101   
+                                          VAR    BASINP    GEOM     BASIS   MCVARS     RHF    F12ABS    GEOM     BASIS     RHF  
+                                         7350      701(1)  1002     2102   
+                                         EF12     GEOM     BASIS     RHF  
+
+ PROGRAMS   *        TOTAL    HF-SCF       INT   RESTART
+ CPU TIMES  *     32578.08  29249.24   3328.60      0.04
+ REAL TIME  *      3087.09 SEC
+ DISK USED  *       130.14 GB
+ **********************************************************************************************************************************
+
+
+ PROGRAM * CCSD (Unrestricted open-shell coupled cluster)     Authors: C. Hampel, H.-J. Werner, 1991, M. Deegan, P.J. Knowles, 1992
+
+                           UCCSD-F12 implementation by G. Knizia and H.-J. Werner, 2008
+
+                   Density fitting integral evaluation by F.R. Manby, 2003,2007, G. Knizia, 2010
+
+
+ Basis set VTZ-F12/JKFIT generated.      Number of basis functions:   1142 
+ Basis set CC-PVTZ-F12/OPTRI generated.  Number of basis functions:   894 
+ Basis set CC-PVTZ-F12/MP2FIT generated. Number of basis functions:   1156 
+
+ Convergence thresholds:  THRVAR = 1.00D-08  THRDEN = 1.00D-06
+
+ CCSD(T)     terms to be evaluated (factor= 1.000)
+
+
+ Number of core orbitals:           7 (   7 )
+ Number of closed-shell orbitals:  19 (  19 )
+ Number of active  orbitals:        1 (   1 )
+ Number of external orbitals:     506 ( 506 )
+
+ For minimal I/O algorithm in triples, increase memory by 326.44 Mwords to 1326.49 Mwords.
+
+ For full I/O caching in triples, increase memory by 2924.55 Mwords to 3924.60 Mwords.
+
+ Number of N-1 electron functions:              39
+ Number of N-2 electron functions:             741
+ Number of singly external CSFs:             19773
+ Number of doubly external CSFs:         143984451
+ Total number of CSFs:                   144004224
+
+ Molecular orbitals read from record     2102.2  Type=RHF/CANONICAL  
+
+ Multipassing necessary in transformation. To avoid, increase memory by 696.26 Mwords.
+
+ Integral transformation finished. Total CPU:6889.16 sec, npass=  2  Memory used: 951.48 MW
+
+ Geminal basis:    OPTFULL  GEM_TYPE=SLATER  BETA=1.0  NGEM=6
+
+ Optimizing Gaussian exponents for each gem_beta
+
+ Geminal optimization for beta= 1.0000
+ Weight function:   m=0, omega= 1.4646
+
+ Augmented Hessian optimization of geminal fit. Trust ratio= 0.40000
+ Convergence reached after   2 iterations. Final gradient= 8.66D-16, Step= 4.23D-06, Delta= 1.28D-09
+
+ Alpha:                 0.19532     0.81920     2.85917     9.50073    35.69989   197.79328
+ Coeff:                 0.27070     0.30552     0.18297     0.10986     0.06810     0.04224
+
+
+ WFN_F12=FIX,EG    DECOUPLE_EXPL=F   HYBRID=0    NOX=F   SEMIINT_F12=T   CORE_SINGLES=F
+
+
+ AO(A)-basis ORBITAL           loaded. Number of functions:     533
+ RI(R)-basis CC-PVTZ-F12/OPTRI loaded. Number of functions:     894
+ DF-basis VTZ-F12/JKFIT        loaded. Number of functions:    1142
+
+ Screening thresholds:   THRAO=  1.00D-10  THRMO=  1.00D-09  THRPROD=  1.00D-09
+                         THRSW=  1.00D-05  THROV=  1.00D-12  THRAOF12= 1.00D-08
+
+ CPU time for one-electron matrices             282.06 sec
+
+ Construction of ABS:
+ Pseudo-inverse stability          2.42E-11
+ Smallest eigenvalue of S          2.66E-05  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               2.48E-06  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     2.66E-05  (threshold= 2.66E-05, 0 functions deleted, 894 kept)
+
+ Construction of CABS:
+ Pseudo-inverse stability          1.03E-09
+ Smallest eigenvalue of S          1.16E-07  (threshold= 1.00E-08)
+ Ratio eigmin/eigmax               1.16E-07  (threshold= 1.00E-09)
+ Smallest eigenvalue of S kept     1.16E-07  (threshold= 1.16E-07, 0 functions deleted, 894 kept)
+
+ CPU time for basis constructions                 2.37 sec
+ Fock operators(MO) rebuilt from dump record.
+ CPU time for Fock operator transformation        3.51 sec
+
+                                      TOTAL          ALPHA          BETA    
+  Singles Contributions MO        -0.002690647   -0.001358087   -0.001332560
+  Singles Contributions CABS      -0.002714837   -0.001388438   -0.001326399
+  Pure DF-RHF relaxation          -0.002708991
+
+ CPU time for RHF CABS relaxation                 3.83 sec
+ CPU time for singles (tot)                       9.07 sec
+
+ AO(A)-basis ORBITAL           loaded. Number of functions:     533
+ RI(R)-basis CC-PVTZ-F12/OPTRI loaded. Number of functions:     894
+ DF-basis CC-PVTZ-F12/MP2FIT   loaded. Number of functions:    1156
+
+ Screening thresholds:   THRAO=  1.00D-10  THRMO=  1.00D-09  THRPROD=  1.00D-09
+                         THRSW=  1.00D-05  THROV=  1.00D-12  THRAOF12= 1.00D-08
+
+ CPU time for transformed integrals            1650.93 sec
+ CPU time for F12 matrices                       55.27 sec
+
+ Diagonal F12 ansatz with fixed amplitudes:   TS= 0.5000  TT= 0.2500  TN= 0.3750
+
+ ITER.     SQ.NORM      CORR.ENERGY   TOTAL ENERGY  ENERGY CHANGE      VAR         CPU   MICRO    DIIS
+   1      1.37165827    -1.34817141  -308.72820338    -1.3509E+00   3.70E-01     26.03  1  1  1   0  0
+   2      1.37130746    -1.34760105  -308.72763301     5.7037E-04   1.40E-04     90.97  0  0  0   1  1
+   3      1.37159894    -1.34791292  -308.72794489    -3.1188E-04   9.27E-07    169.45  0  0  0   2  2
+   4      1.37160225    -1.34791462  -308.72794658    -1.6903E-06   6.54E-09    261.67  0  0  0   3  3
+   5      1.37160293    -1.34791463  -308.72794659    -1.0999E-08   7.08E-11    369.19  0  0  0   4  4
+
+ - - Continuing with F12/conv. amplitude coupling turned on.
+
+   6      1.37162426    -1.34845924  -308.72849121    -5.4463E-04   1.00E-04    452.98  1  1  1   1  1
+   7      1.37162386    -1.34845939  -308.72849136    -1.4925E-07   2.56E-09    550.83  1  1  1   2  2
+
+ CPU time for iterative RMP2-F12                550.83 sec
+
+
+ DF-RMP2-F12 doubles corrections:
+ - - - - - - - - - - - - - - - - 
+  Approx.                             TOTAL           A-B            A-A            B-B    
+  RMP2-F12/3C(FIX)                -0.100760584   -0.094048295   -0.003586349   -0.003125940
+  RMP2-F12/3*C(FIX)               -0.100215818   -0.093729117   -0.003467004   -0.003019697
+  RMP2-F12/3*C(DX)                -0.100391960   -0.093892173   -0.003474046   -0.003025742
+  RMP2-F12/3*C(FIX,DX)            -0.104099502   -0.097442266   -0.003552755   -0.003104482
+
+ DF-RMP2-F12 doubles energies:
+ - - - - - - - - - - - - - - -
+  Approx.                             TOTAL           A-B            A-A            B-B    
+  RMP2                            -1.245008161   -0.946055225   -0.155426234   -0.143526702
+  RMP2-F12/3C(FIX)                -1.345768746   -1.040103521   -0.159012583   -0.146652642
+  RMP2-F12/3*C(FIX)               -1.345223979   -1.039784342   -0.158893238   -0.146546399
+  RMP2-F12/3*C(DX)                -1.345400122   -1.039947398   -0.158900280   -0.146552444
+  RMP2-F12/3*C(FIX,DX)            -1.349107664   -1.043497491   -0.158978989   -0.146631183
+
+
+  Reference energy                   -307.377322975724
+  CABS relaxation correction to RHF    -0.002708991033
+  New reference energy               -307.380031966757
+
+  RMP2-F12 singles (MO) energy         -0.002690647101
+  RMP2-F12 pair energy                 -1.345768745588
+  RMP2-F12 correlation energy          -1.348459392689
+
+ !RMP2-F12/3C(FIX) energy            -308.728491359447
+
+ Starting RMP2 calculation, locsing= 0
+
+ ITER.      SQ.NORM     CORR.ENERGY   TOTAL ENERGY   ENERGY CHANGE        DEN1      VAR(S)    VAR(P)  DIIS     TIME
+   1      1.36722453    -1.24288792  -308.62021089    -1.24288792    -0.00451553  0.27D-04  0.18D-02  1  1 11587.39
+   2      1.37146785    -1.24775498  -308.62507796    -0.00486707    -0.00000886  0.11D-05  0.43D-05  2  2 11709.47
+   3      1.37160859    -1.24783646  -308.62515944    -0.00008148    -0.00000008  0.57D-07  0.24D-07  3  3 11827.48
+   4      1.37161294    -1.24783701  -308.62515998    -0.00000054    -0.00000000  0.21D-08  0.17D-09  4  4 11949.84
+
+ Norm of t1 vector:      0.04317441      S-energy:    -0.00269049      T1 diagnostic:  0.00059487
+ Norm of t2 vector:      0.60806982      P-energy:    -1.24514652
+                                         Alpha-Beta:  -0.94652860
+                                         Alpha-Alpha: -0.15524183
+                                         Beta-Beta:   -0.14337608
+
+ Spin contamination <S**2-Sz**2-Sz>     0.00025599
+  Reference energy                   -307.377322975724
+  CABS singles correction              -0.002708991033
+  New reference energy               -307.380031966757
+  RHF-RMP2 correlation energy          -1.247837006045
+ !RHF-RMP2 energy                    -308.627868972802
+
+  F12/3C(FIX) correction               -0.100760584327
+  RHF-RMP2-F12 correlation energy      -1.348597590372
+ !RHF-RMP2-F12 total energy          -308.728629557129
+
+ Starting UCCSD calculation
+
+ ITER.      SQ.NORM     CORR.ENERGY   TOTAL ENERGY   ENERGY CHANGE        DEN1      VAR(S)    VAR(P)  DIIS     TIME
+   1      1.37200329    -1.23383508  -308.61115806    -1.23383508    -0.03305396  0.61D-02  0.65D-02  1  1 25983.89
+   2      1.40270194    -1.26466699  -308.64198997    -0.03083191    -0.00307717  0.34D-03  0.99D-03  2  2 41166.97
+   3      1.41592772    -1.27101985  -308.64834283    -0.00635286    -0.00045252  0.28D-03  0.86D-04  3  3 56469.18
+   4      1.42240238    -1.27348578  -308.65080875    -0.00246593    -0.00010505  0.64D-04  0.22D-04  4  4 72102.51
+   5      1.42609738    -1.27403807  -308.65136105    -0.00055229    -0.00003239  0.31D-04  0.38D-05  5  5 87086.14
+   6      1.42835132    -1.27423569  -308.65155866    -0.00019761    -0.00000905  0.71D-05  0.16D-05  6  6101944.36
+   7      1.42978885    -1.27437241  -308.65169538    -0.00013672    -0.00000216  0.19D-05  0.37D-06  6  1115251.40
+   8      1.43026234    -1.27440155  -308.65172453    -0.00002915    -0.00000053  0.33D-06  0.12D-06  6  2130625.21
+   9      1.43044401    -1.27440801  -308.65173099    -0.00000646    -0.00000012  0.95D-07  0.22D-07  6  3145855.84
+  10      1.43047644    -1.27440423  -308.65172721     0.00000378    -0.00000003  0.23D-07  0.55D-08  6  5161116.89
+  11      1.43051622    -1.27440486  -308.65172783    -0.00000062    -0.00000001  0.62D-08  0.12D-08  6  4174843.13
+
+ Norm of t1 vector:      0.15458515      S-energy:    -0.00316377      T1 diagnostic:  0.01632840
+                                                                       D1 diagnostic:  0.06780022
+                                                                       D2 diagnostic:  0.18497578 (internal)
+ Norm of t2 vector:      0.63766735      P-energy:    -1.27124109
+                                         Alpha-Beta:  -0.99810052
+                                         Alpha-Alpha: -0.14218988
+                                         Beta-Beta:   -0.13095068
+
+ Singles amplitudes (print threshold =  0.500E-01):
+
+         I         SYM. A    A   T(IA) [Beta-Beta]
+
+         9         1         1      0.05345027
+        19         1         1     -0.06842190
+
+ Spin contamination <S**2-Sz**2-Sz>     0.00044860
+
+ For minimal I/O algorithm in triples, increase memory by 522.58 Mwords to 1522.63 Mwords.
+
+ For full I/O caching in triples, increase memory by 3136.12 Mwords to 4136.17 Mwords.
+
+ A further 111.29 Mwords of memory are needed for the triples to run. Increase memory to 1111.34 Mwords.
+
+ GLOBAL ERROR fehler on processor   0                                         


### PR DESCRIPTION
Molpro can generate an error asking for more Mwords in multiple different ways. One of the outputs can appear like so:

```console
For minimal I/O algorithm in triples, increase memory by 522.58 Mwords to 1522.63 Mwords.

 For full I/O caching in triples, increase memory by 3136.12 Mwords to 4136.17 Mwords.

 A further 111.29 Mwords of memory are needed for the triples to run. Increase memory to 1111.34 Mwords.

 GLOBAL ERROR fehler on processor   0  
```

Currently, our trsh.py will reverse search this test and pick up on the line

```console
 A further 111.29 Mwords of memory are needed for the triples to run. Increase memory to 1111.34 Mwords.
```

And then break the loop and increase the memory by 111.29Mwords (in this example). However, as it can be seen, there is suggestions for larger Mword increases but they are not parsed. Therefore, I have added into the trsh.py check to also look for the line
```console
 For full I/O caching in triples, increase memory by 3136.12 Mwords to 4136.17 Mwords.
```