### PR TITLE
Gaussian Troubleshoot Combinations Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ timer.dat
 
 # .trunk folder
 .trunk
+
+# ignore files created from tests
+nul
+run.out

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ timer.dat
 
 # .vscode
 .vscode
+
+# .trunk folder
+.trunk

--- a/arc/imports.py
+++ b/arc/imports.py
@@ -24,7 +24,7 @@ if os.path.isfile(local_arc_settings_path):
         import settings as local_settings
     except ImportError:
         pass
-    if local_settings and 'pytest' not in sys.modules:
+    if local_settings:
         local_settings_dict = {key: val for key, val in vars(local_settings).items() if '__' not in key}
         settings.update(local_settings_dict)
         # Set global_ess_settings to None if using a local settings file (ARC's defaults are dummies)

--- a/arc/job/adapter_test.py
+++ b/arc/job/adapter_test.py
@@ -364,7 +364,7 @@ class TestJobAdapter(unittest.TestCase):
                          'trsh': {}}
         self.assertEqual(self.job_1.args, expected_args)
         self.job_1.write_input_file()
-        new_expected_args = {'keyword': {'general': 'val_tst_1 val_tst_2     val_tst_3 scf=xqc'},  #  scf=xqc
+        new_expected_args = {'keyword': {'general': 'val_tst_1 val_tst_2     val_tst_3'}, 
                              'block': {'specific_key_2': 'val_tst_4\nval_tst_5'},
                              'trsh': {}}
         self.assertEqual(self.job_1.args, new_expected_args)

--- a/arc/job/adapters/common_test.py
+++ b/arc/job/adapters/common_test.py
@@ -110,19 +110,36 @@ class TestJobCommon(unittest.TestCase):
 
         input_dict = common.update_input_dict_with_args(args={'block': {'1': """a\nb"""}},
                                                         input_dict={'block': ''})
-        self.assertEqual(input_dict, {'block': """\n\na\nb\n"""})
+        self.assertEqual(input_dict, {'block': """\n\na\nb"""})
 
         input_dict = common.update_input_dict_with_args(args={'block': {'1': """a\nb"""}},
                                                         input_dict={'block': """x\ny\n"""})
-        self.assertEqual(input_dict, {'block': """x\ny\na\nb\n"""})
+        self.assertEqual(input_dict, {'block': """x\ny\na\nb"""})
 
         input_dict = common.update_input_dict_with_args(args={'keyword': {'scan_trsh': 'keyword 1'}},
                                                         input_dict={})
-        self.assertEqual(input_dict, {'scan_trsh': 'keyword 1 '})
+        self.assertEqual(input_dict, {'scan_trsh': 'keyword 1'})
 
         input_dict = common.update_input_dict_with_args(args={'keyword': {'opt': 'keyword 2'}},
                                                         input_dict={})
-        self.assertEqual(input_dict, {'keywords': 'keyword 2 '})
+        self.assertEqual(input_dict, {'keywords': 'keyword 2'})
+
+    def test_update_input_dict_with_multiple_args(self):
+        """Test the update_input_dict_with_args() function with multiple arguments in args."""
+        args = {
+            'block': {'1': 'block text 1'},
+            'keyword': {'opt': 'keyword opt'},
+            'trsh': ['trsh value 1']
+        }
+        input_dict = {'block': 'existing block', 'keywords': 'existing keywords', 'trsh': 'existing trsh'}
+        expected_dict = {
+            'block': 'existing block\nblock text 1',
+            'keywords': 'existing keywords keyword opt',
+            'trsh': 'existing trsh trsh value 1'
+        }
+
+        result_dict = common.update_input_dict_with_args(args=args, input_dict=input_dict)
+        self.assertEqual(result_dict, expected_dict)
 
     def test_set_job_args(self):
         """Test the set_job_args() function"""
@@ -151,6 +168,66 @@ class TestJobCommon(unittest.TestCase):
 
         ans = common.which(command=['python'], return_bool=False, raise_error=False)
         self.assertIn('bin/python', ans)
+    
+    def test_combine_parameters(self):
+        """Test the combine_parameters function for normal input."""
+        input_dict = {'param1': 'value1 term1 value2', 'param2': 'another value term2'}
+        terms = ['term1', 'term2']
+        expected_dict = {'param1': 'value1  value2', 'param2': 'another value '}
+        expected_parameters = ['term1', 'term2']
+
+        modified_dict, parameters = common.combine_parameters(input_dict, terms)
+        
+        self.assertEqual(modified_dict, expected_dict)
+        self.assertEqual(parameters, expected_parameters)
+
+    def test_combine_parameters_empty_input(self):
+        """Test the combine_parameters function with empty input."""
+        input_dict = {}
+        terms = ['term1', 'term2']
+        expected_dict = {}
+        expected_parameters = []
+
+        modified_dict, parameters = common.combine_parameters(input_dict, terms)
+        
+        self.assertEqual(modified_dict, expected_dict)
+        self.assertEqual(parameters, expected_parameters)
+
+    def test_combine_parameters_no_match(self):
+        """Test the combine_parameters function with no matching terms."""
+        input_dict = {'param1': 'value1 value2', 'param2': 'another value'}
+        terms = ['nonexistent']
+        expected_dict = {'param1': 'value1 value2', 'param2': 'another value'}
+        expected_parameters = []
+
+        modified_dict, parameters = common.combine_parameters(input_dict, terms)
+        
+        self.assertEqual(modified_dict, expected_dict)
+        self.assertEqual(parameters, expected_parameters)
+
+    def test_input_dict_strip(self):
+        """Test the input_dict_strip() function"""
+        input_dict = {
+            'key1': '  value1  ',
+            'key2': ' value2  ',
+            'key3': '\nvalue3\n',
+            'key4': ' value4\n',
+            'key5': None,
+            'key6': 42,  # Not a string, should remain unchanged
+            'key7': '\nvalue7 '
+        }
+
+        expected_stripped_dict = {
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': '\nvalue3\n',
+            'key4': 'value4\n',
+            'key6': 42,  # Should not be stripped
+            'key7': '\nvalue7'
+        }
+
+        stripped_dict = common.input_dict_strip(input_dict)
+        self.assertEqual(stripped_dict, expected_stripped_dict)
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/job/adapters/gaussian_test.py
+++ b/arc/job/adapters/gaussian_test.py
@@ -15,7 +15,7 @@ from arc.job.adapters.gaussian import GaussianAdapter
 from arc.level import Level
 from arc.settings.settings import input_filenames, output_filenames, servers, submit_filenames
 from arc.species import ARCSpecies
-
+import arc.job.trsh as trsh
 
 class TestGaussianAdapter(unittest.TestCase):
     """
@@ -130,6 +130,149 @@ class TestGaussianAdapter(unittest.TestCase):
                             species=[ARCSpecies(label='anion', xyz=['O 0 0 1'], charge=-1, is_ts=False)],
                             testing=True,
                             )
+        cls.job_10 = GaussianAdapter(execution_type='local',
+                            job_type='optfreq',
+                            level=Level(method='wb97xd'),
+                            fine=True,
+                            project='test',
+                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                            species=[ARCSpecies(label='anion', xyz=['O 0 0 1'], charge=-1, is_ts=False)],
+                            testing=True,
+                            args={'trsh': {'trsh': ['int=(Acc2E=14)']}},
+                            )
+
+        # Setting up for ESS troubleshooting input file writing
+
+        label = 'anion'
+        level_of_theory = {'method': 'wb97xd'}
+        server = 'server1'
+        job_type = 'optfreq'
+        software = 'gaussian'
+        fine = True
+        memory_gb = 16
+        num_heavy_atoms = 2
+        ess_trsh_methods = ['int=(Acc2E=14)']
+        cpu_cores = 8
+
+        # Gaussian: Checkfile error
+        job_status = {'keywords': ['CheckFile']}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        spc_11 = ARCSpecies(label='ethanol', xyz=["""C	1.1658210	-0.4043550	0.0000000
+                                                    C	0.0000000	0.5518050	0.0000000
+                                                    O	-1.1894600	-0.2141940	0.0000000
+                                                    H	-1.9412580	0.3751850	0.0000000
+                                                    H	2.1054020	0.1451160	0.0000000
+                                                    H	1.1306240	-1.0387850	0.8830320
+                                                    H	1.1306240	-1.0387850	-0.8830320
+                                                    H	0.0476820	1.1930570	0.8835910
+                                                    H	0.0476820	1.1930570	-0.8835910"""],
+                           directed_rotors={'brute_force_sp': [[1, 2], [2, 3]]})
+        cls.job_11 = GaussianAdapter(execution_type='local',
+                            job_type='optfreq',
+                            level=Level(method='wb97xd'),
+                            fine=True,
+                            ess_trsh_methods=ess_trsh_methods,
+                            project='test',
+                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                            species=[spc_11],
+                            testing=True,
+                            args=args
+                            )
+        
+        # Gaussian: Checkfile error and SCF error
+        # First SCF error - qc,nosymm
+        job_status = {'keywords': ['SCF']}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_12 = GaussianAdapter(execution_type='local',
+                                          job_type='optfreq',
+                                          level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+        
+        # Gaussian: Additional SCF error
+        # Second SCF error - Includes previous SCF error and NDump=30
+        job_status = {'keywords': ['SCF']}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_13 = GaussianAdapter(execution_type='local',
+                                          job_type='optfreq',
+                                          level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+        
+        # Gaussian: Additional SCF error
+        # Third SCF error - Includes previous SCF errors and NoDIIS
+        job_status = {'keywords': ['SCF']}
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_14 = GaussianAdapter(execution_type='local',
+                                          job_type='optfreq',
+                                          level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+
+        # Gaussian: Internal coordinate error including a checkfile error and SCF errors
+        #           Job type is switched to opt
+        job_status = {'keywords': ['InternalCoordinateError']}
+        job_type_15 = 'opt' # Need to switch job types for this error
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                          job_type_15, software, fine, memory_gb,  
+                                                                            num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_15 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
 
     def test_set_cpu_and_mem(self):
         """Test assigning number of cpu's and memory"""
@@ -154,7 +297,7 @@ class TestGaussianAdapter(unittest.TestCase):
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc) cbs-qb3   IOp(2/9=2000) IOp(1/12=5,3/44=0) scf=xqc  
+#P opt=(calcfc) cbs-qb3   IOp(2/9=2000) IOp(1/12=5,3/44=0)  
 
 spc1
 
