### PR TITLE
Fix env

### DIFF
--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -335,13 +335,9 @@ for autotst_pypath in [autotst_pypath_1, autotst_pypath_2, autotst_pypath_3, aut
 paths = list()
 paths.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))),
                             'xtb_env', 'bin', 'xtb'))
-paths.append(os.path.join(home, 'anaconda3', 'envs', 'arc_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, 'anaconda3', 'envs', 'xtb_env', 'bin', 'xtb'))
-paths.append(os.path.join(home, 'miniconda3', 'envs', 'arc_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, 'miniconda3', 'envs', 'xtb_env', 'bin', 'xtb'))
-paths.append(os.path.join(home, '.conda', 'envs', 'arc_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, '.conda', 'envs', 'xtb_env', 'bin', 'xtb'))
-paths.append(os.path.join('/Local/ce_dana', 'anaconda3', 'envs', 'arc_env', 'bin', 'xtb'))
 paths.append(os.path.join('/Local/ce_dana', 'anaconda3', 'envs', 'xtb_env', 'bin', 'xtb'))
 for xtb_path in paths:
     if os.path.isfile(xtb_path):

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -334,7 +334,7 @@ for autotst_pypath in [autotst_pypath_1, autotst_pypath_2, autotst_pypath_3, aut
 
 paths = list()
 paths.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))),
-                            'arc_env', 'bin', 'xtb'))
+                            'xtb_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, 'anaconda3', 'envs', 'arc_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, 'anaconda3', 'envs', 'xtb_env', 'bin', 'xtb'))
 paths.append(os.path.join(home, 'miniconda3', 'envs', 'arc_env', 'bin', 'xtb'))
@@ -349,7 +349,7 @@ for xtb_path in paths:
         break
 
 arc_pypath_1 = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))),
-                            'arc_env', 'bin', 'python')
+                            'xtb_env', 'bin', 'python')
 arc_pypath_2 = os.path.join(home, 'anaconda3', 'envs', 'arc_env', 'bin', 'python')
 arc_pypath_3 = os.path.join(home, 'miniconda3', 'envs', 'arc_env', 'bin', 'python')
 arc_pypath_4 = os.path.join(home, '.conda', 'envs', 'arc_env', 'bin', 'python')

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -349,7 +349,7 @@ for xtb_path in paths:
         break
 
 arc_pypath_1 = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))),
-                            'xtb_env', 'bin', 'python')
+                            'arc_env', 'bin', 'python')
 arc_pypath_2 = os.path.join(home, 'anaconda3', 'envs', 'arc_env', 'bin', 'python')
 arc_pypath_3 = os.path.join(home, 'miniconda3', 'envs', 'arc_env', 'bin', 'python')
 arc_pypath_4 = os.path.join(home, '.conda', 'envs', 'arc_env', 'bin', 'python')

--- a/arc/utils/wip.py
+++ b/arc/utils/wip.py
@@ -1,26 +1,12 @@
-#!/usr/bin/env python
-# encoding: utf-8
-#
-# Decorator to mark a unit test as a "work_in_progress"
-# From http://www.natpryce.com/articles/000788.html
-# Copyright 2011 Nat Pryce. Posted 2011-05-30
+import unittest
 from functools import wraps
-
-from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
-
-
-def fail(message):
-    raise AssertionError(message)
-
 
 def work_in_progress(f):
     @wraps(f)
-    def run_test(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         try:
             f(*args, **kwargs)
         except Exception as e:
-            raise SkipTest("WIP test failed: " + str(e))
-        fail("test passed but marked as work in progress")
-
-    return attr('work_in_progress')(run_test)
+            raise unittest.SkipTest("WIP test failed: " + str(e))
+        raise AssertionError("test passed but marked as work in progress")
+    return wrapper

--- a/devtools/install_xtb.sh
+++ b/devtools/install_xtb.sh
@@ -38,6 +38,10 @@ else
     conda activate xtb_env
 fi
 
-$COMMAND_PKG install -c conda-forge xtb -y
+# Install xtb
+$COMMAND_PKG install -n xtb_env -c conda-forge  xtb=6.3.3 -y
+
+# Install pyyaml
 $COMMAND_PKG install -c anaconda pyyaml -y
-$COMMAND_PKG activate base
+
+$COMMAND_PKG deactivate

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,12 @@ channels:
   - defaults
   - rmg
   - conda-forge
+  - cantera
+  - anaconda
 dependencies:
   - cairo
   - cairocffi
-  - rmg::cantera >=2.3.0
+  - cantera::cantera=2.6
   - conda-forge::cclib >=1.7.0
   - rmg::chemprop
   - coolprop
@@ -25,9 +27,8 @@ dependencies:
   - mpmath
   - rmg::muq2
   - networkx
-  - nose
   - rmg::numdifftools
-  - numpy >=1.10.0
+  - numpy==1.20.1
   - conda-forge::openbabel >= 3
   - pandas
   - psutil
@@ -57,5 +58,4 @@ dependencies:
   - mako
   - pytables
   - anaconda::pytest
-  - conda-forge::xtb
   - conda-forge::pytest-cov


### PR DESCRIPTION
This PR contains two features:

1. An update to the ARC environment, specifically numpy and cantera version update, and removal of nosetests, which is deprecated
2. replacing the `@wip` decorator with a one that is not dependent on nosetests.