### PR TITLE
Rename the output file of a recent opt job before post_sp_actions

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1169,6 +1169,8 @@ class Scheduler(object):
                 for opt_job_name, opt_job in self.job_dict[label]['opt'].items():
                     if int(opt_job_name.split('_a')[-1]) > int(recent_opt_job_name.split('_a')[-1]):
                         recent_opt_job_name, recent_opt_job = opt_job_name, opt_job
+                if recent_opt_job is not None:
+                    recent_opt_job.rename_output_file()
                 self.post_sp_actions(label=label,
                                      sp_path=os.path.join(recent_opt_job.local_path_to_output_file),
                                      level=level,


### PR DESCRIPTION
Job output files are automatically renamed to `output.out` in ARC, unless they are YAML files. Recently I had several instances where I ran ops ans sp jobs at the same DFT level, making ARC to practically skip the redundant sp job, extracting the electronic energy straight from the converged opt job. The opt jobs indeed converged, but their output file wasn't renamed, causing ARC to crash since it cannot find the expected file.

To be on the safe side, I'm adding a call to the `rename_output_file()` Job method before calling `post_sp_actions`.