@@ -172,7 +315,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc) SCRF=(smd, Solvent=water) uwb97xd/def2tzvp   IOp(2/9=2000) scf=xqc  
+#P opt=(calcfc) SCRF=(smd, Solvent=water) uwb97xd/def2tzvp   IOp(2/9=2000)   
 
 spc1
 
@@ -190,7 +333,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(modredundant, calcfc, noeigentest, maxStep=5) scf=(tight, direct) integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000) scf=xqc  
+#P opt=(modredundant, calcfc, noeigentest, maxStep=5)  integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000)    scf=(tight, direct)
 
 ethanol
 
@@ -213,7 +356,6 @@ gaussian
 block
 
 
-
 """
         self.assertEqual(content_4, job_4_expected_input_file)
 
@@ -224,7 +366,7 @@ block
 %mem=14336mb
 %NProcShared=8
 
-#P  uwb97xd/def2tzvp freq IOp(7/33=1) scf=(tight, direct) integral=(grid=ultrafine, Acc2E=12)  IOp(2/9=2000) scf=xqc  
+#P  uwb97xd/def2tzvp freq IOp(7/33=1)  integral=(grid=ultrafine, Acc2E=12)  IOp(2/9=2000)    scf=(tight, direct)
 
 birad_singlet
 
@@ -242,7 +384,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc) uwb97xd/def2tzvp   IOp(2/9=2000) scf=xqc  
+#P opt=(calcfc) uwb97xd/def2tzvp   IOp(2/9=2000)   
 
 anion
 
@@ -260,7 +402,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P irc=(CalcAll, reverse, maxpoints=50, stepsize=7) wb97xd/def2tzvp   IOp(2/9=2000) scf=xqc  
+#P irc=(CalcAll, reverse, maxpoints=50, stepsize=7) wb97xd/def2tzvp   IOp(2/9=2000)   
 
 IRC
 
@@ -319,6 +461,163 @@ O       0.00000000    0.00000000    1.00000000
     def test_gaussian_def2tzvp(self):
         """Test a Gaussian job using def2-tzvp"""
         self.assertEqual(self.job_9.level.basis.lower(), 'def2tzvp')
+    
+    def test_trsh_write_input_file(self):
+        """Test writing a trsh input file
+        1. Test with getting Acc2E14 as the trsh method and thus changing the input file integral algorithm, and is also 'fine' thus it will have direct and tight SCF (but not xqc)
+        2. Test with getting Acc2E14 as the trsh method but also checkfile=None in ess_trsh_methods, thus it will have both changes in the input file
+        3. Test with getting Acc2E14 as the trsh method but also checkfile=None in ess_trsh_methods and first SCF error thus it will have all three changes in the input file
+        4. Test with getting Acc2E14 as the trsh method but also checkfile=None in ess_trsh_methods and first and second SCF error and also the input file already has the integral algorithm change thus it will have all four changes in the input file
+        5. Test with getting Acc2E14 as the trsh method but also checkfile=None in ess_trsh_methods and first, second and third SCF error and also the input file already has the integral algorithm change and also the input file already has the scf algorithm change thus it will have all five changes in the input file
+        6. Test with all previous errors but now include an internal coordinate error thus it will have all six changes in the input file
+        """
+        self.job_10.write_input_file()
+        with open(os.path.join(self.job_10.local_path, input_filenames[self.job_10.job_adapter]), 'r') as f:
+            content_10 = f.read()
+        job_10_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) uwb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(tight,direct)
+
+anion
+
+-1 2
+O       0.00000000    0.00000000    1.00000000
+
+
+"""
+        self.assertEqual(content_10, job_10_expected_input_file)
+
+        self.job_11.write_input_file()
+        with open(os.path.join(self.job_11.local_path, input_filenames[self.job_11.job_adapter]), 'r') as f:
+            content_11 = f.read()
+        job_11_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(tight,direct)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_11, job_11_expected_input_file)
+
+        self.job_12.write_input_file()
+        with open(os.path.join(self.job_12.local_path, input_filenames[self.job_12.job_adapter]), 'r') as f:
+            content_12 = f.read()
+        job_12_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_12, job_12_expected_input_file)
+
+        self.job_13.write_input_file()
+        with open(os.path.join(self.job_13.local_path, input_filenames[self.job_13.job_adapter]), 'r') as f:
+            content_13 = f.read()
+        job_13_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm,NDump=30)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_13, job_13_expected_input_file)
+
+        self.job_14.write_input_file()
+        with open(os.path.join(self.job_14.local_path, input_filenames[self.job_14.job_adapter]), 'r') as f:
+            content_14 = f.read()
+        job_14_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm,NDump=30,NoDIIS)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_14, job_14_expected_input_file)
+
+        self.job_15.write_input_file()
+        with open(os.path.join(self.job_15.local_path, input_filenames[self.job_15.job_adapter]), 'r') as f:
+            content_15 = f.read()
+        job_15_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)   opt=(cartesian,nosymm)   scf=(tight,direct,xqc,nosymm,NDump=30,NoDIIS)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_15, job_15_expected_input_file)
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/job/adapters/orca_test.py
+++ b/arc/job/adapters/orca_test.py
@@ -86,7 +86,7 @@ class TestOrcaAdapter(unittest.TestCase):
         self.job_1.write_input_file()
         with open(os.path.join(self.job_1.local_path, input_filenames[self.job_1.job_adapter]), 'r') as f:
             content_1 = f.read()
