### PR TITLE
Avoid using number of processes in confermers job

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -385,7 +385,7 @@ class JobAdapter(ABC):
                 if len(self.species) > 1:
                     self.iterate_by.append('species')
                 if job_type == 'conformers':
-                    if self.species is not None and sum(len(species.conformers) for species in self.species) > 10:
+                    if self.species is not None and sum(len(species.conformers) for species in self.species) > 100:
                         self.iterate_by.append('conformers')
                         self.number_of_processes += sum([len(species.conformers) for species in self.species])
                 for species in self.species:


### PR DESCRIPTION
While working on 2-nbutylfuran: `CCCCC1=CC=CO1` for a BDE job, some Gaussian jobs weren't computed (such as SP jobs) due to using a pipe.
An example line: `Running local job array (**pipe**) conformer18 (a3503) using gaussian for nbutylfuran_BDE_8_21_A`.
At the same time, furfuryl: `OCC1=CC=CO1`, converged and the pipe wasn't used.
An input file in txt format is attached in order to reproduce this issue.
[input.txt](https://github.com/ReactionMechanismGenerator/ARC/files/12393308/input.txt)
To overcome this, in job/adapter.py, the number of conformers before increasing the number of processes, was increased from 10 to 100.

