### PR TITLE
Gauss Trsh Fixes

### DIFF
--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -522,4 +522,15 @@ def combine_parameters(input_dict: dict, terms: list) -> Tuple[dict, List]:
                         value = re.sub(term, '', value)
             input_dict_copy[key] = value
 
+    # Parameters may appear as one word, so need to split them via comma
+    parameters = [param.split(',') for param in parameters]
+    # Flatten the list of lists
+    parameters = [item for sublist in parameters for item in sublist]
+    # Remove empty spaces from the beginning and end of each parameter
+    parameters = [param.strip() for param in parameters]
+    # Parameters may appear multiple times in the input_dict, so remove duplicates
+    parameters = list(set(parameters))
+    # Sort the list
+    parameters.sort()
+
     return input_dict_copy, parameters

--- a/arc/job/adapters/gaussian_test.py
+++ b/arc/job/adapters/gaussian_test.py
@@ -333,7 +333,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(modredundant, calcfc, noeigentest, maxStep=5) integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000)    scf=(tight, direct)
+#P opt=(calcfc,maxStep=5,modredundant,noeigentest) integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000)    scf=(direct,tight)
 
 ethanol
 
@@ -366,7 +366,7 @@ block
 %mem=14336mb
 %NProcShared=8
 
-#P  uwb97xd/def2tzvp freq IOp(7/33=1)  integral=(grid=ultrafine, Acc2E=12)  IOp(2/9=2000)    scf=(tight, direct)
+#P  uwb97xd/def2tzvp freq IOp(7/33=1)  integral=(grid=ultrafine, Acc2E=12)  IOp(2/9=2000)    scf=(direct,tight)
 
 birad_singlet
 

--- a/arc/job/adapters/gaussian_test.py
+++ b/arc/job/adapters/gaussian_test.py
@@ -187,7 +187,7 @@ class TestGaussianAdapter(unittest.TestCase):
         
         # Gaussian: Checkfile error and SCF error
         # First SCF error - qc,nosymm
-        job_status = {'keywords': ['SCF']}
+        job_status = {'keywords': ['SCF', 'NoSymm']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
                                                                        job_type, software, fine, memory_gb,
@@ -297,7 +297,7 @@ class TestGaussianAdapter(unittest.TestCase):
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc) cbs-qb3   IOp(2/9=2000) IOp(1/12=5,3/44=0)  
+#P opt=(calcfc)  cbs-qb3   IOp(2/9=2000) IOp(1/12=5,3/44=0)  
 
 spc1
 
@@ -333,7 +333,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(modredundant, calcfc, noeigentest, maxStep=5)  integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000)    scf=(tight, direct)
+#P opt=(modredundant, calcfc, noeigentest, maxStep=5) integral=(grid=ultrafine, Acc2E=12) guess=mix wb97xd/def2tzvp   IOp(2/9=2000)    scf=(tight, direct)
 
 ethanol
 
@@ -384,7 +384,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc) uwb97xd/def2tzvp   IOp(2/9=2000)   
+#P opt=(calcfc)  uwb97xd/def2tzvp   IOp(2/9=2000)   
 
 anion
 
@@ -478,7 +478,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) uwb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(tight,direct)
+#P opt=(calcfc,maxstep=5,tight)  uwb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(direct,tight)
 
 anion
 
@@ -496,7 +496,7 @@ O       0.00000000    0.00000000    1.00000000
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(tight,direct)
+#P opt=(calcfc,maxstep=5,tight) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    scf=(direct,tight)
 
 ethanol
 
@@ -522,7 +522,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm)
+#P opt=(calcfc,maxstep=5,tight) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(direct,tight,xqc)
 
 ethanol
 
@@ -548,7 +548,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm,NDump=30)
+#P opt=(calcfc,maxstep=5,tight) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(NDump=30,direct,tight,xqc)
 
 ethanol
 
@@ -574,7 +574,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     scf=(tight,direct,xqc,nosymm,NDump=30,NoDIIS)
+#P opt=(calcfc,maxstep=5,tight) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(NDump=30,NoDIIS,direct,tight,xqc)
 
 ethanol
 
@@ -600,7 +600,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc, tight, maxstep=5) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)   opt=(cartesian,nosymm)   scf=(tight,direct,xqc,nosymm,NDump=30,NoDIIS)
+#P opt=(calcfc,cartesian,maxstep=5,tight) guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(NDump=30,NoDIIS,direct,tight,xqc)
 
 ethanol
 

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -304,14 +304,14 @@ class TestTrsh(unittest.TestCase):
         self.assertFalse(couldnt_trsh)
 
         # Gaussian: test 2
-        job_status = {'keywords': ['InternalCoordinateError']}
+        job_status = {'keywords': ['InternalCoordinateError', 'NoSymm']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
                                                                        job_type, software, fine, memory_gb,
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
 
         self.assertTrue(remove_checkfile)
-        self.assertEqual(trsh_keyword, ['opt=(cartesian,nosymm)', 'int=(Acc2E=14)'] )
+        self.assertEqual(trsh_keyword, ['opt=(cartesian)', 'int=(Acc2E=14)', 'nosymm'] )
 
         # Test Q-Chem
         software = 'qchem'


### PR DESCRIPTION
@Lilachn91 pointed out that `nosymm` should not be part of the opt or scf combination of parameters but be its own parameter. This has been implemented. Furthermore, at times we end up creating an input file that may have `opt=([param1])` and `opt=([param2])` when rather they should be combined into one `opt=([param1,param2])`