### PR TITLE
Changed a ValueError in h_abstraciton heuristics into a warning

### DIFF
--- a/arc/job/adapters/ts/heuristics.py
+++ b/arc/job/adapters/ts/heuristics.py
@@ -938,7 +938,8 @@ def h_abstraction(arc_reaction: 'ARCReaction',
         Entries are Cartesian coordinates of TS guesses for all reactions.
     """
     if not len(rmg_reactions):
-        raise ValueError('Cannot generate TS guesses without an RMG Reaction object instance.')
+        logger.warning(f'Cannot generate TS guesses for {arc_reaction} without an RMG Reaction object instance.')
+        return list()
 
     xyz_guesses = list()
     dihedral_increment = dihedral_increment or DIHEDRAL_INCREMENT


### PR DESCRIPTION
ARC shouldn't crush if a single TS cannot be found using heuristics. Converted an error into a logger warning.