### PR TITLE
Commented out the reset of the job_dict conformers

### DIFF
--- a/arc/job/adapters/ts/heuristics.py
+++ b/arc/job/adapters/ts/heuristics.py
@@ -1011,7 +1011,7 @@ def h_abstraction(arc_reaction: 'ARCReaction',
                     d3=d3,
                     reactants_reversed=reactants_reversed,
                 )
-            except ValueError as e:
+            except (ValueError, IndexError) as e:
                 logger.error(f'Could not generate a guess using Heuristics for H abstraction reaction, got:\n{e}')
 
             if xyz_guess is not None and not colliding_atoms(xyz_guess):

--- a/arc/main.py
+++ b/arc/main.py
@@ -553,7 +553,7 @@ class ARC(object):
         logger.info('\n')
         for rxn in self.reactions:
             if not isinstance(rxn, ARCReaction):
-                raise ValueError(f'All reactions be ARCReaction objects. Got {type(rxn)}')
+                raise ValueError(f'All reactions must be ARCReaction objects. Got {type(rxn)}')
         self.scheduler = Scheduler(project=self.project,
                                    species_list=self.species,
                                    rxn_list=self.reactions,

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1743,7 +1743,7 @@ class Scheduler(object):
         if self.species_dict[label].initial_xyz is None and self.species_dict[label].final_xyz is None \
                 and not self.testing:
             if len(self.species_dict[label].conformers) > 1:
-                self.job_dict[label]['conformers'] = dict()
+                #self.job_dict[label]['conformers'] = dict()
                 for i, xyz in enumerate(self.species_dict[label].conformers):
                     self.run_job(label=label,
                                  xyz=xyz,


### PR DESCRIPTION
The current workaround is to remove the reset of the self.job_dict[label]['conformers']

@alongd was there a specific reason for this line of code originally?