### PR TITLE
Change CI cleaning

### DIFF
--- a/.github/workflows/cont_int.yml
+++ b/.github/workflows/cont_int.yml
@@ -121,7 +121,7 @@ jobs:
         ref: v2.0.6
         fetch-depth: 1
 
-    - name: Cache Packages Packages
+    - name: Cache Packages
       uses: actions/cache@v2
       env:
         CACHE_NUMBER: 0

--- a/.github/workflows/cont_int.yml
+++ b/.github/workflows/cont_int.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Clean Ubuntu Image
-      uses: jlumbroso/free-disk-space@main
+      uses: kfir4444/free-disk-space@main
       with:
         # This may remove tools actually needed - currently does not
         tool-cache: true

--- a/devtools/sella_environment.yml
+++ b/devtools/sella_environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pandas
   - ncurses
   - pip:
-    - sella
+    - sella==2.2.1
   


### PR DESCRIPTION
This PR fixes 2 things,
The first is that the free-space action sometimes caused unnecessary failures, which is fixed by forking the action and patching it, and a PR to the main action repo is opened.
The second one is a Sella issue, which is (probably) caused by a syntax error in their new release (from 15.6). This issue is fixed by using the previous release, and informing the Sella developers on this issue.