### PR TITLE
Fix Reaction.get_element_mass()

### DIFF
--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -907,10 +907,10 @@ class ARCReaction(object):
         Get the mass of all elements of a reaction. Uses the atom order of the reactants.
 
         Returns:
-            List[float]: The RMS of the normal mode displacements.
+            List[float]: The masses of all elements in the reactants.
         """
         masses = list()
-        for reactant in self.r_species:
+        for reactant in self.get_reactants_and_products()[0]:
             for atom in reactant.mol.atoms:
                 masses.append(get_element_mass(atom.element.symbol)[0])
         return masses

--- a/arc/reaction_test.py
+++ b/arc/reaction_test.py
@@ -1708,6 +1708,9 @@ H       1.12853146   -0.86793870    0.06973060"""
         self.assertTrue(almost_equal_lists(self.rxn3.get_element_mass(),
                                            [12.0, 12.0, 14.00307400443, 1.00782503224, 1.00782503224, 1.00782503224,
                                             1.00782503224, 1.00782503224, 1.00782503224]))
+        self.assertTrue(almost_equal_lists(self.rxn5.get_element_mass(),
+                                           [14.00307400443, 1.00782503224, 1.00782503224,
+                                            14.00307400443, 1.00782503224, 1.00782503224]))
 
     def test_get_bonds(self):
         """Test the get_bonds() method."""


### PR DESCRIPTION
The `get_element_mass` method in Reaction iterates through the elements of the reactants and returns the mass of the respective elements. However, it doesn't take into account that when a reaction has two identical reactant (e.g., `OH + OH <=> H2O2`), ARC only stores one instance of the reactant species to avoid running duplicate identical QM jobs.
This method was fixed and it uses now the `get_reactants_and_products` method that considers identical reactants/products.
A test was added.