### PR TITLE
conformer search with solvation effect

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -970,6 +970,11 @@ class ARC(object):
         self.conformer_level = Level(repr=self.conformer_level)
         logger.info(f'Conformers:{default_flag} {self.conformer_level}')
 
+        if self.conf_generation_level is not None:
+            default_flag = ''
+            self.conf_generation_level = Level(repr=self.conf_generation_level)
+            logger.info(f'Conformers_generation:{default_flag} {self.conf_generation_level}')
+
         if self.reactions or any([spc.is_ts for spc in self.species]):
             if not self.ts_guess_level:
                 self.ts_guess_level = default_levels_of_theory['ts_guesses']

--- a/arc/main.py
+++ b/arc/main.py
@@ -81,6 +81,7 @@ class ARC(object):
                                          instead (e.g., ``opt_level``).
         composite_method (str, dict, Level, optional): Composite method.
         conformer_level (str, dict, Level, optional): Level of theory for conformer searches.
+        conf_generation_level (str, dict, Level, optional): Level of theory for conformer generation.
         opt_level (str, dict, Level, optional): Level of theory for geometry optimization.
         freq_level (str, dict, Level, optional): Level of theory for frequency calculations.
         sp_level (str, dict, Level, optional): Level of theory for single point calculations.
@@ -167,6 +168,7 @@ class ARC(object):
         level_of_theory (str): A shortcut representing either sp//geometry levels or a composite method.
         composite_method (Level): Composite method.
         conformer_level (Level): Level of theory for conformer searches.
+        conf_generation_level (Level): Level of theory for conformer generation.
         opt_level (Level): Level of theory for geometry optimization.
         freq_level (Level): Level of theory for frequency calculations.
         sp_level (Level): Level of theory for single point calculations.
@@ -242,6 +244,7 @@ class ARC(object):
                  compute_thermo: bool = True,
                  compute_transport: bool = False,
                  conformer_level: Optional[Union[str, dict, Level]] = None,
+                 conf_generation_level: Optional[Union[str, dict, Level]] = None,
                  dont_gen_confs: List[str] = None,
                  e_confs: float = 5.0,
                  ess_settings: Dict[str, Union[str, List[str]]] = None,
@@ -342,6 +345,7 @@ class ARC(object):
         self.level_of_theory = level_of_theory
         self.composite_method = composite_method or None
         self.conformer_level = conformer_level or None
+        self.conf_generation_level = conf_generation_level or None
         self.opt_level = opt_level or None
         self.freq_level = freq_level or None
         self.sp_level = sp_level or None
@@ -485,6 +489,8 @@ class ARC(object):
             restart_dict['compute_transport'] = self.compute_transport
         if self.conformer_level is not None:
             restart_dict['conformer_level'] = self.conformer_level.as_dict()
+        if self.conf_generation_level is not None:
+            restart_dict['conf_generation_level'] = self.conf_generation_level.as_dict()
         if self.dont_gen_confs:
             restart_dict['dont_gen_confs'] = self.dont_gen_confs
         if self.ts_adapters:
@@ -587,6 +593,7 @@ class ARC(object):
                                    rxn_list=self.reactions,
                                    composite_method=self.composite_method,
                                    conformer_level=self.conformer_level,
+                                   conf_generation_level=self.conf_generation_level,
                                    opt_level=self.opt_level,
                                    freq_level=self.freq_level,
                                    sp_level=self.sp_level,

