### PR TITLE
Special chars creating submit issues

### DIFF
--- a/arc/job/local.py
+++ b/arc/job/local.py
@@ -241,7 +241,7 @@ def submit_job(path: str,
     job_status, job_id = '', ''
     submit_cmd = submit_cmd or submit_command[cluster_soft]
     submit_filename = submit_filename or submit_filenames[cluster_soft]
-    cmd = f"cd {path}; {submit_cmd} {submit_filename}"
+    cmd = f'cd "{path}"; {submit_cmd} {submit_filename}'
     stdout, stderr = execute_command(cmd)
     if not len(stdout):
         time.sleep(10)
@@ -390,7 +390,7 @@ def change_mode(mode: str,
     if os.path.isfile(path):
         path = os.path.dirname(path)
     recursive = ' -R' if recursive else ''
-    command = [f'cd {path}'] if path else []
+    command = [f'cd "{path}"'] if path else []
     command.append(f'chmod{recursive} {mode} {file_name}')
     execute_command(command=command)
 


### PR DESCRIPTION
 issue was stemming from local.py, the var called cmd
cmd = f'cd {path}; {submit_cmd} {submit_filename}'

here we defined path but never put it in quotations so special chars like `[` and `]` would be misinterpreted by the shell

so in python would change to the direct of /rxn_120_CCN/ instead of /rxn_120_[CH2]CN/ (assuming out intention was to go to  /rxn_120_[CH2]CN/)

so just needed to change it to

cmd = f'cd "{path}"; {submit_cmd} {submit_filename}'
