### PR TITLE
Report electronic energy in an output file

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -155,6 +155,7 @@ class ARC(object):
                                  Only used for restarting.
         running_jobs (dict, optional): A dictionary of jobs submitted in a precious ARC instance, used for restarting.
         ts_adapters (list, optional): Entries represent different TS adapters.
+        report_e_elect (bool, optional): Whether to report electronic energy. Default is ``False``.
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -221,6 +222,8 @@ class ARC(object):
                              format (``True``) or classical two-parameter Arrhenius equation format (``False``).
         trsh_ess_jobs (bool): Whether to attempt troubleshooting failed ESS jobs. Default is ``True``.
         ts_adapters (list): Entries represent different TS adapters.
+        report_e_elect (bool): Whether to report electronic energy.
+
     """
 
     def __init__(self,
@@ -269,6 +272,7 @@ class ARC(object):
                  ts_adapters: List[str] = None,
                  ts_guess_level: Optional[Union[str, dict, Level]] = None,
                  verbose=logging.INFO,
+                 report_e_elect: Optional[bool] = False,
                  ):
 
         if project is None:
@@ -320,6 +324,7 @@ class ARC(object):
         self.arkane_level_of_theory = Level(repr=arkane_level_of_theory) if arkane_level_of_theory is not None else None
         self.freq_scale_factor = freq_scale_factor
         self.ts_adapters = ts_adapters
+        self.report_e_elect = report_e_elect
         for ts_adapter in self.ts_adapters or list():
             if ts_adapter.lower() not in _registered_job_adapters.keys():
                 raise InputError(f'Unknown TS adapter: "{ts_adapter}"')
@@ -526,6 +531,8 @@ class ARC(object):
                 if not isinstance(self.ts_guess_level, (dict, str)) else self.ts_guess_level
         if self.verbose != logging.INFO:
             restart_dict['verbose'] = int(self.verbose)
+        if self.report_e_elect:
+            restart_dict['report_e_elect'] = self.report_e_elect
         return restart_dict
 
     def write_input_file(self, path=None):
@@ -592,6 +599,7 @@ class ARC(object):
                                    trsh_ess_jobs=self.trsh_ess_jobs,
                                    fine_only=self.fine_only,
                                    ts_adapters=self.ts_adapters,
+                                   report_e_elect=self.report_e_elect,
                                    )
 
         save_yaml_file(path=os.path.join(self.project_directory, 'output', 'status.yml'), content=self.scheduler.output)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -23,6 +23,7 @@ from arc.common import (extremum_list,
                         get_logger,
                         get_number_with_ordinal_indicator,
                         is_angle_linear,
+                        read_yaml_file,
                         safe_copy_file,
                         save_yaml_file,
                         sort_two_lists_by_the_first,
@@ -2556,6 +2557,9 @@ class Scheduler(object):
         if species_has_freq(self.output[label], self.species_dict[label].yml_path):
             self.check_rxn_e0_by_spc(label)
 
+        if self.report_e_elect:
+            self.save_e_elect(label)
+
         # set *at the end* to differentiate between sp jobs when using complex solvation corrections
         self.output[label]['job_types']['sp'] = True
 
@@ -3617,6 +3621,18 @@ class Scheduler(object):
         path = os.path.join(self.project_directory, 'output', 'rxns', 'TS_guess_report.yml')
         if content:
             save_yaml_file(path=path, content=content)
+
+    def save_e_elect(self, label: str):
+        """
+        Save the electronic energy of the corresponding species.
+        It will append if the file already exists.
+        """
+        path = os.path.join(self.project_directory, 'output', 'e_elect_summary.yml')
+        content = dict()
+        if os.path.isfile(path):
+            content = read_yaml_file(path)
+        content[label] = self.species_dict[label].e_elect
+        save_yaml_file(path=path, content=content)
 
 
 def species_has_freq(species_output_dict: dict,

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -160,6 +160,7 @@ class Scheduler(object):
         freq_scale_factor (float, optional): The harmonic frequencies scaling factor.
         trsh_ess_jobs (bool, optional): Whether to attempt troubleshooting failed ESS jobs. Default is ``True``.
         ts_adapters (list, optional): Entries represent different TS adapters.
+        report_e_elect (bool, optional): Whether to report electronic energy. Default is ``False``.
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -214,6 +215,7 @@ class Scheduler(object):
         freq_scale_factor (float): The harmonic frequencies scaling factor.
         trsh_ess_jobs (bool): Whether to attempt troubleshooting failed ESS jobs. Default is ``True``.
         ts_adapters (list): Entries represent different TS adapters.
+        report_e_elect (bool): Whether to report electronic energy.
     """
 
     def __init__(self,
@@ -248,6 +250,7 @@ class Scheduler(object):
                  kinetics_adapter: str = 'arkane',
                  freq_scale_factor: float = 1.0,
                  ts_adapters: List[str] = None,
+                 report_e_elect: Optional[bool] = False,
                  ) -> None:
 
         self.project = project
@@ -279,6 +282,7 @@ class Scheduler(object):
         self.ts_adapters = ts_adapters if ts_adapters is not None else default_ts_adapters
         self.ts_adapters = [ts_adapter.lower() for ts_adapter in self.ts_adapters]
         self.output = dict()
+        self.report_e_elect = report_e_elect
 
         self.species_dict, self.rxn_dict = dict(), dict()
         for species in self.species_list:


### PR DESCRIPTION
1. Add the "report_e_elect" as the argument/attribute, and method "save_e_elect" to decide whether electronic energy will be in the output or not, after the single-point energy calculation.
2. A test case is also added for this purpose to check if e_elect_summary.yml is created and have the electronic energy info