-        job_1_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno 
+        job_1_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
 !sp 
 
 %maxcore 1792
@@ -113,7 +113,7 @@ H      -0.53338088   -0.77135867   -0.54806440
         self.job_2.write_input_file()
         with open(os.path.join(self.job_2.local_path, input_filenames[self.job_2.job_adapter]), 'r') as f:
             content_2 = f.read()
-        job_2_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno 
+        job_2_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
 !sp 
 
 %maxcore 1792
@@ -131,7 +131,6 @@ end
 end
             
 
-
 * xyz 0 2
 C       0.03807240    0.00035621   -0.00484242
 O       1.35198769    0.01264937   -0.17195885
@@ -148,7 +147,7 @@ H      -0.53338088   -0.77135867   -0.54806440
         self.job_3.write_input_file()
         with open(os.path.join(self.job_3.local_path, input_filenames[self.job_3.job_adapter]), 'r') as f:
             content_3 = f.read()
-        job_3_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno 
+        job_3_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
 !sp 
 
 %maxcore 1792
@@ -163,7 +162,6 @@ end
 
 !CPCM(water)
             
-
 
 * xyz 0 2
 C       0.03807240    0.00035621   -0.00484242

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -53,6 +53,15 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('Error termination via Lnk1e', line)
         self.assertIn('g09/l913.exe', line)
 
