### PR TITLE
Extracted sorting indices and sort the plot by them

### DIFF
--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -1138,7 +1138,9 @@ def plot_1d_rotor_scan(angles: Optional[Union[list, tuple, np.array]] = None,
     marker_color, line_color = plt.cm.viridis([0.1, 0.9])
     fig = plt.figure(figsize=(4, 3), dpi=120)
     plt.subplot(1, 1, 1)
-    plt.plot(angles, energies, '.-', markerfacecolor=marker_color,
+    sort = np.argsort(angles)
+    plt.plot(np.array(angles)[sort], np.array(energies)[sort],
+             '.-', markerfacecolor=marker_color,
              markeredgecolor=marker_color, color=line_color)
     plt.xlabel('Dihedral angle increment (degrees)')
     min_angle = int(np.ceil(min(angles) / 10.0)) * 10


### PR DESCRIPTION
This is to avoid plotting errors, such as:
![3, 4](https://user-images.githubusercontent.com/75449651/228196817-e4576c96-fdf3-4b46-817e-694f15f6484e.png)
That after the patch becomes:
![image](https://user-images.githubusercontent.com/75449651/228196908-e48be2f2-d637-4d40-8d2f-8827018f5c39.png)
