### PR TITLE
Changing MOPAC channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - rmg::lpsolve55
   - markupsafe
   - matplotlib >=1.5
-  - rmg::mopac
+  - conda-forge::mopac
   - mpmath
   - rmg::muq2
   - networkx


### PR DESCRIPTION
RMG team has removed mopac from the rmg channel, thus we need to change the channel of our mopac installation from rmg to conda-forge