### PR TITLE
Don't consider conformers for which RDKit could not compute energy

### DIFF
--- a/arc/species/conformers_test.py
+++ b/arc/species/conformers_test.py
@@ -2596,6 +2596,13 @@ Cl      2.38846685    0.24054066    0.55443324
         cheat_mol2 = Molecule(smiles='C')
         self.assertIsNone(conformers.cheat_sheet([cheat_mol2]))
 
+    def test_conformers_with_xyz_wo_energy(self):
+        """Test that ARC can generate conformers even if RDKit cannot compute FF energies (but can suggest xyz)."""
+        smiles = '[O]OOC=CC#CCO'
+        mol = Molecule(smiles=smiles)
+        confs = conformers.generate_conformers(mol_list=[mol], label='spc_1')
+        self.assertGreater(len(confs), 0)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
Don't consider conformers for which RDKit could not compute energy, since we don't know how to rank the conformers by energy. This could potentially be problematic if one of these conformers has a lower E, but we can't return too much confs to the scheduler to be DFT'ed. We think that ARC's DFT scans may compensate if indeed a lower conformer exists.
In addition, if all conformers have no FF energies, we return them all (a hypothetical case).