### PR TITLE
Removing file 1 and file 2 from Molpro's input file

### DIFF
--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -38,8 +38,6 @@ default_job_settings, global_ess_settings, input_filenames, output_filenames, se
 
 input_template = """***,${label}
 memory,${memory},m;
-file,1,file1.int    !allocate permanent integral file
-file,2,file2.wfu    !allocate permanent wave-function (dump) file
 
 geometry={angstrom;
 ${xyz}}

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -77,8 +77,6 @@ class TestMolproAdapter(unittest.TestCase):
             content_1 = f.read()
         job_1_expected_input_file = """***,spc1
 memory,40,m;
-file,1,file1.int    !allocate permanent integral file
-file,2,file2.wfu    !allocate permanent wave-function (dump) file
 
 geometry={angstrom;
 O       0.00000000    0.00000000    1.00000000}
@@ -108,8 +106,6 @@ uccsd(t)-f12;
             content_2 = f.read()
         job_2_expected_input_file = """***,spc1
 memory,40,m;
-file,1,file1.int    !allocate permanent integral file
-file,2,file2.wfu    !allocate permanent wave-function (dump) file
 
 geometry={angstrom;
 O       0.00000000    0.00000000    1.00000000}


### PR DESCRIPTION
Removing tow lines from Molpro's input file to write file 1 and file 2 due to an error that I'm encountering while running ARC or executing the Molpro job. Changed the tests accordingly.