+        path = os.path.join(self.base_path['gaussian'], 'l301_checkfile.out')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='Zr2O4H', job_type='opt')
+        self.assertEqual(status, 'errored')
+        self.assertEqual(keywords, ['CheckFile'])
+        self.assertEqual(error, 'No data on chk file.')
+        self.assertIn('Error termination via Lnk1e', line)
+        self.assertIn('g09/l301.exe', line)
+
         path = os.path.join(self.base_path['gaussian'], 'l301.out')
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label='Zr2O4H', job_type='opt')
@@ -61,6 +70,15 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, 'The basis set 6-311G is not appropriate for the this chemistry.')
         self.assertIn('Error termination via Lnk1e', line)
         self.assertIn('g16/l301.exe', line)
+
+        path = os.path.join(self.base_path['gaussian'], 'l401.out')
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label='Zr2O4H', job_type='opt')
+        self.assertEqual(status, 'errored')
+        self.assertEqual(keywords, ['CheckFile'])
+        self.assertEqual(error, 'Basis set data is not on the checkpoint file.')
+        self.assertIn('Error termination via Lnk1e', line)
+        self.assertIn('g09/l401.exe', line)
 
         path = os.path.join(self.base_path['gaussian'], 'l9999.out')
         status, keywords, error, line = trsh.determine_ess_status(
@@ -292,8 +310,8 @@ class TestTrsh(unittest.TestCase):
                                                                        job_type, software, fine, memory_gb,
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
 
-        self.assertFalse(remove_checkfile)
-        self.assertEqual(trsh_keyword, 'opt=(cartesian,nosymm)')
+        self.assertTrue(remove_checkfile)
+        self.assertEqual(trsh_keyword, ['opt=(cartesian,nosymm)', 'int=(Acc2E=14)'] )
 
         # Test Q-Chem
         software = 'qchem'

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -575,9 +575,8 @@ class ARCSpecies(object):
                 self._number_of_heavy_atoms = len([symbol for symbol in self.get_xyz()['symbols'] if symbol != 'H'])
             elif self.is_ts:
                 for ts_guess in self.ts_guesses:
-                    if ts_guess.xyz is not None:
-                        self._number_of_heavy_atoms = \
-                            len([line for line in ts_guess.xyz.splitlines() if line.split()[0] != 'H'])
+                    if ts_guess.get_xyz() is not None:
+                        self._number_of_heavy_atoms = len([symbol for symbol in ts_guess.get_xyz()['symbols'] if symbol != 'H'])
         return self._number_of_heavy_atoms
 
     @number_of_heavy_atoms.setter

--- a/arc/testing/trsh/gaussian/l301_checkfile.out
+++ b/arc/testing/trsh/gaussian/l301_checkfile.out
@@ -1,0 +1,259 @@
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /usr/local/g09/l1.exe "/gtmp/calvin.p/scratch/g09/439484.zeus-master/Gau-69918.inp" -scrdir="/gtmp/calvin.p/scratch/g09/439484.zeus-master/"
+ Entering Link 1 = /usr/local/g09/l1.exe PID=     69919.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                15-May-2023 
+ ******************************************
+ %chk=check.chk
+ %mem=32768mb
+ %NProcShared=16
+ Will use up to   16 processors via shared memory.
+ ----------------------------------------------------------------------
+ #P guess=read b2plypd3/def2tzvp freq IOp(7/33=1) scf=(tight, direct) i
+ ntegral=(grid=ultrafine, Acc2E=12) IOp(2/9=2000) scf=xqc
+ ----------------------------------------------------------------------
+ 1/10=4,30=1,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=44,7=101,11=9,16=1,25=1,30=1,71=2,74=-60,75=-5,116=-2,140=1/1,2,3;
+ 4/5=1/1;
+ 5/5=2,8=3,13=1,32=2,38=6,87=12,98=1/2,8;
+ 8/6=3,8=1,10=1,19=11,30=-1,87=12/1;
+ 9/15=3,16=-3,87=12/6;
+ 11/6=1,8=1,15=11,17=12,24=-1,27=1,28=-2,29=300,32=6,42=3,87=12/1,2,10;
+ 10/6=2,21=1,87=12/2;
+ 8/6=4,8=1,10=1,19=11,30=-1,87=12/11,4;
+ 10/5=1,20=4,87=12/2;
+ 11/12=2,14=11,16=1,17=2,28=-2,42=3,87=12/2,10,12;
+ 6/7=2,8=2,9=2,10=2/1;
+ 7/8=1,10=1,12=2,25=1,33=1,44=2,87=12/1,2,3,16;
+ 1/10=4,30=1/3;
+ 99//99;
+ Leave Link    1 at Mon May 15 13:52:48 2023, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l101.exe)
+ ---
+ DMF
+ ---
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ C                    -2.49339   0.27299  -0.32162 
+ C                    -1.10105  -0.12419  -0.00514 
+ C                     0.03357  -0.24831  -0.74109 
+ C                     1.06361  -0.67586   0.15913 
+ C                     0.48984  -0.78454   1.38526 
+ C                     0.9918   -1.17367   2.72434 
+ O                    -0.83591  -0.44957   1.29912 
+ H                    -3.19712  -0.52852  -0.08955 
+ H                    -2.79393   1.15412   0.24828 
+ H                    -2.57546   0.50549  -1.38172 
+ H                     0.1254   -0.05834  -1.79689 
+ H                     2.09521  -0.87598  -0.07533 
+ H                     0.86503  -0.36466   3.44609 
+ H                     2.05127  -1.415     2.6619 
+ H                     0.46183  -2.04729   3.10827 
+ 
+ NAtoms=     15 NQM=       15 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          12          12          12          12          12          12          16           1           1           1
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  15.9949146   1.0078250   1.0078250   1.0078250
+ NucSpn=           0           0           0           0           0           0           0           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   8.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        11          12          13          14          15
+ IAtWgt=           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Mon May 15 13:52:48 2023, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon May 15 13:52:48 2023, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.493390    0.272985   -0.321616
+      2          6           0       -1.101054   -0.124185   -0.005136
+      3          6           0        0.033571   -0.248306   -0.741090
+      4          6           0        1.063610   -0.675860    0.159133
+      5          6           0        0.489843   -0.784542    1.385260
+      6          6           0        0.991801   -1.173666    2.724336
+      7          8           0       -0.835912   -0.449571    1.299117
+      8          1           0       -3.197119   -0.528519   -0.089545
+      9          1           0       -2.793929    1.154116    0.248282
+     10          1           0       -2.575461    0.505489   -1.381719
+     11          1           0        0.125403   -0.058340   -1.796888
+     12          1           0        2.095214   -0.875979   -0.075333
+     13          1           0        0.865026   -0.364657    3.446093
+     14          1           0        2.051268   -1.415002    2.661903
+     15          1           0        0.461831   -2.047293    3.108274
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.482060   0.000000
+     3  C    2.614046   1.358090   0.000000
+     4  C    3.712637   2.239888   1.433243   0.000000
+     5  C    3.596035   2.213645   2.239888   1.358090   0.000000
+     6  C    4.849451   3.596035   3.712637   2.614045   1.482061
+     7  O    2.428188   1.370129   2.226871   2.226871   1.370129
+     8  H    1.091559   2.136375   3.307626   4.270522   3.979232
+     9  H    1.091558   2.136375   3.307628   4.270523   3.979230
+    10  H    1.088399   2.113137   2.790280   4.124639   4.326250
+    11  H    3.023951   2.172305   1.076675   2.255567   3.284243
+    12  H    4.736672   3.284243   2.255566   1.076675   2.172305
+    13  H    5.087355   3.979231   4.270522   3.307626   2.136375
+    14  H    5.692504   4.326250   4.124638   2.790279   2.113136
+    15  H    5.087354   3.979231   4.270523   3.307627   2.136376
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    2.428188   0.000000
+     8  H    5.087356   2.740422   0.000000
+     9  H    5.087353   2.740419   1.762938   0.000000
+    10  H    5.692504   3.335424   1.767864   1.767866   0.000000
+    11  H    4.736672   3.265338   3.765002   3.765006   2.790150
+    12  H    3.023952   3.265339   5.303746   5.303747   5.042847
+    13  H    1.091559   2.740421   5.387820   5.091230   5.991817
+    14  H    1.088398   3.335424   5.991818   5.991817   6.437840
+    15  H    1.091559   2.740420   5.091231   5.387815   5.991817
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.740883   0.000000
+    13  H    5.303746   3.765004   0.000000
+    14  H    5.042847   2.790150   1.767866   0.000000
+    15  H    5.303747   3.765006   1.762938   1.767866   0.000000
+ Stoichiometry    C6H8O
+ Framework group  C1[X(C6H8O)]
+ Deg. of freedom    39
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.424726    0.682143    0.000000
+      2          6           0       -1.106823    0.004179    0.000000
+      3          6           0       -0.716621   -1.296648    0.000000
+      4          6           0        0.716622   -1.296648    0.000000
+      5          6           0        1.106823    0.004179    0.000000
+      6          6           0        2.424726    0.682143    0.000000
+      7          8           0        0.000000    0.811766    0.000000
+      8          1           0       -2.545617    1.314515    0.881471
+      9          1           0       -2.545614    1.314521   -0.881467
+     10          1           0       -3.218920   -0.062079   -0.000003
+     11          1           0       -1.370442   -2.152070    0.000000
+     12          1           0        1.370441   -2.152071    0.000000
+     13          1           0        2.545615    1.314517   -0.881470
+     14          1           0        3.218920   -0.062079    0.000002
+     15          1           0        2.545614    1.314520    0.881468
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      6.2014743      2.1345992      1.6198837
+ Leave Link  202 at Mon May 15 13:52:48 2023, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   300 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   265 symmetry adapted basis functions of A   symmetry.
+   265 basis functions,   421 primitive gaussians,   300 cartesian basis functions
+    26 alpha electrons       26 beta electrons
+       nuclear repulsion energy       290.8652401896 Hartrees.
+ IExCor=  419 DFT=T Ex+Corr=B2PLYPD3 ExCW=0 ScaHFX=  0.530000
+ ScaDFX=  0.470000  0.470000  0.730000  0.730000 ScalE2=  0.270000  0.270000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=141
+ No data on chk file.
+ Error termination via Lnk1e in /usr/local/g09/l301.exe at Mon May 15 13:52:48 2023.
+ Job cpu time:       0 days  0 hours  0 minutes  3.0 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1

