### PR TITLE
Make sure to update, upgrate and autoremove before latex installation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Install LaTeX
       run: |
+        sudo apt update -y && sudo apt upgrade -y && sudo apt autoremove -y
         sudo apt install texlive-latex-base -y
         sudo apt-get install texlive-latex-extra -y
         sudo apt-get install -y dvipng


### PR DESCRIPTION
This is due to the Failed to fetch error, which (according to [this](https://askubuntu.com/questions/1241009/failed-to-fetch-installation-errors)) is caused by outdated repository information.