### PR TITLE
Fixed the sella env

### DIFF
--- a/arc/job/adapters/xtb_test.py
+++ b/arc/job/adapters/xtb_test.py
@@ -260,7 +260,7 @@ $end"""
                          ('C', 'C', 'O', 'H', 'H', 'H', 'H', 'H'))
 
     def test_opt_ts(self):
-        """Test optimizing a TS using Stella."""
+        """Test optimizing a TS using Sella."""
         self.assertIsNone(self.job_10.species[0].final_xyz)
         self.job_10.execute_incore()
         self.assertTrue(almost_equal_coords(self.job_10.species[0].final_xyz, self.ts_xyz))

--- a/devtools/sella_environment.yml
+++ b/devtools/sella_environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pyyaml
   - pandas
   - ncurses
+  - numpy==1.26.4
   - pip:
     - sella
     - typing-extensions


### PR DESCRIPTION
Numpy came up with version 2.0.0, which modified the API. Sella still works with <2.0.0, so locked in the last version.