--- a/arc/testing/trsh/gaussian/l401.out
+++ b/arc/testing/trsh/gaussian/l401.out
@@ -1,0 +1,237 @@
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /usr/local/g09/l1.exe "/gtmp/calvin.p/scratch/g09/387588.zeus-master/Gau-642.inp" -scrdir="/gtmp/calvin.p/scratch/g09/387588.zeus-master/"
+ Entering Link 1 = /usr/local/g09/l1.exe PID=       643.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                24-Apr-2023 
+ ******************************************
+ %chk=check.chk
+ %mem=4096mb
+ %NProcShared=16
+ Will use up to   16 processors via shared memory.
+ ----------------------------------------------------------------------
+ #P opt=(calcfc, tight, maxstep=5) guess=read ub2plypd3/def2tzvp scf=(t
+ ight, direct) integral=(grid=ultrafine, Acc2E=12) IOp(2/9=2000) scf=xq
+ c
+ ----------------------------------------------------------------------
+ 1/7=10,8=5,10=4,18=20,19=15,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=44,7=101,11=2,16=1,25=1,30=1,71=2,74=-60,75=-5,116=2,140=1/1,2,3;
+ 4/5=1/1;
+ 5/5=2,8=3,13=1,32=2,38=6,87=12/2,8;
+ 8/6=3,8=1,10=1,19=11,30=-1,87=12/1;
+ 9/15=3,16=-3,87=12/6;
+ 11/6=1,8=1,15=11,17=12,24=-1,27=1,28=-2,29=300,32=6,42=3,87=12/1,2,10;
+ 10/6=2,21=1,87=12/2;
+ 8/6=4,8=1,10=1,19=11,30=-1,87=12/11,4;
+ 10/5=1,20=4,87=12/2;
+ 11/12=2,14=11,16=1,17=2,28=-2,42=3,87=12/2,10,12;
+ 6/7=2,8=2,9=2,10=2/1;
+ 7/10=1,12=2,25=1,44=2,87=12/1,2,3,16;
+ 1/7=10,8=5,10=4,18=20,19=15/3(2);
+ 2/9=2000/2;
+ 99//99;
+ 2/9=2000/2;
+ 3/5=44,7=101,11=2,16=1,25=1,30=1,71=1,74=-60,75=-5,116=2/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,8=3,13=1,32=2,38=5,87=12/2,8;
+ 8/6=4,10=1,87=12/1;
+ 9/15=2,16=-3,87=12/6;
+ 10/5=1,87=12/2;
+ 7/12=2,87=12/1,2,3,16;
+ 1/7=10,8=5,18=20,19=15/3(-8);
+ 2/9=2000/2;
+ 6/7=2,8=2,9=2,10=2/1;
+ 99//99;
+ Leave Link    1 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         0.7
+ (Enter /usr/local/g09/l101.exe)
+ ---
+ NH2
+ ---
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 2
+ N                     0.00024   0.4234    0. 
+ H                    -0.80505  -0.21124   0. 
+ H                     0.80481  -0.21216   0. 
+ 
+ NAtoms=      3 NQM=        3 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3
+ IAtWgt=          14           1           1
+ AtmWgt=  14.0030740   1.0078250   1.0078250
+ NucSpn=           2           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000
+ NMagM=    0.4037610   2.7928460   2.7928460
+ AtZNuc=   7.0000000   1.0000000   1.0000000
+ Leave Link  101 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         1.8
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.0253         calculate D2E/DX2 analytically  !
+ ! R2    R(1,3)                  1.0253         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,3)              103.4527         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=5.00D-02 FncErr=1.00D-07 GrdErr=1.00D-07
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.000243    0.423397    0.000000
+      2          1           0       -0.805053   -0.211237    0.000000
+      3          1           0        0.804810   -0.212160    0.000000
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  N    0.000000
+     2  H    1.025311   0.000000
+     3  H    1.025310   1.609863   0.000000
+ Stoichiometry    H2N(2)
+ Framework group  CS[SG(H2N)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        0.000000    0.141132    0.000000
+      2          1           0        0.804932   -0.493964    0.000000
+      3          1           0       -0.804932   -0.493963    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    711.0962360    386.9760326    250.6002638
+ Leave Link  202 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    35 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    13 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    31 symmetry adapted basis functions of A'  symmetry.
+ There are    12 symmetry adapted basis functions of A"  symmetry.
+    43 basis functions,    67 primitive gaussians,    48 cartesian basis functions
+     5 alpha electrons        4 beta electrons
+       nuclear repulsion energy         7.5543077488 Hartrees.
+ IExCor=  419 DFT=T Ex+Corr=B2PLYPD3 ExCW=0 ScaHFX=  0.530000
+ ScaDFX=  0.470000  0.470000  0.730000  0.730000 ScalE2=  0.270000  0.270000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=141
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D3(BJ) Dispersion energy=       -0.0003067212 Hartrees.
+ Nuclear repulsion after empirical dispersion term =        7.5540010277 Hartrees.
+ Leave Link  301 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=     190 NPrTT=     556 LenC2=     191 LenP2D=     543.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=    43 RedAO= T EigKep=  8.62D-03  NBF=    31    12
+ NBsUse=    43 1.00D-06 EigRej= -1.00D+00 NBFU=    31    12
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    48    48    48    48    48 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         1.9
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Apr 24 20:17:17 2023, MaxMem=   536870912 cpu:         0.3
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ Basis set data is not on the checkpoint file.
+ Error termination via Lnk1e in /usr/local/g09/l401.exe at Mon Apr 24 20:17:17 2023.
+ Job cpu time:       0 days  0 hours  0 minutes  6.6 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1


### PR DESCRIPTION
The current version of ARC cannot fully troubleshoot Gaussian due to lack of combination troubleshooting. This PR attempts to rectify this issue.

For example, if a job receives a first error of L401/301, and so we remove the chkfile by changing `guess=read` to `guess=mix` but then it its next failed run it gives another error where we need to add `scf=(nosymm)`, then this modification will create an `input.gjf` file that uses BOTH troubleshooting methods.