### PR TITLE
Don't trsh conformer isomorphism if no XYZ is given

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -3325,7 +3325,8 @@ class Scheduler(object):
 
             # rerun conformer job at higher level for all conformers
             for conformer in range(0, num_of_conformers):
-
+                if conformer >= len(self.species_dict[label].conformers_before_opt):
+                    break
                 # initial xyz before troubleshooting
                 xyz = self.species_dict[label].conformers_before_opt[conformer]
 


### PR DESCRIPTION
I got the following trace when running C2H5NO2 (smiles `[O-][N+](=O)CC`) at CBS-QB3:

```
Warning: Isomorphism check for all conformers of species C2H5NO2 failed at wb97xd/def2svp. Attempting to troubleshoot using a different level.
Troubleshooting conformer job in gaussian using wb97xd/def2TZVP for species C2H5NO2
Traceback (most recent call last):
  File "/Code/ARC/ARC.py", line 69, in <module>
    main()
  File "/Code/ARC/ARC.py", line 65, in main
    arc_object.execute()
  File "/Code/ARC/arc/main.py", line 583, in execute
    fine_only=self.fine_only,
  File "/Code/ARC/arc/scheduler.py", line 481, in __init__
    self.schedule_jobs()
  File "/Code/ARC/arc/scheduler.py", line 534, in schedule_jobs
    self.determine_most_stable_conformer(label)  # also checks isomorphism
  File "/Code/ARC/arc/scheduler.py", line 2004, in determine_most_stable_conformer
    self.troubleshoot_conformer_isomorphism(label=label)
  File "/Code/ARC/arc/scheduler.py", line 3340, in troubleshoot_conformer_isomorphism
    xyz = self.species_dict[label].conformers_before_opt[conformer]
```

Some debugging exposed that ARC tried to troubleshoot the second conformer (index 1), but the Species `.conformers_before_opt` attribute contained only a tuple of length 1 with XYZ.

A check for the iterator was now added to avoid crashing.