--- a/arc/main.py
+++ b/arc/main.py
@@ -575,15 +575,21 @@ class ARC(object):
             Status dictionary indicating which species converged successfully.
         """
         logger.info('\n')
+        considered_list = list()
         for species in self.species:
             if not isinstance(species, ARCSpecies):
                 raise ValueError(f'All species must be ARCSpecies objects. Got {type(species)}')
             if species.is_ts:
                 logger.info(f'Considering transition state: {species.label}')
             else:
-                logger.info(f'Considering species: {species.label}')
-                if species.mol is not None:
-                    display(species.mol.copy(deep=True))
+                if not species.multi_species:
+                    logger.info(f'Considering species: {species.label}')
+                    if species.mol is not None:
+                        display(species.mol.copy(deep=True))
+                elif species.multi_species not in considered_list:
+                    logger.info(f'Considering species: {species.multi_species}')
+                    considered_list.append(species.multi_species)
+
         logger.info('\n')
         for rxn in self.reactions:
             if not isinstance(rxn, ARCReaction):

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -428,8 +428,9 @@ class Scheduler(object):
                 if not self.job_types['conformers'] and len(species.conformers) == 1:
                     # conformers weren't asked for, assign initial_xyz
                     species.initial_xyz = species.conformers[0]
-                if species.label not in self.running_jobs:
-                    self.running_jobs[species.label if not species.multi_species else species.multi_species] = list()
+                label = species.label if not species.multi_species else species.multi_species
+                if label not in self.running_jobs.keys():
+                    self.running_jobs[label] = list()
                 if self.output[species.label]['convergence']:
                     continue
                 if species.is_monoatomic():

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -568,9 +568,9 @@ class Scheduler(object):
                                     self.determine_most_stable_conformer(label)  # also checks isomorphism
                                 if self.species_dict[label].initial_xyz is not None:
                                     # if initial_xyz is None, then we're probably troubleshooting conformers, don't opt
-                                    if not self.composite_method:
+                                    if not self.composite_method and (self.job_types['opt'] or self.job_types['fine']):
                                         self.run_opt_job(label, fine=self.fine_only)
-                                    else:
+                                    elif self.composite_method and self.job_types['composite']:
                                         self.run_composite_job(label)
                             self.timer = False
                             break

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -130,6 +130,7 @@ class Scheduler(object):
         project_directory (str): Folder path for the project: the input file path or ARC/Projects/project-name.
         composite_method (str, optional): A composite method to use.
         conformer_level (Union[str, dict], optional): The level of theory to use for conformer comparisons.
+        conf_generation_level (Union[str, dict], optional): The level of theory to use for conformer generation.
         opt_level (Union[str, dict], optional): The level of theory to use for geometry optimizations.
         freq_level (Union[str, dict], optional): The level of theory to use for frequency calculations.
         sp_level (Union[str, dict], optional): The level of theory to use for single point energy calculations.
@@ -201,6 +202,7 @@ class Scheduler(object):
                         Allowed values are He, Ne, Ar, Kr, H2, N2, O2.
         composite_method (str): A composite method to use.
         conformer_level (dict): The level of theory to use for conformer comparisons.
+        conf_generation_level (dict): The level of theory to use for conformer generation.
         opt_level (dict): The level of theory to use for geometry optimizations.
         freq_level (dict): The level of theory to use for frequency calculations.
         sp_level (dict): The level of theory to use for single point energy calculations.
@@ -229,6 +231,7 @@ class Scheduler(object):
                  project_directory: str,
                  composite_method: Optional[Level] = None,
                  conformer_level: Optional[Level] = None,
+                 conf_generation_level: Optional[Level] = None,
                  opt_level: Optional[Level] = None,
                  freq_level: Optional[Level] = None,
                  sp_level: Optional[Level] = None,
@@ -308,6 +311,7 @@ class Scheduler(object):
         self.servers = list()
         self.composite_method = composite_method
         self.conformer_level = conformer_level
+        self.conf_generation_level = conf_generation_level
         self.ts_guess_level = ts_guess_level
         self.opt_level = opt_level
         self.freq_level = freq_level
@@ -1098,7 +1102,10 @@ class Scheduler(object):
                         n_confs=n_confs,
                         e_confs=self.e_confs,
                         plot_path=os.path.join(self.project_directory, 'output', 'Species',
-                                               label, 'geometry', 'conformers'))
+                                               label, 'geometry', 'conformers'),
+                        conf_generation_level=self.conf_generation_level if self.conf_generation_level is not None else None,
+                        conf_path=os.path.join(self.project_directory, 'calcs', 'Species', f'{label}_multi'),
+                        )
                 self.process_conformers(label)
             # TSs:
             elif self.species_dict[label].is_ts \

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -175,6 +175,9 @@ output_filenames = {'cfour': 'output.out',
                     }
 
 default_levels_of_theory = {'conformer': 'wb97xd/def2svp',  # it's recommended to choose a method with dispersion
+                            'conf_generation': {'method': 'UFF',
+                                                'solvation_method': 'SMD',
+                                                'solvent': 'water'}, # good default for Gaussian
                             'ts_guesses': 'wb97xd/def2svp',
                             'opt': 'wb97xd/def2tzvp',  # good default for Gaussian
                             # 'opt': 'wb97m-v/def2tzvp',  # good default for QChem

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1210,11 +1210,12 @@ def get_force_field_energies_solvation(label: str,
     content['n_confs'] = 1
     content['compute_thermo'] = False
     content['species'] = list()
+    species_per_job = 500
     for i, xyz in enumerate(ff_xyzs):
         spc_dict = dict()
         spc_dict['label'] = f'{label}_multi_{i}'
         spc_dict['xyz'] = xyz
-        spc_dict['multi_species'] = f'{label}_multi'
+        spc_dict['multi_species'] = f'{label}_multi_cluster_{i//species_per_job}'
         content['species'].append(spc_dict)
     save_yaml_file(path=os.path.join(ARC_child_path, 'input.yml'), content=content)
     commands = ['source ~/.bashrc', 'conda activate arc_env', f'python {ARC_PATH}/ARC.py {ARC_child_path}/input.yml']

--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1230,10 +1230,14 @@ def get_force_field_energies_solvation(label: str,
         logger.warning(f'Got the following error when trying to submit job:\n{stderr}.')
     xyzs = list()
     energies = list()
+    content = dict()
     energy_dict = read_yaml_file(os.path.join(ARC_child_path, 'output', 'e_elect_summary.yml'))
     for i in range(len(ff_xyzs)):
         xyzs.append(parse_xyz_from_file(os.path.join(ARC_child_path, 'output', 'Species', f'{label}_multi_{i}', 'geometry', f'{label}_multi_{i}.xyz')))
         energies.append(energy_dict[f'{label}_multi_{i}'])
+        content[f'{label}_multi_{i}'] = {'xyz': xyzs[-1], 'energy': energies[-1]}
+    save_yaml_file(path=os.path.join(ARC_child_path, 'output', 'energy_geometry_summary.yml'), content=content)
+    logger.info(f'{label} conformer with solvation effect are spawned from a subprocess.')
     return xyzs, energies
 
 

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1059,6 +1059,8 @@ class ARCSpecies(object):
                             n_confs: int = 10,
                             e_confs: float = 5,
                             plot_path: str = None,
+                            conf_generation_level: dict = None,
+                            conf_path: str = None,
                             ) -> None:
         """
         Generate conformers.
@@ -1070,6 +1072,8 @@ class ARCSpecies(object):
                                        (unique) generated conformers will be stored in the .conformers attribute.
             plot_path (str, optional): A folder path in which the plot will be saved.
                                        If None, the plot will not be shown (nor saved).
+            conf_generation_level (dict, optional): The level of theory to use for conformer generation.
+            conf_path (str, optional): A folder path in which the conformers will be saved.
         """
         if self.is_ts:
             return
@@ -1095,6 +1099,8 @@ class ARCSpecies(object):
                                                       return_all_conformers=False,
                                                       plot_path=plot_path,
                                                       diastereomers=diastereomers,
+                                                      conf_generation_level=conf_generation_level,
+                                                      conf_path=conf_path,
                                                       )
         if len(lowest_confs):
             self.conformers.extend([conf['xyz'] for conf in lowest_confs])


### PR DESCRIPTION
The new added level of theory and other features allow us to find conformers considering solvation effect.
It includes opening a subprocess to run multi_species opt job with solvent over the conformers from the RDkit conformers (without solvent), followed by designated post processes.