### PR TITLE
Load running jobs' xyz as dict from restart

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -824,7 +824,7 @@ class JobAdapter(ABC):
         if self.tsg is not None:
             job_dict['tsg'] = self.tsg
         if self.xyz is not None:
-            job_dict['xyz'] = xyz_to_str(self.xyz)
+            job_dict['xyz'] = self.xyz
         return job_dict
 
     def format_max_job_time(self, time_format: str) -> str:


### PR DESCRIPTION
Otherwise, ARC fails when it tries to compute dihedral angles after a restarted scan job has finished