### PR TITLE
Define output dict for multi species in main.py

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -154,6 +154,8 @@ class ARC(object):
         trsh_ess_jobs (bool, optional): Whether to attempt troubleshooting failed ESS jobs. Default is ``True``.
         output (dict, optional): Output dictionary with status and final QM file paths for all species.
                                  Only used for restarting.
+        output_multi_spc (dict, optional): Output dictionary with status and final QM file paths for the multi species. 
+                                           Only used for restarting.
         running_jobs (dict, optional): A dictionary of jobs submitted in a precious ARC instance, used for restarting.
         ts_adapters (list, optional): Entries represent different TS adapters.
         report_e_elect (bool, optional): Whether to report electronic energy. Default is ``False``.
@@ -180,6 +182,8 @@ class ARC(object):
             Job types not defined in adaptive levels will have non-adaptive (regular) levels.
         output (dict): Output dictionary with status and final QM file paths for all species. Only used for restarting,
                        the actual object used is in the Scheduler class.
+        output_multi_spc (dict): Output dictionary with status and final QM file paths for the multi species. 
+                                 Only used for restarting, the actual object used is in the Scheduler class.
         bac_type (str): The bond additivity correction type. 'p' for Petersson- or 'm' for Melius-type BAC.
                         ``None`` to not use BAC.
         arkane_level_of_theory (Level): The Arkane level of theory to use for AEC and BAC.
@@ -258,6 +262,7 @@ class ARC(object):
                  opt_level: Optional[Union[str, dict, Level]] = None,
                  orbitals_level: Optional[Union[str, dict, Level]] = None,
                  output: Optional[dict] = None,
+                 output_multi_spc: Optional[dict] = None,
                  project: Optional[str] = None,
                  project_directory: Optional[str] = None,
                  reactions: Optional[List[Union[ARCReaction, Reaction]]] = None,
@@ -291,6 +296,7 @@ class ARC(object):
         if not os.path.exists(self.project_directory):
             os.makedirs(self.project_directory)
         self.output = output
+        self.output_multi_spc = output_multi_spc
         self.standardize_output_paths()  # depends on self.project_directory
         self.running_jobs = running_jobs or dict()
         for jobs in self.running_jobs.values():
@@ -515,6 +521,7 @@ class ARC(object):
             restart_dict['orbitals_level'] = self.orbitals_level.as_dict() \
                 if not isinstance(self.orbitals_level, (dict, str)) else self.orbitals_level
         restart_dict['output'] = self.output
+        restart_dict['output_multi_spc'] = self.output_multi_spc if self.output_multi_spc else dict()
         restart_dict['project'] = self.project
         restart_dict['reactions'] = [rxn.as_dict() for rxn in self.reactions]
         restart_dict['running_jobs'] = self.running_jobs

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -137,6 +137,7 @@ class TestARC(unittest.TestCase):
                                        'method_type': 'dft',
                                        'software': 'gaussian'},
                          'output': {},
+                         'output_multi_spc': {},
                          'project': 'arc_test',
                          'reactions': [],
                          'running_jobs': {},

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1183,11 +1183,13 @@ class Scheduler(object):
                                                or self.species_dict[label].get_xyz(generate=False)
         if self.species_dict[label].initial_xyz is None:
             raise SpeciesError(f'Cannot execute opt job for {label} without xyz (got None for Species.initial_xyz)')
+        label_single_spc = None
+        key = None
         if self.species_dict[label].multi_species:
             key = 'fine' if fine else 'opt'
             if self.output_multi_spc[self.species_dict[label].multi_species].get(key, False):
                 return
-            self.output_multi_spc[self.species_dict[label].multi_species][key] = True
+            label_single_spc = label
             label = [species.label for species in self.species_list
                      if species.multi_species == self.species_dict[label].multi_species]
         self.run_job(label=label, 
@@ -1195,6 +1197,8 @@ class Scheduler(object):
                      level_of_theory=self.opt_level,
                      job_type='opt', 
                      fine=fine)
+        if label_single_spc is not None and key is not None:
+            self.output_multi_spc[self.species_dict[label_single_spc].multi_species][key] = True
 
     def run_composite_job(self, label: str):
         """


### PR DESCRIPTION
We have problem when we launch `restart.yml` saying unexpected keyword argument 'output_multi_spc'. It turns out previously we defined `Scheduler.output_multi_spc` parallel to `Scheduler.output` in `Scheduler` `__init__`, however, we forgot to define it in the `ARC` class in `main.py`. So now we add the relevant terms in `main.py`.