### PR TITLE
Don't execute jobs on a server if the maximum job limit has been reached

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -518,7 +518,8 @@ class JobAdapter(ABC):
         }
 
         if queue is None:
-            logger.warning(f'Queue not defined for server {self.server}. Assuming the queue name is defined in your submit.py script.')
+            logger.debug(f'Queue not defined for server {self.server}. '
+                         f'Assuming the queue name is defined in your submit.py script.')
             del format_params['queue']
 
         try:

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -39,6 +39,7 @@ servers = {
         'address': 'server1.host.edu',
         'un': '<username>',
         'key': 'path_to_rsa_key',
+        'max_simultaneous_jobs': 10,  # optional, "check_status_command" must be set to only return jobs for your user
     },
     'server2': {
         'cluster_soft': 'Slurm',
@@ -58,7 +59,7 @@ servers = {
         'cluster_soft': 'HTCondor',
         'un': '<username>',
         'cpus': 48,
-        'queues': {'':''}, #{'queue_name':'HH:MM:SS'}
+        'queues': {'':''},  # {'queue_name':'HH:MM:SS'}
         'excluded_queues': ['queue_name1', 'queue_name2'],
     },
 }


### PR DESCRIPTION
Limit the overall number of simultaneous jobs on a server if the user defined `max_simultaneous_jobs` in the servers dict in settings.
This feature was not tested yet.