### PR TITLE
Load reaction correctly from an ARC restart

### DIFF
--- a/arc/reaction.py
+++ b/arc/reaction.py
@@ -302,10 +302,10 @@ class ARCReaction(object):
             self.r_species, self.p_species = list(), list()
             for spc in species_list:
                 for r_spc_dict in reaction_dict['r_species']:
-                    if spc.label == r_spc_dict['label']:
+                    if r_spc_dict['label'] in [spc.label, spc.original_label]:
                         self.r_species.append(spc)
                 for p_spc_dict in reaction_dict['p_species']:
-                    if spc.label == p_spc_dict['label']:
+                    if p_spc_dict['label'] in [spc.label, spc.original_label]:
                         self.p_species.append(spc)
         else:
             self.r_species = [ARCSpecies(species_dict=r_dict) for r_dict in reaction_dict['r_species']] \

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -921,7 +921,7 @@ class ARCSpecies(object):
         # The data from the YAML file is loaded into the `species` argument of the `load_yaml` method in Arkane
         yml_content = read_yaml_file(self.yml_path)
         arkane_spc.load_yaml(path=self.yml_path, label=label, pdep=False)
-        self.label = label if label is not None else arkane_spc.label
+        self.label = label or self.label or arkane_spc.label
         self.final_xyz = xyz_from_data(coords=arkane_spc.conformer.coordinates.value,
                                        numbers=arkane_spc.conformer.number.value)
         if 'mol' in yml_content:

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -2645,7 +2645,8 @@ H      -1.47626400   -0.10694600   -1.88883800"""
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
 
-        file_paths = [os.path.join(ARC_PATH, 'nul'), os.path.join(ARC_PATH, 'run.out')]
+        file_paths = [os.path.join(ARC_PATH, 'nul'), os.path.join(ARC_PATH, 'run.out'),
+                      os.path.join(ARC_PATH, 'arc', 'species', 'nul'), os.path.join(ARC_PATH, 'arc', 'species', 'run.out')]
         for file_path in file_paths:
             if os.path.isfile(file_path):
                 os.remove(file_path)


### PR DESCRIPTION
When a species is loaded from an Artkane YAML file and has a different label than in that file, it currently messes up the loading process of a reaction from a restart file. Plus, another possible complication (in addition or independently) is that a species label could be modified by ARC for convenient folder naming.

Here we consider these two issues when loading species and reactions from an ARC restart file