### PR TITLE
Fix the molpro input file memory

### DIFF
--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -319,13 +319,8 @@ ${self.species[0].occ}wf,spin=${input_dict['spin']},charge=${input_dict['charge'
         """
         Set the input_file_memory attribute.
         """
-        # Molpro's memory is per cpu core and in MW (mega word; 1 MW ~= 8 MB; 1 GB = 128 MW)
-        # https://www.molpro.net/pipermail/molpro-user/2010-April/003723.html
-        # In the link, they describe the conversion of 100,000,000 Words (100Mword) is equivalent to
-        # 800,000,000 bytes (800 mb). 
-        # Formula - (100,000,000 [Words]/( 800,000,000 [Bytes] / (job mem in gb * 1000,000,000 [Bytes])))/ 1000,000 [Words -> MegaWords] 
-        # The division by 1E6 is for converting into MWords
-        self.input_file_memory = math.ceil((1E8/(8E8 /(self.job_memory_gb * 1E9)))/1E6)
+        # Molpro's memory is per cpu core and in MW (mega word; 1000 MW = 7.45 GB on a 64-bit machine)
+        self.input_file_memory = math.ceil(self.job_memory_gb / (7.45e-3 * self.cpu_cores))
         
     def execute_incore(self):
         """

--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -320,6 +320,15 @@ ${self.species[0].occ}wf,spin=${input_dict['spin']},charge=${input_dict['charge'
         Set the input_file_memory attribute.
         """
         # Molpro's memory is per cpu core and in MW (mega word; 1000 MW = 7.45 GB on a 64-bit machine)
+        # The conversion from mW to GB was done using this (https://deviceanalytics.com/words-to-bytes-converter/)
+        # specifying a 64-bit architecture.
+        #
+        # See also:
+        # https://www.molpro.net/pipermail/molpro-user/2010-April/003723.html
+        # In the link, they describe the conversion of 100,000,000 Words (100Mword) is equivalent to
+        # 800,000,000 bytes (800 mb).
+        # Formula - (100,000,000 [Words]/( 800,000,000 [Bytes] / (job mem in gb * 1000,000,000 [Bytes])))/ 1000,000 [Words -> MegaWords]
+        # The division by 1E6 is for converting into MWords
         self.input_file_memory = math.ceil(self.job_memory_gb / (7.45e-3 * self.cpu_cores))
         
     def execute_incore(self):

--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -8,6 +8,7 @@ import datetime
 import math
 import os
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+import socket
 
 from mako.template import Template
 
@@ -329,7 +330,8 @@ ${self.species[0].occ}wf,spin=${input_dict['spin']},charge=${input_dict['charge'
         # 800,000,000 bytes (800 mb).
         # Formula - (100,000,000 [Words]/( 800,000,000 [Bytes] / (job mem in gb * 1000,000,000 [Bytes])))/ 1000,000 [Words -> MegaWords]
         # The division by 1E6 is for converting into MWords
-        self.input_file_memory = math.ceil(self.job_memory_gb / (7.45e-3 * self.cpu_cores))
+                # Due to Zeus's configuration, there is only 1 nproc so the memory should not be divided by cpu_cores. 
+        self.input_file_memory = math.ceil(self.job_memory_gb / (7.45e-3 * self.cpu_cores)) if 'zeus' not in socket.gethostname() else math.ceil(self.job_memory_gb / (7.45e-3))
         
     def execute_incore(self):
         """

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -46,16 +46,29 @@ class TestMolproAdapter(unittest.TestCase):
 
     def test_set_input_file_memory(self):
         """Test setting the input_file_memory argument"""
-        expected_memory = math.ceil((1E8/(8E8 /(14 * 1E9)))/1E6)
-        self.assertEqual(self.job_1.input_file_memory, expected_memory)
+        self.job_1.input_file_memory = None
+        self.job_1.cpu_cores = 48
+        self.job_1.set_input_file_memory()
+        self.assertEqual(self.job_1.input_file_memory, 40)
+
+        self.job_1.cpu_cores = 8
+        self.job_1.set_input_file_memory()
+        self.assertEqual(self.job_1.input_file_memory, 235)
+
+        self.job_1.input_file_memory = None
+        self.job_1.cpu_cores = 1
+        self.job_1.set_input_file_memory()
+        self.assertEqual(self.job_1.input_file_memory, 1880)
 
     def test_write_input_file(self):
         """Test writing Gaussian input files"""
+        self.job_1.cpu_cores = 48
+        self.job_1.set_input_file_memory()
         self.job_1.write_input_file()
         with open(os.path.join(self.job_1.local_path, input_filenames[self.job_1.job_adapter]), 'r') as f:
             content_1 = f.read()
         job_1_expected_input_file = """***,spc1
-memory,1750,m;
+memory,40,m;
 file,1,file1.int    !allocate permanent integral file
 file,2,file2.wfu    !allocate permanent wave-function (dump) file
 


### PR DESCRIPTION
Molpro's input file memory is per cpu core, this PR returns this consideration into the calculation.
The conversion from mW to GB was done using [this website](https://deviceanalytics.com/words-to-bytes-converter/) specifying a 64-bit architecture.

A test was added

I snack in two minor TS-related commits into this small PR:
1. Added a shortcut to specify `xyz` when initializing an `ARCReaction` object (in addition to `ts_xyz_guess` which is less intuitive)
2. Initialize user TS guesses with the `success` flag (relates to the method used to generate the guess and whether it gave any guesses, which is always true for a user guess - it has nothing to do with whether the guess is actually reasonable or not)