### PR TITLE
Gaussian unconverge trsh

### DIFF
--- a/arc/job/adapters/gaussian_test.py
+++ b/arc/job/adapters/gaussian_test.py
@@ -218,7 +218,7 @@ class TestGaussianAdapter(unittest.TestCase):
                             )
         
         # Gaussian: Checkfile error and SCF error
-        # First SCF error - qc,nosymm
+        # First SCF error - maxcycle=128,nosymm
         job_status = {'keywords': ['SCF', 'NoSymm']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -240,7 +240,7 @@ class TestGaussianAdapter(unittest.TestCase):
                                             )
         
         # Gaussian: Additional SCF error
-        # Second SCF error - Includes previous SCF error and NDamp=30
+        # Second SCF error - Includes previous SCF error and xqc
         job_status = {'keywords': ['SCF']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -262,7 +262,7 @@ class TestGaussianAdapter(unittest.TestCase):
                                             )
         
         # Gaussian: Additional SCF error
-        # Third SCF error - Includes previous SCF errors and NoDIIS
+        # Third SCF error - Includes previous SCF errors and NDamp=30
         job_status = {'keywords': ['SCF']}
         output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
             memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
@@ -327,6 +327,118 @@ class TestGaussianAdapter(unittest.TestCase):
                                             testing=True,
                                             args=args
                                             )
+        
+        # Gaussian: L9999 error, including MaxOptCycles and SCF error
+        # Occures when max steps have exceeded during optimization
+        job_status = {'keywords': ['L9999', 'MaxOptCycles', 'SCF']}
+        ess_trsh_methods = ['']
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                          job_type, software, fine, memory_gb,
+                                                                          num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_17 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+        
+        # Gaussian L502 error, including InaccurateQuadrature
+        job_status = {'keywords': ['L502', 'InaccurateQuadrature']}
+        ess_trsh_methods = ['']
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                            job_type, software, fine, memory_gb,
+                                                                            num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_18 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+
+        # Gaussian L502 Error (already troubleshooted with L502 error), excluding InaccurateQuadrature
+        job_status = {'keywords': ['SCF', 'GL502', 'NoSymm']}
+        ess_trsh_methods = ['scf=(qc)', 'scf=(NDamp=30)', 'scf=(NoDIIS)', 'guess=INDO', 'nosymm']
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                            job_type, software, fine, memory_gb,
+                                                                            num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_19 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+
+        # Gaussian L502 Error (already troubleshooted with L502 error), including InaccurateQuadrature
+        job_status = {'keywords': ['GL502', 'InaccurateQuadrature']}
+        ess_trsh_methods = ['scf=(qc)', 'scf=(NDamp=30)', 'scf=(NoDIIS)', 'guess=INDO', 'nosymm', 'int=grid=300590']
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                            job_type, software, fine, memory_gb,
+                                                                            num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_20 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+        
+        # Gaussian L502 Error (already troubleshooted with L502 error), including InaccurateQuadrature
+        job_status = {'keywords': ['GL502', 'InaccurateQuadrature']}
+        ess_trsh_methods = ['scf=(qc)', 'scf=(NDamp=30)', 'scf=(NoDIIS)', 'guess=INDO', 'nosymm', 'int=grid=300590', 'scf=(NoVarAcc)']
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                            job_type, software, fine, memory_gb,
+                                                                            num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        args = {'keyword': {}, 'block': {}}
+        if trsh_keyword:
+            args['trsh'] = {'trsh': trsh_keyword}
+        cls.job_21 = GaussianAdapter(execution_type='local',
+                                            job_type='opt',
+                                            level=Level(method='wb97xd'),
+                                            fine=True,
+                                            ess_trsh_methods=ess_trsh_methods,
+                                            project='test',
+                                            project_directory=os.path.join(ARC_PATH, 'arc', 'testing', 'test_GaussianAdapter'),
+                                            species=[spc_11],
+                                            testing=True,
+                                            args=args
+                                            )
+        
 
     def test_set_cpu_and_mem(self):
         """Test assigning number of cpu's and memory"""
@@ -651,7 +763,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(direct,tight,xqc)
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(direct,tight,xqc)
 
 ethanol
 
@@ -677,7 +789,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(NDamp=30,direct,tight,xqc)
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(NDamp=30,direct,tight,xqc)
 
 ethanol
 
@@ -703,7 +815,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     nosymm scf=(NDamp=30,NoDIIS,direct,tight,xqc)
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(NDamp=30,NoDIIS,direct,tight,xqc)
 
 ethanol
 
@@ -729,7 +841,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(calcfc,cartesian,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(NDamp=30,NoDIIS,direct,tight,xqc)
+#P opt=(calcfc,cartesian,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)       nosymm scf=(NDamp=30,NoDIIS,direct,tight,xqc)
 
 ethanol
 
@@ -756,7 +868,7 @@ H       0.04768200    1.19305700   -0.88359100
 %mem=14336mb
 %NProcShared=8
 
-#P opt=(cartesian) integral=(grid=ultrafine, Acc2E=14) guess=INDO wb97xd   IOp(2/9=2000)       nosymm  scf=(NDamp=30,NoDIIS,direct,tight,xqc)
+#P opt=(cartesian) integral=(grid=ultrafine, Acc2E=14) guess=INDO wb97xd   IOp(2/9=2000)        nosymm  scf=(NDamp=30,NoDIIS,direct,tight,xqc)
 
 ethanol
 
@@ -775,6 +887,139 @@ H       0.04768200    1.19305700   -0.88359100
 """
 
         self.assertEqual(content_16, job_16_expected_input_file)
+
+        self.job_17.write_input_file()
+        with open(os.path.join(self.job_17.local_path, input_filenames[self.job_17.job_adapter]), 'r') as f:
+            content_17 = f.read()
+        job_17_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc,maxcycle=200,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)       scf=(direct,tight,xqc)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_17, job_17_expected_input_file)
+        
+        self.job_18.write_input_file()
+        with open(os.path.join(self.job_18.local_path, input_filenames[self.job_18.job_adapter]), 'r') as f:
+            content_18 = f.read()
+        job_18_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)    int=grid=300590  scf=(direct,tight)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_18, job_18_expected_input_file)
+
+        self.job_19.write_input_file()
+        with open(os.path.join(self.job_19.local_path, input_filenames[self.job_19.job_adapter]), 'r') as f:
+            content_19 = f.read()
+        job_19_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      nosymm scf=(NDamp=30,NoDIIS,direct,tight,xqc)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+        self.assertEqual(content_19, job_19_expected_input_file)
+
+        self.job_20.write_input_file()
+        with open(os.path.join(self.job_20.local_path, input_filenames[self.job_20.job_adapter]), 'r') as f:
+            content_20 = f.read()
+        job_20_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc,maxstep=5,tight)  guess=mix wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)      scf=(NDamp=30,NoDIIS,NoVarAcc,direct,tight,xqc)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+
+        self.assertEqual(content_20, job_20_expected_input_file)
+        
+        self.job_21.write_input_file()
+        with open(os.path.join(self.job_21.local_path, input_filenames[self.job_21.job_adapter]), 'r') as f:
+            content_21 = f.read()
+        job_21_expected_input_file = """%chk=check.chk
+%mem=14336mb
+%NProcShared=8
+
+#P opt=(calcfc,maxstep=5,tight) guess=INDO wb97xd  integral=(grid=ultrafine, Acc2E=14) IOp(2/9=2000)     int=grid=300590   scf=(NDamp=30,NoDIIS,NoVarAcc,direct,tight,xqc)
+
+ethanol
+
+0 1
+C       1.16582100   -0.40435500    0.00000000
+C       0.00000000    0.55180500    0.00000000
+O      -1.18946000   -0.21419400    0.00000000
+H      -1.94125800    0.37518500    0.00000000
+H       2.10540200    0.14511600    0.00000000
+H       1.13062400   -1.03878500    0.88303200
+H       1.13062400   -1.03878500   -0.88303200
+H       0.04768200    1.19305700    0.88359100
+H       0.04768200    1.19305700   -0.88359100
+
+
+"""
+
+        self.assertEqual(content_21, job_21_expected_input_file)
+
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/testing/trsh/gaussian/inaccurate_quadrature.out
+++ b/arc/testing/trsh/gaussian/inaccurate_quadrature.out
@@ -1,0 +1,11187 @@
+
+ Cycle  94  Pass 1  IDiag  1:
+ E= -668.941347923252     Delta-E=        0.000000001683 Rises=F Damp=F
+ DIIS: error= 1.00D-05 at cycle  82 NSaved=   6.
+ NSaved= 6 IEnMin= 2 EnMin= -668.941347934283     IErMin= 4 ErrMin= 6.18D-06
+ ErrMax= 1.00D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.46D-09 BMatP= 5.17D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.247D+01-0.247D+00 0.123D+01 0.310D+00 0.138D+01 0.798D+00
+ Coeff:     -0.247D+01-0.247D+00 0.123D+01 0.310D+00 0.138D+01 0.798D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=5.61D-08 MaxDP=3.08D-06 DE= 1.68D-09 OVMax= 8.77D-06
+
+ Cycle  95  Pass 1  IDiag  1:
+ E= -668.941347922741     Delta-E=        0.000000000511 Rises=F Damp=F
+ DIIS: error= 7.56D-06 at cycle  83 NSaved=   7.
+ NSaved= 7 IEnMin= 2 EnMin= -668.941347934283     IErMin= 4 ErrMin= 6.18D-06
+ ErrMax= 7.56D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.43D-09 BMatP= 5.17D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.120D+01-0.161D+00 0.104D+01-0.440D+00 0.528D+00 0.452D+00
+ Coeff-Com:  0.774D+00
+ Coeff:     -0.120D+01-0.161D+00 0.104D+01-0.440D+00 0.528D+00 0.452D+00
+ Coeff:      0.774D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.30D-08 MaxDP=1.90D-06 DE= 5.11D-10 OVMax= 4.86D-06
+
+ Cycle  96  Pass 1  IDiag  1:
+ E= -668.941347922398     Delta-E=        0.000000000343 Rises=F Damp=F
+ DIIS: error= 3.66D-06 at cycle  84 NSaved=   8.
+ NSaved= 8 IEnMin= 2 EnMin= -668.941347934283     IErMin= 8 ErrMin= 3.66D-06
+ ErrMax= 3.66D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.43D-09 BMatP= 3.43D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.468D+00-0.674D-01 0.157D+01-0.205D+01-0.101D+01 0.212D+00
+ Coeff-Com:  0.354D+01-0.165D+01
+ Coeff:      0.468D+00-0.674D-01 0.157D+01-0.205D+01-0.101D+01 0.212D+00
+ Coeff:      0.354D+01-0.165D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.91D-08 MaxDP=2.09D-06 DE= 3.43D-10 OVMax= 3.28D-06
+
+ Cycle  97  Pass 1  IDiag  1:
+ E= -668.941347922350     Delta-E=        0.000000000048 Rises=F Damp=F
+ DIIS: error= 2.11D-06 at cycle  85 NSaved=   9.
+ NSaved= 9 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 2.11D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.90D-10 BMatP= 1.43D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.181D+00-0.667D-01 0.534D+00-0.893D+00-0.248D+00 0.104D+00
+ Coeff-Com:  0.131D+01-0.494D+00 0.572D+00
+ Coeff:      0.181D+00-0.667D-01 0.534D+00-0.893D+00-0.248D+00 0.104D+00
+ Coeff:      0.131D+01-0.494D+00 0.572D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.59D-08 MaxDP=2.42D-06 DE= 4.84D-11 OVMax= 3.91D-06
+
+ Cycle  98  Pass 1  IDiag  1:
+ E= -668.941347922234     Delta-E=        0.000000000116 Rises=F Damp=F
+ DIIS: error= 2.74D-06 at cycle  86 NSaved=  10.
+ NSaved=10 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 2.74D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.79D-10 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.952D-01-0.581D-01 0.383D+00-0.720D+00-0.168D+00 0.803D-01
+ Coeff-Com:  0.980D+00-0.340D+00 0.395D+00 0.352D+00
+ Coeff:      0.952D-01-0.581D-01 0.383D+00-0.720D+00-0.168D+00 0.803D-01
+ Coeff:      0.980D+00-0.340D+00 0.395D+00 0.352D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.68D-08 MaxDP=2.11D-06 DE= 1.16D-10 OVMax= 3.73D-06
+
+ Cycle  99  Pass 1  IDiag  1:
+ E= -668.941347922010     Delta-E=        0.000000000224 Rises=F Damp=F
+ DIIS: error= 4.35D-06 at cycle  87 NSaved=  11.
+ NSaved=11 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 4.35D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.72D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.121D+00-0.387D-01 0.282D+00-0.130D+00-0.285D+00-0.800D-02
+ Coeff-Com:  0.339D+00 0.123D+00 0.224D+00 0.128D+01-0.908D+00
+ Coeff:      0.121D+00-0.387D-01 0.282D+00-0.130D+00-0.285D+00-0.800D-02
+ Coeff:      0.339D+00 0.123D+00 0.224D+00 0.128D+01-0.908D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.18D-07 MaxDP=6.27D-06 DE= 2.24D-10 OVMax= 1.05D-05
+
+ Cycle 100  Pass 1  IDiag  1:
+ E= -668.941347922505     Delta-E=       -0.000000000495 Rises=F Damp=F
+ DIIS: error= 2.18D-06 at cycle  88 NSaved=  12.
+ NSaved=12 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 2.18D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.82D-10 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.401D-01-0.626D-01 0.251D+00-0.464D+00 0.282D-01 0.756D-01
+ Coeff-Com:  0.569D+00-0.268D+00 0.186D+00 0.463D+00-0.393D+00 0.574D+00
+ Coeff:      0.401D-01-0.626D-01 0.251D+00-0.464D+00 0.282D-01 0.756D-01
+ Coeff:      0.569D+00-0.268D+00 0.186D+00 0.463D+00-0.393D+00 0.574D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.23D-08 MaxDP=1.42D-06 DE=-4.95D-10 OVMax= 2.18D-06
+
+ Cycle 101  Pass 1  IDiag  1:
+ E= -668.941347922413     Delta-E=        0.000000000093 Rises=F Damp=F
+ DIIS: error= 2.21D-06 at cycle  89 NSaved=  13.
+ NSaved=13 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 2.21D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.10D-10 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.153D+00 0.726D-01-0.557D+00 0.111D+01-0.216D+00-0.280D+00
+ Coeff-Com: -0.162D+01 0.749D+00-0.819D+00-0.170D+01-0.481D+00-0.108D+01
+ Coeff-Com:  0.598D+01
+ Coeff:     -0.153D+00 0.726D-01-0.557D+00 0.111D+01-0.216D+00-0.280D+00
+ Coeff:     -0.162D+01 0.749D+00-0.819D+00-0.170D+01-0.481D+00-0.108D+01
+ Coeff:      0.598D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-07 MaxDP=4.30D-06 DE= 9.25D-11 OVMax= 1.27D-05
+
+ Cycle 102  Pass 1  IDiag  1:
+ E= -668.941347922909     Delta-E=       -0.000000000496 Rises=F Damp=F
+ DIIS: error= 4.68D-06 at cycle  90 NSaved=  14.
+ NSaved=14 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 4.68D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.29D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.107D+00 0.534D-01-0.459D+00 0.103D+01 0.929D-01-0.128D+00
+ Coeff-Com: -0.138D+01 0.852D+00-0.271D+00 0.203D+01-0.281D+01-0.483D+00
+ Coeff-Com:  0.128D+01 0.129D+01
+ Coeff:     -0.107D+00 0.534D-01-0.459D+00 0.103D+01 0.929D-01-0.128D+00
+ Coeff:     -0.138D+01 0.852D+00-0.271D+00 0.203D+01-0.281D+01-0.483D+00
+ Coeff:      0.128D+01 0.129D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=2.27D-07 MaxDP=1.27D-05 DE=-4.96D-10 OVMax= 2.73D-05
+
+ Cycle 103  Pass 1  IDiag  1:
+ E= -668.941347925450     Delta-E=       -0.000000002541 Rises=F Damp=F
+ DIIS: error= 6.06D-06 at cycle  91 NSaved=  15.
+ NSaved=15 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 6.06D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.41D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.119D+00 0.358D-01-0.453D+00 0.994D+00 0.194D+00-0.946D-01
+ Coeff-Com: -0.133D+01 0.812D+00-0.200D+00 0.249D+01-0.305D+01-0.221D+00
+ Coeff-Com:  0.597D+00 0.125D+01 0.104D+00
+ Coeff:     -0.119D+00 0.358D-01-0.453D+00 0.994D+00 0.194D+00-0.946D-01
+ Coeff:     -0.133D+01 0.812D+00-0.200D+00 0.249D+01-0.305D+01-0.221D+00
+ Coeff:      0.597D+00 0.125D+01 0.104D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.97D-08 MaxDP=2.29D-06 DE=-2.54D-09 OVMax= 5.52D-06
+
+ Cycle 104  Pass 1  IDiag  1:
+ E= -668.941347926041     Delta-E=       -0.000000000591 Rises=F Damp=F
+ DIIS: error= 6.63D-06 at cycle  92 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 6.63D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.36D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-4.15D-16
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.884D-01 0.150D+00-0.554D+00 0.112D+01-0.519D+00-0.359D+00
+ Coeff-Com: -0.161D+01 0.850D+00-0.923D+00-0.269D+01-0.207D+01 0.741D+01
+ Coeff-Com:  0.870D+00-0.732D+00 0.146D+00
+ Coeff:     -0.884D-01 0.150D+00-0.554D+00 0.112D+01-0.519D+00-0.359D+00
+ Coeff:     -0.161D+01 0.850D+00-0.923D+00-0.269D+01-0.207D+01 0.741D+01
+ Coeff:      0.870D+00-0.732D+00 0.146D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.98D-07 MaxDP=2.28D-05 DE=-5.91D-10 OVMax= 4.89D-05
+
+ Cycle 105  Pass 1  IDiag  1:
+ E= -668.941347922346     Delta-E=        0.000000003695 Rises=F Damp=F
+ DIIS: error= 4.06D-06 at cycle  93 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 4.06D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.04D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.15D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.726D-01-0.140D-01-0.344D+00-0.288D+00 0.390D+00 0.212D-01
+ Coeff-Com: -0.107D+00-0.355D+00-0.915D-01 0.809D+00 0.789D+00 0.470D+00
+ Coeff-Com: -0.248D+01 0.202D+01 0.257D+00
+ Coeff:     -0.726D-01-0.140D-01-0.344D+00-0.288D+00 0.390D+00 0.212D-01
+ Coeff:     -0.107D+00-0.355D+00-0.915D-01 0.809D+00 0.789D+00 0.470D+00
+ Coeff:     -0.248D+01 0.202D+01 0.257D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.08D-07 MaxDP=4.60D-06 DE= 3.70D-09 OVMax= 1.07D-05
+
+ Cycle 106  Pass 1  IDiag  1:
+ E= -668.941347921343     Delta-E=        0.000000001003 Rises=F Damp=F
+ DIIS: error= 9.34D-06 at cycle  94 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.11D-06
+ ErrMax= 9.34D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.03D-09 BMatP= 2.90D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.26D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.848D-01 0.211D-01 0.254D+00 0.255D+00 0.190D+00 0.921D-01
+ Coeff-Com: -0.191D+00 0.471D+00 0.655D+00-0.104D+01-0.981D-01 0.541D+01
+ Coeff-Com: -0.438D+01 0.224D+00-0.774D+00
+ Coeff:     -0.848D-01 0.211D-01 0.254D+00 0.255D+00 0.190D+00 0.921D-01
+ Coeff:     -0.191D+00 0.471D+00 0.655D+00-0.104D+01-0.981D-01 0.541D+01
+ Coeff:     -0.438D+01 0.224D+00-0.774D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=5.63D-07 MaxDP=3.12D-05 DE= 1.00D-09 OVMax= 5.98D-05
+
+ Cycle 107  Pass 1  IDiag  1:
+ E= -668.941347927390     Delta-E=       -0.000000006047 Rises=F Damp=F
+ DIIS: error= 9.97D-06 at cycle  95 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 2.18D-06
+ ErrMax= 9.97D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.54D-09 BMatP= 4.10D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-5.43D-16
+ Inversion failed.  Reducing to 15 matrices.
+ Large coefficients: NSaved= 15 BigCof=   15.62 CofMax=   10.00 Det=-5.77D-16
+ Inversion failed.  Reducing to 14 matrices.
+ Large coefficients: NSaved= 14 BigCof=   15.63 CofMax=   10.00 Det=-5.77D-16
+ Inversion failed.  Reducing to 13 matrices.
+ Large coefficients: NSaved= 13 BigCof=   14.74 CofMax=   10.00 Det=-5.91D-16
+ Inversion failed.  Reducing to 12 matrices.
+ Coeff-Com: -0.144D+00-0.226D-02-0.108D+00 0.512D+00 0.424D+00 0.888D-01
+ Coeff-Com: -0.396D+00 0.963D-01 0.778D+01-0.706D+01-0.756D+00 0.557D+00
+ Coeff:     -0.144D+00-0.226D-02-0.108D+00 0.512D+00 0.424D+00 0.888D-01
+ Coeff:     -0.396D+00 0.963D-01 0.778D+01-0.706D+01-0.756D+00 0.557D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=2.79D-08 MaxDP=1.03D-06 DE=-6.05D-09 OVMax= 4.76D-06
+
+ Cycle 108  Pass 1  IDiag  1:
+ E= -668.941347927912     Delta-E=       -0.000000000522 Rises=F Damp=F
+ DIIS: error= 1.11D-05 at cycle  96 NSaved=  13.
+ NSaved=13 IEnMin= 2 EnMin= -668.941347934283     IErMin= 8 ErrMin= 4.68D-06
+ ErrMax= 1.11D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.03D-08 BMatP= 1.29D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 13 BigCof=   15.50 CofMax=   10.00 Det=-3.86D-16
+ Inversion failed.  Reducing to 12 matrices.
+ Large coefficients: NSaved= 12 BigCof=   21.67 CofMax=   10.00 Det=-4.63D-16
+ Inversion failed.  Reducing to 11 matrices.
+ Large coefficients: NSaved= 11 BigCof=   21.69 CofMax=   10.00 Det=-6.94D-16
+ Inversion failed.  Reducing to 10 matrices.
+ Large coefficients: NSaved= 10 BigCof=   21.00 CofMax=   10.00 Det=-4.06D-15
+ Inversion failed.  Reducing to  9 matrices.
+ Large coefficients: NSaved=  9 BigCof=   23.04 CofMax=   10.00 Det=-1.77D-14
+ Inversion failed.  Reducing to  8 matrices.
+ Large coefficients: NSaved=  8 BigCof=   23.74 CofMax=   10.00 Det=-4.26D-14
+ Inversion failed.  Reducing to  7 matrices.
+ Large coefficients: NSaved=  7 BigCof=   23.85 CofMax=   10.00 Det=-4.47D-14
+ Inversion failed.  Reducing to  6 matrices.
+ Coeff-Com:  0.940D+00-0.569D-01 0.199D+00 0.774D+00 0.353D+01-0.438D+01
+ Coeff:      0.940D+00-0.569D-01 0.199D+00 0.774D+00 0.353D+01-0.438D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.15D-07 MaxDP=1.32D-05 DE=-5.22D-10 OVMax= 4.15D-05
+
+ Cycle 109  Pass 1  IDiag  1:
+ E= -668.941347923934     Delta-E=        0.000000003978 Rises=F Damp=F
+ DIIS: error= 7.28D-06 at cycle  97 NSaved=   7.
+ NSaved= 7 IEnMin= 2 EnMin= -668.941347934283     IErMin= 4 ErrMin= 6.63D-06
+ ErrMax= 7.28D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.69D-09 BMatP= 4.36D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.162D+00-0.611D-01-0.287D+00 0.927D+00 0.698D+00-0.151D+01
+ Coeff-Com:  0.139D+01
+ Coeff:     -0.162D+00-0.611D-01-0.287D+00 0.927D+00 0.698D+00-0.151D+01
+ Coeff:      0.139D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.45D-07 MaxDP=8.76D-06 DE= 3.98D-09 OVMax= 1.68D-05
+
+ Cycle 110  Pass 1  IDiag  1:
+ E= -668.941347922677     Delta-E=        0.000000001257 Rises=F Damp=F
+ DIIS: error= 4.84D-06 at cycle  98 NSaved=   8.
+ NSaved= 8 IEnMin= 2 EnMin= -668.941347934283     IErMin= 8 ErrMin= 4.84D-06
+ ErrMax= 4.84D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.11D-09 BMatP= 3.69D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.262D+00-0.369D-01-0.223D+00 0.119D+01 0.317D+00-0.118D+01
+ Coeff-Com:  0.864D+00 0.326D+00
+ Coeff:     -0.262D+00-0.369D-01-0.223D+00 0.119D+01 0.317D+00-0.118D+01
+ Coeff:      0.864D+00 0.326D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.91D-08 MaxDP=2.40D-06 DE= 1.26D-09 OVMax= 7.15D-06
+
+ Cycle 111  Pass 1  IDiag  1:
+ E= -668.941347922567     Delta-E=        0.000000000110 Rises=F Damp=F
+ DIIS: error= 3.37D-06 at cycle  99 NSaved=   9.
+ NSaved= 9 IEnMin= 2 EnMin= -668.941347934283     IErMin= 9 ErrMin= 3.37D-06
+ ErrMax= 3.37D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.51D-10 BMatP= 2.11D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.327D+00 0.167D-01 0.242D-01 0.101D+01 0.127D+00-0.967D+00
+ Coeff-Com:  0.324D+00-0.208D+00 0.997D+00
+ Coeff:     -0.327D+00 0.167D-01 0.242D-01 0.101D+01 0.127D+00-0.967D+00
+ Coeff:      0.324D+00-0.208D+00 0.997D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.64D-08 MaxDP=2.52D-06 DE= 1.10D-10 OVMax= 7.05D-06
+
+ Cycle 112  Pass 1  IDiag  1:
+ E= -668.941347922372     Delta-E=        0.000000000195 Rises=F Damp=F
+ DIIS: error= 2.10D-06 at cycle 100 NSaved=  10.
+ NSaved=10 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 2.10D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.03D-10 BMatP= 9.51D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.112D+00 0.122D+00 0.175D-01 0.304D+00-0.785D-01-0.338D+00
+ Coeff-Com: -0.458D-02-0.818D+00-0.103D+01 0.294D+01
+ Coeff:     -0.112D+00 0.122D+00 0.175D-01 0.304D+00-0.785D-01-0.338D+00
+ Coeff:     -0.458D-02-0.818D+00-0.103D+01 0.294D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.38D-07 MaxDP=6.98D-06 DE= 1.95D-10 OVMax= 1.99D-05
+
+ Cycle 113  Pass 1  IDiag  1:
+ E= -668.941347921424     Delta-E=        0.000000000949 Rises=F Damp=F
+ DIIS: error= 1.26D-05 at cycle 101 NSaved=  11.
+ NSaved=11 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 1.26D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.70D-09 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.967D-01 0.148D+00-0.235D-01-0.172D+00-0.161D+00-0.100D+00
+ Coeff-Com:  0.211D-01-0.492D+00-0.268D+01 0.435D+01 0.207D+00
+ Coeff:     -0.967D-01 0.148D+00-0.235D-01-0.172D+00-0.161D+00-0.100D+00
+ Coeff:      0.211D-01-0.492D+00-0.268D+01 0.435D+01 0.207D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.74D-07 MaxDP=9.36D-06 DE= 9.49D-10 OVMax= 1.50D-05
+
+ Cycle 114  Pass 1  IDiag  1:
+ E= -668.941347913276     Delta-E=        0.000000008147 Rises=F Damp=F
+ DIIS: error= 3.55D-05 at cycle 102 NSaved=  12.
+ NSaved=12 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 3.55D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.19D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.437D-01 0.161D+00 0.300D+00-0.355D+00-0.557D-01-0.165D+00
+ Coeff-Com: -0.387D-01-0.632D+00-0.152D+01 0.278D+01 0.767D+00-0.195D+00
+ Coeff:     -0.437D-01 0.161D+00 0.300D+00-0.355D+00-0.557D-01-0.165D+00
+ Coeff:     -0.387D-01-0.632D+00-0.152D+01 0.278D+01 0.767D+00-0.195D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.18D-07 MaxDP=6.86D-06 DE= 8.15D-09 OVMax= 1.05D-05
+
+ Cycle 115  Pass 1  IDiag  1:
+ E= -668.941347919160     Delta-E=       -0.000000005884 Rises=F Damp=F
+ DIIS: error= 2.11D-05 at cycle 103 NSaved=  13.
+ NSaved=13 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 2.11D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.34D-08 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.456D-01 0.117D+00 0.394D+00-0.504D+00-0.635D+00 0.477D+00
+ Coeff-Com: -0.606D+00-0.896D+00-0.345D+00 0.261D+01 0.274D+00-0.339D+00
+ Coeff-Com:  0.503D+00
+ Coeff:     -0.456D-01 0.117D+00 0.394D+00-0.504D+00-0.635D+00 0.477D+00
+ Coeff:     -0.606D+00-0.896D+00-0.345D+00 0.261D+01 0.274D+00-0.339D+00
+ Coeff:      0.503D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=7.00D-08 MaxDP=4.14D-06 DE=-5.88D-09 OVMax= 6.61D-06
+
+ Cycle 116  Pass 1  IDiag  1:
+ E= -668.941347915827     Delta-E=        0.000000003333 Rises=F Damp=F
+ DIIS: error= 3.11D-05 at cycle 104 NSaved=  14.
+ NSaved=14 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 3.11D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.07D-08 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.739D-01 0.139D+00 0.386D+00-0.560D+00-0.575D+00 0.421D+00
+ Coeff-Com: -0.629D+00-0.105D+01-0.276D+00 0.274D+01 0.299D+00-0.501D-01
+ Coeff-Com:  0.687D+00-0.456D+00
+ Coeff:     -0.739D-01 0.139D+00 0.386D+00-0.560D+00-0.575D+00 0.421D+00
+ Coeff:     -0.629D+00-0.105D+01-0.276D+00 0.274D+01 0.299D+00-0.501D-01
+ Coeff:      0.687D+00-0.456D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=3.70D-08 MaxDP=2.04D-06 DE= 3.33D-09 OVMax= 3.30D-06
+
+ Cycle 117  Pass 1  IDiag  1:
+ E= -668.941347913439     Delta-E=        0.000000002388 Rises=F Damp=F
+ DIIS: error= 3.49D-05 at cycle 105 NSaved=  15.
+ NSaved=15 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 3.49D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.17D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 15 BigCof=   15.38 CofMax=   10.00 Det=-7.92D-16
+ Inversion failed.  Reducing to 14 matrices.
+ Large coefficients: NSaved= 14 BigCof=   13.81 CofMax=   10.00 Det=-8.33D-16
+ Inversion failed.  Reducing to 13 matrices.
+ Coeff-Com: -0.579D-01 0.125D+00 0.373D+00-0.585D+00-0.129D+00 0.471D-01
+ Coeff-Com: -0.343D+00-0.686D+00-0.152D+01 0.343D+01 0.227D+00 0.118D+01
+ Coeff-Com: -0.107D+01
+ Coeff:     -0.579D-01 0.125D+00 0.373D+00-0.585D+00-0.129D+00 0.471D-01
+ Coeff:     -0.343D+00-0.686D+00-0.152D+01 0.343D+01 0.227D+00 0.118D+01
+ Coeff:     -0.107D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=5.05D-08 MaxDP=2.65D-06 DE= 2.39D-09 OVMax= 5.62D-06
+
+ Cycle 118  Pass 1  IDiag  1:
+ E= -668.941347916423     Delta-E=       -0.000000002984 Rises=F Damp=F
+ DIIS: error= 2.96D-05 at cycle 106 NSaved=  14.
+ NSaved=14 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 2.96D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.32D-08 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.491D-01 0.993D-01 0.403D+00-0.772D+00-0.260D+00 0.252D+00
+ Coeff-Com: -0.383D+00-0.505D+00-0.196D+01 0.390D+01 0.256D-01 0.314D+01
+ Coeff-Com: -0.179D+01-0.110D+01
+ Coeff:     -0.491D-01 0.993D-01 0.403D+00-0.772D+00-0.260D+00 0.252D+00
+ Coeff:     -0.383D+00-0.505D+00-0.196D+01 0.390D+01 0.256D-01 0.314D+01
+ Coeff:     -0.179D+01-0.110D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.65D-08 MaxDP=2.44D-06 DE=-2.98D-09 OVMax= 3.67D-06
+
+ Cycle 119  Pass 1  IDiag  1:
+ E= -668.941347913764     Delta-E=        0.000000002659 Rises=F Damp=F
+ DIIS: error= 3.41D-05 at cycle 107 NSaved=  15.
+ NSaved=15 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 3.41D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.14D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 15 BigCof=   18.43 CofMax=   10.00 Det=-2.02D-16
+ Inversion failed.  Reducing to 14 matrices.
+ Coeff-Com:  0.193D-01 0.938D-01 0.379D+00-0.770D+00-0.319D+00 0.367D+00
+ Coeff-Com: -0.761D+00-0.825D+00-0.721D+00 0.353D+01-0.263D+00 0.231D+01
+ Coeff-Com: -0.635D+00-0.140D+01
+ Coeff:      0.193D-01 0.938D-01 0.379D+00-0.770D+00-0.319D+00 0.367D+00
+ Coeff:     -0.761D+00-0.825D+00-0.721D+00 0.353D+01-0.263D+00 0.231D+01
+ Coeff:     -0.635D+00-0.140D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=2.96D-08 MaxDP=1.49D-06 DE= 2.66D-09 OVMax= 3.16D-06
+
+ Cycle 120  Pass 1  IDiag  1:
+ E= -668.941347915226     Delta-E=       -0.000000001462 Rises=F Damp=F
+ DIIS: error= 3.40D-05 at cycle 108 NSaved=  15.
+ NSaved=15 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 3.40D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.90D-08 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.640D-01 0.255D+00 0.454D-01-0.406D-01-0.234D+01 0.161D+01
+ Coeff-Com:  0.400D-01-0.101D+01-0.345D+01 0.439D+01 0.228D+01-0.174D+01
+ Coeff-Com:  0.111D+01 0.265D+01-0.273D+01
+ Coeff:     -0.640D-01 0.255D+00 0.454D-01-0.406D-01-0.234D+01 0.161D+01
+ Coeff:      0.400D-01-0.101D+01-0.345D+01 0.439D+01 0.228D+01-0.174D+01
+ Coeff:      0.111D+01 0.265D+01-0.273D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=2.52D-07 MaxDP=1.20D-05 DE=-1.46D-09 OVMax= 2.36D-05
+
+ Cycle 121  Pass 1  IDiag  1:
+ E= -668.941347893400     Delta-E=        0.000000021826 Rises=F Damp=F
+ DIIS: error= 8.09D-05 at cycle 109 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 8.09D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.03D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-2.15D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com:  0.619D-01 0.145D+00 0.243D+00-0.153D+00-0.118D+01 0.859D+00
+ Coeff-Com: -0.353D+00-0.412D+00-0.308D+01 0.453D+01 0.439D+00 0.160D+01
+ Coeff-Com: -0.286D+00-0.148D+01 0.699D-01
+ Coeff:      0.619D-01 0.145D+00 0.243D+00-0.153D+00-0.118D+01 0.859D+00
+ Coeff:     -0.353D+00-0.412D+00-0.308D+01 0.453D+01 0.439D+00 0.160D+01
+ Coeff:     -0.286D+00-0.148D+01 0.699D-01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=2.70D-07 MaxDP=1.42D-05 DE= 2.18D-08 OVMax= 2.13D-05
+
+ Cycle 122  Pass 1  IDiag  1:
+ E= -668.941347916312     Delta-E=       -0.000000022912 Rises=F Damp=F
+ DIIS: error= 2.92D-05 at cycle 110 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 2.92D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.33D-08 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.90D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.291D+00 0.276D+00 0.803D+00-0.368D+00-0.170D+01 0.101D+01
+ Coeff-Com:  0.104D+01 0.147D+01-0.968D+01 0.760D+01 0.147D+01 0.943D+00
+ Coeff-Com: -0.389D+01 0.173D+00 0.215D+01
+ Coeff:     -0.291D+00 0.276D+00 0.803D+00-0.368D+00-0.170D+01 0.101D+01
+ Coeff:      0.104D+01 0.147D+01-0.968D+01 0.760D+01 0.147D+01 0.943D+00
+ Coeff:     -0.389D+01 0.173D+00 0.215D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.58D-07 MaxDP=8.70D-06 DE=-2.29D-08 OVMax= 2.42D-05
+
+ Cycle 123  Pass 1  IDiag  1:
+ E= -668.941347911066     Delta-E=        0.000000005246 Rises=F Damp=F
+ DIIS: error= 6.14D-05 at cycle 111 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 6.14D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.91D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.84D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.186D+00 0.206D+00 0.844D+00-0.532D+00-0.221D+01 0.151D+01
+ Coeff-Com:  0.599D+00 0.112D+01-0.800D+01 0.698D+01 0.113D+01 0.173D+01
+ Coeff-Com: -0.407D+01 0.168D+01 0.200D+00
+ Coeff:     -0.186D+00 0.206D+00 0.844D+00-0.532D+00-0.221D+01 0.151D+01
+ Coeff:      0.599D+00 0.112D+01-0.800D+01 0.698D+01 0.113D+01 0.173D+01
+ Coeff:     -0.407D+01 0.168D+01 0.200D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=2.75D-06 DE= 5.25D-09 OVMax= 5.64D-06
+
+ Cycle 124  Pass 1  IDiag  1:
+ E= -668.941347908129     Delta-E=        0.000000002937 Rises=F Damp=F
+ DIIS: error= 7.01D-05 at cycle 112 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 7.01D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.31D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.77D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.201D+00 0.203D+00 0.885D+00-0.417D+00-0.183D+01 0.118D+01
+ Coeff-Com:  0.422D+00 0.873D+00-0.713D+01 0.646D+01 0.911D+00-0.216D+01
+ Coeff-Com:  0.162D+01 0.548D-01 0.128D+00
+ Coeff:     -0.201D+00 0.203D+00 0.885D+00-0.417D+00-0.183D+01 0.118D+01
+ Coeff:      0.422D+00 0.873D+00-0.713D+01 0.646D+01 0.911D+00-0.216D+01
+ Coeff:      0.162D+01 0.548D-01 0.128D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=8.20D-08 MaxDP=3.91D-06 DE= 2.94D-09 OVMax= 7.99D-06
+
+ Cycle 125  Pass 1  IDiag  1:
+ E= -668.941347914255     Delta-E=       -0.000000006126 Rises=F Damp=F
+ DIIS: error= 4.62D-05 at cycle 113 NSaved=  16.
+ NSaved=16 IEnMin= 2 EnMin= -668.941347934283     IErMin=10 ErrMin= 2.10D-06
+ ErrMax= 4.62D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.35D-07 BMatP= 4.03D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-1.62D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.208D+00 0.202D+00 0.884D+00-0.413D+00-0.187D+01 0.121D+01
+ Coeff-Com:  0.438D+00 0.894D+00-0.730D+01 0.660D+01 0.918D+00-0.211D+01
+ Coeff-Com:  0.151D+01 0.114D+00 0.134D+00
+ Coeff:     -0.208D+00 0.202D+00 0.884D+00-0.413D+00-0.187D+01 0.121D+01
+ Coeff:      0.438D+00 0.894D+00-0.730D+01 0.660D+01 0.918D+00-0.211D+01
+ Coeff:      0.151D+01 0.114D+00 0.134D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=9.44D-09 MaxDP=4.05D-07 DE=-6.13D-09 OVMax= 6.98D-07
+
+ Density matrix is not changing but DIIS error= 4.62D-05 CofLast= 1.34D-01.
+ Cycle 126  Pass 1  IDiag  1:
+ E= -668.941347913573     Delta-E=        0.000000000681 Rises=F Damp=F
+ DIIS: error= 5.04D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.941347913573     IErMin= 1 ErrMin= 5.04D-05
+ ErrMax= 5.04D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.49D-07 BMatP= 1.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=8.12D-07 MaxDP=4.69D-05 DE= 6.81D-10 OVMax= 1.05D-04
+
+ Cycle 127  Pass 1  IDiag  1:
+ E= -668.941347936308     Delta-E=       -0.000000022735 Rises=F Damp=F
+ DIIS: error= 2.56D-05 at cycle 115 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.941347936308     IErMin= 2 ErrMin= 2.56D-05
+ ErrMax= 2.56D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.75D-08 BMatP= 1.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.305D+00 0.695D+00
+ Coeff:      0.305D+00 0.695D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=4.95D-07 MaxDP=3.35D-05 DE=-2.27D-08 OVMax= 7.76D-05
+
+ Cycle 128  Pass 1  IDiag  1:
+ E= -668.941347932472     Delta-E=        0.000000003836 Rises=F Damp=F
+ DIIS: error= 1.93D-05 at cycle 116 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -668.941347936308     IErMin= 3 ErrMin= 1.93D-05
+ ErrMax= 1.93D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.00D-08 BMatP= 6.75D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.223D-01 0.406D+00 0.616D+00
+ Coeff:     -0.223D-01 0.406D+00 0.616D+00
+ Gap=     0.322 Goal=   None    Shift=    0.000
+ Gap=     0.238 Goal=   None    Shift=    0.000
+ RMSDP=1.66D-07 MaxDP=8.72D-06 DE= 3.84D-09 OVMax= 2.62D-05
+
+ >>>>>>>>>> Convergence criterion not met.
+ SCF Done:  E(UwB97XD) =  -668.941347932     A.U. after  129 cycles
+            NFock=128  Conv=0.17D-06     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0207 S= 3.0030
+ <L.S>= 0.000000000000E+00
+ KE= 6.650507302662D+02 PE=-2.332439378285D+03 EE= 6.186414516098D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0207,   after    12.0001
+ Convergence failure -- run terminated.
+ Error termination via Lnk1e in /usr/local/g09/l502.exe at Sat Aug 10 05:43:16 2024.
+ Job cpu time:       0 days  7 hours 15 minutes 49.5 seconds.
+ File lengths (MBytes):  RWF=     95 Int=      0 D2E=      0 Chk=      4 Scr=      1
+cd ..
+cd conformer1
+cat input.log
+     5  C    5.181087   3.544681   2.459397   1.475922   0.000000
+     6  C    5.552768   4.129359   2.870776   2.466636   1.486578
+     7  C    4.787405   3.696884   2.480587   2.812437   2.484977
+     8  C    3.429531   2.579423   1.484852   2.475214   2.864532
+     9  H    4.933658   5.605779   4.985265   5.453682   6.628237
+    10  H    2.339785   1.112940   2.165799   3.266808   3.824156
+    11  H    2.414621   1.100960   2.156572   2.709261   3.701140
+    12  H    4.488076   3.334733   2.225749   1.101297   2.220996
+    13  H    5.607380   3.830483   3.107526   2.227559   1.099950
+    14  H    6.634932   5.217927   3.957975   3.421781   2.253501
+    15  H    5.486412   4.603101   3.472959   3.889165   3.478318
+    16  H    3.207166   2.957523   2.239383   3.441479   3.957046
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403627   0.000000
+     8  C    2.446552   1.389221   0.000000
+     9  H    6.593718   5.872221   4.983981   0.000000
+    10  H    4.248264   3.767028   2.823919   6.510832   0.000000
+    11  H    4.622114   4.478300   3.500615   6.107698   1.769891
+    12  H    3.094565   3.455955   3.117148   4.907940   4.178898
+    13  H    2.232742   3.269748   3.645734   7.612190   3.908003
+    14  H    1.093675   2.172192   3.424596   7.325177   5.287254
+    15  H    2.154817   1.093999   2.142298   6.226175   4.565899
+    16  H    3.434137   2.164880   1.093837   4.616167   3.150591
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.347803   0.000000
+    13  H    3.794102   3.040588   0.000000
+    14  H    5.679818   3.896035   2.788605   0.000000
+    15  H    5.469309   4.448194   4.207237   2.484696   0.000000
+    16  H    4.003350   3.951554   4.724096   4.318491   2.477665
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.7052271      0.9270207      0.8362208
+ Leave Link  202 at Sun Aug 11 01:55:23 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4633156612 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071839702 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4561316911 Hartrees.
+ Leave Link  301 at Sun Aug 11 01:55:23 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7943.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.08D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 01:55:23 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 01:55:23 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.007969   -0.009882   -0.029333
+         Rot=    0.999970    0.005322    0.004441   -0.003434 Ang=   0.89 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 01:55:23 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.942885407433
+ DIIS: error= 1.24D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.942885407433     IErMin= 1 ErrMin= 1.24D-03
+ ErrMax= 1.24D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.36D-03 BMatP= 1.36D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ GapD=    0.701 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=1.78D-04 MaxDP=3.80D-03              OVMax= 6.21D-03
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943551369023     Delta-E=       -0.000665961590 Rises=F Damp=F
+ DIIS: error= 3.48D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943551369023     IErMin= 2 ErrMin= 3.48D-04
+ ErrMax= 3.48D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.44D-05 BMatP= 1.36D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.228D+00 0.123D+01
+ Coeff:     -0.228D+00 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.72D-05 MaxDP=1.10D-03 DE=-6.66D-04 OVMax= 3.14D-03
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943615237273     Delta-E=       -0.000063868250 Rises=F Damp=F
+ DIIS: error= 9.76D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943615237273     IErMin= 3 ErrMin= 9.76D-05
+ ErrMax= 9.76D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.87D-06 BMatP= 7.44D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.764D-02-0.151D+00 0.114D+01
+ Coeff:      0.764D-02-0.151D+00 0.114D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.31D-05 MaxDP=5.78D-04 DE=-6.39D-05 OVMax= 1.07D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943619745448     Delta-E=       -0.000004508175 Rises=F Damp=F
+ DIIS: error= 5.91D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943619745448     IErMin= 4 ErrMin= 5.91D-05
+ ErrMax= 5.91D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.41D-06 BMatP= 4.87D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.340D-01-0.235D+00 0.518D+00 0.682D+00
+ Coeff:      0.340D-01-0.235D+00 0.518D+00 0.682D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.82D-06 MaxDP=2.25D-04 DE=-4.51D-06 OVMax= 4.85D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943620919883     Delta-E=       -0.000001174435 Rises=F Damp=F
+ DIIS: error= 1.80D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943620919883     IErMin= 5 ErrMin= 1.80D-05
+ ErrMax= 1.80D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.28D-07 BMatP= 2.41D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.272D-02-0.121D-02-0.138D+00 0.805D-01 0.106D+01
+ Coeff:      0.272D-02-0.121D-02-0.138D+00 0.805D-01 0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.24D-06 MaxDP=1.77D-04 DE=-1.17D-06 OVMax= 3.92D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943621188940     Delta-E=       -0.000000269057 Rises=F Damp=F
+ DIIS: error= 1.60D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943621188940     IErMin= 6 ErrMin= 1.60D-05
+ ErrMax= 1.60D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.63D-08 BMatP= 2.28D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.491D-02 0.407D-01-0.146D+00-0.885D-01 0.407D+00 0.792D+00
+ Coeff:     -0.491D-02 0.407D-01-0.146D+00-0.885D-01 0.407D+00 0.792D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.51D-06 MaxDP=1.38D-04 DE=-2.69D-07 OVMax= 3.19D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943621276227     Delta-E=       -0.000000087287 Rises=F Damp=F
+ DIIS: error= 1.68D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943621276227     IErMin= 6 ErrMin= 1.60D-05
+ ErrMax= 1.68D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.74D-08 BMatP= 6.63D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.175D-03-0.140D-02 0.224D-01-0.777D-02-0.159D+00-0.482D-02
+ Coeff-Com:  0.115D+01
+ Coeff:     -0.175D-03-0.140D-02 0.224D-01-0.777D-02-0.159D+00-0.482D-02
+ Coeff:      0.115D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.26D-06 MaxDP=1.76D-04 DE=-8.73D-08 OVMax= 3.99D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943621343271     Delta-E=       -0.000000067044 Rises=F Damp=F
+ DIIS: error= 1.61D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943621343271     IErMin= 6 ErrMin= 1.60D-05
+ ErrMax= 1.61D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.31D-08 BMatP= 1.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.981D-03-0.823D-02 0.304D-01 0.185D-01-0.899D-01-0.160D+00
+ Coeff-Com:  0.166D-01 0.119D+01
+ Coeff:      0.981D-03-0.823D-02 0.304D-01 0.185D-01-0.899D-01-0.160D+00
+ Coeff:      0.166D-01 0.119D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.37D-06 MaxDP=1.94D-04 DE=-6.70D-08 OVMax= 4.39D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943621408869     Delta-E=       -0.000000065598 Rises=F Damp=F
+ DIIS: error= 1.54D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943621408869     IErMin= 9 ErrMin= 1.54D-05
+ ErrMax= 1.54D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.16D-08 BMatP= 1.31D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.130D-03 0.254D-02-0.182D-01 0.929D-03 0.100D+00 0.347D-01
+ Coeff-Com: -0.594D+00-0.230D+00 0.170D+01
+ Coeff:     -0.130D-03 0.254D-02-0.182D-01 0.929D-03 0.100D+00 0.347D-01
+ Coeff:     -0.594D+00-0.230D+00 0.170D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.82D-06 MaxDP=3.15D-04 DE=-6.56D-08 OVMax= 7.14D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943621508431     Delta-E=       -0.000000099563 Rises=F Damp=F
+ DIIS: error= 1.43D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943621508431     IErMin=10 ErrMin= 1.43D-05
+ ErrMax= 1.43D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.03D-08 BMatP= 1.16D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.142D-02 0.117D-01-0.436D-01-0.263D-01 0.122D+00 0.223D+00
+ Coeff-Com:  0.684D-01-0.168D+01-0.231D+00 0.256D+01
+ Coeff:     -0.142D-02 0.117D-01-0.436D-01-0.263D-01 0.122D+00 0.223D+00
+ Coeff:      0.684D-01-0.168D+01-0.231D+00 0.256D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.06D-06 MaxDP=7.51D-04 DE=-9.96D-08 OVMax= 1.70D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943621719393     Delta-E=       -0.000000210962 Rises=F Damp=F
+ DIIS: error= 1.20D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943621719393     IErMin=11 ErrMin= 1.20D-05
+ ErrMax= 1.20D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.68D-09 BMatP= 1.03D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.311D-03-0.487D-02 0.321D-01 0.145D-02-0.169D+00-0.889D-01
+ Coeff-Com:  0.944D+00 0.515D+00-0.272D+01-0.281D+00 0.278D+01
+ Coeff:      0.311D-03-0.487D-02 0.321D-01 0.145D-02-0.169D+00-0.889D-01
+ Coeff:      0.944D+00 0.515D+00-0.272D+01-0.281D+00 0.278D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.87D-05 MaxDP=1.56D-03 DE=-2.11D-07 OVMax= 3.52D-03
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943622045682     Delta-E=       -0.000000326289 Rises=F Damp=F
+ DIIS: error= 7.31D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943622045682     IErMin=12 ErrMin= 7.31D-06
+ ErrMax= 7.31D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.88D-09 BMatP= 7.68D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.160D-02-0.139D-01 0.577D-01 0.286D-01-0.192D+00-0.271D+00
+ Coeff-Com:  0.293D+00 0.198D+01-0.810D+00-0.277D+01 0.111D+01 0.160D+01
+ Coeff:      0.160D-02-0.139D-01 0.577D-01 0.286D-01-0.192D+00-0.271D+00
+ Coeff:      0.293D+00 0.198D+01-0.810D+00-0.277D+01 0.111D+01 0.160D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.94D-05 MaxDP=1.61D-03 DE=-3.26D-07 OVMax= 3.64D-03
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943622227815     Delta-E=       -0.000000182133 Rises=F Damp=F
+ DIIS: error= 2.66D-06 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943622227815     IErMin=13 ErrMin= 2.66D-06
+ ErrMax= 2.66D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.95D-10 BMatP= 3.88D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.130D-04 0.742D-03-0.836D-02 0.283D-02 0.494D-01 0.207D-01
+ Coeff-Com: -0.361D+00-0.286D-01 0.103D+01-0.134D+00-0.102D+01 0.753D-01
+ Coeff-Com:  0.137D+01
+ Coeff:      0.130D-04 0.742D-03-0.836D-02 0.283D-02 0.494D-01 0.207D-01
+ Coeff:     -0.361D+00-0.286D-01 0.103D+01-0.134D+00-0.102D+01 0.753D-01
+ Coeff:      0.137D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.84D-06 MaxDP=7.33D-04 DE=-1.82D-07 OVMax= 1.66D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943622258554     Delta-E=       -0.000000030739 Rises=F Damp=F
+ DIIS: error= 9.89D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943622258554     IErMin=14 ErrMin= 9.89D-07
+ ErrMax= 9.89D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.51D-10 BMatP= 9.95D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.411D-03 0.372D-02-0.166D-01-0.652D-02 0.562D-01 0.790D-01
+ Coeff-Com: -0.143D+00-0.529D+00 0.368D+00 0.716D+00-0.430D+00-0.431D+00
+ Coeff-Com:  0.252D+00 0.108D+01
+ Coeff:     -0.411D-03 0.372D-02-0.166D-01-0.652D-02 0.562D-01 0.790D-01
+ Coeff:     -0.143D+00-0.529D+00 0.368D+00 0.716D+00-0.430D+00-0.431D+00
+ Coeff:      0.252D+00 0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.53D-06 MaxDP=2.10D-04 DE=-3.07D-08 OVMax= 4.74D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943622261389     Delta-E=       -0.000000002835 Rises=F Damp=F
+ DIIS: error= 5.55D-07 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943622261389     IErMin=15 ErrMin= 5.55D-07
+ ErrMax= 5.55D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.93D-11 BMatP= 2.51D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.406D-04-0.568D-03 0.377D-02 0.399D-03-0.188D-01-0.107D-01
+ Coeff-Com:  0.949D-01 0.778D-01-0.278D+00-0.628D-01 0.284D+00 0.274D-01
+ Coeff-Com: -0.328D+00-0.171D+00 0.138D+01
+ Coeff:      0.406D-04-0.568D-03 0.377D-02 0.399D-03-0.188D-01-0.107D-01
+ Coeff:      0.949D-01 0.778D-01-0.278D+00-0.628D-01 0.284D+00 0.274D-01
+ Coeff:     -0.328D+00-0.171D+00 0.138D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.11D-07 MaxDP=5.77D-05 DE=-2.84D-09 OVMax= 1.30D-04
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943622261789     Delta-E=       -0.000000000400 Rises=F Damp=F
+ DIIS: error= 3.24D-07 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943622261789     IErMin=16 ErrMin= 3.24D-07
+ ErrMax= 3.24D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.44D-11 BMatP= 6.93D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.119D-03-0.110D-02 0.512D-02 0.192D-02-0.183D-01-0.229D-01
+ Coeff-Com:  0.501D-01 0.161D+00-0.132D+00-0.214D+00 0.151D+00 0.129D+00
+ Coeff-Com: -0.110D+00-0.375D+00 0.209D+00 0.116D+01
+ Coeff:      0.119D-03-0.110D-02 0.512D-02 0.192D-02-0.183D-01-0.229D-01
+ Coeff:      0.501D-01 0.161D+00-0.132D+00-0.214D+00 0.151D+00 0.129D+00
+ Coeff:     -0.110D+00-0.375D+00 0.209D+00 0.116D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.37D-07 MaxDP=1.77D-05 DE=-4.00D-10 OVMax= 3.98D-05
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943622261876     Delta-E=       -0.000000000087 Rises=F Damp=F
+ DIIS: error= 1.44D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943622261876     IErMin=17 ErrMin= 1.44D-07
+ ErrMax= 1.44D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.60D-12 BMatP= 2.44D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.352D-07 0.649D-04-0.706D-03 0.846D-04 0.441D-02 0.777D-03
+ Coeff-Com: -0.275D-01-0.629D-02 0.848D-01-0.930D-02-0.847D-01 0.156D-01
+ Coeff-Com:  0.103D+00-0.193D-01-0.476D+00 0.260D+00 0.115D+01
+ Coeff:     -0.352D-07 0.649D-04-0.706D-03 0.846D-04 0.441D-02 0.777D-03
+ Coeff:     -0.275D-01-0.629D-02 0.848D-01-0.930D-02-0.847D-01 0.156D-01
+ Coeff:      0.103D+00-0.193D-01-0.476D+00 0.260D+00 0.115D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.09D-07 MaxDP=7.46D-06 DE=-8.66D-11 OVMax= 1.66D-05
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943622261892     Delta-E=       -0.000000000016 Rises=F Damp=F
+ DIIS: error= 4.34D-08 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943622261892     IErMin=18 ErrMin= 4.34D-08
+ ErrMax= 4.34D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.97D-13 BMatP= 6.60D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.198D-04 0.198D-03-0.101D-02-0.316D-03 0.416D-02 0.387D-02
+ Coeff-Com: -0.152D-01-0.286D-01 0.442D-01 0.323D-01-0.474D-01-0.150D-01
+ Coeff-Com:  0.433D-01 0.536D-01-0.146D+00-0.123D+00 0.253D+00 0.943D+00
+ Coeff:     -0.198D-04 0.198D-03-0.101D-02-0.316D-03 0.416D-02 0.387D-02
+ Coeff:     -0.152D-01-0.286D-01 0.442D-01 0.323D-01-0.474D-01-0.150D-01
+ Coeff:      0.433D-01 0.536D-01-0.146D+00-0.123D+00 0.253D+00 0.943D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.28D-08 MaxDP=1.19D-06 DE=-1.59D-11 OVMax= 2.67D-06
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943622261902     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 1.91D-08 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943622261902     IErMin=19 ErrMin= 1.91D-08
+ ErrMax= 1.91D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.83D-13 BMatP= 9.97D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.186D-05 0.810D-05 0.252D-04-0.609D-04-0.331D-03 0.191D-03
+ Coeff-Com:  0.343D-02-0.189D-02-0.101D-01 0.474D-02 0.942D-02-0.372D-02
+ Coeff-Com: -0.140D-01 0.115D-01 0.755D-01-0.749D-01-0.211D+00 0.179D+00
+ Coeff-Com:  0.103D+01
+ Coeff:     -0.186D-05 0.810D-05 0.252D-04-0.609D-04-0.331D-03 0.191D-03
+ Coeff:      0.343D-02-0.189D-02-0.101D-01 0.474D-02 0.942D-02-0.372D-02
+ Coeff:     -0.140D-01 0.115D-01 0.755D-01-0.749D-01-0.211D+00 0.179D+00
+ Coeff:      0.103D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.66D-09 MaxDP=3.15D-07 DE=-1.00D-11 OVMax= 7.34D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943622262     A.U. after   19 cycles
+            NFock= 19  Conv=0.77D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650266173365D+02 PE=-2.333696802948D+03 EE= 6.192704316587D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 01:56:38 2024, MaxMem=  4294967296 cpu:      1189.9
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 01:56:38 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7943.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 01:56:38 2024, MaxMem=  4294967296 cpu:         2.1
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 01:56:38 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:       113.2
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.07553182D-01-5.77209544D-02 9.24711309D-02
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000084104   -0.000064724    0.000156382
+      2        6          -0.000058651   -0.000060821   -0.000376049
+      3        6          -0.000139494    0.000101039    0.000130368
+      4        6           0.000280905    0.000135372    0.000088588
+      5        6          -0.000154093    0.000047048    0.000028112
+      6        6           0.000138861   -0.000015803   -0.000034925
+      7        6           0.000021033    0.000045783    0.000010987
+      8        6          -0.000091449   -0.000171193   -0.000181899
+      9        1           0.000002529    0.000003639    0.000004037
+     10        1          -0.000023623    0.000002420    0.000038493
+     11        1          -0.000071257    0.000015064    0.000016830
+     12        1          -0.000053633   -0.000046342    0.000053038
+     13        1           0.000051530   -0.000039607    0.000037732
+     14        1          -0.000016097    0.000048541    0.000037437
+     15        1           0.000042811   -0.000035962   -0.000013076
+     16        1          -0.000013478    0.000035542    0.000003945
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000376049 RMS     0.000100712
+ Leave Link  716 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000215363 RMS     0.000061284
+ Search for a local minimum.
+ Step number  69 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .61284D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   51   52   53   54
+                                                     55   56   57   58   59
+                                                     60   61   62   63   64
+                                                     65   66   67   68   69
+ DE= -2.02D-06 DEPred=-6.47D-07 R= 3.12D+00
+ TightC=F SS=  1.41D+00  RLast= 1.25D-01 DXNew= 4.0386D-01 3.7632D-01
+ Trust test= 3.12D+00 RLast= 1.25D-01 DXMaxT set to 3.76D-01
+ ITU=  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1  1  1  1  1  1
+ ITU=  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1  1  1  1  1  1
+ ITU=  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0  0  1  0  0  1
+ ITU=  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---    0.00003   0.00005   0.00046   0.00101   0.00300
+     Eigenvalues ---    0.00589   0.00980   0.01268   0.01560   0.01881
+     Eigenvalues ---    0.02098   0.02331   0.03870   0.04115   0.04938
+     Eigenvalues ---    0.08413   0.08868   0.09556   0.10313   0.10655
+     Eigenvalues ---    0.11135   0.11527   0.13092   0.14414   0.15625
+     Eigenvalues ---    0.17693   0.18911   0.21651   0.25946   0.28733
+     Eigenvalues ---    0.33550   0.34365   0.35430   0.35536   0.36666
+     Eigenvalues ---    0.38319   0.38469   0.38553   0.38597   0.41202
+     Eigenvalues ---    0.42737   0.71662
+ Eigenvalue     1 is   3.38D-05 Eigenvector:
+                          D1        D3        D2        A1        R2
+   1                   -0.53315  -0.52950  -0.52695  -0.34810   0.17183
+                          D6        D8        D4        D15       D14
+   1                   -0.04187  -0.03691  -0.03227  -0.02067  -0.02013
+ Eigenvalue     2 is   5.05D-05 Eigenvector:
+                          R2        D2        D1        D3        A1
+   1                    0.97001   0.12748   0.12710   0.12704  -0.09241
+                          D6        D4        D8        D7        D5
+   1                   -0.02173  -0.02104  -0.02023  -0.01322  -0.01253
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    69   68   67   66   65
+ RFO step:  Lambda=-4.63417055D-07.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC=  7.33D-08 SmlDif=  1.00D-05
+ RMS Error=  0.2372032599D-03 NUsed= 5 EDIIS=F
+ Point number   5 has GDIIS coefficient -1.34D+01 and has been removed
+ DidBck=F Rises=F RFO-DIIS coefs:    3.76616   -2.55013   -7.15445    6.93842    0.00000
+ Iteration  1 RMS(Cart)=  0.16242060 RMS(Int)=  0.00980001
+ Iteration  2 RMS(Cart)=  0.03215428 RMS(Int)=  0.00033615
+ Iteration  3 RMS(Cart)=  0.00039999 RMS(Int)=  0.00000962
+ Iteration  4 RMS(Cart)=  0.00000007 RMS(Int)=  0.00000962
+ ITry= 1 IFail=0 DXMaxC= 1.17D+00 DCOld= 1.00D+10 DXMaxT= 3.76D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.44067  -0.00016   0.00044  -0.00007   0.00037   3.44103
+    R2        9.32326   0.00000   0.20221  -0.00226   0.19995   9.52321
+    R3        2.81240   0.00011  -0.00030   0.00014  -0.00016   2.81224
+    R4        2.10315  -0.00003   0.00020  -0.00005   0.00015   2.10331
+    R5        2.08051   0.00003  -0.00020   0.00007  -0.00013   2.08038
+    R6        2.79859   0.00022  -0.00005  -0.00008  -0.00013   2.79845
+    R7        2.80596   0.00011  -0.00037   0.00012  -0.00025   2.80571
+    R8        2.78909  -0.00006   0.00020   0.00004   0.00025   2.78933
+    R9        2.08115  -0.00001   0.00001   0.00000   0.00002   2.08117
+   R10        2.80922   0.00007  -0.00033   0.00009  -0.00023   2.80899
+   R11        2.07860   0.00007  -0.00011  -0.00001  -0.00012   2.07848
+   R12        2.65247   0.00010   0.00032  -0.00029   0.00004   2.65251
+   R13        2.06675   0.00001  -0.00003   0.00002  -0.00001   2.06673
+   R14        2.62525   0.00016  -0.00068   0.00014  -0.00054   2.62471
+   R15        2.06736   0.00003  -0.00007   0.00002  -0.00005   2.06731
+   R16        2.06705   0.00000  -0.00001   0.00005   0.00003   2.06709
+    A1        1.78214  -0.00005  -0.12014  -0.04148  -0.16162   1.62052
+    A2        1.99130   0.00018  -0.00045  -0.00003  -0.00048   1.99083
+    A3        1.80004  -0.00004  -0.00103   0.00029  -0.00074   1.79930
+    A4        1.90189  -0.00012   0.00111  -0.00011   0.00100   1.90289
+    A5        1.95353   0.00000  -0.00041   0.00018  -0.00022   1.95330
+    A6        1.95351  -0.00004   0.00045  -0.00016   0.00028   1.95380
+    A7        1.85272   0.00001   0.00028  -0.00014   0.00014   1.85286
+    A8        2.13380   0.00011   0.00004   0.00005   0.00013   2.13394
+    A9        2.10065  -0.00014  -0.00011   0.00013   0.00006   2.10071
+   A10        1.97476   0.00001   0.00008  -0.00005   0.00005   1.97481
+   A11        1.96453   0.00003  -0.00013   0.00000  -0.00014   1.96438
+   A12        2.06523  -0.00003  -0.00033   0.00005  -0.00027   2.06496
+   A13        2.06487   0.00003  -0.00056   0.00004  -0.00051   2.06436
+   A14        1.96763   0.00003  -0.00027   0.00008  -0.00019   1.96744
+   A15        2.07682   0.00002  -0.00019  -0.00001  -0.00020   2.07662
+   A16        2.06991  -0.00005   0.00025  -0.00014   0.00010   2.07001
+   A17        2.06924  -0.00001  -0.00006   0.00012   0.00006   2.06930
+   A18        2.11095  -0.00003   0.00011  -0.00004   0.00007   2.11102
+   A19        2.10080   0.00004  -0.00005  -0.00009  -0.00015   2.10066
+   A20        2.13502   0.00004  -0.00009   0.00003  -0.00007   2.13495
+   A21        2.07223  -0.00004   0.00002   0.00001   0.00003   2.07226
+   A22        2.07282   0.00000   0.00007  -0.00005   0.00003   2.07285
+   A23        2.08207  -0.00006   0.00031  -0.00012   0.00018   2.08225
+   A24        2.09063   0.00003  -0.00027   0.00003  -0.00023   2.09039
+   A25        2.10993   0.00004  -0.00003   0.00007   0.00004   2.10997
+    D1       -0.36228   0.00003  -0.13309  -0.04478  -0.17787  -0.54014
+    D2       -2.48512  -0.00005  -0.13166  -0.04518  -0.17684  -2.66196
+    D3        1.83499   0.00001  -0.13194  -0.04511  -0.17704   1.65795
+    D4        2.37092  -0.00003   0.00332  -0.00207   0.00126   2.37218
+    D5       -1.20219  -0.00006   0.00370  -0.00174   0.00195  -1.20023
+    D6       -1.87653   0.00005   0.00142  -0.00159  -0.00017  -1.87670
+    D7        0.83355   0.00002   0.00179  -0.00126   0.00052   0.83407
+    D8        0.20103   0.00003   0.00181  -0.00176   0.00006   0.20109
+    D9        2.91112   0.00000   0.00219  -0.00143   0.00075   2.91186
+   D10        1.88153  -0.00004   0.00062   0.00008   0.00071   1.88223
+   D11       -1.89125   0.00001  -0.00105   0.00022  -0.00084  -1.89208
+   D12       -0.85673   0.00003   0.00034  -0.00027   0.00006  -0.85667
+   D13        1.65368   0.00008  -0.00134  -0.00013  -0.00148   1.65220
+   D14       -2.28679  -0.00004  -0.00150   0.00032  -0.00118  -2.28796
+   D15        0.89041  -0.00001  -0.00173   0.00085  -0.00088   0.88953
+   D16        0.45998  -0.00004  -0.00117   0.00065  -0.00053   0.45945
+   D17       -2.64601  -0.00001  -0.00141   0.00118  -0.00023  -2.64624
+   D18        0.88805  -0.00002   0.00063  -0.00036   0.00027   0.88831
+   D19       -1.65396  -0.00001   0.00089  -0.00020   0.00068  -1.65327
+   D20       -1.62251  -0.00005   0.00222  -0.00050   0.00172  -1.62079
+   D21        2.11867  -0.00003   0.00247  -0.00034   0.00213   2.12081
+   D22       -0.52446  -0.00001  -0.00084   0.00064  -0.00020  -0.52466
+   D23        2.54626  -0.00002  -0.00100   0.00055  -0.00045   2.54581
+   D24        2.02013   0.00000  -0.00125   0.00053  -0.00073   2.01941
+   D25       -1.19233  -0.00001  -0.00141   0.00044  -0.00098  -1.19331
+   D26        0.12676   0.00001  -0.00002  -0.00029  -0.00031   0.12645
+   D27       -3.10068   0.00001  -0.00007  -0.00040  -0.00047  -3.10114
+   D28       -2.94438   0.00003   0.00013  -0.00021  -0.00008  -2.94446
+   D29        0.11137   0.00003   0.00008  -0.00031  -0.00023   0.11114
+   D30       -0.09403  -0.00001   0.00111  -0.00036   0.00075  -0.09329
+   D31        3.01155  -0.00004   0.00134  -0.00090   0.00044   3.01199
+   D32        3.13343  -0.00001   0.00116  -0.00026   0.00090   3.13433
+   D33       -0.04417  -0.00004   0.00139  -0.00080   0.00059  -0.04358
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000215     0.000450     YES
+ RMS     Force            0.000061     0.000300     YES
+ Maximum Displacement     1.167334     0.001800     NO
+ RMS     Displacement     0.190391     0.001200     NO
+ Predicted change in Energy=-1.539058D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.864786   -1.641155   -0.962366
+      2          6           0       -1.436875   -1.502662    0.159072
+      3          6           0       -0.624419   -0.272154   -0.042001
+      4          6           0       -0.135302    0.546172    1.091184
+      5          6           0        1.319794    0.412149    1.299664
+      6          6           0        2.100587    0.625274    0.052873
+      7          6           0        1.510026    0.287334   -1.174831
+      8          6           0        0.179388   -0.097239   -1.278000
+      9          1           0       -3.464703    3.355719   -1.222336
+     10          1           0       -0.854242   -2.425486   -0.059451
+     11          1           0       -1.786145   -1.599751    1.198563
+     12          1           0       -0.598536    1.530442    1.262953
+     13          1           0        1.687880   -0.320600    2.032696
+     14          1           0        3.086883    1.097043    0.080545
+     15          1           0        2.095995    0.406936   -2.090863
+     16          1           0       -0.290038   -0.239049   -2.255777
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.820915   0.000000
+     3  C    2.782172   1.488175   0.000000
+     4  C    4.056051   2.600124   1.480878   0.000000
+     5  C    5.181076   3.544951   2.459329   1.476052   0.000000
+     6  C    5.551787   4.129531   2.870546   2.466485   1.486455
+     7  C    4.785728   3.696973   2.480360   2.812281   2.484933
+     8  C    3.427871   2.579282   1.484720   2.475083   2.864324
+     9  H    5.039467   5.442815   4.756245   4.932629   6.157636
+    10  H    2.339384   1.113022   2.165632   3.266739   3.824369
+    11  H    2.415532   1.100890   2.156645   2.709575   3.702002
+    12  H    4.488537   3.334829   2.225518   1.101308   2.220792
+    13  H    5.607230   3.830383   3.106999   2.227495   1.099885
+    14  H    6.633834   5.218143   3.957712   3.421597   2.253427
+    15  H    5.484299   4.603253   3.472701   3.888894   3.478245
+    16  H    3.204395   2.956932   2.239132   3.441316   3.956864
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403646   0.000000
+     8  C    2.446273   1.388934   0.000000
+     9  H    6.328818   5.845098   5.020499   0.000000
+    10  H    4.248619   3.767390   2.823824   6.448964   0.000000
+    11  H    4.622773   4.478709   3.500603   5.764979   1.769995
+    12  H    3.093363   3.454583   3.116240   4.209894   4.178936
+    13  H    2.232645   3.269472   3.645017   7.117560   3.907686
+    14  H    1.093669   2.172113   3.424249   7.051411   5.287747
+    15  H    2.154831   1.093974   2.142037   6.353819   4.566524
+    16  H    3.433949   2.164660   1.093855   4.906001   3.150029
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.348532   0.000000
+    13  H    3.794846   3.040816   0.000000
+    14  H    5.680587   3.894643   2.788873   0.000000
+    15  H    5.469746   4.446442   4.207090   2.484577   0.000000
+    16  H    4.002788   3.950662   4.723326   4.318233   2.477427
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.7179961      0.9267617      0.8409339
+ Leave Link  202 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.6391369219 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071987936 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.6319381283 Hartrees.
+ Leave Link  301 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2729 LenP2D=    7959.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 01:56:45 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.011168   -0.024877   -0.089411
+         Rot=    0.999748    0.015088    0.014187   -0.008654 Ang=   2.57 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0261 S= 3.0037
+ Leave Link  401 at Sun Aug 11 01:56:46 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.937801597154
+ DIIS: error= 2.99D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.937801597154     IErMin= 1 ErrMin= 2.99D-03
+ ErrMax= 2.99D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.07D-02 BMatP= 1.07D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.702 Goal=     0.100 Shift=    0.000
+ T=  113. Gap= 0.319 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.738 Goal=     0.100 Shift=    0.000
+ T=  113. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.702 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=4.86D-04 MaxDP=1.00D-02              OVMax= 1.69D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943062465537     Delta-E=       -0.005260868382 Rises=F Damp=F
+ DIIS: error= 8.43D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943062465537     IErMin= 2 ErrMin= 8.43D-04
+ ErrMax= 8.43D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.83D-04 BMatP= 1.07D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.229D+00 0.123D+01
+ Coeff:     -0.229D+00 0.123D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.87D-04 MaxDP=2.84D-03 DE=-5.26D-03 OVMax= 8.52D-03
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943567109721     Delta-E=       -0.000504644184 Rises=F Damp=F
+ DIIS: error= 2.61D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943567109721     IErMin= 3 ErrMin= 2.61D-04
+ ErrMax= 2.61D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.46D-05 BMatP= 5.83D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.212D-01-0.225D+00 0.120D+01
+ Coeff:      0.212D-01-0.225D+00 0.120D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.45D-05 MaxDP=1.21D-03 DE=-5.05D-04 OVMax= 3.46D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943604472276     Delta-E=       -0.000037362555 Rises=F Damp=F
+ DIIS: error= 1.39D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943604472276     IErMin= 4 ErrMin= 1.39D-04
+ ErrMax= 1.39D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.39D-05 BMatP= 3.46D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.323D-01-0.220D+00 0.493D+00 0.694D+00
+ Coeff:      0.323D-01-0.220D+00 0.493D+00 0.694D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.33D-05 MaxDP=5.63D-04 DE=-3.74D-05 OVMax= 1.24D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943611939571     Delta-E=       -0.000007467295 Rises=F Damp=F
+ DIIS: error= 8.03D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943611939571     IErMin= 5 ErrMin= 8.03D-05
+ ErrMax= 8.03D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.94D-06 BMatP= 1.39D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.602D-03 0.140D-01-0.184D+00 0.112D+00 0.106D+01
+ Coeff:      0.602D-03 0.140D-01-0.184D+00 0.112D+00 0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.50D-05 MaxDP=5.17D-04 DE=-7.47D-06 OVMax= 1.22D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943614417215     Delta-E=       -0.000002477644 Rises=F Damp=F
+ DIIS: error= 5.15D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943614417215     IErMin= 6 ErrMin= 5.15D-05
+ ErrMax= 5.15D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.14D-07 BMatP= 1.94D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-02 0.407D-01-0.148D+00-0.728D-01 0.377D+00 0.808D+00
+ Coeff:     -0.501D-02 0.407D-01-0.148D+00-0.728D-01 0.377D+00 0.808D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.30D-06 MaxDP=4.11D-04 DE=-2.48D-06 OVMax= 9.80D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943615219756     Delta-E=       -0.000000802540 Rises=F Damp=F
+ DIIS: error= 5.24D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943615219756     IErMin= 6 ErrMin= 5.15D-05
+ ErrMax= 5.24D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.74D-07 BMatP= 5.14D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.311D-03-0.869D-03 0.254D-01-0.235D-01-0.176D+00 0.599D-01
+ Coeff-Com:  0.112D+01
+ Coeff:     -0.311D-03-0.869D-03 0.254D-01-0.235D-01-0.176D+00 0.599D-01
+ Coeff:      0.112D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.04D-06 MaxDP=5.33D-04 DE=-8.03D-07 OVMax= 1.24D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943615871244     Delta-E=       -0.000000651488 Rises=F Damp=F
+ DIIS: error= 4.95D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943615871244     IErMin= 8 ErrMin= 4.95D-05
+ ErrMax= 4.95D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.25D-07 BMatP= 1.74D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.110D-02-0.922D-02 0.357D-01 0.153D-01-0.101D+00-0.180D+00
+ Coeff-Com:  0.613D-01 0.118D+01
+ Coeff:      0.110D-02-0.922D-02 0.357D-01 0.153D-01-0.101D+00-0.180D+00
+ Coeff:      0.613D-01 0.118D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.41D-06 MaxDP=5.98D-04 DE=-6.51D-07 OVMax= 1.37D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943616501516     Delta-E=       -0.000000630272 Rises=F Damp=F
+ DIIS: error= 4.73D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943616501516     IErMin= 9 ErrMin= 4.73D-05
+ ErrMax= 4.73D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.10D-07 BMatP= 1.25D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.815D-04 0.795D-03-0.125D-01 0.103D-01 0.796D-01-0.191D-01
+ Coeff-Com: -0.494D+00-0.416D-02 0.144D+01
+ Coeff:      0.815D-04 0.795D-03-0.125D-01 0.103D-01 0.796D-01-0.191D-01
+ Coeff:     -0.494D+00-0.416D-02 0.144D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.94D-06 MaxDP=8.16D-04 DE=-6.30D-07 OVMax= 1.86D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943617301338     Delta-E=       -0.000000799822 Rises=F Damp=F
+ DIIS: error= 4.44D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943617301338     IErMin=10 ErrMin= 4.44D-05
+ ErrMax= 4.44D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.82D-08 BMatP= 1.10D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.151D-02 0.123D-01-0.478D-01-0.219D-01 0.125D+00 0.245D+00
+ Coeff-Com:  0.179D-01-0.156D+01-0.355D+00 0.259D+01
+ Coeff:     -0.151D-02 0.123D-01-0.478D-01-0.219D-01 0.125D+00 0.245D+00
+ Coeff:      0.179D-01-0.156D+01-0.355D+00 0.259D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.49D-05 MaxDP=2.06D-03 DE=-8.00D-07 OVMax= 4.68D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943619119082     Delta-E=       -0.000001817744 Rises=F Damp=F
+ DIIS: error= 3.79D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943619119082     IErMin=11 ErrMin= 3.79D-05
+ ErrMax= 3.79D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.58D-08 BMatP= 9.82D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.270D-03-0.488D-02 0.362D-01-0.124D-01-0.187D+00-0.454D-01
+ Coeff-Com:  0.937D+00 0.439D+00-0.270D+01-0.678D+00 0.322D+01
+ Coeff:      0.270D-03-0.488D-02 0.362D-01-0.124D-01-0.187D+00-0.454D-01
+ Coeff:      0.937D+00 0.439D+00-0.270D+01-0.678D+00 0.322D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.16D-05 MaxDP=5.10D-03 DE=-1.82D-06 OVMax= 1.16D-02
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943622486299     Delta-E=       -0.000003367217 Rises=F Damp=F
+ DIIS: error= 2.27D-05 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943622486299     IErMin=12 ErrMin= 2.27D-05
+ ErrMax= 2.27D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.59D-08 BMatP= 7.58D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.179D-02-0.157D-01 0.685D-01 0.204D-01-0.218D+00-0.294D+00
+ Coeff-Com:  0.387D+00 0.194D+01-0.760D+00-0.311D+01 0.136D+01 0.162D+01
+ Coeff:      0.179D-02-0.157D-01 0.685D-01 0.204D-01-0.218D+00-0.294D+00
+ Coeff:      0.387D+00 0.194D+01-0.760D+00-0.311D+01 0.136D+01 0.162D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.66D-05 MaxDP=5.50D-03 DE=-3.37D-06 OVMax= 1.25D-02
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943624316843     Delta-E=       -0.000001830544 Rises=F Damp=F
+ DIIS: error= 6.68D-06 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943624316843     IErMin=13 ErrMin= 6.68D-06
+ ErrMax= 6.68D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.98D-09 BMatP= 3.59D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.171D-03-0.889D-03-0.213D-03 0.712D-02 0.155D-01-0.225D-01
+ Coeff-Com: -0.185D+00 0.149D+00 0.581D+00-0.241D+00-0.632D+00 0.176D+00
+ Coeff-Com:  0.115D+01
+ Coeff:      0.171D-03-0.889D-03-0.213D-03 0.712D-02 0.155D-01-0.225D-01
+ Coeff:     -0.185D+00 0.149D+00 0.581D+00-0.241D+00-0.632D+00 0.176D+00
+ Coeff:      0.115D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.93D-05 MaxDP=1.58D-03 DE=-1.83D-06 OVMax= 3.61D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943624497035     Delta-E=       -0.000000180192 Rises=F Damp=F
+ DIIS: error= 2.57D-06 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943624497035     IErMin=14 ErrMin= 2.57D-06
+ ErrMax= 2.57D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.39D-09 BMatP= 7.98D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.337D-03 0.294D-02-0.132D-01-0.359D-02 0.400D-01 0.594D-01
+ Coeff-Com: -0.776D-01-0.391D+00 0.126D+00 0.621D+00-0.250D+00-0.366D+00
+ Coeff-Com:  0.121D-01 0.124D+01
+ Coeff:     -0.337D-03 0.294D-02-0.132D-01-0.359D-02 0.400D-01 0.594D-01
+ Coeff:     -0.776D-01-0.391D+00 0.126D+00 0.621D+00-0.250D+00-0.366D+00
+ Coeff:      0.121D-01 0.124D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.03D-05 MaxDP=8.46D-04 DE=-1.80D-07 OVMax= 1.93D-03
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943624527243     Delta-E=       -0.000000030208 Rises=F Damp=F
+ DIIS: error= 3.70D-07 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943624527243     IErMin=15 ErrMin= 3.70D-07
+ ErrMax= 3.70D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.35D-10 BMatP= 1.39D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.180D-04 0.932D-04 0.123D-04-0.613D-03-0.203D-02 0.353D-02
+ Coeff-Com:  0.191D-01-0.154D-01-0.668D-01 0.259D-01 0.672D-01-0.416D-01
+ Coeff-Com: -0.123D+00 0.257D+00 0.877D+00
+ Coeff:     -0.180D-04 0.932D-04 0.123D-04-0.613D-03-0.203D-02 0.353D-02
+ Coeff:      0.191D-01-0.154D-01-0.668D-01 0.259D-01 0.672D-01-0.416D-01
+ Coeff:     -0.123D+00 0.257D+00 0.877D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.46D-06 MaxDP=1.20D-04 DE=-3.02D-08 OVMax= 2.74D-04
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943624527821     Delta-E=       -0.000000000578 Rises=F Damp=F
+ DIIS: error= 1.53D-07 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943624527821     IErMin=16 ErrMin= 1.53D-07
+ ErrMax= 1.53D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.99D-11 BMatP= 1.35D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.188D-04-0.181D-03 0.951D-03 0.119D-03-0.357D-02-0.308D-02
+ Coeff-Com:  0.111D-01 0.243D-01-0.286D-01-0.369D-01 0.393D-01 0.125D-01
+ Coeff-Com: -0.377D-01-0.285D-01 0.223D+00 0.828D+00
+ Coeff:      0.188D-04-0.181D-03 0.951D-03 0.119D-03-0.357D-02-0.308D-02
+ Coeff:      0.111D-01 0.243D-01-0.286D-01-0.369D-01 0.393D-01 0.125D-01
+ Coeff:     -0.377D-01-0.285D-01 0.223D+00 0.828D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.49D-08 MaxDP=7.03D-06 DE=-5.78D-10 OVMax= 1.64D-05
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943624527842     Delta-E=       -0.000000000021 Rises=F Damp=F
+ DIIS: error= 8.49D-08 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943624527842     IErMin=17 ErrMin= 8.49D-08
+ ErrMax= 8.49D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.62D-12 BMatP= 1.99D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.299D-05-0.207D-04 0.543D-04 0.987D-04-0.667D-04-0.487D-03
+ Coeff-Com: -0.137D-02 0.357D-02 0.507D-02-0.521D-02-0.356D-02 0.603D-02
+ Coeff-Com:  0.127D-01-0.544D-01-0.113D+00 0.194D+00 0.957D+00
+ Coeff:      0.299D-05-0.207D-04 0.543D-04 0.987D-04-0.667D-04-0.487D-03
+ Coeff:     -0.137D-02 0.357D-02 0.507D-02-0.521D-02-0.356D-02 0.603D-02
+ Coeff:      0.127D-01-0.544D-01-0.113D+00 0.194D+00 0.957D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.61D-08 MaxDP=1.41D-06 DE=-2.09D-11 OVMax= 3.45D-06
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943624527841     Delta-E=        0.000000000002 Rises=F Damp=F
+ DIIS: error= 3.15D-08 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=17 EnMin= -668.943624527842     IErMin=18 ErrMin= 3.15D-08
+ ErrMax= 3.15D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.43D-13 BMatP= 3.62D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.336D-05 0.341D-04-0.192D-03 0.341D-05 0.739D-03 0.622D-03
+ Coeff-Com: -0.283D-02-0.434D-02 0.733D-02 0.688D-02-0.939D-02-0.187D-02
+ Coeff-Com:  0.115D-01-0.626D-02-0.580D-01-0.791D-01 0.204D+00 0.931D+00
+ Coeff:     -0.336D-05 0.341D-04-0.192D-03 0.341D-05 0.739D-03 0.622D-03
+ Coeff:     -0.283D-02-0.434D-02 0.733D-02 0.688D-02-0.939D-02-0.187D-02
+ Coeff:      0.115D-01-0.626D-02-0.580D-01-0.791D-01 0.204D+00 0.931D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.66D-09 MaxDP=3.25D-07 DE= 1.59D-12 OVMax= 8.74D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943624528     A.U. after   18 cycles
+            NFock= 18  Conv=0.77D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0259 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650277643161D+02 PE=-2.334048908916D+03 EE= 6.194455819440D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0259,   after    12.0001
+ Leave Link  502 at Sun Aug 11 01:57:56 2024, MaxMem=  4294967296 cpu:      1125.0
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 01:57:56 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2729 LenP2D=    7959.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 01:57:56 2024, MaxMem=  4294967296 cpu:         1.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 01:57:56 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 01:58:03 2024, MaxMem=  4294967296 cpu:       113.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.00474636D-01-3.93078816D-02 1.29574178D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000076326   -0.000050598    0.000248177
+      2        6          -0.000024619   -0.000143213   -0.000524584
+      3        6          -0.000142859    0.000075716    0.000178572
+      4        6           0.000351708    0.000199343    0.000114677
+      5        6          -0.000279709    0.000055596    0.000050222
+      6        6           0.000241859    0.000003862   -0.000048339
+      7        6           0.000132671    0.000077183   -0.000003762
+      8        6          -0.000225284   -0.000210469   -0.000276499
+      9        1          -0.000015593    0.000015810   -0.000009783
+     10        1          -0.000034430    0.000027241    0.000061986
+     11        1          -0.000119821    0.000021965    0.000023209
+     12        1          -0.000066729   -0.000069102    0.000081360
+     13        1           0.000069694   -0.000056299    0.000076388
+     14        1          -0.000016961    0.000065242    0.000043758
+     15        1           0.000061970   -0.000054211   -0.000018711
+     16        1          -0.000008224    0.000041934    0.000003329
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000524584 RMS     0.000144881
+ Leave Link  716 at Sun Aug 11 01:58:03 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000352523 RMS     0.000096181
+ Search for a local minimum.
+ Step number  70 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .96181D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   55   56   57
+                                                     58   59   60   61   63
+                                                     64   65   66   67   68
+                                                     69   70
+ DE= -2.27D-06 DEPred=-1.54D-06 R= 1.47D+00
+ TightC=F SS=  1.41D+00  RLast= 4.00D-01 DXNew= 6.3290D-01 1.2014D+00
+ Trust test= 1.47D+00 RLast= 4.00D-01 DXMaxT set to 6.33D-01
+ ITU=  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1  1  1  1  1
+ ITU=  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1  1  1  1  1
+ ITU=  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0  0  1  0  0
+ ITU=  1  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---    0.00003   0.00005   0.00032   0.00199   0.00296
+     Eigenvalues ---    0.00575   0.00973   0.01264   0.01546   0.01869
+     Eigenvalues ---    0.02093   0.02330   0.03902   0.04107   0.04878
+     Eigenvalues ---    0.08407   0.08826   0.09557   0.10313   0.10637
+     Eigenvalues ---    0.11127   0.11526   0.13090   0.14422   0.15586
+     Eigenvalues ---    0.17739   0.18880   0.21676   0.25911   0.28707
+     Eigenvalues ---    0.33484   0.34386   0.35332   0.35595   0.36658
+     Eigenvalues ---    0.38318   0.38468   0.38555   0.38601   0.41160
+     Eigenvalues ---    0.42358   0.71605
+ Eigenvalue     1 is   2.95D-05 Eigenvector:
+                          R2        D3        D1        D2        D6
+   1                   -0.54760   0.45217   0.45175   0.44873   0.14108
+                          D4        D8        A1        D14       D10
+   1                    0.13358   0.12926   0.07670   0.07057  -0.06874
+ Eigenvalue     2 is   5.31D-05 Eigenvector:
+                          R2        D3        D1        D2        A1
+   1                    0.82746   0.31561   0.31520   0.31431  -0.06951
+                          D6        D4        D8        D15       D14
+   1                    0.05195   0.04930   0.04761   0.03262   0.03261
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    70   69   68   67   66
+ RFO step:  Lambda=-1.42798027D-06.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC=  2.38D-07 SmlDif=  1.00D-05
+ RMS Error=  0.4345703170D-03 NUsed= 5 EDIIS=F
+ DidBck=T Rises=F RFO-DIIS coefs:    0.31132   -0.56041    2.00692   -5.66229    4.90445
+ Iteration  1 RMS(Cart)=  0.21755350 RMS(Int)=  0.01789574
+ Iteration  2 RMS(Cart)=  0.03070740 RMS(Int)=  0.00025944
+ Iteration  3 RMS(Cart)=  0.00047116 RMS(Int)=  0.00000176
+ Iteration  4 RMS(Cart)=  0.00000008 RMS(Int)=  0.00000176
+ ITry= 1 IFail=0 DXMaxC= 1.47D+00 DCOld= 1.00D+10 DXMaxT= 6.33D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.44103  -0.00019  -0.00339  -0.00019  -0.00359   3.43744
+    R2        9.52321   0.00002  -0.12142   0.01719  -0.10423   9.41898
+    R3        2.81224   0.00014   0.00196   0.00007   0.00203   2.81427
+    R4        2.10331  -0.00005   0.00017   0.00000   0.00017   2.10347
+    R5        2.08038   0.00006   0.00042   0.00002   0.00044   2.08082
+    R6        2.79845   0.00028   0.00072  -0.00001   0.00071   2.79917
+    R7        2.80571   0.00018   0.00105   0.00009   0.00115   2.80686
+    R8        2.78933  -0.00010  -0.00074  -0.00006  -0.00080   2.78853
+    R9        2.08117  -0.00002  -0.00024  -0.00002  -0.00026   2.08091
+   R10        2.80899   0.00016   0.00017   0.00001   0.00018   2.80917
+   R11        2.07848   0.00011   0.00036  -0.00001   0.00035   2.07883
+   R12        2.65251   0.00017  -0.00033  -0.00028  -0.00061   2.65190
+   R13        2.06673   0.00001   0.00000   0.00001   0.00000   2.06674
+   R14        2.62471   0.00033   0.00108   0.00034   0.00142   2.62612
+   R15        2.06731   0.00004   0.00015   0.00000   0.00015   2.06746
+   R16        2.06709   0.00000  -0.00011   0.00000  -0.00012   2.06697
+    A1        1.62052   0.00016   0.19897  -0.00244   0.19653   1.81706
+    A2        1.99083   0.00035   0.00234   0.00029   0.00263   1.99346
+    A3        1.79930  -0.00007   0.00258   0.00022   0.00280   1.80209
+    A4        1.90289  -0.00022  -0.00170  -0.00025  -0.00195   1.90094
+    A5        1.95330  -0.00003   0.00011  -0.00006   0.00005   1.95336
+    A6        1.95380  -0.00008  -0.00159  -0.00012  -0.00171   1.95209
+    A7        1.85286   0.00002  -0.00175  -0.00008  -0.00183   1.85103
+    A8        2.13394   0.00008  -0.00261  -0.00044  -0.00305   2.13089
+    A9        2.10071  -0.00011  -0.00315   0.00017  -0.00298   2.09772
+   A10        1.97481   0.00002  -0.00042  -0.00020  -0.00062   1.97419
+   A11        1.96438   0.00005   0.00137  -0.00005   0.00132   1.96571
+   A12        2.06496  -0.00003   0.00070   0.00008   0.00078   2.06574
+   A13        2.06436   0.00003   0.00217   0.00006   0.00222   2.06659
+   A14        1.96744   0.00005   0.00065   0.00007   0.00073   1.96817
+   A15        2.07662   0.00002   0.00071   0.00007   0.00077   2.07740
+   A16        2.07001  -0.00007  -0.00053   0.00007  -0.00045   2.06956
+   A17        2.06930  -0.00002  -0.00068   0.00013  -0.00056   2.06874
+   A18        2.11102  -0.00004  -0.00001  -0.00004  -0.00005   2.11097
+   A19        2.10066   0.00006   0.00070  -0.00004   0.00066   2.10132
+   A20        2.13495   0.00003   0.00059  -0.00002   0.00057   2.13553
+   A21        2.07226  -0.00004  -0.00028   0.00006  -0.00022   2.07204
+   A22        2.07285   0.00001  -0.00024  -0.00005  -0.00029   2.07256
+   A23        2.08225  -0.00010   0.00022  -0.00016   0.00006   2.08232
+   A24        2.09039   0.00005  -0.00008   0.00015   0.00007   2.09047
+   A25        2.10997   0.00005  -0.00014   0.00001  -0.00013   2.10984
+    D1       -0.54014   0.00004   0.20618  -0.00202   0.20416  -0.33598
+    D2       -2.66196  -0.00007   0.20302  -0.00225   0.20077  -2.46119
+    D3        1.65795   0.00002   0.20446  -0.00216   0.20230   1.86025
+    D4        2.37218  -0.00005   0.02675   0.00180   0.02855   2.40073
+    D5       -1.20023  -0.00008   0.00989   0.00046   0.01035  -1.18988
+    D6       -1.87670   0.00008   0.03173   0.00223   0.03397  -1.84274
+    D7        0.83407   0.00005   0.01487   0.00089   0.01577   0.84984
+    D8        0.20109   0.00003   0.02849   0.00201   0.03050   0.23159
+    D9        2.91186   0.00000   0.01163   0.00067   0.01230   2.92416
+   D10        1.88223  -0.00004  -0.01344  -0.00187  -0.01531   1.86693
+   D11       -1.89208   0.00003  -0.00639  -0.00173  -0.00812  -1.90020
+   D12       -0.85667   0.00002   0.00292  -0.00071   0.00221  -0.85446
+   D13        1.65220   0.00009   0.00996  -0.00056   0.00940   1.66159
+   D14       -2.28796  -0.00003   0.01345   0.00234   0.01579  -2.27217
+   D15        0.88953   0.00000   0.01337   0.00221   0.01558   0.90511
+   D16        0.45945  -0.00004  -0.00243   0.00104  -0.00139   0.45807
+   D17       -2.64624  -0.00002  -0.00251   0.00091  -0.00160  -2.64784
+   D18        0.88831  -0.00001  -0.00084  -0.00012  -0.00096   0.88735
+   D19       -1.65327   0.00000  -0.00197  -0.00048  -0.00244  -1.65572
+   D20       -1.62079  -0.00006  -0.00731  -0.00027  -0.00758  -1.62837
+   D21        2.12081  -0.00005  -0.00843  -0.00063  -0.00907   2.11174
+   D22       -0.52466  -0.00001  -0.00088   0.00068  -0.00021  -0.52487
+   D23        2.54581  -0.00003  -0.00083   0.00150   0.00066   2.54647
+   D24        2.01941   0.00001   0.00069   0.00103   0.00173   2.02114
+   D25       -1.19331  -0.00001   0.00074   0.00185   0.00260  -1.19071
+   D26        0.12645   0.00002   0.00170  -0.00036   0.00134   0.12779
+   D27       -3.10114   0.00002   0.00275  -0.00052   0.00223  -3.09891
+   D28       -2.94446   0.00004   0.00168  -0.00118   0.00051  -2.94395
+   D29        0.11114   0.00004   0.00273  -0.00134   0.00140   0.11254
+   D30       -0.09329  -0.00003  -0.00029  -0.00055  -0.00084  -0.09412
+   D31        3.01199  -0.00005  -0.00020  -0.00041  -0.00061   3.01138
+   D32        3.13433  -0.00002  -0.00133  -0.00040  -0.00173   3.13260
+   D33       -0.04358  -0.00005  -0.00125  -0.00026  -0.00151  -0.04508
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000353     0.000450     YES
+ RMS     Force            0.000096     0.000300     YES
+ Maximum Displacement     1.466778     0.001800     NO
+ RMS     Displacement     0.240157     0.001200     NO
+ Predicted change in Energy=-3.729474D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 01:58:03 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.920028   -1.511545   -0.848502
+      2          6           0       -1.430786   -1.482341    0.195591
+      3          6           0       -0.615204   -0.243466    0.061896
+      4          6           0       -0.025840    0.441198    1.235779
+      5          6           0        1.435367    0.256378    1.326317
+      6          6           0        2.136119    0.581216    0.056178
+      7          6           0        1.454644    0.384199   -1.154647
+      8          6           0        0.108828    0.041236   -1.203377
+      9          1           0       -3.691778    3.276484   -1.998521
+     10          1           0       -0.870607   -2.386142   -0.133586
+     11          1           0       -1.723653   -1.669338    1.240449
+     12          1           0       -0.451741    1.408271    1.545552
+     13          1           0        1.832893   -0.554855    1.954030
+     14          1           0        3.135077    1.026362    0.062873
+     15          1           0        1.981134    0.583691   -2.092712
+     16          1           0       -0.428917    0.011623   -2.155395
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819017   0.000000
+     3  C    2.783714   1.489249   0.000000
+     4  C    4.066172   2.599205   1.481255   0.000000
+     5  C    5.179271   3.537869   2.460375   1.475629   0.000000
+     6  C    5.546414   4.123168   2.872265   2.466806   1.486548
+     7  C    4.777586   3.692266   2.481574   2.812334   2.484329
+     8  C    3.422139   2.578529   1.485326   2.475397   2.864497
+     9  H    4.984312   5.707243   5.108882   5.651429   6.816392
+    10  H    2.340117   1.113110   2.166681   3.253098   3.798914
+    11  H    2.412452   1.101121   2.156562   2.708682   3.700698
+    12  H    4.511016   3.337149   2.226251   1.101173   2.221733
+    13  H    5.599973   3.821511   3.109713   2.227756   1.100069
+    14  H    6.628414   5.211364   3.959428   3.421918   2.253482
+    15  H    5.473524   4.598481   3.473830   3.889358   3.477751
+    16  H    3.199007   2.960204   2.239676   3.441957   3.956991
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403325   0.000000
+     8  C    2.447032   1.389683   0.000000
+     9  H    6.741709   5.963481   5.054077   0.000000
+    10  H    4.228667   3.758211   2.827704   6.595629   0.000000
+    11  H    4.622265   4.478290   3.500906   6.231019   1.769030
+    12  H    3.098270   3.460362   3.120839   5.152525   4.170435
+    13  H    2.232588   3.269369   3.646498   7.798963   3.875651
+    14  H    1.093671   2.172230   3.425207   7.477857   5.265860
+    15  H    2.154473   1.094054   2.142593   6.280282   4.559662
+    16  H    3.434370   2.165205   1.093793   4.618461   3.167346
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.344029   0.000000
+    13  H    3.794772   3.039782   0.000000
+    14  H    5.679854   3.899930   2.787904   0.000000
+    15  H    5.469146   4.453738   4.206470   2.484771   0.000000
+    16  H    4.004214   3.955775   4.724834   4.318849   2.477809
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6756723      0.9279852      0.8353432
+ Leave Link  202 at Sun Aug 11 01:58:03 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4217798989 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071803787 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4145995202 Hartrees.
+ Leave Link  301 at Sun Aug 11 01:58:04 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7935.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 01:58:04 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 01:58:04 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.025497    0.019919    0.106294
+         Rot=    0.999644   -0.018866   -0.016326    0.009500 Ang=  -3.06 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0258 S= 3.0037
+ Leave Link  401 at Sun Aug 11 01:58:04 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.934446563971
+ DIIS: error= 4.28D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.934446563971     IErMin= 1 ErrMin= 4.28D-03
+ ErrMax= 4.28D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.69D-02 BMatP= 1.69D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.702 Goal=     0.100 Shift=    0.000
+ T=  328. Gap= 0.320 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.740 Goal=     0.100 Shift=    0.000
+ T=  328. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.702 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=6.25D-04 MaxDP=1.34D-02              OVMax= 2.19D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.942741333496     Delta-E=       -0.008294769525 Rises=F Damp=F
+ DIIS: error= 1.20D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.942741333496     IErMin= 2 ErrMin= 1.20D-03
+ ErrMax= 1.20D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.25D-04 BMatP= 1.69D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.228D+00 0.123D+01
+ Coeff:     -0.228D+00 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ T=  163. Gap= 0.320 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ T=  163. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.237 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.36D-04 MaxDP=3.87D-03 DE=-8.29D-03 OVMax= 1.10D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943534490467     Delta-E=       -0.000793156971 Rises=F Damp=F
+ DIIS: error= 3.40D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943534490467     IErMin= 3 ErrMin= 3.40D-04
+ ErrMax= 3.40D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.15D-05 BMatP= 9.25D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.541D-02-0.138D+00 0.113D+01
+ Coeff:      0.541D-02-0.138D+00 0.113D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.10D-05 MaxDP=1.95D-03 DE=-7.93D-04 OVMax= 3.77D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943589902799     Delta-E=       -0.000055412332 Rises=F Damp=F
+ DIIS: error= 2.21D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943589902799     IErMin= 4 ErrMin= 2.21D-04
+ ErrMax= 2.21D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.17D-05 BMatP= 6.15D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.339D-01-0.235D+00 0.524D+00 0.677D+00
+ Coeff:      0.339D-01-0.235D+00 0.524D+00 0.677D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.50D-05 MaxDP=8.49D-04 DE=-5.54D-05 OVMax= 1.71D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943605129508     Delta-E=       -0.000015226709 Rises=F Damp=F
+ DIIS: error= 6.70D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943605129508     IErMin= 5 ErrMin= 6.70D-05
+ ErrMax= 6.70D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.82D-06 BMatP= 3.17D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.247D-02 0.700D-03-0.144D+00 0.689D-01 0.107D+01
+ Coeff:      0.247D-02 0.700D-03-0.144D+00 0.689D-01 0.107D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.87D-05 MaxDP=6.21D-04 DE=-1.52D-05 OVMax= 1.39D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943608565218     Delta-E=       -0.000003435709 Rises=F Damp=F
+ DIIS: error= 5.61D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943608565218     IErMin= 6 ErrMin= 5.61D-05
+ ErrMax= 5.61D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.96D-07 BMatP= 2.82D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.464D-02 0.390D-01-0.142D+00-0.865D-01 0.398D+00 0.796D+00
+ Coeff:     -0.464D-02 0.390D-01-0.142D+00-0.865D-01 0.398D+00 0.796D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.79D-06 MaxDP=4.85D-04 DE=-3.44D-06 OVMax= 1.12D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943609643611     Delta-E=       -0.000001078393 Rises=F Damp=F
+ DIIS: error= 5.91D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943609643611     IErMin= 6 ErrMin= 5.61D-05
+ ErrMax= 5.91D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.22D-07 BMatP= 7.96D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.378D-03 0.919D-04 0.186D-01-0.105D-01-0.154D+00 0.215D-01
+ Coeff-Com:  0.112D+01
+ Coeff:     -0.378D-03 0.919D-04 0.186D-01-0.105D-01-0.154D+00 0.215D-01
+ Coeff:      0.112D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.93D-06 MaxDP=6.12D-04 DE=-1.08D-06 OVMax= 1.39D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943610476774     Delta-E=       -0.000000833163 Rises=F Damp=F
+ DIIS: error= 5.66D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943610476774     IErMin= 6 ErrMin= 5.61D-05
+ ErrMax= 5.66D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.65D-07 BMatP= 2.22D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.950D-03-0.802D-02 0.296D-01 0.187D-01-0.863D-01-0.164D+00
+ Coeff-Com: -0.471D-02 0.121D+01
+ Coeff:      0.950D-03-0.802D-02 0.296D-01 0.187D-01-0.863D-01-0.164D+00
+ Coeff:     -0.471D-02 0.121D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.55D-06 MaxDP=6.97D-04 DE=-8.33D-07 OVMax= 1.57D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943611311381     Delta-E=       -0.000000834607 Rises=F Damp=F
+ DIIS: error= 5.44D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943611311381     IErMin= 9 ErrMin= 5.44D-05
+ ErrMax= 5.44D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.46D-07 BMatP= 1.65D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.541D-04 0.993D-03-0.127D-01 0.374D-02 0.831D-01 0.557D-02
+ Coeff-Com: -0.537D+00-0.119D+00 0.157D+01
+ Coeff:      0.541D-04 0.993D-03-0.127D-01 0.374D-02 0.831D-01 0.557D-02
+ Coeff:     -0.537D+00-0.119D+00 0.157D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.26D-05 MaxDP=1.04D-03 DE=-8.35D-07 OVMax= 2.35D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943612475132     Delta-E=       -0.000001163751 Rises=F Damp=F
+ DIIS: error= 5.07D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943612475132     IErMin=10 ErrMin= 5.07D-05
+ ErrMax= 5.07D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.29D-07 BMatP= 1.46D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.140D-02 0.116D-01-0.430D-01-0.269D-01 0.118D+00 0.229D+00
+ Coeff-Com:  0.102D+00-0.173D+01-0.182D+00 0.252D+01
+ Coeff:     -0.140D-02 0.116D-01-0.430D-01-0.269D-01 0.118D+00 0.229D+00
+ Coeff:      0.102D+00-0.173D+01-0.182D+00 0.252D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.04D-05 MaxDP=2.51D-03 DE=-1.16D-06 OVMax= 5.68D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943614992092     Delta-E=       -0.000002516960 Rises=F Damp=F
+ DIIS: error= 4.29D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943614992092     IErMin=11 ErrMin= 4.29D-05
+ ErrMax= 4.29D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.88D-08 BMatP= 1.29D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.351D-04-0.234D-02 0.214D-01-0.197D-02-0.128D+00-0.441D-01
+ Coeff-Com:  0.747D+00 0.385D+00-0.225D+01-0.384D+00 0.266D+01
+ Coeff:      0.351D-04-0.234D-02 0.214D-01-0.197D-02-0.128D+00-0.441D-01
+ Coeff:      0.747D+00 0.385D+00-0.225D+01-0.384D+00 0.266D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.82D-05 MaxDP=4.83D-03 DE=-2.52D-06 OVMax= 1.09D-02
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943618746481     Delta-E=       -0.000003754389 Rises=F Damp=F
+ DIIS: error= 2.87D-05 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943618746481     IErMin=12 ErrMin= 2.87D-05
+ ErrMax= 2.87D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.67D-08 BMatP= 9.88D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.157D-02-0.138D-01 0.567D-01 0.296D-01-0.186D+00-0.277D+00
+ Coeff-Com:  0.186D+00 0.218D+01-0.767D+00-0.305D+01 0.117D+01 0.167D+01
+ Coeff:      0.157D-02-0.138D-01 0.567D-01 0.296D-01-0.186D+00-0.277D+00
+ Coeff:      0.186D+00 0.218D+01-0.767D+00-0.305D+01 0.117D+01 0.167D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.87D-05 MaxDP=5.69D-03 DE=-3.75D-06 OVMax= 1.29D-02
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943621371871     Delta-E=       -0.000002625390 Rises=F Damp=F
+ DIIS: error= 1.25D-05 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943621371871     IErMin=13 ErrMin= 1.25D-05
+ ErrMax= 1.25D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.90D-08 BMatP= 5.67D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.245D-04 0.110D-02-0.990D-02 0.858D-03 0.561D-01 0.304D-01
+ Coeff-Com: -0.349D+00-0.126D+00 0.963D+00 0.152D+00-0.115D+01-0.405D-01
+ Coeff-Com:  0.147D+01
+ Coeff:     -0.245D-04 0.110D-02-0.990D-02 0.858D-03 0.561D-01 0.304D-01
+ Coeff:     -0.349D+00-0.126D+00 0.963D+00 0.152D+00-0.115D+01-0.405D-01
+ Coeff:      0.147D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.34D-05 MaxDP=2.78D-03 DE=-2.63D-06 OVMax= 6.27D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943621950726     Delta-E=       -0.000000578855 Rises=F Damp=F
+ DIIS: error= 5.24D-06 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943621950726     IErMin=14 ErrMin= 5.24D-06
+ ErrMax= 5.24D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.40D-09 BMatP= 1.90D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.496D-03 0.437D-02-0.184D-01-0.857D-02 0.575D-01 0.927D-01
+ Coeff-Com: -0.777D-01-0.673D+00 0.246D+00 0.925D+00-0.355D+00-0.548D+00
+ Coeff-Com:  0.117D-01 0.134D+01
+ Coeff:     -0.496D-03 0.437D-02-0.184D-01-0.857D-02 0.575D-01 0.927D-01
+ Coeff:     -0.777D-01-0.673D+00 0.246D+00 0.925D+00-0.355D+00-0.548D+00
+ Coeff:      0.117D-01 0.134D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.71D-05 MaxDP=1.42D-03 DE=-5.79D-07 OVMax= 3.20D-03
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943622066035     Delta-E=       -0.000000115309 Rises=F Damp=F
+ DIIS: error= 2.33D-06 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943622066035     IErMin=15 ErrMin= 2.33D-06
+ ErrMax= 2.33D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.56D-09 BMatP= 5.40D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.833D-04 0.574D-03-0.145D-02-0.108D-02-0.821D-03 0.113D-01
+ Coeff-Com:  0.394D-01-0.735D-01-0.110D+00 0.886D-01 0.142D+00-0.712D-01
+ Coeff-Com: -0.269D+00 0.260D+00 0.986D+00
+ Coeff:     -0.833D-04 0.574D-03-0.145D-02-0.108D-02-0.821D-03 0.113D-01
+ Coeff:      0.394D-01-0.735D-01-0.110D+00 0.886D-01 0.142D+00-0.712D-01
+ Coeff:     -0.269D+00 0.260D+00 0.986D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.96D-06 MaxDP=3.26D-04 DE=-1.15D-07 OVMax= 7.37D-04
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943622076042     Delta-E=       -0.000000010007 Rises=F Damp=F
+ DIIS: error= 1.40D-06 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943622076042     IErMin=16 ErrMin= 1.40D-06
+ ErrMax= 1.40D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.99D-10 BMatP= 1.56D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.117D-03-0.103D-02 0.436D-02 0.226D-02-0.136D-01-0.218D-01
+ Coeff-Com:  0.120D-01 0.177D+00-0.437D-01-0.247D+00 0.747D-01 0.156D+00
+ Coeff-Com:  0.989D-02-0.480D+00 0.896D-01 0.128D+01
+ Coeff:      0.117D-03-0.103D-02 0.436D-02 0.226D-02-0.136D-01-0.218D-01
+ Coeff:      0.120D-01 0.177D+00-0.437D-01-0.247D+00 0.747D-01 0.156D+00
+ Coeff:      0.989D-02-0.480D+00 0.896D-01 0.128D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.82D-06 MaxDP=1.45D-04 DE=-1.00D-08 OVMax= 3.28D-04
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943622078846     Delta-E=       -0.000000002805 Rises=F Damp=F
+ DIIS: error= 5.82D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943622078846     IErMin=17 ErrMin= 5.82D-07
+ ErrMax= 5.82D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.57D-10 BMatP= 5.99D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.188D-05 0.492D-04-0.592D-03-0.124D-03 0.427D-02 0.929D-03
+ Coeff-Com: -0.251D-01-0.575D-02 0.673D-01 0.132D-01-0.822D-01 0.149D-01
+ Coeff-Com:  0.116D+00-0.174D+00-0.367D+00 0.238D+00 0.120D+01
+ Coeff:      0.188D-05 0.492D-04-0.592D-03-0.124D-03 0.427D-02 0.929D-03
+ Coeff:     -0.251D-01-0.575D-02 0.673D-01 0.132D-01-0.822D-01 0.149D-01
+ Coeff:      0.116D+00-0.174D+00-0.367D+00 0.238D+00 0.120D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.44D-07 MaxDP=4.51D-05 DE=-2.80D-09 OVMax= 1.01D-04
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943622079376     Delta-E=       -0.000000000529 Rises=F Damp=F
+ DIIS: error= 1.82D-07 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943622079376     IErMin=18 ErrMin= 1.82D-07
+ ErrMax= 1.82D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.79D-11 BMatP= 1.57D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.212D-04 0.205D-03-0.991D-03-0.423D-03 0.388D-02 0.412D-02
+ Coeff-Com: -0.104D-01-0.322D-01 0.307D-01 0.447D-01-0.409D-01-0.233D-01
+ Coeff-Com:  0.310D-01 0.543D-01-0.825D-01-0.180D+00 0.196D+00 0.101D+01
+ Coeff:     -0.212D-04 0.205D-03-0.991D-03-0.423D-03 0.388D-02 0.412D-02
+ Coeff:     -0.104D-01-0.322D-01 0.307D-01 0.447D-01-0.409D-01-0.233D-01
+ Coeff:      0.310D-01 0.543D-01-0.825D-01-0.180D+00 0.196D+00 0.101D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.15D-07 MaxDP=6.63D-06 DE=-5.29D-10 OVMax= 1.58D-05
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943622079411     Delta-E=       -0.000000000035 Rises=F Damp=F
+ DIIS: error= 9.35D-08 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943622079411     IErMin=19 ErrMin= 9.35D-08
+ ErrMax= 9.35D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.53D-12 BMatP= 1.79D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.429D-05 0.340D-04-0.119D-03-0.762D-04 0.289D-03 0.569D-03
+ Coeff-Com:  0.758D-03-0.484D-02-0.166D-02 0.605D-02 0.137D-02-0.591D-02
+ Coeff-Com: -0.849D-02 0.366D-01 0.345D-01-0.767D-01-0.130D+00 0.214D+00
+ Coeff-Com:  0.934D+00
+ Coeff:     -0.429D-05 0.340D-04-0.119D-03-0.762D-04 0.289D-03 0.569D-03
+ Coeff:      0.758D-03-0.484D-02-0.166D-02 0.605D-02 0.137D-02-0.591D-02
+ Coeff:     -0.849D-02 0.366D-01 0.345D-01-0.767D-01-0.130D+00 0.214D+00
+ Coeff:      0.934D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.33D-08 MaxDP=7.86D-07 DE=-3.52D-11 OVMax= 1.91D-06
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.943622079403     Delta-E=        0.000000000008 Rises=F Damp=F
+ DIIS: error= 5.42D-08 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943622079411     IErMin=20 ErrMin= 5.42D-08
+ ErrMax= 5.42D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.34D-13 BMatP= 2.53D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.337D-05-0.354D-04 0.188D-03 0.590D-04-0.772D-03-0.772D-03
+ Coeff-Com:  0.262D-02 0.583D-02-0.785D-02-0.828D-02 0.101D-01 0.369D-02
+ Coeff-Com: -0.996D-02-0.137D-02 0.287D-01 0.135D-01-0.772D-01-0.121D+00
+ Coeff-Com:  0.274D+00 0.888D+00
+ Coeff:      0.337D-05-0.354D-04 0.188D-03 0.590D-04-0.772D-03-0.772D-03
+ Coeff:      0.262D-02 0.583D-02-0.785D-02-0.828D-02 0.101D-01 0.369D-02
+ Coeff:     -0.996D-02-0.137D-02 0.287D-01 0.135D-01-0.772D-01-0.121D+00
+ Coeff:      0.274D+00 0.888D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.11D-09 MaxDP=1.32D-07 DE= 8.19D-12 OVMax= 4.26D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943622079     A.U. after   20 cycles
+            NFock= 20  Conv=0.71D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650252745629D+02 PE=-2.333611997804D+03 EE= 6.192285016412D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 01:59:22 2024, MaxMem=  4294967296 cpu:      1250.6
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 01:59:22 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7935.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 01:59:23 2024, MaxMem=  4294967296 cpu:         2.1
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 01:59:23 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:       114.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.06807906D-01-5.64174154D-02 9.18570136D-02
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000005899   -0.000006517   -0.000001224
+      2        6          -0.000003397   -0.000002598   -0.000004822
+      3        6          -0.000001921    0.000014356    0.000012460
+      4        6          -0.000008768   -0.000001916   -0.000000794
+      5        6          -0.000002824   -0.000007790    0.000007373
+      6        6           0.000019650    0.000006888   -0.000008775
+      7        6           0.000000327    0.000006826   -0.000002868
+      8        6          -0.000002720   -0.000001107   -0.000019428
+      9        1           0.000006466   -0.000003984    0.000006035
+     10        1           0.000001001   -0.000000933   -0.000000206
+     11        1          -0.000000651    0.000001063    0.000004155
+     12        1          -0.000007364    0.000001838    0.000003706
+     13        1           0.000003980   -0.000005029    0.000004238
+     14        1          -0.000000814    0.000005080    0.000001223
+     15        1           0.000004785   -0.000005909   -0.000001046
+     16        1          -0.000001853   -0.000000268   -0.000000027
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000019650 RMS     0.000006417
+ Leave Link  716 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000066360 RMS     0.000009472
+ Search for a local minimum.
+ Step number  71 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .94715D-05 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   51   52   53   54   55
+                                                     56   57   58   59   60
+                                                     61   62   63   64   65
+                                                     66   67   68   69   70
+                                                     71
+ DE=  2.45D-06 DEPred=-3.73D-06 R=-6.57D-01
+ Trust test=-6.57D-01 RLast= 4.21D-01 DXMaxT set to 3.16D-01
+ ITU= -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1  1  1  1
+ ITU=  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1  1  1  1
+ ITU=  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0  0  1  0
+ ITU=  0  1  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---    0.00004   0.00009   0.00051   0.00198   0.00295
+     Eigenvalues ---    0.00575   0.00963   0.01241   0.01468   0.01823
+     Eigenvalues ---    0.02115   0.02310   0.03869   0.04029   0.04753
+     Eigenvalues ---    0.08319   0.08826   0.09536   0.10276   0.10497
+     Eigenvalues ---    0.11116   0.11539   0.13136   0.14334   0.15239
+     Eigenvalues ---    0.17009   0.18451   0.19860   0.23393   0.28638
+     Eigenvalues ---    0.33358   0.34340   0.34851   0.35472   0.36585
+     Eigenvalues ---    0.38321   0.38464   0.38498   0.38592   0.39994
+     Eigenvalues ---    0.41635   0.56374
+ Eigenvalue     1 is   3.75D-05 Eigenvector:
+                          R2        A1        D1        D3        D2
+   1                    0.97766  -0.15098   0.08362   0.08067   0.07911
+                          D6        D8        D4        D15       D14
+   1                    0.01865   0.01674   0.01235   0.01158   0.01097
+ Eigenvalue     2 is   8.72D-05 Eigenvector:
+                          D1        D3        D2        A1        R2
+   1                   -0.56249  -0.56166  -0.56044  -0.19779   0.11116
+                          D6        D15       D8        D14       D4
+   1                   -0.02180  -0.01908  -0.01846  -0.01806  -0.01756
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    71   70   69   68   67
+ RFO step:  Lambda=-1.15541268D-07.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC=  7.23D-07 SmlDif=  1.00D-05
+ RMS Error=  0.2217565256D-03 NUsed= 5 EDIIS=F
+ DidBck=T Rises=F RFO-DIIS coefs:    0.77761    0.32278   -0.73040    0.40968    0.22034
+ Iteration  1 RMS(Cart)=  0.02148500 RMS(Int)=  0.00017099
+ Iteration  2 RMS(Cart)=  0.00036844 RMS(Int)=  0.00000180
+ Iteration  3 RMS(Cart)=  0.00000006 RMS(Int)=  0.00000180
+ ITry= 1 IFail=0 DXMaxC= 1.28D-01 DCOld= 1.00D+10 DXMaxT= 3.16D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43744   0.00000  -0.00011   0.00000  -0.00010   3.43734
+    R2        9.41898  -0.00001   0.02056   0.00082   0.02138   9.44036
+    R3        2.81427   0.00001   0.00009   0.00000   0.00010   2.81437
+    R4        2.10347   0.00000   0.00003   0.00000   0.00002   2.10350
+    R5        2.08082   0.00000   0.00001   0.00000   0.00001   2.08083
+    R6        2.79917   0.00000   0.00001  -0.00002  -0.00001   2.79916
+    R7        2.80686   0.00002   0.00003  -0.00001   0.00002   2.80688
+    R8        2.78853   0.00001   0.00001   0.00000   0.00001   2.78855
+    R9        2.08091   0.00001  -0.00001   0.00000  -0.00001   2.08090
+   R10        2.80917   0.00002  -0.00001   0.00005   0.00004   2.80921
+   R11        2.07883   0.00001   0.00000   0.00001   0.00002   2.07885
+   R12        2.65190   0.00001   0.00000   0.00002   0.00002   2.65192
+   R13        2.06674   0.00000   0.00000   0.00000   0.00000   2.06674
+   R14        2.62612   0.00001  -0.00007   0.00009   0.00002   2.62614
+   R15        2.06746   0.00000   0.00000   0.00000   0.00001   2.06747
+   R16        2.06697   0.00000   0.00001  -0.00001   0.00000   2.06697
+    A1        1.81706  -0.00007  -0.01944  -0.00045  -0.01988   1.79717
+    A2        1.99346  -0.00002   0.00000   0.00009   0.00009   1.99355
+    A3        1.80209   0.00001   0.00003   0.00002   0.00005   1.80214
+    A4        1.90094   0.00000   0.00008  -0.00005   0.00003   1.90097
+    A5        1.95336   0.00001   0.00001  -0.00003  -0.00001   1.95334
+    A6        1.95209   0.00000  -0.00004  -0.00005  -0.00009   1.95200
+    A7        1.85103   0.00000  -0.00008   0.00001  -0.00007   1.85096
+    A8        2.13089   0.00000   0.00000  -0.00021  -0.00022   2.13067
+    A9        2.09772   0.00000  -0.00018   0.00012  -0.00007   2.09766
+   A10        1.97419   0.00000   0.00002  -0.00001   0.00001   1.97420
+   A11        1.96571   0.00000   0.00006  -0.00001   0.00005   1.96576
+   A12        2.06574   0.00000   0.00000   0.00004   0.00003   2.06577
+   A13        2.06659   0.00000   0.00005   0.00002   0.00006   2.06665
+   A14        1.96817   0.00000   0.00001   0.00001   0.00002   1.96818
+   A15        2.07740   0.00000   0.00000   0.00002   0.00002   2.07741
+   A16        2.06956   0.00000  -0.00006   0.00004  -0.00002   2.06954
+   A17        2.06874   0.00000  -0.00004  -0.00002  -0.00006   2.06868
+   A18        2.11097   0.00000   0.00001   0.00002   0.00003   2.11100
+   A19        2.10132   0.00000   0.00001   0.00001   0.00003   2.10135
+   A20        2.13553   0.00000   0.00003   0.00000   0.00003   2.13556
+   A21        2.07204   0.00000  -0.00002   0.00002  -0.00001   2.07203
+   A22        2.07256   0.00000   0.00000  -0.00001  -0.00001   2.07255
+   A23        2.08232   0.00000   0.00005  -0.00003   0.00003   2.08234
+   A24        2.09047   0.00000  -0.00006   0.00003  -0.00003   2.09044
+   A25        2.10984   0.00000   0.00001   0.00000   0.00001   2.10985
+    D1       -0.33598   0.00000  -0.02062   0.00003  -0.02059  -0.35657
+    D2       -2.46119   0.00000  -0.02065   0.00000  -0.02065  -2.48184
+    D3        1.86025   0.00000  -0.02061   0.00000  -0.02061   1.83963
+    D4        2.40073  -0.00001   0.00100   0.00039   0.00139   2.40212
+    D5       -1.18988   0.00000   0.00052   0.00015   0.00067  -1.18921
+    D6       -1.84274   0.00000   0.00105   0.00047   0.00151  -1.84122
+    D7        0.84984   0.00000   0.00056   0.00022   0.00079   0.85063
+    D8        0.23159   0.00000   0.00092   0.00043   0.00135   0.23294
+    D9        2.92416   0.00000   0.00044   0.00019   0.00063   2.92479
+   D10        1.86693   0.00000  -0.00021  -0.00030  -0.00051   1.86642
+   D11       -1.90020   0.00000  -0.00003  -0.00023  -0.00027  -1.90047
+   D12       -0.85446   0.00000   0.00028  -0.00011   0.00018  -0.85428
+   D13        1.66159   0.00000   0.00046  -0.00004   0.00042   1.66202
+   D14       -2.27217   0.00000   0.00010   0.00043   0.00053  -2.27164
+   D15        0.90511   0.00000   0.00024   0.00019   0.00043   0.90554
+   D16        0.45807   0.00000  -0.00034   0.00016  -0.00018   0.45788
+   D17       -2.64784   0.00000  -0.00020  -0.00008  -0.00029  -2.64812
+   D18        0.88735   0.00000  -0.00004   0.00003  -0.00001   0.88735
+   D19       -1.65572   0.00000   0.00006  -0.00009  -0.00002  -1.65574
+   D20       -1.62837   0.00000  -0.00020  -0.00004  -0.00024  -1.62861
+   D21        2.11174   0.00000  -0.00009  -0.00016  -0.00026   2.11148
+   D22       -0.52487   0.00000  -0.00013   0.00000  -0.00013  -0.52500
+   D23        2.54647   0.00000  -0.00033   0.00012  -0.00021   2.54626
+   D24        2.02114   0.00000  -0.00021   0.00011  -0.00010   2.02103
+   D25       -1.19071   0.00000  -0.00041   0.00023  -0.00018  -1.19089
+   D26        0.12779   0.00000   0.00009   0.00006   0.00015   0.12794
+   D27       -3.09891   0.00001   0.00015   0.00010   0.00025  -3.09866
+   D28       -2.94395   0.00000   0.00029  -0.00006   0.00022  -2.94373
+   D29        0.11254   0.00000   0.00034  -0.00002   0.00032   0.11286
+   D30       -0.09412   0.00000   0.00015  -0.00014   0.00001  -0.09411
+   D31        3.01138   0.00000   0.00001   0.00011   0.00012   3.01149
+   D32        3.13260   0.00000   0.00009  -0.00018  -0.00009   3.13251
+   D33       -0.04508   0.00000  -0.00005   0.00006   0.00001  -0.04507
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000066     0.000450     YES
+ RMS     Force            0.000009     0.000300     YES
+ Maximum Displacement     0.128434     0.001800     NO
+ RMS     Displacement     0.021755     0.001200     NO
+ Predicted change in Energy=-9.613368D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.912426   -1.529019   -0.860810
+      2          6           0       -1.430305   -1.485444    0.192775
+      3          6           0       -0.617167   -0.245626    0.052522
+      4          6           0       -0.036218    0.450796    1.223676
+      5          6           0        1.424831    0.270060    1.324519
+      6          6           0        2.132438    0.585087    0.055687
+      7          6           0        1.458605    0.375541   -1.157322
+      8          6           0        0.113841    0.029157   -1.210945
+      9          1           0       -3.669784    3.291595   -1.930556
+     10          1           0       -0.865433   -2.390849   -0.123774
+     11          1           0       -1.729582   -1.663074    1.237458
+     12          1           0       -0.466150    1.419540    1.522444
+     13          1           0        1.820412   -0.534625    1.961833
+     14          1           0        3.130287    1.032682    0.064293
+     15          1           0        1.990273    0.567565   -2.094028
+     16          1           0       -0.418113   -0.010416   -2.165847
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.818962   0.000000
+     3  C    2.783791   1.489300   0.000000
+     4  C    4.066611   2.599088   1.481251   0.000000
+     5  C    5.179203   3.537576   2.460419   1.475635   0.000000
+     6  C    5.546176   4.122988   2.872355   2.466841   1.486568
+     7  C    4.777152   3.692131   2.481612   2.812350   2.484311
+     8  C    3.421813   2.578533   1.485338   2.475415   2.864490
+     9  H    4.995625   5.687170   5.075727   5.587676   6.758719
+    10  H    2.340119   1.113123   2.166725   3.252408   3.797801
+    11  H    2.412430   1.101128   2.156549   2.708527   3.700664
+    12  H    4.512002   3.337146   2.226264   1.101167   2.221776
+    13  H    5.599633   3.821097   3.109787   2.227780   1.100078
+    14  H    6.628160   5.211187   3.959497   3.421917   2.253517
+    15  H    5.472929   4.598333   3.473859   3.889404   3.477743
+    16  H    3.198574   2.960293   2.239667   3.442009   3.956989
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403336   0.000000
+     8  C    2.447070   1.389693   0.000000
+     9  H    6.703442   5.949927   5.047491   0.000000
+    10  H    4.227958   3.757963   2.827958   6.589310   0.000000
+    11  H    4.622339   4.478333   3.500934   6.192693   1.769001
+    12  H    3.098443   3.460601   3.121053   5.068636   4.169954
+    13  H    2.232601   3.269317   3.646471   7.741634   3.874156
+    14  H    1.093671   2.172257   3.425236   7.437948   5.265141
+    15  H    2.154482   1.094058   2.142595   6.283574   4.559514
+    16  H    3.434407   2.165215   1.093791   4.640258   3.168062
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.343649   0.000000
+    13  H    3.794809   3.039768   0.000000
+    14  H    5.679942   3.900028   2.787988   0.000000
+    15  H    5.469175   4.454070   4.206386   2.484817   0.000000
+    16  H    4.004212   3.956080   4.724778   4.318880   2.477810
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6766546      0.9277509      0.8362914
+ Leave Link  202 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4436336296 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071817534 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4364518763 Hartrees.
+ Leave Link  301 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7935.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.002020   -0.003991   -0.010149
+         Rot=    0.999996    0.001666    0.001576   -0.001347 Ang=   0.30 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0261 S= 3.0037
+ Leave Link  401 at Sun Aug 11 01:59:30 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943548646036
+ DIIS: error= 3.76D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943548646036     IErMin= 1 ErrMin= 3.76D-04
+ ErrMax= 3.76D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.37D-04 BMatP= 1.37D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ RMSDP=5.48D-05 MaxDP=1.04D-03              OVMax= 1.85D-03
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943615984721     Delta-E=       -0.000067338685 Rises=F Damp=F
+ DIIS: error= 9.46D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943615984721     IErMin= 2 ErrMin= 9.46D-05
+ ErrMax= 9.46D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.42D-06 BMatP= 1.37D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.229D+00 0.123D+01
+ Coeff:     -0.229D+00 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.12D-05 MaxDP=3.19D-04 DE=-6.73D-05 OVMax= 9.50D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943622430731     Delta-E=       -0.000006446010 Rises=F Damp=F
+ DIIS: error= 2.86D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943622430731     IErMin= 3 ErrMin= 2.86D-05
+ ErrMax= 2.86D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.32D-07 BMatP= 7.42D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.237D-01-0.238D+00 0.121D+01
+ Coeff:      0.237D-01-0.238D+00 0.121D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.34D-06 MaxDP=1.33D-04 DE=-6.45D-06 OVMax= 4.22D-04
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943622916712     Delta-E=       -0.000000485981 Rises=F Damp=F
+ DIIS: error= 1.56D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943622916712     IErMin= 4 ErrMin= 1.56D-05
+ ErrMax= 1.56D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.64D-07 BMatP= 4.32D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.319D-01-0.216D+00 0.483D+00 0.702D+00
+ Coeff:      0.319D-01-0.216D+00 0.483D+00 0.702D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.55D-06 MaxDP=6.00D-05 DE=-4.86D-07 OVMax= 1.52D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943623009624     Delta-E=       -0.000000092912 Rises=F Damp=F
+ DIIS: error= 1.04D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943623009624     IErMin= 5 ErrMin= 1.04D-05
+ ErrMax= 1.04D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.53D-08 BMatP= 1.64D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.252D-03 0.201D-01-0.203D+00 0.114D+00 0.107D+01
+ Coeff:     -0.252D-03 0.201D-01-0.203D+00 0.114D+00 0.107D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.76D-06 MaxDP=6.74D-05 DE=-9.29D-08 OVMax= 1.44D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943623043356     Delta-E=       -0.000000033732 Rises=F Damp=F
+ DIIS: error= 5.76D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943623043356     IErMin= 6 ErrMin= 5.76D-06
+ ErrMax= 5.76D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.69D-09 BMatP= 2.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.529D-02 0.425D-01-0.153D+00-0.748D-01 0.379D+00 0.811D+00
+ Coeff:     -0.529D-02 0.425D-01-0.153D+00-0.748D-01 0.379D+00 0.811D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.37D-07 MaxDP=4.72D-05 DE=-3.37D-08 OVMax= 1.10D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943623053926     Delta-E=       -0.000000010570 Rises=F Damp=F
+ DIIS: error= 5.84D-06 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943623053926     IErMin= 6 ErrMin= 5.76D-06
+ ErrMax= 5.84D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.26D-09 BMatP= 6.69D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.200D-03-0.200D-02 0.312D-01-0.264D-01-0.194D+00 0.628D-01
+ Coeff-Com:  0.113D+01
+ Coeff:     -0.200D-03-0.200D-02 0.312D-01-0.264D-01-0.194D+00 0.628D-01
+ Coeff:      0.113D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.15D-07 MaxDP=6.18D-05 DE=-1.06D-08 OVMax= 1.41D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943623062377     Delta-E=       -0.000000008451 Rises=F Damp=F
+ DIIS: error= 5.49D-06 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943623062377     IErMin= 8 ErrMin= 5.49D-06
+ ErrMax= 5.49D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.57D-09 BMatP= 2.26D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.114D-02-0.956D-02 0.381D-01 0.138D-01-0.112D+00-0.172D+00
+ Coeff-Com:  0.126D+00 0.111D+01
+ Coeff:      0.114D-02-0.956D-02 0.381D-01 0.138D-01-0.112D+00-0.172D+00
+ Coeff:      0.126D+00 0.111D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.94D-07 MaxDP=6.43D-05 DE=-8.45D-09 OVMax= 1.46D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943623069880     Delta-E=       -0.000000007503 Rises=F Damp=F
+ DIIS: error= 5.25D-06 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943623069880     IErMin= 9 ErrMin= 5.25D-06
+ ErrMax= 5.25D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.36D-09 BMatP= 1.57D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.580D-04 0.950D-03-0.129D-01 0.111D-01 0.781D-01-0.237D-01
+ Coeff-Com: -0.464D+00 0.318D-01 0.138D+01
+ Coeff:      0.580D-04 0.950D-03-0.129D-01 0.111D-01 0.781D-01-0.237D-01
+ Coeff:     -0.464D+00 0.318D-01 0.138D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.04D-06 MaxDP=8.57D-05 DE=-7.50D-09 OVMax= 1.94D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943623079191     Delta-E=       -0.000000009311 Rises=F Damp=F
+ DIIS: error= 4.94D-06 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943623079191     IErMin=10 ErrMin= 4.94D-06
+ ErrMax= 4.94D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.22D-09 BMatP= 1.36D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.144D-02 0.116D-01-0.447D-01-0.203D-01 0.114D+00 0.223D+00
+ Coeff-Com:  0.854D-02-0.138D+01-0.520D+00 0.260D+01
+ Coeff:     -0.144D-02 0.116D-01-0.447D-01-0.203D-01 0.114D+00 0.223D+00
+ Coeff:      0.854D-02-0.138D+01-0.520D+00 0.260D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.58D-06 MaxDP=2.13D-04 DE=-9.31D-09 OVMax= 4.82D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943623100239     Delta-E=       -0.000000021048 Rises=F Damp=F
+ DIIS: error= 4.28D-06 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943623100239     IErMin=11 ErrMin= 4.28D-06
+ ErrMax= 4.28D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.64D-10 BMatP= 1.22D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.404D-03-0.597D-02 0.412D-01-0.144D-01-0.201D+00-0.415D-01
+ Coeff-Com:  0.933D+00 0.417D+00-0.264D+01-0.906D+00 0.341D+01
+ Coeff:      0.404D-03-0.597D-02 0.412D-01-0.144D-01-0.201D+00-0.415D-01
+ Coeff:      0.933D+00 0.417D+00-0.264D+01-0.906D+00 0.341D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.87D-06 MaxDP=5.69D-04 DE=-2.10D-08 OVMax= 1.29D-03
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943623142882     Delta-E=       -0.000000042643 Rises=F Damp=F
+ DIIS: error= 2.62D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943623142882     IErMin=12 ErrMin= 2.62D-06
+ ErrMax= 2.62D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.60D-10 BMatP= 9.64D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.190D-02-0.164D-01 0.722D-01 0.180D-01-0.228D+00-0.282D+00
+ Coeff-Com:  0.433D+00 0.183D+01-0.611D+00-0.345D+01 0.154D+01 0.168D+01
+ Coeff:      0.190D-02-0.164D-01 0.722D-01 0.180D-01-0.228D+00-0.282D+00
+ Coeff:      0.433D+00 0.183D+01-0.611D+00-0.345D+01 0.154D+01 0.168D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.12D-06 MaxDP=6.73D-04 DE=-4.26D-08 OVMax= 1.52D-03
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943623167862     Delta-E=       -0.000000024980 Rises=F Damp=F
+ DIIS: error= 6.98D-07 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943623167862     IErMin=13 ErrMin= 6.98D-07
+ ErrMax= 6.98D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.58D-11 BMatP= 4.60D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.723D-04 0.117D-03-0.545D-02 0.669D-02 0.367D-01-0.904D-02
+ Coeff-Com: -0.241D+00 0.536D-01 0.728D+00-0.425D-01-0.883D+00 0.116D+00
+ Coeff-Com:  0.124D+01
+ Coeff:      0.723D-04 0.117D-03-0.545D-02 0.669D-02 0.367D-01-0.904D-02
+ Coeff:     -0.241D+00 0.536D-01 0.728D+00-0.425D-01-0.883D+00 0.116D+00
+ Coeff:      0.124D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.71D-06 MaxDP=2.24D-04 DE=-2.50D-08 OVMax= 5.07D-04
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943623170051     Delta-E=       -0.000000002190 Rises=F Damp=F
+ DIIS: error= 1.10D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943623170051     IErMin=14 ErrMin= 1.10D-07
+ ErrMax= 1.10D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.61D-12 BMatP= 6.58D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.275D-03 0.256D-02-0.127D-01-0.104D-02 0.428D-01 0.443D-01
+ Coeff-Com: -0.124D+00-0.293D+00 0.254D+00 0.553D+00-0.430D+00-0.256D+00
+ Coeff-Com:  0.302D+00 0.918D+00
+ Coeff:     -0.275D-03 0.256D-02-0.127D-01-0.104D-02 0.428D-01 0.443D-01
+ Coeff:     -0.124D+00-0.293D+00 0.254D+00 0.553D+00-0.430D+00-0.256D+00
+ Coeff:      0.302D+00 0.918D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.68D-07 MaxDP=3.87D-05 DE=-2.19D-09 OVMax= 8.75D-05
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943623170111     Delta-E=       -0.000000000060 Rises=F Damp=F
+ DIIS: error= 3.43D-08 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943623170111     IErMin=15 ErrMin= 3.43D-08
+ ErrMax= 3.43D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.15D-13 BMatP= 8.61D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.312D-04 0.202D-03-0.465D-03-0.600D-03-0.903D-03 0.543D-02
+ Coeff-Com:  0.156D-01-0.313D-01-0.559D-01 0.489D-01 0.648D-01-0.417D-01
+ Coeff-Com: -0.106D+00 0.807D-01 0.102D+01
+ Coeff:     -0.312D-04 0.202D-03-0.465D-03-0.600D-03-0.903D-03 0.543D-02
+ Coeff:      0.156D-01-0.313D-01-0.559D-01 0.489D-01 0.648D-01-0.417D-01
+ Coeff:     -0.106D+00 0.807D-01 0.102D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.36D-08 MaxDP=4.34D-06 DE=-5.96D-11 OVMax= 9.86D-06
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943623170111     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.63D-08 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943623170111     IErMin=16 ErrMin= 1.63D-08
+ ErrMax= 1.63D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.02D-13 BMatP= 8.15D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.268D-04-0.280D-03 0.159D-02-0.345D-04-0.638D-02-0.390D-02
+ Coeff-Com:  0.232D-01 0.296D-01-0.557D-01-0.589D-01 0.828D-01 0.191D-01
+ Coeff-Com: -0.781D-01-0.988D-01 0.359D+00 0.787D+00
+ Coeff:      0.268D-04-0.280D-03 0.159D-02-0.345D-04-0.638D-02-0.390D-02
+ Coeff:      0.232D-01 0.296D-01-0.557D-01-0.589D-01 0.828D-01 0.191D-01
+ Coeff:     -0.781D-01-0.988D-01 0.359D+00 0.787D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.80D-09 MaxDP=7.56D-07 DE=-2.27D-13 OVMax= 1.71D-06
+
+ SCF Done:  E(UwB97XD) =  -668.943623170     A.U. after   16 cycles
+            NFock= 16  Conv=0.98D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650251041165D+02 PE=-2.333655459660D+03 EE= 6.192502804968D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:00:34 2024, MaxMem=  4294967296 cpu:      1009.9
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:00:34 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7935.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:00:34 2024, MaxMem=  4294967296 cpu:         1.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:00:34 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:       113.0
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.06252147D-01-5.37917889D-02 9.63223094D-02
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000004998   -0.000001629   -0.000001019
+      2        6           0.000000527   -0.000001309   -0.000002125
+      3        6          -0.000004970    0.000003866    0.000011185
+      4        6          -0.000003394    0.000001166    0.000000923
+      5        6           0.000003384   -0.000005918   -0.000000644
+      6        6           0.000001942    0.000006651   -0.000001719
+      7        6          -0.000006796    0.000000509   -0.000002978
+      8        6           0.000010666    0.000000300   -0.000010596
+      9        1           0.000006319   -0.000004095    0.000005968
+     10        1           0.000001282   -0.000000176   -0.000000980
+     11        1          -0.000000963    0.000000105    0.000001022
+     12        1          -0.000005361    0.000004204    0.000001082
+     13        1           0.000000696   -0.000001838    0.000000557
+     14        1           0.000000589    0.000000178    0.000000295
+     15        1           0.000001755   -0.000001055    0.000000181
+     16        1          -0.000000678   -0.000000959   -0.000001153
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000011185 RMS     0.000003950
+ Leave Link  716 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000063817 RMS     0.000008762
+ Search for a local minimum.
+ Step number  72 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .87620D-05 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   50   51   52   53   54
+                                                     55   56   57   58   59
+                                                     60   61   62   63   64
+                                                     65   66   67   68   69
+                                                     70   71   72
+ DE= -1.09D-06 DEPred=-9.61D-07 R= 1.13D+00
+ TightC=F SS=  1.41D+00  RLast= 4.62D-02 DXNew= 5.3220D-01 1.3868D-01
+ Trust test= 1.13D+00 RLast= 4.62D-02 DXMaxT set to 3.16D-01
+ ITU=  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1  1  1
+ ITU=  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1  1  1
+ ITU=  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0  0  1
+ ITU=  0  0  1  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---    0.00002   0.00005   0.00078   0.00098   0.00302
+     Eigenvalues ---    0.00575   0.00933   0.01223   0.01416   0.01761
+     Eigenvalues ---    0.02121   0.02288   0.03689   0.03979   0.04742
+     Eigenvalues ---    0.08206   0.08836   0.09558   0.10302   0.10497
+     Eigenvalues ---    0.11140   0.11535   0.13215   0.14271   0.14861
+     Eigenvalues ---    0.16657   0.18571   0.19324   0.23180   0.28529
+     Eigenvalues ---    0.33457   0.33978   0.34820   0.35471   0.36532
+     Eigenvalues ---    0.38320   0.38410   0.38498   0.38590   0.39868
+     Eigenvalues ---    0.41678   0.52364
+ Eigenvalue     1 is   2.04D-05 Eigenvector:
+                          D1        D3        D2        A1        R2
+   1                   -0.50166  -0.50110  -0.50040  -0.37121   0.32716
+                          D6        D8        D4        D15       D14
+   1                   -0.02082  -0.01897  -0.01836  -0.01338  -0.01333
+ Eigenvalue     2 is   4.52D-05 Eigenvector:
+                          R2        D1        D3        D2        A1
+   1                    0.92311   0.21876   0.21715   0.21593  -0.07009
+                          D15       D14       D6        D10       D8
+   1                    0.01498   0.01322   0.01259  -0.01217   0.01096
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    72   71   70   69   68
+ RFO step:  Lambda=-1.67153302D-07.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC=  2.02D-06 SmlDif=  1.00D-05
+ RMS Error=  0.3317957074D-03 NUsed= 5 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    0.87591   -0.17596    0.31393   -0.84128    0.82739
+ Iteration  1 RMS(Cart)=  0.01360616 RMS(Int)=  0.00006600
+ Iteration  2 RMS(Cart)=  0.00008070 RMS(Int)=  0.00000156
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000156
+ ITry= 1 IFail=0 DXMaxC= 8.16D-02 DCOld= 1.00D+10 DXMaxT= 3.16D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43734   0.00000   0.00008   0.00002   0.00010   3.43744
+    R2        9.44036  -0.00001  -0.00029   0.00329   0.00300   9.44337
+    R3        2.81437   0.00001  -0.00002  -0.00004  -0.00006   2.81431
+    R4        2.10350   0.00000  -0.00001  -0.00002  -0.00002   2.10347
+    R5        2.08083   0.00000   0.00000   0.00000  -0.00001   2.08082
+    R6        2.79916   0.00000  -0.00002   0.00000  -0.00002   2.79914
+    R7        2.80688   0.00001  -0.00002   0.00002   0.00000   2.80688
+    R8        2.78855   0.00001   0.00003  -0.00003   0.00000   2.78855
+    R9        2.08090   0.00001   0.00001   0.00000   0.00001   2.08091
+   R10        2.80921   0.00000   0.00000   0.00002   0.00002   2.80922
+   R11        2.07885   0.00000  -0.00001   0.00001   0.00001   2.07885
+   R12        2.65192   0.00000   0.00003   0.00003   0.00005   2.65197
+   R13        2.06674   0.00000   0.00000   0.00000   0.00000   2.06674
+   R14        2.62614   0.00000  -0.00010   0.00006  -0.00004   2.62610
+   R15        2.06747   0.00000   0.00000   0.00000   0.00000   2.06747
+   R16        2.06697   0.00000   0.00001  -0.00001   0.00000   2.06697
+    A1        1.79717  -0.00006  -0.01116  -0.00046  -0.01162   1.78555
+    A2        1.99355  -0.00003  -0.00012   0.00007  -0.00005   1.99350
+    A3        1.80214   0.00001  -0.00005   0.00000  -0.00005   1.80209
+    A4        1.90097   0.00001   0.00009  -0.00012  -0.00004   1.90093
+    A5        1.95334   0.00001   0.00005  -0.00001   0.00003   1.95337
+    A6        1.95200   0.00001   0.00003   0.00001   0.00004   1.95204
+    A7        1.85096   0.00000   0.00002   0.00005   0.00006   1.85102
+    A8        2.13067   0.00001   0.00020   0.00000   0.00019   2.13086
+    A9        2.09766  -0.00001   0.00001   0.00008   0.00008   2.09774
+   A10        1.97420   0.00000   0.00006   0.00000   0.00005   1.97425
+   A11        1.96576   0.00000  -0.00001  -0.00002  -0.00002   1.96573
+   A12        2.06577   0.00000  -0.00003   0.00003   0.00001   2.06578
+   A13        2.06665   0.00000  -0.00004   0.00001  -0.00003   2.06662
+   A14        1.96818   0.00000  -0.00002   0.00000  -0.00001   1.96817
+   A15        2.07741   0.00000  -0.00003   0.00000  -0.00003   2.07738
+   A16        2.06954   0.00000  -0.00004   0.00002  -0.00003   2.06952
+   A17        2.06868   0.00000   0.00000   0.00000   0.00000   2.06868
+   A18        2.11100   0.00000   0.00000   0.00000   0.00000   2.11100
+   A19        2.10135   0.00000  -0.00002   0.00001  -0.00001   2.10134
+   A20        2.13556   0.00000   0.00000  -0.00001  -0.00001   2.13555
+   A21        2.07203   0.00000  -0.00001   0.00001   0.00000   2.07203
+   A22        2.07255   0.00000   0.00001   0.00000   0.00001   2.07256
+   A23        2.08234   0.00000   0.00002  -0.00004  -0.00001   2.08233
+   A24        2.09044   0.00000  -0.00004   0.00005   0.00001   2.09045
+   A25        2.10985   0.00000   0.00001  -0.00001   0.00000   2.10985
+    D1       -0.35657   0.00000  -0.01173   0.00045  -0.01129  -0.36785
+    D2       -2.48184   0.00000  -0.01168   0.00042  -0.01126  -2.49310
+    D3        1.83963   0.00000  -0.01171   0.00042  -0.01129   1.82834
+    D4        2.40212  -0.00001  -0.00116  -0.00033  -0.00149   2.40063
+    D5       -1.18921   0.00000  -0.00051  -0.00012  -0.00063  -1.18984
+    D6       -1.84122  -0.00001  -0.00128  -0.00029  -0.00157  -1.84280
+    D7        0.85063   0.00000  -0.00063  -0.00008  -0.00071   0.84991
+    D8        0.23294   0.00000  -0.00120  -0.00024  -0.00144   0.23150
+    D9        2.92479   0.00000  -0.00055  -0.00003  -0.00058   2.92421
+   D10        1.86642   0.00000   0.00072   0.00010   0.00082   1.86724
+   D11       -1.90047   0.00000   0.00061   0.00014   0.00074  -1.89972
+   D12       -0.85428   0.00000   0.00013  -0.00011   0.00001  -0.85427
+   D13        1.66202   0.00000   0.00001  -0.00007  -0.00006   1.66195
+   D14       -2.27164   0.00000  -0.00081  -0.00005  -0.00085  -2.27249
+   D15        0.90554   0.00000  -0.00065  -0.00021  -0.00086   0.90468
+   D16        0.45788   0.00000  -0.00017   0.00014  -0.00003   0.45785
+   D17       -2.64812   0.00000  -0.00001  -0.00002  -0.00004  -2.64816
+   D18        0.88735   0.00000  -0.00002   0.00003   0.00001   0.88736
+   D19       -1.65574   0.00000   0.00014  -0.00001   0.00013  -1.65561
+   D20       -1.62861   0.00000   0.00009  -0.00001   0.00008  -1.62853
+   D21        2.11148   0.00000   0.00025  -0.00005   0.00020   2.11168
+   D22       -0.52500   0.00000  -0.00007   0.00001  -0.00006  -0.52506
+   D23        2.54626   0.00000  -0.00032   0.00021  -0.00010   2.54616
+   D24        2.02103   0.00000  -0.00022   0.00005  -0.00017   2.02086
+   D25       -1.19089   0.00000  -0.00047   0.00025  -0.00022  -1.19111
+   D26        0.12794   0.00000   0.00002   0.00002   0.00004   0.12797
+   D27       -3.09866   0.00000   0.00003   0.00001   0.00004  -3.09862
+   D28       -2.94373   0.00000   0.00026  -0.00018   0.00008  -2.94365
+   D29        0.11286   0.00000   0.00027  -0.00019   0.00008   0.11294
+   D30       -0.09411   0.00000   0.00012  -0.00010   0.00002  -0.09409
+   D31        3.01149   0.00000  -0.00004   0.00007   0.00002   3.01152
+   D32        3.13251   0.00000   0.00011  -0.00009   0.00002   3.13253
+   D33       -0.04507   0.00000  -0.00005   0.00007   0.00002  -0.04505
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000064     0.000450     YES
+ RMS     Force            0.000009     0.000300     YES
+ Maximum Displacement     0.081615     0.001800     NO
+ RMS     Displacement     0.013628     0.001200     NO
+ Predicted change in Energy=-7.047664D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.909350   -1.537461   -0.867100
+      2          6           0       -1.430439   -1.487264    0.190785
+      3          6           0       -0.618033   -0.247443    0.046722
+      4          6           0       -0.042709    0.456655    1.216051
+      5          6           0        1.418260    0.279021    1.323391
+      6          6           0        2.130076    0.588054    0.055429
+      7          6           0        1.461159    0.370376   -1.158901
+      8          6           0        0.117228    0.021343   -1.215568
+      9          1           0       -3.653499    3.297562   -1.887367
+     10          1           0       -0.863846   -2.393732   -0.119540
+     11          1           0       -1.732777   -1.659901    1.235421
+     12          1           0       -0.475379    1.426376    1.507620
+     13          1           0        1.812789   -0.521422    1.966677
+     14          1           0        3.127078    1.037507    0.065208
+     15          1           0        1.996019    0.557955   -2.094690
+     16          1           0       -0.411068   -0.024657   -2.172212
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819015   0.000000
+     3  C    2.783765   1.489266   0.000000
+     4  C    4.066158   2.599189   1.481243   0.000000
+     5  C    5.179388   3.538029   2.460394   1.475638   0.000000
+     6  C    5.546592   4.123413   2.872322   2.466841   1.486577
+     7  C    4.777691   3.692400   2.481586   2.812376   2.484343
+     8  C    3.422203   2.578565   1.485338   2.475448   2.864506
+     9  H    4.997214   5.670562   5.051912   5.544345   6.718876
+    10  H    2.340114   1.113110   2.166708   3.253117   3.799167
+    11  H    2.412449   1.101125   2.156548   2.708600   3.700837
+    12  H    4.510858   3.336989   2.226263   1.101170   2.221763
+    13  H    5.600109   3.821671   3.109693   2.227767   1.100081
+    14  H    6.628584   5.211641   3.959457   3.421897   2.253527
+    15  H    5.473608   4.598579   3.473842   3.889431   3.477771
+    16  H    3.198953   2.960083   2.239673   3.442045   3.957007
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403364   0.000000
+     8  C    2.447070   1.389671   0.000000
+     9  H    6.675749   5.937913   5.040170   0.000000
+    10  H    4.229094   3.758485   2.827785   6.580137   0.000000
+    11  H    4.622480   4.478396   3.500921   6.165827   1.769030
+    12  H    3.098393   3.460586   3.121066   5.012756   4.170346
+    13  H    2.232594   3.269279   3.646396   7.701857   3.875851
+    14  H    1.093671   2.172279   3.425226   7.409226   5.266404
+    15  H    2.154505   1.094058   2.142583   6.282155   4.559880
+    16  H    3.434416   2.165199   1.093793   4.650982   3.167174
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.343689   0.000000
+    13  H    3.794985   3.039796   0.000000
+    14  H    5.680106   3.899932   2.788046   0.000000
+    15  H    5.469227   4.454055   4.206344   2.484839   0.000000
+    16  H    4.004111   3.956109   4.724693   4.318880   2.477804
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6793107      0.9275622      0.8367498
+ Leave Link  202 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4547281199 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071824986 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4475456214 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7937.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.001663   -0.001656   -0.005912
+         Rot=    0.999999    0.001034    0.000882   -0.000653 Ang=   0.17 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0261 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:00:41 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943595519535
+ DIIS: error= 2.42D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943595519535     IErMin= 1 ErrMin= 2.42D-04
+ ErrMax= 2.42D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.22D-05 BMatP= 5.22D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ RMSDP=3.47D-05 MaxDP=7.17D-04              OVMax= 1.20D-03
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943621180041     Delta-E=       -0.000025660506 Rises=F Damp=F
+ DIIS: error= 6.78D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943621180041     IErMin= 2 ErrMin= 6.78D-05
+ ErrMax= 6.78D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.85D-06 BMatP= 5.22D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.228D+00 0.123D+01
+ Coeff:     -0.228D+00 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.31D-05 MaxDP=2.19D-04 DE=-2.57D-05 OVMax= 6.01D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943623622152     Delta-E=       -0.000002442111 Rises=F Damp=F
+ DIIS: error= 1.94D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943623622152     IErMin= 3 ErrMin= 1.94D-05
+ ErrMax= 1.94D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.76D-07 BMatP= 2.85D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.129D-01-0.179D+00 0.117D+01
+ Coeff:      0.129D-01-0.179D+00 0.117D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.49D-06 MaxDP=1.07D-04 DE=-2.44D-06 OVMax= 2.09D-04
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943623790896     Delta-E=       -0.000000168744 Rises=F Damp=F
+ DIIS: error= 1.13D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943623790896     IErMin= 4 ErrMin= 1.13D-05
+ ErrMax= 1.13D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.39D-08 BMatP= 1.76D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.332D-01-0.229D+00 0.522D+00 0.674D+00
+ Coeff:      0.332D-01-0.229D+00 0.522D+00 0.674D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.79D-06 MaxDP=4.32D-05 DE=-1.69D-07 OVMax= 8.72D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943623831062     Delta-E=       -0.000000040166 Rises=F Damp=F
+ DIIS: error= 3.62D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943623831062     IErMin= 5 ErrMin= 3.62D-06
+ ErrMax= 3.62D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.39D-09 BMatP= 8.39D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.181D-02 0.475D-02-0.152D+00 0.849D-01 0.106D+01
+ Coeff:      0.181D-02 0.475D-02-0.152D+00 0.849D-01 0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.93D-07 MaxDP=3.08D-05 DE=-4.02D-08 OVMax= 6.91D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943623840791     Delta-E=       -0.000000009729 Rises=F Damp=F
+ DIIS: error= 2.79D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943623840791     IErMin= 6 ErrMin= 2.79D-06
+ ErrMax= 2.79D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.22D-09 BMatP= 8.39D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.482D-02 0.398D-01-0.145D+00-0.802D-01 0.392D+00 0.798D+00
+ Coeff:     -0.482D-02 0.398D-01-0.145D+00-0.802D-01 0.392D+00 0.798D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.57D-07 MaxDP=2.40D-05 DE=-9.73D-09 OVMax= 5.54D-05
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943623843662     Delta-E=       -0.000000002872 Rises=F Damp=F
+ DIIS: error= 2.94D-06 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943623843662     IErMin= 6 ErrMin= 2.79D-06
+ ErrMax= 2.94D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.72D-10 BMatP= 2.22D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.914D-04-0.209D-02 0.255D-01-0.977D-02-0.169D+00-0.293D-02
+ Coeff-Com:  0.116D+01
+ Coeff:     -0.914D-04-0.209D-02 0.255D-01-0.977D-02-0.169D+00-0.293D-02
+ Coeff:      0.116D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.08D-07 MaxDP=3.10D-05 DE=-2.87D-09 OVMax= 7.06D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943623845801     Delta-E=       -0.000000002138 Rises=F Damp=F
+ DIIS: error= 2.80D-06 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943623845801     IErMin= 6 ErrMin= 2.79D-06
+ ErrMax= 2.80D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.09D-10 BMatP= 5.72D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.926D-03-0.779D-02 0.299D-01 0.157D-01-0.881D-01-0.155D+00
+ Coeff-Com:  0.489D-01 0.116D+01
+ Coeff:      0.926D-03-0.779D-02 0.299D-01 0.157D-01-0.881D-01-0.155D+00
+ Coeff:      0.489D-01 0.116D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.05D-07 MaxDP=3.29D-05 DE=-2.14D-09 OVMax= 7.43D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943623847758     Delta-E=       -0.000000001957 Rises=F Damp=F
+ DIIS: error= 2.70D-06 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943623847758     IErMin= 9 ErrMin= 2.70D-06
+ ErrMax= 2.70D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.58D-10 BMatP= 4.09D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.554D-04 0.172D-02-0.143D-01 0.346D-02 0.830D-01 0.148D-01
+ Coeff-Com: -0.524D+00-0.943D-01 0.153D+01
+ Coeff:     -0.554D-04 0.172D-02-0.143D-01 0.346D-02 0.830D-01 0.148D-01
+ Coeff:     -0.524D+00-0.943D-01 0.153D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.92D-07 MaxDP=4.87D-05 DE=-1.96D-09 OVMax= 1.10D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943623850457     Delta-E=       -0.000000002700 Rises=F Damp=F
+ DIIS: error= 2.52D-06 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943623850457     IErMin=10 ErrMin= 2.52D-06
+ ErrMax= 2.52D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.18D-10 BMatP= 3.58D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.117D-02 0.963D-02-0.368D-01-0.200D-01 0.100D+00 0.192D+00
+ Coeff-Com:  0.435D-01-0.144D+01-0.236D+00 0.239D+01
+ Coeff:     -0.117D-02 0.963D-02-0.368D-01-0.200D-01 0.100D+00 0.192D+00
+ Coeff:      0.435D-01-0.144D+01-0.236D+00 0.239D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.33D-06 MaxDP=1.10D-04 DE=-2.70D-09 OVMax= 2.48D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943623855983     Delta-E=       -0.000000005526 Rises=F Damp=F
+ DIIS: error= 2.18D-06 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943623855983     IErMin=11 ErrMin= 2.18D-06
+ ErrMax= 2.18D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.50D-10 BMatP= 3.18D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.238D-03-0.387D-02 0.268D-01-0.191D-02-0.142D+00-0.617D-01
+ Coeff-Com:  0.794D+00 0.354D+00-0.230D+01-0.456D+00 0.279D+01
+ Coeff:      0.238D-03-0.387D-02 0.268D-01-0.191D-02-0.142D+00-0.617D-01
+ Coeff:      0.794D+00 0.354D+00-0.230D+01-0.456D+00 0.279D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.79D-06 MaxDP=2.31D-04 DE=-5.53D-09 OVMax= 5.23D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943623865171     Delta-E=       -0.000000009188 Rises=F Damp=F
+ DIIS: error= 1.48D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943623865171     IErMin=12 ErrMin= 1.48D-06
+ ErrMax= 1.48D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.47D-10 BMatP= 2.50D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.155D-02-0.135D-01 0.571D-01 0.244D-01-0.187D+00-0.264D+00
+ Coeff-Com:  0.304D+00 0.196D+01-0.743D+00-0.316D+01 0.127D+01 0.175D+01
+ Coeff:      0.155D-02-0.135D-01 0.571D-01 0.244D-01-0.187D+00-0.264D+00
+ Coeff:      0.304D+00 0.196D+01-0.743D+00-0.316D+01 0.127D+01 0.175D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.56D-06 MaxDP=2.95D-04 DE=-9.19D-09 OVMax= 6.68D-04
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943623872180     Delta-E=       -0.000000007009 Rises=F Damp=F
+ DIIS: error= 6.33D-07 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943623872180     IErMin=13 ErrMin= 6.33D-07
+ ErrMax= 6.33D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.51D-11 BMatP= 1.47D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.416D-04 0.127D-02-0.111D-01 0.315D-02 0.603D-01 0.279D-01
+ Coeff-Com: -0.403D+00-0.573D-01 0.113D+01 0.726D-01-0.136D+01 0.404D-01
+ Coeff-Com:  0.150D+01
+ Coeff:     -0.416D-04 0.127D-02-0.111D-01 0.315D-02 0.603D-01 0.279D-01
+ Coeff:     -0.403D+00-0.573D-01 0.113D+01 0.726D-01-0.136D+01 0.404D-01
+ Coeff:      0.150D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.99D-06 MaxDP=1.65D-04 DE=-7.01D-09 OVMax= 3.72D-04
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943623873808     Delta-E=       -0.000000001628 Rises=F Damp=F
+ DIIS: error= 2.08D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943623873808     IErMin=14 ErrMin= 2.08D-07
+ ErrMax= 2.08D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.25D-11 BMatP= 4.51D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.464D-03 0.420D-02-0.192D-01-0.606D-02 0.641D-01 0.889D-01
+ Coeff-Com: -0.170D+00-0.598D+00 0.406D+00 0.959D+00-0.594D+00-0.524D+00
+ Coeff-Com:  0.287D+00 0.110D+01
+ Coeff:     -0.464D-03 0.420D-02-0.192D-01-0.606D-02 0.641D-01 0.889D-01
+ Coeff:     -0.170D+00-0.598D+00 0.406D+00 0.959D+00-0.594D+00-0.524D+00
+ Coeff:      0.287D+00 0.110D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.16D-07 MaxDP=5.10D-05 DE=-1.63D-09 OVMax= 1.15D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943623873982     Delta-E=       -0.000000000174 Rises=F Damp=F
+ DIIS: error= 1.31D-07 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943623873982     IErMin=15 ErrMin= 1.31D-07
+ ErrMax= 1.31D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.03D-12 BMatP= 1.25D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.180D-04-0.437D-03 0.373D-02-0.397D-03-0.209D-01-0.768D-02
+ Coeff-Com:  0.119D+00 0.442D-01-0.347D+00-0.620D-01 0.431D+00 0.494D-02
+ Coeff-Com: -0.463D+00-0.883D-01 0.139D+01
+ Coeff:      0.180D-04-0.437D-03 0.373D-02-0.397D-03-0.209D-01-0.768D-02
+ Coeff:      0.119D+00 0.442D-01-0.347D+00-0.620D-01 0.431D+00 0.494D-02
+ Coeff:     -0.463D+00-0.883D-01 0.139D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.02D-07 MaxDP=1.64D-05 DE=-1.74D-10 OVMax= 3.70D-05
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943623874010     Delta-E=       -0.000000000028 Rises=F Damp=F
+ DIIS: error= 5.77D-08 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943623874010     IErMin=16 ErrMin= 5.77D-08
+ ErrMax= 5.77D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.34D-12 BMatP= 4.03D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.163D-03-0.155D-02 0.763D-02 0.202D-02-0.280D-01-0.321D-01
+ Coeff-Com:  0.909D-01 0.226D+00-0.232D+00-0.358D+00 0.313D+00 0.193D+00
+ Coeff-Com: -0.224D+00-0.433D+00 0.423D+00 0.105D+01
+ Coeff:      0.163D-03-0.155D-02 0.763D-02 0.202D-02-0.280D-01-0.321D-01
+ Coeff:      0.909D-01 0.226D+00-0.232D+00-0.358D+00 0.313D+00 0.193D+00
+ Coeff:     -0.224D+00-0.433D+00 0.423D+00 0.105D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.32D-08 MaxDP=6.62D-06 DE=-2.77D-11 OVMax= 1.49D-05
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943623874017     Delta-E=       -0.000000000008 Rises=F Damp=F
+ DIIS: error= 2.75D-08 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943623874017     IErMin=17 ErrMin= 2.75D-08
+ ErrMax= 2.75D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.61D-13 BMatP= 1.34D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.353D-05 0.460D-04-0.707D-03 0.170D-03 0.495D-02 0.110D-03
+ Coeff-Com: -0.325D-01 0.827D-03 0.959D-01-0.558D-02-0.119D+00 0.211D-01
+ Coeff-Com:  0.127D+00-0.195D-01-0.384D+00 0.843D-01 0.123D+01
+ Coeff:      0.353D-05 0.460D-04-0.707D-03 0.170D-03 0.495D-02 0.110D-03
+ Coeff:     -0.325D-01 0.827D-03 0.959D-01-0.558D-02-0.119D+00 0.211D-01
+ Coeff:      0.127D+00-0.195D-01-0.384D+00 0.843D-01 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.57D-08 MaxDP=1.87D-06 DE=-7.50D-12 OVMax= 4.19D-06
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943623874021     Delta-E=       -0.000000000004 Rises=F Damp=F
+ DIIS: error= 8.52D-09 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943623874021     IErMin=18 ErrMin= 8.52D-09
+ ErrMax= 8.52D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.66D-14 BMatP= 2.61D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.276D-04 0.278D-03-0.146D-02-0.340D-03 0.594D-02 0.541D-02
+ Coeff-Com: -0.223D-01-0.387D-01 0.610D-01 0.591D-01-0.802D-01-0.259D-01
+ Coeff-Com:  0.651D-01 0.649D-01-0.146D+00-0.154D+00 0.246D+00 0.961D+00
+ Coeff:     -0.276D-04 0.278D-03-0.146D-02-0.340D-03 0.594D-02 0.541D-02
+ Coeff:     -0.223D-01-0.387D-01 0.610D-01 0.591D-01-0.802D-01-0.259D-01
+ Coeff:      0.651D-01 0.649D-01-0.146D+00-0.154D+00 0.246D+00 0.961D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.11D-09 MaxDP=3.29D-07 DE=-3.64D-12 OVMax= 7.40D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943623874     A.U. after   18 cycles
+            NFock= 18  Conv=0.51D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650250740202D+02 PE=-2.333677642628D+03 EE= 6.192613991122D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:01:53 2024, MaxMem=  4294967296 cpu:      1134.6
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:01:53 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2721 LenP2D=    7937.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:01:53 2024, MaxMem=  4294967296 cpu:         1.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:01:53 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:       114.6
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.05998131D-01-5.27389785D-02 9.84684124D-02
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000004049   -0.000000530   -0.000001625
+      2        6           0.000002196    0.000000093   -0.000001395
+      3        6          -0.000007523    0.000004605   -0.000000257
+      4        6           0.000000687    0.000001995    0.000005048
+      5        6           0.000004619   -0.000006682   -0.000000544
+      6        6          -0.000000367    0.000005048   -0.000001164
+      7        6          -0.000009678    0.000000117   -0.000003296
+      8        6           0.000012279   -0.000003187   -0.000002396
+      9        1           0.000005966   -0.000003694    0.000005715
+     10        1           0.000001193   -0.000001136   -0.000000954
+     11        1           0.000000037    0.000000040    0.000001280
+     12        1          -0.000005263    0.000004311   -0.000000480
+     13        1           0.000000132   -0.000000655    0.000000166
+     14        1           0.000000208    0.000000667    0.000000627
+     15        1           0.000001425   -0.000001117    0.000000357
+     16        1          -0.000001862    0.000000126   -0.000001081
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000012279 RMS     0.000003656
+ Leave Link  716 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000060525 RMS     0.000008384
+ Search for a local minimum.
+ Step number  73 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .83842D-05 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   50   51   52   53
+                                                     54   55   56   57   58
+                                                     59   60   61   62   63
+                                                     64   65   66   67   68
+                                                     69   70   71   72   73
+ DE= -7.04D-07 DEPred=-7.05D-07 R= 9.99D-01
+ Trust test= 9.99D-01 RLast= 2.32D-02 DXMaxT set to 3.16D-01
+ ITU=  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1  1
+ ITU=  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1  1
+ ITU=  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0  0
+ ITU=  1  0  0  1  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---    0.00002   0.00005   0.00057   0.00098   0.00302
+     Eigenvalues ---    0.00583   0.00871   0.01135   0.01364   0.01730
+     Eigenvalues ---    0.02121   0.02276   0.03199   0.03956   0.04600
+     Eigenvalues ---    0.08119   0.08804   0.09670   0.10255   0.10468
+     Eigenvalues ---    0.11132   0.11507   0.13432   0.14164   0.14821
+     Eigenvalues ---    0.16175   0.18368   0.19112   0.22919   0.28499
+     Eigenvalues ---    0.33323   0.33921   0.34683   0.35431   0.36538
+     Eigenvalues ---    0.38324   0.38378   0.38488   0.38590   0.39258
+     Eigenvalues ---    0.41921   0.50429
+ Eigenvalue     1 is   2.16D-05 Eigenvector:
+                          D1        D3        D2        A1        R2
+   1                    0.53185   0.53129   0.53007   0.35482  -0.14272
+                          D6        D8        D4        D14       D15
+   1                    0.04154   0.03788   0.03778   0.02370   0.02278
+ Eigenvalue     2 is   4.72D-05 Eigenvector:
+                          R2        D1        A1        D3        D2
+   1                    0.97442   0.11257  -0.11249   0.11066   0.10939
+                          D15       D6        D14       D8        D10
+   1                    0.01258   0.01257   0.01085   0.01052  -0.00979
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    73   72   71   70   69
+ RFO step:  Lambda=-1.60462709D-07.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC=  2.27D-06 SmlDif=  1.00D-05
+ RMS Error=  0.3332005903D-03 NUsed= 5 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    3.94309   -4.02089    1.17228    0.28208   -0.37656
+ Iteration  1 RMS(Cart)=  0.06478691 RMS(Int)=  0.00150285
+ Iteration  2 RMS(Cart)=  0.00307470 RMS(Int)=  0.00000283
+ Iteration  3 RMS(Cart)=  0.00000375 RMS(Int)=  0.00000110
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000110
+ ITry= 1 IFail=0 DXMaxC= 4.08D-01 DCOld= 1.00D+10 DXMaxT= 3.16D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43744   0.00000   0.00021   0.00009   0.00030   3.43774
+    R2        9.44337  -0.00001   0.05125  -0.00805   0.04319   9.48656
+    R3        2.81431   0.00000  -0.00016  -0.00005  -0.00021   2.81409
+    R4        2.10347   0.00000  -0.00002  -0.00005  -0.00007   2.10340
+    R5        2.08082   0.00000  -0.00004   0.00003  -0.00001   2.08081
+    R6        2.79914   0.00000  -0.00002   0.00000  -0.00002   2.79913
+    R7        2.80688   0.00000  -0.00001  -0.00007  -0.00007   2.80681
+    R8        2.78855   0.00000   0.00002   0.00002   0.00004   2.78859
+    R9        2.08091   0.00001   0.00001   0.00001   0.00002   2.08093
+   R10        2.80922   0.00000  -0.00006   0.00011   0.00005   2.80927
+   R11        2.07885   0.00000  -0.00002   0.00003   0.00001   2.07886
+   R12        2.65197   0.00000   0.00009   0.00011   0.00020   2.65217
+   R13        2.06674   0.00000   0.00000   0.00001   0.00000   2.06674
+   R14        2.62610  -0.00001  -0.00022   0.00003  -0.00018   2.62591
+   R15        2.06747   0.00000  -0.00001   0.00001   0.00000   2.06747
+   R16        2.06697   0.00000   0.00002   0.00001   0.00002   2.06699
+    A1        1.78555  -0.00006  -0.05506   0.00036  -0.05470   1.73085
+    A2        1.99350  -0.00003  -0.00018  -0.00003  -0.00022   1.99329
+    A3        1.80209   0.00001  -0.00022   0.00007  -0.00015   1.80194
+    A4        1.90093   0.00001   0.00006  -0.00011  -0.00005   1.90088
+    A5        1.95337   0.00001   0.00003   0.00009   0.00012   1.95350
+    A6        1.95204   0.00001   0.00017  -0.00005   0.00013   1.95217
+    A7        1.85102   0.00000   0.00014   0.00004   0.00017   1.85120
+    A8        2.13086   0.00001   0.00056  -0.00001   0.00055   2.13141
+    A9        2.09774  -0.00001   0.00005   0.00015   0.00020   2.09794
+   A10        1.97425   0.00000   0.00009   0.00008   0.00016   1.97441
+   A11        1.96573   0.00000  -0.00006   0.00000  -0.00006   1.96568
+   A12        2.06578   0.00000  -0.00005  -0.00002  -0.00007   2.06570
+   A13        2.06662   0.00000  -0.00013   0.00003  -0.00010   2.06653
+   A14        1.96817   0.00000  -0.00006  -0.00002  -0.00008   1.96810
+   A15        2.07738   0.00000  -0.00010   0.00001  -0.00010   2.07729
+   A16        2.06952   0.00000  -0.00006   0.00000  -0.00007   2.06945
+   A17        2.06868   0.00000   0.00004  -0.00004   0.00000   2.06868
+   A18        2.11100   0.00000   0.00000   0.00000   0.00000   2.11100
+   A19        2.10134   0.00000  -0.00004   0.00001  -0.00003   2.10132
+   A20        2.13555   0.00000  -0.00002   0.00000  -0.00002   2.13553
+   A21        2.07203   0.00000  -0.00002   0.00000  -0.00002   2.07201
+   A22        2.07256   0.00000   0.00003   0.00001   0.00004   2.07260
+   A23        2.08233   0.00000   0.00001  -0.00002   0.00000   2.08233
+   A24        2.09045   0.00000  -0.00003   0.00000  -0.00002   2.09042
+   A25        2.10985   0.00000   0.00001   0.00001   0.00002   2.10987
+    D1       -0.36785   0.00000  -0.05872  -0.00281  -0.06153  -0.42938
+    D2       -2.49310   0.00000  -0.05850  -0.00296  -0.06146  -2.55456
+    D3        1.82834   0.00000  -0.05858  -0.00299  -0.06157   1.76677
+    D4        2.40063  -0.00001  -0.00272  -0.00164  -0.00436   2.39627
+    D5       -1.18984   0.00000  -0.00087  -0.00104  -0.00190  -1.19175
+    D6       -1.84280  -0.00001  -0.00311  -0.00150  -0.00461  -1.84741
+    D7        0.84991   0.00000  -0.00126  -0.00090  -0.00215   0.84776
+    D8        0.23150   0.00000  -0.00279  -0.00143  -0.00422   0.22728
+    D9        2.92421   0.00000  -0.00094  -0.00082  -0.00176   2.92245
+   D10        1.86724   0.00000   0.00179   0.00062   0.00241   1.86965
+   D11       -1.89972   0.00000   0.00140   0.00065   0.00204  -1.89768
+   D12       -0.85427   0.00000   0.00008   0.00003   0.00011  -0.85416
+   D13        1.66195   0.00000  -0.00032   0.00006  -0.00026   1.66170
+   D14       -2.27249   0.00000  -0.00204  -0.00053  -0.00257  -2.27506
+   D15        0.90468   0.00000  -0.00185  -0.00056  -0.00242   0.90227
+   D16        0.45785   0.00000  -0.00023   0.00000  -0.00023   0.45762
+   D17       -2.64816   0.00000  -0.00004  -0.00003  -0.00007  -2.64823
+   D18        0.88736   0.00000   0.00006  -0.00001   0.00005   0.88741
+   D19       -1.65561   0.00000   0.00043   0.00001   0.00044  -1.65517
+   D20       -1.62853   0.00000   0.00042  -0.00001   0.00041  -1.62812
+   D21        2.11168   0.00000   0.00080   0.00001   0.00081   2.11249
+   D22       -0.52506   0.00000  -0.00012  -0.00011  -0.00023  -0.52529
+   D23        2.54616   0.00000  -0.00018  -0.00048  -0.00066   2.54550
+   D24        2.02086   0.00000  -0.00051  -0.00012  -0.00064   2.02022
+   D25       -1.19111   0.00000  -0.00057  -0.00050  -0.00107  -1.19218
+   D26        0.12797   0.00000  -0.00004   0.00016   0.00012   0.12810
+   D27       -3.09862   0.00000  -0.00011   0.00023   0.00012  -3.09850
+   D28       -2.94365   0.00000   0.00002   0.00054   0.00055  -2.94309
+   D29        0.11294   0.00000  -0.00006   0.00061   0.00055   0.11350
+   D30       -0.09409   0.00000   0.00024  -0.00010   0.00014  -0.09395
+   D31        3.01152   0.00000   0.00005  -0.00006  -0.00002   3.01150
+   D32        3.13253   0.00000   0.00032  -0.00017   0.00015   3.13268
+   D33       -0.04505   0.00000   0.00012  -0.00014  -0.00001  -0.04506
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000061     0.000450     YES
+ RMS     Force            0.000008     0.000300     YES
+ Maximum Displacement     0.407721     0.001800     NO
+ RMS     Displacement     0.067148     0.001200     NO
+ Predicted change in Energy=-2.818662D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.890969   -1.578063   -0.901969
+      2          6           0       -1.431102   -1.493460    0.180168
+      3          6           0       -0.620998   -0.254647    0.016914
+      4          6           0       -0.073254    0.486697    1.176413
+      5          6           0        1.386375    0.321902    1.317452
+      6          6           0        2.121159    0.599030    0.055198
+      7          6           0        1.477688    0.341761   -1.165245
+      8          6           0        0.137408   -0.017778   -1.238008
+      9          1           0       -3.601973    3.331442   -1.671611
+     10          1           0       -0.855943   -2.405590   -0.095771
+     11          1           0       -1.751343   -1.639188    1.223563
+     12          1           0       -0.517324    1.461693    1.430937
+     13          1           0        1.772846   -0.457337    1.990961
+     14          1           0        3.114769    1.055754    0.071412
+     15          1           0        2.029796    0.505767   -2.095429
+     16          1           0       -0.371627   -0.095012   -2.203061
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819172   0.000000
+     3  C    2.783620   1.489154   0.000000
+     4  C    4.064778   2.599476   1.481233   0.000000
+     5  C    5.179900   3.539369   2.460357   1.475658   0.000000
+     6  C    5.547732   4.124645   2.872222   2.466818   1.486604
+     7  C    4.779142   3.693133   2.481469   2.812435   2.484455
+     8  C    3.423226   2.578582   1.485300   2.475542   2.864556
+     9  H    5.020071   5.605484   4.959573   5.353100   6.547934
+    10  H    2.340103   1.113073   2.166668   3.255208   3.803210
+    11  H    2.412543   1.101119   2.156533   2.708799   3.701347
+    12  H    4.507411   3.336517   2.226215   1.101181   2.221728
+    13  H    5.601450   3.823324   3.109411   2.227728   1.100085
+    14  H    6.629732   5.212990   3.959303   3.421746   2.253553
+    15  H    5.475456   4.599246   3.473749   3.889490   3.477866
+    16  H    3.199900   2.959379   2.239634   3.442130   3.957070
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403469   0.000000
+     8  C    2.447061   1.389573   0.000000
+     9  H    6.572838   5.915874   5.038676   0.000000
+    10  H    4.232454   3.759993   2.827207   6.552670   0.000000
+    11  H    4.622875   4.478527   3.500812   6.042684   1.769111
+    12  H    3.098135   3.460417   3.121022   4.757817   4.171496
+    13  H    2.232579   3.269145   3.646109   7.527148   3.880809
+    14  H    1.093673   2.172359   3.425162   7.302843   5.270238
+    15  H    2.154587   1.094058   2.142522   6.315131   4.560934
+    16  H    3.434445   2.165133   1.093804   4.739005   3.164491
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.343841   0.000000
+    13  H    3.795469   3.039932   0.000000
+    14  H    5.680600   3.899385   2.788345   0.000000
+    15  H    5.469328   4.453861   4.206207   2.484926   0.000000
+    16  H    4.003729   3.956071   4.724390   4.318848   2.477771
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6871725      0.9266242      0.8388132
+ Leave Link  202 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.5003188753 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071856385 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4931332368 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7945.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.004977   -0.008451   -0.030558
+         Rot=    0.999971    0.005216    0.004793   -0.002960 Ang=   0.88 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0261 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:02:00 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.942884767016
+ DIIS: error= 1.19D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.942884767016     IErMin= 1 ErrMin= 1.19D-03
+ ErrMax= 1.19D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.37D-03 BMatP= 1.37D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ GapD=    0.701 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=1.75D-04 MaxDP=3.53D-03              OVMax= 6.13D-03
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943556383542     Delta-E=       -0.000671616526 Rises=F Damp=F
+ DIIS: error= 3.26D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943556383542     IErMin= 2 ErrMin= 3.26D-04
+ ErrMax= 3.26D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.44D-05 BMatP= 1.37D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.229D+00 0.123D+01
+ Coeff:     -0.229D+00 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.67D-05 MaxDP=1.08D-03 DE=-6.72D-04 OVMax= 3.07D-03
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943620349059     Delta-E=       -0.000063965517 Rises=F Damp=F
+ DIIS: error= 9.73D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943620349059     IErMin= 3 ErrMin= 9.73D-05
+ ErrMax= 9.73D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.53D-06 BMatP= 7.44D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.158D-01-0.195D+00 0.118D+01
+ Coeff:      0.158D-01-0.195D+00 0.118D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.29D-05 MaxDP=4.97D-04 DE=-6.40D-05 OVMax= 1.12D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943624853796     Delta-E=       -0.000004504737 Rises=F Damp=F
+ DIIS: error= 5.54D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943624853796     IErMin= 4 ErrMin= 5.54D-05
+ ErrMax= 5.54D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.07D-06 BMatP= 4.53D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.330D-01-0.227D+00 0.518D+00 0.676D+00
+ Coeff:      0.330D-01-0.227D+00 0.518D+00 0.676D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.81D-06 MaxDP=2.18D-04 DE=-4.50D-06 OVMax= 4.36D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943625870143     Delta-E=       -0.000001016347 Rises=F Damp=F
+ DIIS: error= 2.23D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943625870143     IErMin= 5 ErrMin= 2.23D-05
+ ErrMax= 2.23D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.28D-07 BMatP= 2.07D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.135D-02 0.826D-02-0.164D+00 0.915D-01 0.106D+01
+ Coeff:      0.135D-02 0.826D-02-0.164D+00 0.915D-01 0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.14D-06 MaxDP=1.67D-04 DE=-1.02D-06 OVMax= 3.80D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943626144153     Delta-E=       -0.000000274010 Rises=F Damp=F
+ DIIS: error= 1.57D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943626144153     IErMin= 6 ErrMin= 1.57D-05
+ ErrMax= 1.57D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.96D-08 BMatP= 2.28D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.488D-02 0.401D-01-0.146D+00-0.770D-01 0.385D+00 0.803D+00
+ Coeff:     -0.488D-02 0.401D-01-0.146D+00-0.770D-01 0.385D+00 0.803D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.41D-06 MaxDP=1.31D-04 DE=-2.74D-07 OVMax= 3.06D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943626227463     Delta-E=       -0.000000083309 Rises=F Damp=F
+ DIIS: error= 1.63D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943626227463     IErMin= 6 ErrMin= 1.57D-05
+ ErrMax= 1.63D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.71D-08 BMatP= 5.96D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.145D-03-0.182D-02 0.258D-01-0.134D-01-0.172D+00 0.147D-01
+ Coeff-Com:  0.115D+01
+ Coeff:     -0.145D-03-0.182D-02 0.258D-01-0.134D-01-0.172D+00 0.147D-01
+ Coeff:      0.115D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.23D-06 MaxDP=1.70D-04 DE=-8.33D-08 OVMax= 3.89D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943626292020     Delta-E=       -0.000000064558 Rises=F Damp=F
+ DIIS: error= 1.55D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943626292020     IErMin= 8 ErrMin= 1.55D-05
+ ErrMax= 1.55D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.23D-08 BMatP= 1.71D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.978D-03-0.820D-02 0.316D-01 0.155D-01-0.917D-01-0.163D+00
+ Coeff-Com:  0.537D-01 0.116D+01
+ Coeff:      0.978D-03-0.820D-02 0.316D-01 0.155D-01-0.917D-01-0.163D+00
+ Coeff:      0.537D-01 0.116D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.25D-06 MaxDP=1.83D-04 DE=-6.46D-08 OVMax= 4.15D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943626352099     Delta-E=       -0.000000060078 Rises=F Damp=F
+ DIIS: error= 1.49D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943626352099     IErMin= 9 ErrMin= 1.49D-05
+ ErrMax= 1.49D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.08D-08 BMatP= 1.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.880D-05 0.139D-02-0.136D-01 0.552D-02 0.816D-01 0.348D-02
+ Coeff-Com: -0.517D+00-0.461D-01 0.148D+01
+ Coeff:     -0.880D-05 0.139D-02-0.136D-01 0.552D-02 0.816D-01 0.348D-02
+ Coeff:     -0.517D+00-0.461D-01 0.148D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.19D-06 MaxDP=2.62D-04 DE=-6.01D-08 OVMax= 5.95D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943626432501     Delta-E=       -0.000000080402 Rises=F Damp=F
+ DIIS: error= 1.39D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943626432501     IErMin=10 ErrMin= 1.39D-05
+ ErrMax= 1.39D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.67D-09 BMatP= 1.08D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.129D-02 0.106D-01-0.406D-01-0.209D-01 0.108D+00 0.212D+00
+ Coeff-Com:  0.397D-01-0.150D+01-0.299D+00 0.249D+01
+ Coeff:     -0.129D-02 0.106D-01-0.406D-01-0.209D-01 0.108D+00 0.212D+00
+ Coeff:      0.397D-01-0.150D+01-0.299D+00 0.249D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.59D-06 MaxDP=6.27D-04 DE=-8.04D-08 OVMax= 1.42D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943626606050     Delta-E=       -0.000000173549 Rises=F Damp=F
+ DIIS: error= 1.19D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943626606050     IErMin=11 ErrMin= 1.19D-05
+ ErrMax= 1.19D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.53D-09 BMatP= 9.67D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.296D-03-0.465D-02 0.320D-01-0.425D-02-0.165D+00-0.650D-01
+ Coeff-Com:  0.883D+00 0.412D+00-0.251D+01-0.605D+00 0.303D+01
+ Coeff:      0.296D-03-0.465D-02 0.320D-01-0.425D-02-0.165D+00-0.650D-01
+ Coeff:      0.883D+00 0.412D+00-0.251D+01-0.605D+00 0.303D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.75D-05 MaxDP=1.45D-03 DE=-1.74D-07 OVMax= 3.27D-03
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943626913990     Delta-E=       -0.000000307940 Rises=F Damp=F
+ DIIS: error= 7.62D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943626913990     IErMin=12 ErrMin= 7.62D-06
+ ErrMax= 7.62D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.98D-09 BMatP= 7.53D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.169D-02-0.147D-01 0.631D-01 0.240D-01-0.204D+00-0.285D+00
+ Coeff-Com:  0.352D+00 0.201D+01-0.765D+00-0.324D+01 0.136D+01 0.170D+01
+ Coeff:      0.169D-02-0.147D-01 0.631D-01 0.240D-01-0.204D+00-0.285D+00
+ Coeff:      0.352D+00 0.201D+01-0.765D+00-0.324D+01 0.136D+01 0.170D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.10D-05 MaxDP=1.74D-03 DE=-3.08D-07 OVMax= 3.94D-03
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943627115491     Delta-E=       -0.000000201501 Rises=F Damp=F
+ DIIS: error= 2.62D-06 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943627115491     IErMin=13 ErrMin= 2.62D-06
+ ErrMax= 2.62D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.98D-10 BMatP= 3.98D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.168D-05 0.788D-03-0.859D-02 0.432D-02 0.486D-01 0.147D-01
+ Coeff-Com: -0.329D+00-0.220D-01 0.938D+00 0.289D-01-0.110D+01 0.525D-01
+ Coeff-Com:  0.137D+01
+ Coeff:      0.168D-05 0.788D-03-0.859D-02 0.432D-02 0.486D-01 0.147D-01
+ Coeff:     -0.329D+00-0.220D-01 0.938D+00 0.289D-01-0.110D+01 0.525D-01
+ Coeff:      0.137D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.18D-06 MaxDP=7.60D-04 DE=-2.02D-07 OVMax= 1.72D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943627145859     Delta-E=       -0.000000030368 Rises=F Damp=F
+ DIIS: error= 7.72D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943627145859     IErMin=14 ErrMin= 7.72D-07
+ ErrMax= 7.72D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.93D-10 BMatP= 8.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.362D-03 0.327D-02-0.152D-01-0.401D-02 0.499D-01 0.683D-01
+ Coeff-Com: -0.133D+00-0.454D+00 0.302D+00 0.723D+00-0.444D+00-0.387D+00
+ Coeff-Com:  0.245D+00 0.105D+01
+ Coeff:     -0.362D-03 0.327D-02-0.152D-01-0.401D-02 0.499D-01 0.683D-01
+ Coeff:     -0.133D+00-0.454D+00 0.302D+00 0.723D+00-0.444D+00-0.387D+00
+ Coeff:      0.245D+00 0.105D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.29D-06 MaxDP=1.89D-04 DE=-3.04D-08 OVMax= 4.28D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943627148009     Delta-E=       -0.000000002150 Rises=F Damp=F
+ DIIS: error= 5.22D-07 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943627148009     IErMin=15 ErrMin= 5.22D-07
+ ErrMax= 5.22D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.38D-11 BMatP= 1.93D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.144D-04-0.295D-03 0.243D-02-0.344D-03-0.131D-01-0.396D-02
+ Coeff-Com:  0.695D-01 0.324D-01-0.201D+00-0.481D-01 0.248D+00-0.178D-02
+ Coeff-Com: -0.283D+00-0.643D-01 0.126D+01
+ Coeff:      0.144D-04-0.295D-03 0.243D-02-0.344D-03-0.131D-01-0.396D-02
+ Coeff:      0.695D-01 0.324D-01-0.201D+00-0.481D-01 0.248D+00-0.178D-02
+ Coeff:     -0.283D+00-0.643D-01 0.126D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.51D-07 MaxDP=4.45D-05 DE=-2.15D-09 OVMax= 1.01D-04
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943627148270     Delta-E=       -0.000000000261 Rises=F Damp=F
+ DIIS: error= 2.71D-07 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943627148270     IErMin=16 ErrMin= 2.71D-07
+ ErrMax= 2.71D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.08D-11 BMatP= 5.38D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D-03-0.935D-03 0.455D-02 0.110D-02-0.161D-01-0.186D-01
+ Coeff-Com:  0.475D-01 0.133D+00-0.114D+00-0.209D+00 0.158D+00 0.109D+00
+ Coeff-Com: -0.109D+00-0.332D+00 0.211D+00 0.114D+01
+ Coeff:      0.100D-03-0.935D-03 0.455D-02 0.110D-02-0.161D-01-0.186D-01
+ Coeff:      0.475D-01 0.133D+00-0.114D+00-0.209D+00 0.158D+00 0.109D+00
+ Coeff:     -0.109D+00-0.332D+00 0.211D+00 0.114D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.03D-07 MaxDP=1.53D-05 DE=-2.61D-10 OVMax= 3.44D-05
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943627148345     Delta-E=       -0.000000000075 Rises=F Damp=F
+ DIIS: error= 1.28D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943627148345     IErMin=17 ErrMin= 1.28D-07
+ ErrMax= 1.28D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.76D-12 BMatP= 2.08D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.354D-06 0.632D-04-0.726D-03 0.211D-03 0.449D-02 0.348D-03
+ Coeff-Com: -0.277D-01-0.307D-02 0.805D-01 0.316D-02-0.975D-01 0.161D-01
+ Coeff-Com:  0.113D+00-0.337D-01-0.552D+00 0.229D+00 0.127D+01
+ Coeff:      0.354D-06 0.632D-04-0.726D-03 0.211D-03 0.449D-02 0.348D-03
+ Coeff:     -0.277D-01-0.307D-02 0.805D-01 0.316D-02-0.975D-01 0.161D-01
+ Coeff:      0.113D+00-0.337D-01-0.552D+00 0.229D+00 0.127D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.05D-07 MaxDP=6.46D-06 DE=-7.50D-11 OVMax= 1.44D-05
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943627148367     Delta-E=       -0.000000000022 Rises=F Damp=F
+ DIIS: error= 4.20D-08 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943627148367     IErMin=18 ErrMin= 4.20D-08
+ ErrMax= 4.20D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.19D-13 BMatP= 6.76D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-04 0.176D-03-0.934D-03-0.174D-03 0.373D-02 0.327D-02
+ Coeff-Com: -0.135D-01-0.240D-01 0.362D-01 0.365D-01-0.480D-01-0.133D-01
+ Coeff-Com:  0.411D-01 0.473D-01-0.141D+00-0.147D+00 0.241D+00 0.979D+00
+ Coeff:     -0.177D-04 0.176D-03-0.934D-03-0.174D-03 0.373D-02 0.327D-02
+ Coeff:     -0.135D-01-0.240D-01 0.362D-01 0.365D-01-0.480D-01-0.133D-01
+ Coeff:      0.411D-01 0.473D-01-0.141D+00-0.147D+00 0.241D+00 0.979D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.58D-08 MaxDP=1.45D-06 DE=-2.23D-11 OVMax= 3.25D-06
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943627148373     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 1.84D-08 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943627148373     IErMin=19 ErrMin= 1.84D-08
+ ErrMax= 1.84D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.60D-13 BMatP= 9.19D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.970D-06 0.107D-06 0.622D-04-0.585D-04-0.455D-03 0.766D-04
+ Coeff-Com:  0.353D-02-0.941D-03-0.101D-01 0.161D-02 0.118D-01-0.286D-02
+ Coeff-Com: -0.159D-01 0.112D-01 0.890D-01-0.652D-01-0.226D+00 0.147D+00
+ Coeff-Com:  0.106D+01
+ Coeff:     -0.970D-06 0.107D-06 0.622D-04-0.585D-04-0.455D-03 0.766D-04
+ Coeff:      0.353D-02-0.941D-03-0.101D-01 0.161D-02 0.118D-01-0.286D-02
+ Coeff:     -0.159D-01 0.112D-01 0.890D-01-0.652D-01-0.226D+00 0.147D+00
+ Coeff:      0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.69D-09 MaxDP=2.54D-07 DE=-5.23D-12 OVMax= 6.28D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627148     A.U. after   19 cycles
+            NFock= 19  Conv=0.77D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650250726396D+02 PE=-2.333768773707D+03 EE= 6.193069406820D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:03:16 2024, MaxMem=  4294967296 cpu:      1206.0
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:03:16 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7945.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:03:16 2024, MaxMem=  4294967296 cpu:         1.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:03:16 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:03:23 2024, MaxMem=  4294967296 cpu:       114.6
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.04204193D-01-4.73659124D-02 1.10496810D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000005415    0.000000043   -0.000000809
+      2        6          -0.000001783    0.000001814    0.000003041
+      3        6          -0.000005463   -0.000004656   -0.000016276
+      4        6           0.000013914    0.000011674    0.000014455
+      5        6          -0.000009569   -0.000007102   -0.000009575
+      6        6          -0.000011714    0.000004521    0.000002738
+      7        6           0.000005643    0.000002397    0.000004436
+      8        6           0.000010934   -0.000005111   -0.000002065
+      9        1           0.000005235   -0.000003662    0.000004714
+     10        1           0.000002090   -0.000002446   -0.000002114
+     11        1          -0.000000452   -0.000000873   -0.000000417
+     12        1          -0.000003678    0.000003482   -0.000000086
+     13        1          -0.000000705    0.000001867    0.000000503
+     14        1           0.000001379   -0.000003105    0.000000374
+     15        1           0.000000319   -0.000000606    0.000000735
+     16        1          -0.000000733    0.000001765    0.000000348
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000016276 RMS     0.000005832
+ Leave Link  716 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000053036 RMS     0.000007624
+ Search for a local minimum.
+ Step number  74 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .76237D-05 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74
+ DE= -3.27D-06 DEPred=-2.82D-06 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 1.28D-01 DXNew= 5.3220D-01 3.8311D-01
+ Trust test= 1.16D+00 RLast= 1.28D-01 DXMaxT set to 3.83D-01
+ ITU=  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1 -1
+ ITU=  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1  1
+ ITU=  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0  0
+ ITU=  0  1  0  0  1  0  0  0  0  0  0  1  0  0
+     Eigenvalues ---   -0.00011   0.00001   0.00012   0.00030   0.00236
+     Eigenvalues ---    0.00547   0.00716   0.01073   0.01351   0.01699
+     Eigenvalues ---    0.02065   0.02254   0.03117   0.03828   0.04515
+     Eigenvalues ---    0.07963   0.08706   0.09299   0.10218   0.10446
+     Eigenvalues ---    0.11106   0.11463   0.12349   0.13439   0.14541
+     Eigenvalues ---    0.15283   0.17258   0.18994   0.22842   0.28199
+     Eigenvalues ---    0.33199   0.33776   0.34462   0.35252   0.36471
+     Eigenvalues ---    0.38218   0.38324   0.38427   0.38587   0.38874
+     Eigenvalues ---    0.41635   0.49047
+ Eigenvalue     1 is  -1.11D-04 should be greater than     0.000000 Eigenvector:
+                          D1        D3        D2        R2        D6
+   1                    0.54744   0.54374   0.53974   0.16899   0.14036
+                          D4        D8        D7        D5        D9
+   1                    0.12828   0.12730   0.08477   0.07269   0.07172
+ Eigenvalue     2 is   1.36D-05 Eigenvector:
+                          R2        A1        D6        D2        D3
+   1                    0.88522  -0.23180   0.15671  -0.15661  -0.15002
+                          D1        D8        D4        D7        D9
+   1                   -0.14250   0.14076   0.13455   0.07815   0.06220
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.11763313D-04 EMin=-1.10806658D-04
+ I=     1 Eig=   -1.11D-04 Dot1= -5.91D-06
+ I=     1 Stepn= -6.00D-01 RXN=   6.00D-01 EDone=F
+ Mixed    1 eigenvectors in step.  Raw Step.Grad=  5.91D-06.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  6.00D-01 in eigenvector direction(s).  Step.Grad=  2.29D-06.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.19245226 RMS(Int)=  0.02793378
+ Iteration  2 RMS(Cart)=  0.10198920 RMS(Int)=  0.00394718
+ Iteration  3 RMS(Cart)=  0.00448511 RMS(Int)=  0.00004273
+ Iteration  4 RMS(Cart)=  0.00000783 RMS(Int)=  0.00004263
+ Iteration  5 RMS(Cart)=  0.00000000 RMS(Int)=  0.00004263
+ ITry= 1 IFail=0 DXMaxC= 1.33D+00 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43774   0.00000   0.00000   0.00800   0.00800   3.44574
+    R2        9.48656  -0.00001   0.00000  -0.10139  -0.10139   9.38517
+    R3        2.81409   0.00001   0.00000  -0.00507  -0.00507   2.80902
+    R4        2.10340   0.00000   0.00000  -0.00120  -0.00120   2.10220
+    R5        2.08081   0.00000   0.00000  -0.00069  -0.00069   2.08013
+    R6        2.79913   0.00001   0.00000   0.00034   0.00037   2.79949
+    R7        2.80681   0.00000   0.00000  -0.00259  -0.00257   2.80425
+    R8        2.78859  -0.00001   0.00000  -0.00020  -0.00019   2.78840
+    R9        2.08093   0.00000   0.00000   0.00047   0.00047   2.08140
+   R10        2.80927  -0.00001   0.00000  -0.00198  -0.00201   2.80727
+   R11        2.07886   0.00000   0.00000  -0.00117  -0.00117   2.07769
+   R12        2.65217  -0.00001   0.00000  -0.00173  -0.00175   2.65042
+   R13        2.06674   0.00000   0.00000   0.00011   0.00011   2.06685
+   R14        2.62591   0.00000   0.00000   0.00003   0.00002   2.62593
+   R15        2.06747   0.00000   0.00000  -0.00043  -0.00043   2.06705
+   R16        2.06699   0.00000   0.00000   0.00031   0.00031   2.06730
+    A1        1.73085  -0.00005   0.00000   0.02347   0.02347   1.75433
+    A2        1.99329  -0.00002   0.00000  -0.00398  -0.00398   1.98930
+    A3        1.80194   0.00001   0.00000  -0.00350  -0.00351   1.79843
+    A4        1.90088   0.00000   0.00000  -0.00074  -0.00073   1.90015
+    A5        1.95350   0.00000   0.00000  -0.00004  -0.00006   1.95344
+    A6        1.95217   0.00001   0.00000   0.00436   0.00436   1.95652
+    A7        1.85120   0.00000   0.00000   0.00384   0.00383   1.85503
+    A8        2.13141   0.00000   0.00000   0.00498   0.00477   2.13618
+    A9        2.09794   0.00000   0.00000   0.00819   0.00800   2.10594
+   A10        1.97441   0.00000   0.00000  -0.00060  -0.00073   1.97368
+   A11        1.96568   0.00000   0.00000  -0.00411  -0.00410   1.96157
+   A12        2.06570   0.00000   0.00000  -0.00147  -0.00154   2.06417
+   A13        2.06653   0.00000   0.00000  -0.00369  -0.00375   2.06278
+   A14        1.96810   0.00000   0.00000  -0.00112  -0.00112   1.96698
+   A15        2.07729   0.00000   0.00000   0.00004   0.00003   2.07732
+   A16        2.06945   0.00000   0.00000   0.00283   0.00284   2.07229
+   A17        2.06868   0.00000   0.00000   0.00375   0.00371   2.07239
+   A18        2.11100   0.00000   0.00000  -0.00100  -0.00099   2.11001
+   A19        2.10132   0.00000   0.00000  -0.00233  -0.00232   2.09899
+   A20        2.13553   0.00000   0.00000  -0.00201  -0.00202   2.13351
+   A21        2.07201   0.00000   0.00000   0.00101   0.00102   2.07302
+   A22        2.07260   0.00000   0.00000   0.00068   0.00068   2.07328
+   A23        2.08233   0.00000   0.00000  -0.00201  -0.00198   2.08035
+   A24        2.09042   0.00000   0.00000   0.00212   0.00209   2.09252
+   A25        2.10987   0.00000   0.00000  -0.00031  -0.00034   2.10953
+    D1       -0.42938   0.00000   0.00000  -0.32847  -0.32846  -0.75784
+    D2       -2.55456   0.00000   0.00000  -0.32384  -0.32385  -2.87841
+    D3        1.76677  -0.00001   0.00000  -0.32625  -0.32624   1.44053
+    D4        2.39627  -0.00001   0.00000  -0.07697  -0.07702   2.31925
+    D5       -1.19175  -0.00001   0.00000  -0.04362  -0.04357  -1.23531
+    D6       -1.84741  -0.00001   0.00000  -0.08421  -0.08427  -1.93167
+    D7        0.84776  -0.00001   0.00000  -0.05086  -0.05081   0.79695
+    D8        0.22728   0.00000   0.00000  -0.07638  -0.07643   0.15085
+    D9        2.92245   0.00000   0.00000  -0.04303  -0.04297   2.87947
+   D10        1.86965   0.00000   0.00000   0.02012   0.02006   1.88971
+   D11       -1.89768   0.00000   0.00000   0.00497   0.00494  -1.89274
+   D12       -0.85416   0.00000   0.00000  -0.01305  -0.01304  -0.86719
+   D13        1.66170   0.00000   0.00000  -0.02819  -0.02815   1.63354
+   D14       -2.27506   0.00000   0.00000  -0.01778  -0.01777  -2.29284
+   D15        0.90227   0.00000   0.00000  -0.01128  -0.01127   0.89099
+   D16        0.45762   0.00000   0.00000   0.01388   0.01387   0.47150
+   D17       -2.64823   0.00000   0.00000   0.02038   0.02037  -2.62786
+   D18        0.88741   0.00000   0.00000   0.00108   0.00111   0.88852
+   D19       -1.65517   0.00000   0.00000  -0.00266  -0.00264  -1.65781
+   D20       -1.62812   0.00000   0.00000   0.01536   0.01535  -1.61277
+   D21        2.11249   0.00000   0.00000   0.01162   0.01160   2.12409
+   D22       -0.52529   0.00000   0.00000   0.00777   0.00777  -0.51752
+   D23        2.54550   0.00000   0.00000   0.01451   0.01451   2.56001
+   D24        2.02022   0.00000   0.00000   0.01046   0.01046   2.03069
+   D25       -1.19218   0.00000   0.00000   0.01720   0.01720  -1.17498
+   D26        0.12810   0.00000   0.00000  -0.00820  -0.00820   0.11989
+   D27       -3.09850   0.00000   0.00000  -0.01254  -0.01255  -3.11105
+   D28       -2.94309   0.00000   0.00000  -0.01495  -0.01495  -2.95804
+   D29        0.11350   0.00000   0.00000  -0.01930  -0.01930   0.09420
+   D30       -0.09395   0.00000   0.00000  -0.00268  -0.00269  -0.09664
+   D31        3.01150   0.00000   0.00000  -0.00921  -0.00921   3.00229
+   D32        3.13268   0.00000   0.00000   0.00164   0.00164   3.13431
+   D33       -0.04506   0.00000   0.00000  -0.00488  -0.00488  -0.04994
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000053     0.000450     YES
+ RMS     Force            0.000008     0.000300     YES
+ Maximum Displacement     1.325732     0.001800     NO
+ RMS     Displacement     0.290570     0.001200     NO
+ Predicted change in Energy=-2.585615D-05
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.873120   -1.463100   -1.041076
+      2          6           0       -1.457692   -1.400103    0.106711
+      3          6           0       -0.563701   -0.230682   -0.100236
+      4          6           0       -0.092501    0.616206    1.020199
+      5          6           0        1.339644    0.415071    1.313071
+      6          6           0        2.193434    0.525949    0.102456
+      7          6           0        1.650082    0.170716   -1.140805
+      8          6           0        0.306425   -0.146147   -1.299328
+      9          1           0       -4.303521    3.292452   -0.978037
+     10          1           0       -0.934344   -2.362437   -0.087030
+     11          1           0       -1.834144   -1.455952    1.139584
+     12          1           0       -0.505102    1.633039    1.114833
+     13          1           0        1.628355   -0.296293    2.100114
+     14          1           0        3.206537    0.933307    0.165135
+     15          1           0        2.286933    0.224474   -2.028499
+     16          1           0       -0.121777   -0.293531   -2.295165
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.823408   0.000000
+     3  C    2.781627   1.486470   0.000000
+     4  C    4.037847   2.600713   1.481426   0.000000
+     5  C    5.178505   3.546160   2.457063   1.475558   0.000000
+     6  C    5.561829   4.128004   2.866246   2.464933   1.485543
+     7  C    4.810265   3.698922   2.478858   2.811582   2.485476
+     8  C    3.451169   2.580981   1.483943   2.473970   2.864810
+     9  H    4.966417   5.594237   5.212414   5.374749   6.736009
+    10  H    2.340483   1.112437   2.163777   3.287396   3.853032
+    11  H    2.415533   1.100755   2.156958   2.709504   3.688327
+    12  H    4.454383   3.335220   2.225598   1.101428   2.219422
+    13  H    5.611754   3.836110   3.106599   2.227155   1.099468
+    14  H    6.645294   5.215673   3.954742   3.422768   2.252024
+    15  H    5.518066   4.606581   3.471524   3.887123   3.478473
+    16  H    3.241993   2.962799   2.239857   3.438040   3.956923
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.402541   0.000000
+     8  C    2.444895   1.389584   0.000000
+     9  H    7.143628   6.724367   5.760103   0.000000
+    10  H    4.261651   3.769159   2.814448   6.642516   0.000000
+    11  H    4.607054   4.470576   3.499417   5.755822   1.770858
+    12  H    3.087498   3.445447   3.106807   4.643463   4.194348
+    13  H    2.232942   3.274466   3.650513   7.585596   3.952211
+    14  H    1.093731   2.170155   3.423524   7.954456   5.298340
+    15  H    2.154206   1.093833   2.142770   7.345069   4.564870
+    16  H    3.432250   2.165076   1.093970   5.664016   3.133129
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.362861   0.000000
+    13  H    3.775755   3.040516   0.000000
+    14  H    5.662735   3.894587   2.783293   0.000000
+    15  H    5.462953   4.433966   4.213119   2.481963   0.000000
+    16  H    4.010102   3.935314   4.730903   4.316929   2.478170
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6937126      0.9167751      0.8336723
+ Leave Link  202 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.1178271372 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071667808 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.1106603564 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2715 LenP2D=    7924.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.08D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.067569    0.030723   -0.096816
+         Rot=    0.999598    0.014324    0.018878    0.015546 Ang=   3.25 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0263 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:03:24 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.930404729307
+ DIIS: error= 4.37D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.930404729307     IErMin= 1 ErrMin= 4.37D-03
+ ErrMax= 4.37D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.50D-02 BMatP= 2.50D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.703 Goal=     0.100 Shift=    0.000
+ T=  340. Gap= 0.319 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.738 Goal=     0.100 Shift=    0.000
+ T=  340. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.703 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=7.56D-04 MaxDP=1.82D-02              OVMax= 2.77D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.942352672385     Delta-E=       -0.011947943077 Rises=F Damp=F
+ DIIS: error= 1.25D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.942352672385     IErMin= 2 ErrMin= 1.25D-03
+ ErrMax= 1.25D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-03 BMatP= 2.50D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.222D+00 0.122D+01
+ Coeff:     -0.222D+00 0.122D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ T=  177. Gap= 0.319 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ T=  177. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.237 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.89D-04 MaxDP=4.97D-03 DE=-1.19D-02 OVMax= 1.38D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943477029614     Delta-E=       -0.001124357230 Rises=F Damp=F
+ DIIS: error= 4.22D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943477029614     IErMin= 3 ErrMin= 4.22D-04
+ ErrMax= 4.22D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.44D-05 BMatP= 1.33D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.154D-01-0.196D+00 0.118D+01
+ Coeff:      0.154D-01-0.196D+00 0.118D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.05D-04 MaxDP=2.65D-03 DE=-1.12D-03 OVMax= 4.77D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943560026718     Delta-E=       -0.000082997104 Rises=F Damp=F
+ DIIS: error= 2.20D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943560026718     IErMin= 4 ErrMin= 2.20D-04
+ ErrMax= 2.20D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.75D-05 BMatP= 8.44D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.323D-01-0.228D+00 0.511D+00 0.685D+00
+ Coeff:      0.323D-01-0.228D+00 0.511D+00 0.685D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.02D-05 MaxDP=8.72D-04 DE=-8.30D-05 OVMax= 2.04D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943578186438     Delta-E=       -0.000018159720 Rises=F Damp=F
+ DIIS: error= 8.20D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943578186438     IErMin= 5 ErrMin= 8.20D-05
+ ErrMax= 8.20D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.09D-06 BMatP= 3.75D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.202D-02 0.390D-02-0.158D+00 0.107D+00 0.104D+01
+ Coeff:      0.202D-02 0.390D-02-0.158D+00 0.107D+00 0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.32D-05 MaxDP=6.04D-04 DE=-1.82D-05 OVMax= 1.35D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943582374045     Delta-E=       -0.000004187607 Rises=F Damp=F
+ DIIS: error= 4.83D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943582374045     IErMin= 6 ErrMin= 4.83D-05
+ ErrMax= 4.83D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.38D-07 BMatP= 4.09D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.401D-02 0.353D-01-0.137D+00-0.609D-01 0.386D+00 0.781D+00
+ Coeff:     -0.401D-02 0.353D-01-0.137D+00-0.609D-01 0.386D+00 0.781D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.89D-06 MaxDP=4.47D-04 DE=-4.19D-06 OVMax= 1.04D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943583418925     Delta-E=       -0.000001044880 Rises=F Damp=F
+ DIIS: error= 5.33D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943583418925     IErMin= 6 ErrMin= 4.83D-05
+ ErrMax= 5.33D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.16D-07 BMatP= 9.38D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.380D-03 0.679D-03 0.138D-01-0.149D-01-0.124D+00 0.583D-01
+ Coeff-Com:  0.107D+01
+ Coeff:     -0.380D-03 0.679D-03 0.138D-01-0.149D-01-0.124D+00 0.583D-01
+ Coeff:      0.107D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.28D-06 MaxDP=5.47D-04 DE=-1.04D-06 OVMax= 1.24D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943584138940     Delta-E=       -0.000000720014 Rises=F Damp=F
+ DIIS: error= 5.23D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943584138940     IErMin= 6 ErrMin= 4.83D-05
+ ErrMax= 5.23D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.52D-07 BMatP= 2.16D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.740D-03-0.650D-02 0.256D-01 0.122D-01-0.765D-01-0.134D+00
+ Coeff-Com: -0.418D-02 0.118D+01
+ Coeff:      0.740D-03-0.650D-02 0.256D-01 0.122D-01-0.765D-01-0.134D+00
+ Coeff:     -0.418D-02 0.118D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.67D-06 MaxDP=6.25D-04 DE=-7.20D-07 OVMax= 1.41D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943584859443     Delta-E=       -0.000000720503 Rises=F Damp=F
+ DIIS: error= 5.12D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943584859443     IErMin= 6 ErrMin= 4.83D-05
+ ErrMax= 5.12D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.34D-07 BMatP= 1.52D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.693D-04 0.703D-03-0.109D-01 0.627D-02 0.687D-01 0.886D-03
+ Coeff-Com: -0.507D+00-0.204D+00 0.165D+01
+ Coeff:      0.693D-04 0.703D-03-0.109D-01 0.627D-02 0.687D-01 0.886D-03
+ Coeff:     -0.507D+00-0.204D+00 0.165D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.21D-05 MaxDP=9.98D-04 DE=-7.21D-07 OVMax= 2.26D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943585928722     Delta-E=       -0.000001069280 Rises=F Damp=F
+ DIIS: error= 4.85D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943585928722     IErMin= 6 ErrMin= 4.83D-05
+ ErrMax= 4.85D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.17D-07 BMatP= 1.34D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.100D-02 0.893D-02-0.366D-01-0.158D-01 0.109D+00 0.188D+00
+ Coeff-Com: -0.519D-03-0.164D+01 0.828D-01 0.231D+01
+ Coeff:     -0.100D-02 0.893D-02-0.366D-01-0.158D-01 0.109D+00 0.188D+00
+ Coeff:     -0.519D-03-0.164D+01 0.828D-01 0.231D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.74D-05 MaxDP=2.26D-03 DE=-1.07D-06 OVMax= 5.13D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943588088600     Delta-E=       -0.000002159878 Rises=F Damp=F
+ DIIS: error= 4.23D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943588088600     IErMin=11 ErrMin= 4.23D-05
+ ErrMax= 4.23D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.97D-08 BMatP= 1.17D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-04-0.157D-02 0.148D-01-0.531D-02-0.788D-01-0.295D-01
+ Coeff-Com:  0.543D+00 0.398D+00-0.171D+01-0.313D+00 0.218D+01
+ Coeff:      0.257D-04-0.157D-02 0.148D-01-0.531D-02-0.788D-01-0.295D-01
+ Coeff:      0.543D+00 0.398D+00-0.171D+01-0.313D+00 0.218D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.77D-05 MaxDP=3.13D-03 DE=-2.16D-06 OVMax= 7.09D-03
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943590536933     Delta-E=       -0.000002448333 Rises=F Damp=F
+ DIIS: error= 3.32D-05 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943590536933     IErMin=12 ErrMin= 3.32D-05
+ ErrMax= 3.32D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.23D-08 BMatP= 8.97D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.101D-02-0.918D-02 0.394D-01 0.143D-01-0.120D+00-0.206D+00
+ Coeff-Com:  0.935D-01 0.172D+01-0.358D+00-0.243D+01 0.415D+00 0.185D+01
+ Coeff:      0.101D-02-0.918D-02 0.394D-01 0.143D-01-0.120D+00-0.206D+00
+ Coeff:      0.935D-01 0.172D+01-0.358D+00-0.243D+01 0.415D+00 0.185D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.60D-05 MaxDP=3.81D-03 DE=-2.45D-06 OVMax= 8.67D-03
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943592727408     Delta-E=       -0.000002190475 Rises=F Damp=F
+ DIIS: error= 2.18D-05 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943592727408     IErMin=13 ErrMin= 2.18D-05
+ ErrMax= 2.18D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.44D-08 BMatP= 6.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.937D-04 0.228D-02-0.189D-01 0.487D-02 0.950D-01 0.409D-01
+ Coeff-Com: -0.585D+00-0.499D+00 0.188D+01 0.382D+00-0.233D+01-0.487D-01
+ Coeff-Com:  0.207D+01
+ Coeff:     -0.937D-04 0.228D-02-0.189D-01 0.487D-02 0.950D-01 0.409D-01
+ Coeff:     -0.585D+00-0.499D+00 0.188D+01 0.382D+00-0.233D+01-0.487D-01
+ Coeff:      0.207D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.16D-05 MaxDP=4.26D-03 DE=-2.19D-06 OVMax= 9.71D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943594140059     Delta-E=       -0.000001412651 Rises=F Damp=F
+ DIIS: error= 9.17D-06 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943594140059     IErMin=14 ErrMin= 9.17D-06
+ ErrMax= 9.17D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.40D-09 BMatP= 3.44D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.523D-03 0.496D-02-0.230D-01-0.592D-02 0.744D-01 0.112D+00
+ Coeff-Com: -0.138D+00-0.935D+00 0.439D+00 0.126D+01-0.502D+00-0.932D+00
+ Coeff-Com:  0.273D+00 0.137D+01
+ Coeff:     -0.523D-03 0.496D-02-0.230D-01-0.592D-02 0.744D-01 0.112D+00
+ Coeff:     -0.138D+00-0.935D+00 0.439D+00 0.126D+01-0.502D+00-0.932D+00
+ Coeff:      0.273D+00 0.137D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.80D-05 MaxDP=2.30D-03 DE=-1.41D-06 OVMax= 5.25D-03
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943594427928     Delta-E=       -0.000000287868 Rises=F Damp=F
+ DIIS: error= 2.17D-06 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943594427928     IErMin=15 ErrMin= 2.17D-06
+ ErrMax= 2.17D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.55D-09 BMatP= 9.40D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.730D-05-0.253D-03 0.311D-02-0.983D-03-0.184D-01-0.410D-02
+ Coeff-Com:  0.123D+00 0.896D-01-0.417D+00-0.510D-01 0.531D+00-0.343D-01
+ Coeff-Com: -0.484D+00 0.880D-01 0.118D+01
+ Coeff:     -0.730D-05-0.253D-03 0.311D-02-0.983D-03-0.184D-01-0.410D-02
+ Coeff:      0.123D+00 0.896D-01-0.417D+00-0.510D-01 0.531D+00-0.343D-01
+ Coeff:     -0.484D+00 0.880D-01 0.118D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.29D-06 MaxDP=5.94D-04 DE=-2.88D-07 OVMax= 1.36D-03
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943594446828     Delta-E=       -0.000000018900 Rises=F Damp=F
+ DIIS: error= 8.48D-07 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943594446828     IErMin=16 ErrMin= 8.48D-07
+ ErrMax= 8.48D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.73D-10 BMatP= 1.55D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.930D-04-0.986D-03 0.524D-02 0.799D-03-0.198D-01-0.220D-01
+ Coeff-Com:  0.646D-01 0.201D+00-0.223D+00-0.244D+00 0.269D+00 0.160D+00
+ Coeff-Com: -0.212D+00-0.221D+00 0.430D+00 0.812D+00
+ Coeff:      0.930D-04-0.986D-03 0.524D-02 0.799D-03-0.198D-01-0.220D-01
+ Coeff:      0.646D-01 0.201D+00-0.223D+00-0.244D+00 0.269D+00 0.160D+00
+ Coeff:     -0.212D+00-0.221D+00 0.430D+00 0.812D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.40D-06 MaxDP=1.13D-04 DE=-1.89D-08 OVMax= 2.60D-04
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943594447746     Delta-E=       -0.000000000918 Rises=F Damp=F
+ DIIS: error= 4.47D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943594447746     IErMin=17 ErrMin= 4.47D-07
+ ErrMax= 4.47D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.87D-11 BMatP= 3.73D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.102D-04-0.542D-04-0.192D-04 0.233D-03 0.123D-02-0.157D-02
+ Coeff-Com: -0.138D-01 0.642D-02 0.448D-01-0.124D-01-0.669D-01 0.243D-01
+ Coeff-Com:  0.608D-01-0.398D-01-0.145D+00 0.475D-01 0.109D+01
+ Coeff:      0.102D-04-0.542D-04-0.192D-04 0.233D-03 0.123D-02-0.157D-02
+ Coeff:     -0.138D-01 0.642D-02 0.448D-01-0.124D-01-0.669D-01 0.243D-01
+ Coeff:      0.608D-01-0.398D-01-0.145D+00 0.475D-01 0.109D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.89D-07 MaxDP=2.29D-05 DE=-9.18D-10 OVMax= 5.22D-05
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943594447838     Delta-E=       -0.000000000092 Rises=F Damp=F
+ DIIS: error= 2.07D-07 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943594447838     IErMin=18 ErrMin= 2.07D-07
+ ErrMax= 2.07D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.23D-11 BMatP= 4.87D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.142D-04 0.159D-03-0.892D-03-0.105D-03 0.360D-02 0.339D-02
+ Coeff-Com: -0.135D-01-0.326D-01 0.450D-01 0.407D-01-0.580D-01-0.216D-01
+ Coeff-Com:  0.449D-01 0.288D-01-0.966D-01-0.155D+00 0.187D+00 0.102D+01
+ Coeff:     -0.142D-04 0.159D-03-0.892D-03-0.105D-03 0.360D-02 0.339D-02
+ Coeff:     -0.135D-01-0.326D-01 0.450D-01 0.407D-01-0.580D-01-0.216D-01
+ Coeff:      0.449D-01 0.288D-01-0.966D-01-0.155D+00 0.187D+00 0.102D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.53D-08 MaxDP=3.89D-06 DE=-9.23D-11 OVMax= 8.90D-06
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943594447856     Delta-E=       -0.000000000018 Rises=F Damp=F
+ DIIS: error= 9.36D-08 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943594447856     IErMin=19 ErrMin= 9.36D-08
+ ErrMax= 9.36D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.37D-12 BMatP= 1.23D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.373D-05 0.313D-04-0.116D-03-0.682D-04 0.266D-03 0.748D-03
+ Coeff-Com:  0.913D-03-0.578D-02-0.265D-02 0.868D-02 0.430D-02-0.731D-02
+ Coeff-Com: -0.556D-02 0.111D-01 0.148D-01-0.383D-01-0.188D+00 0.166D+00
+ Coeff-Com:  0.104D+01
+ Coeff:     -0.373D-05 0.313D-04-0.116D-03-0.682D-04 0.266D-03 0.748D-03
+ Coeff:      0.913D-03-0.578D-02-0.265D-02 0.868D-02 0.430D-02-0.731D-02
+ Coeff:     -0.556D-02 0.111D-01 0.148D-01-0.383D-01-0.188D+00 0.166D+00
+ Coeff:      0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.61D-07 DE=-1.77D-11 OVMax= 2.37D-06
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.943594447854     Delta-E=        0.000000000002 Rises=F Damp=F
+ DIIS: error= 3.33D-08 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943594447856     IErMin=20 ErrMin= 3.33D-08
+ ErrMax= 3.33D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.23D-13 BMatP= 2.37D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.151D-05-0.186D-04 0.116D-03 0.920D-06-0.487D-03-0.393D-03
+ Coeff-Com:  0.211D-02 0.401D-02-0.712D-02-0.474D-02 0.903D-02 0.231D-02
+ Coeff-Com: -0.740D-02-0.289D-02 0.178D-01 0.211D-01-0.519D-01-0.179D+00
+ Coeff-Com:  0.107D+00 0.109D+01
+ Coeff:      0.151D-05-0.186D-04 0.116D-03 0.920D-06-0.487D-03-0.393D-03
+ Coeff:      0.211D-02 0.401D-02-0.712D-02-0.474D-02 0.903D-02 0.231D-02
+ Coeff:     -0.740D-02-0.289D-02 0.178D-01 0.211D-01-0.519D-01-0.179D+00
+ Coeff:      0.107D+00 0.109D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.47D-09 MaxDP=3.61D-07 DE= 2.05D-12 OVMax= 9.06D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943594448     A.U. after   20 cycles
+            NFock= 20  Conv=0.95D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650329072436D+02 PE=-2.333011137882D+03 EE= 6.189239758339D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:04:43 2024, MaxMem=  4294967296 cpu:      1260.3
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:04:43 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2715 LenP2D=    7924.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:04:43 2024, MaxMem=  4294967296 cpu:         1.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:04:43 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:04:50 2024, MaxMem=  4294967296 cpu:       114.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.03645168D-01-7.76504028D-02 1.48053293D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000237083   -0.000066449    0.000250136
+      2        6          -0.000297029   -0.000402455   -0.000813935
+      3        6          -0.000318412    0.000654733    0.000793942
+      4        6           0.000285416    0.000096253   -0.000102181
+      5        6          -0.000467555    0.000272738    0.000421530
+      6        6           0.001085695   -0.000224867   -0.000452168
+      7        6           0.000019085    0.000210671    0.000145021
+      8        6          -0.000390319   -0.000398915   -0.000825801
+      9        1           0.000013701   -0.000008264    0.000004559
+     10        1          -0.000071551   -0.000022893    0.000046743
+     11        1          -0.000070240    0.000107843    0.000084708
+     12        1          -0.000226682   -0.000114495    0.000170181
+     13        1           0.000184243   -0.000195725    0.000178114
+     14        1          -0.000113037    0.000275952    0.000069672
+     15        1           0.000176146   -0.000172675   -0.000005203
+     16        1          -0.000046544   -0.000011453    0.000034681
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001085695 RMS     0.000343042
+ Leave Link  716 at Sun Aug 11 02:04:50 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000742342 RMS     0.000200600
+ Search for a local minimum.
+ Step number  75 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .20060D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   75   74
+ ITU=  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1  1
+ ITU= -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1  1
+ ITU=  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1  0
+ ITU=  0  0  1  0  0  1  0  0  0  0  0  0  1  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.93823.
+ Iteration  1 RMS(Cart)=  0.16863973 RMS(Int)=  0.02676524
+ Iteration  2 RMS(Cart)=  0.10628216 RMS(Int)=  0.00401009
+ Iteration  3 RMS(Cart)=  0.00432378 RMS(Int)=  0.00000323
+ Iteration  4 RMS(Cart)=  0.00000685 RMS(Int)=  0.00000247
+ Iteration  5 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000247
+ ITry= 1 IFail=0 DXMaxC= 1.24D+00 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=T
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.44574  -0.00035  -0.00751   0.00000  -0.00751   3.43823
+    R2        9.38517  -0.00001   0.09513   0.00000   0.09513   9.48030
+    R3        2.80902   0.00036   0.00476   0.00000   0.00476   2.81378
+    R4        2.10220  -0.00002   0.00113   0.00000   0.00113   2.10333
+    R5        2.08013   0.00010   0.00065   0.00000   0.00065   2.08077
+    R6        2.79949   0.00020  -0.00034   0.00000  -0.00034   2.79915
+    R7        2.80425   0.00050   0.00241   0.00000   0.00241   2.80665
+    R8        2.78840   0.00027   0.00018   0.00000   0.00018   2.78858
+    R9        2.08140  -0.00001  -0.00044   0.00000  -0.00044   2.08096
+   R10        2.80727   0.00074   0.00188   0.00000   0.00188   2.80915
+   R11        2.07769   0.00030   0.00110   0.00000   0.00110   2.07879
+   R12        2.65042   0.00033   0.00164   0.00000   0.00165   2.65206
+   R13        2.06685   0.00000  -0.00010   0.00000  -0.00010   2.06675
+   R14        2.62593   0.00067  -0.00002   0.00000  -0.00002   2.62591
+   R15        2.06705   0.00010   0.00040   0.00000   0.00040   2.06744
+   R16        2.06730  -0.00001  -0.00029   0.00000  -0.00029   2.06701
+    A1        1.75433  -0.00010  -0.02202   0.00000  -0.02202   1.73230
+    A2        1.98930   0.00016   0.00373   0.00000   0.00373   1.99304
+    A3        1.79843  -0.00009   0.00329   0.00000   0.00329   1.80173
+    A4        1.90015  -0.00005   0.00069   0.00000   0.00069   1.90083
+    A5        1.95344   0.00009   0.00006   0.00000   0.00006   1.95350
+    A6        1.95652  -0.00015  -0.00409   0.00000  -0.00409   1.95244
+    A7        1.85503   0.00003  -0.00359   0.00000  -0.00359   1.85143
+    A8        2.13618   0.00038  -0.00448   0.00000  -0.00446   2.13171
+    A9        2.10594  -0.00052  -0.00751   0.00000  -0.00750   2.09844
+   A10        1.97368   0.00011   0.00069   0.00000   0.00070   1.97437
+   A11        1.96157   0.00012   0.00385   0.00000   0.00385   1.96542
+   A12        2.06417  -0.00012   0.00144   0.00000   0.00145   2.06561
+   A13        2.06278   0.00007   0.00352   0.00000   0.00352   2.06630
+   A14        1.96698   0.00011   0.00105   0.00000   0.00105   1.96803
+   A15        2.07732   0.00007  -0.00003   0.00000  -0.00003   2.07729
+   A16        2.07229  -0.00020  -0.00266   0.00000  -0.00266   2.06962
+   A17        2.07239  -0.00022  -0.00348   0.00000  -0.00348   2.06891
+   A18        2.11001   0.00000   0.00093   0.00000   0.00093   2.11094
+   A19        2.09899   0.00022   0.00218   0.00000   0.00218   2.10117
+   A20        2.13351   0.00020   0.00190   0.00000   0.00190   2.13540
+   A21        2.07302  -0.00018  -0.00095   0.00000  -0.00095   2.07207
+   A22        2.07328  -0.00001  -0.00064   0.00000  -0.00064   2.07264
+   A23        2.08035  -0.00018   0.00186   0.00000   0.00185   2.08221
+   A24        2.09252   0.00003  -0.00196   0.00000  -0.00196   2.09055
+   A25        2.10953   0.00014   0.00032   0.00000   0.00032   2.10985
+    D1       -0.75784   0.00010   0.30817   0.00000   0.30817  -0.44967
+    D2       -2.87841  -0.00005   0.30385   0.00000   0.30385  -2.57457
+    D3        1.44053  -0.00002   0.30609   0.00000   0.30609   1.74662
+    D4        2.31925   0.00002   0.07226   0.00000   0.07227   2.39152
+    D5       -1.23531  -0.00002   0.04088   0.00000   0.04087  -1.19444
+    D6       -1.93167   0.00008   0.07906   0.00000   0.07906  -1.85261
+    D7        0.79695   0.00004   0.04767   0.00000   0.04767   0.84462
+    D8        0.15085   0.00008   0.07171   0.00000   0.07171   0.22256
+    D9        2.87947   0.00004   0.04032   0.00000   0.04032   2.91979
+   D10        1.88971  -0.00005  -0.01882   0.00000  -0.01882   1.87090
+   D11       -1.89274   0.00008  -0.00464   0.00000  -0.00464  -1.89737
+   D12       -0.86719   0.00013   0.01223   0.00000   0.01223  -0.85496
+   D13        1.63354   0.00026   0.02641   0.00000   0.02641   1.65995
+   D14       -2.29284  -0.00013   0.01668   0.00000   0.01668  -2.27616
+   D15        0.89099  -0.00010   0.01058   0.00000   0.01058   0.90157
+   D16        0.47150  -0.00009  -0.01302   0.00000  -0.01302   0.45848
+   D17       -2.62786  -0.00006  -0.01912   0.00000  -0.01912  -2.64697
+   D18        0.88852  -0.00010  -0.00104   0.00000  -0.00104   0.88748
+   D19       -1.65781   0.00000   0.00247   0.00000   0.00247  -1.65533
+   D20       -1.61277  -0.00016  -0.01440   0.00000  -0.01440  -1.62717
+   D21        2.12409  -0.00006  -0.01089   0.00000  -0.01088   2.11320
+   D22       -0.51752   0.00005  -0.00729   0.00000  -0.00729  -0.52481
+   D23        2.56001  -0.00006  -0.01361   0.00000  -0.01361   2.54639
+   D24        2.03069   0.00005  -0.00982   0.00000  -0.00982   2.02087
+   D25       -1.17498  -0.00007  -0.01614   0.00000  -0.01614  -1.19112
+   D26        0.11989   0.00007   0.00770   0.00000   0.00770   0.12759
+   D27       -3.11105   0.00007   0.01177   0.00000   0.01178  -3.09927
+   D28       -2.95804   0.00019   0.01403   0.00000   0.01403  -2.94402
+   D29        0.09420   0.00019   0.01810   0.00000   0.01810   0.11230
+   D30       -0.09664  -0.00005   0.00253   0.00000   0.00253  -0.09411
+   D31        3.00229  -0.00008   0.00864   0.00000   0.00864   3.01093
+   D32        3.13431  -0.00004  -0.00154   0.00000  -0.00154   3.13278
+   D33       -0.04994  -0.00008   0.00458   0.00000   0.00458  -0.04536
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000742     0.000450     NO
+ RMS     Force            0.000201     0.000300     YES
+ Maximum Displacement     1.242244     0.001800     NO
+ RMS     Displacement     0.272412     0.001200     NO
+ Predicted change in Energy=-4.418571D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:04:50 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.889745   -1.573084   -0.909127
+      2          6           0       -1.432299   -1.488692    0.176722
+      3          6           0       -0.617565   -0.253632    0.009624
+      4          6           0       -0.075024    0.495015    1.166888
+      5          6           0        1.383441    0.328194    1.317217
+      6          6           0        2.125686    0.594802    0.057141
+      7          6           0        1.488457    0.330843   -1.165082
+      8          6           0        0.147846   -0.026436   -1.242731
+      9          1           0       -3.646153    3.334091   -1.626988
+     10          1           0       -0.859765   -2.404059   -0.093740
+     11          1           0       -1.755910   -1.628493    1.219864
+     12          1           0       -0.518090    1.473096    1.411189
+     13          1           0        1.764503   -0.446856    1.998535
+     14          1           0        3.120499    1.048819    0.075684
+     15          1           0        2.045883    0.487840   -2.093286
+     16          1           0       -0.356255   -0.108477   -2.209986
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819434   0.000000
+     3  C    2.783497   1.488988   0.000000
+     4  C    4.063192   2.599561   1.481244   0.000000
+     5  C    5.179922   3.539802   2.460152   1.475652   0.000000
+     6  C    5.548689   4.124864   2.871851   2.466702   1.486539
+     7  C    4.781120   3.693503   2.481306   2.812386   2.484522
+     8  C    3.424963   2.578739   1.485216   2.475449   2.864576
+     9  H    5.016757   5.604798   4.972183   5.349679   6.557483
+    10  H    2.340127   1.113034   2.166490   3.257243   3.806308
+    11  H    2.412728   1.101097   2.156560   2.708777   3.700490
+    12  H    4.504201   3.336446   2.226179   1.101196   2.221587
+    13  H    5.602224   3.824130   3.109237   2.227693   1.100047
+    14  H    6.630782   5.213170   3.959024   3.421811   2.253458
+    15  H    5.478144   4.599713   3.473610   3.889348   3.477908
+    16  H    3.202480   2.959601   2.239648   3.441885   3.957068
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403412   0.000000
+     8  C    2.446928   1.389574   0.000000
+     9  H    6.607127   5.966329   5.082837   0.000000
+    10  H    4.234247   3.760533   2.826403   6.560578   0.000000
+    11  H    4.621878   4.478045   3.500750   6.025348   1.769219
+    12  H    3.097482   3.459501   3.120154   4.741161   4.172995
+    13  H    2.232602   3.269479   3.646387   7.530948   3.885234
+    14  H    1.093677   2.172223   3.425064   7.342285   5.271961
+    15  H    2.154564   1.094044   2.142537   6.381054   4.561146
+    16  H    3.434312   2.165130   1.093815   4.797353   3.162549
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.344945   0.000000
+    13  H    3.794194   3.039970   0.000000
+    14  H    5.679482   3.899091   2.788032   0.000000
+    15  H    5.468954   4.452643   4.206641   2.484739   0.000000
+    16  H    4.004167   3.954804   4.724803   4.318732   2.477797
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6871031      0.9256745      0.8388234
+ Leave Link  202 at Sun Aug 11 02:04:50 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4749365385 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071840861 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4677524523 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:04:51 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:04:51 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:04:51 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.004113    0.001188   -0.006123
+         Rot=    0.999999    0.001066    0.001042    0.000797 Ang=   0.19 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=    -0.058988   -0.034034    0.092110
+         Rot=    0.999645   -0.013208   -0.017826   -0.014721 Ang=  -3.05 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 6.18D-02
+ Max alpha theta=  2.708 degrees.
+ Max  beta theta=  3.141 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:04:51 2024, MaxMem=  4294967296 cpu:         2.3
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943627200689
+ DIIS: error= 1.94D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943627200689     IErMin= 1 ErrMin= 1.94D-05
+ ErrMax= 1.94D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.80D-07 BMatP= 3.80D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    81.314 Goal=     0.100 Shift=    0.000
+ Gap=    81.984 Goal=     0.100 Shift=    0.000
+ RMSDP=2.91D-06 MaxDP=6.06D-05              OVMax= 8.11D-05
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943627336180     Delta-E=       -0.000000135490 Rises=F Damp=F
+ DIIS: error= 2.91D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943627336180     IErMin= 2 ErrMin= 2.91D-06
+ ErrMax= 2.91D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-08 BMatP= 3.80D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.127D+00 0.113D+01
+ Coeff:     -0.127D+00 0.113D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.09D-07 MaxDP=1.82D-05 DE=-1.35D-07 OVMax= 2.77D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943627344582     Delta-E=       -0.000000008402 Rises=F Damp=F
+ DIIS: error= 1.86D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943627344582     IErMin= 3 ErrMin= 1.86D-06
+ ErrMax= 1.86D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.48D-09 BMatP= 1.33D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.529D-01 0.289D+00 0.764D+00
+ Coeff:     -0.529D-01 0.289D+00 0.764D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.99D-07 MaxDP=5.87D-06 DE=-8.40D-09 OVMax= 1.20D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943627345640     Delta-E=       -0.000000001058 Rises=F Damp=F
+ DIIS: error= 7.47D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943627345640     IErMin= 4 ErrMin= 7.47D-07
+ ErrMax= 7.47D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.32D-10 BMatP= 2.48D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.155D-01-0.169D+00 0.150D+00 0.100D+01
+ Coeff:      0.155D-01-0.169D+00 0.150D+00 0.100D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.90D-07 MaxDP=4.52D-06 DE=-1.06D-09 OVMax= 9.44D-06
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943627345978     Delta-E=       -0.000000000338 Rises=F Damp=F
+ DIIS: error= 4.18D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943627345978     IErMin= 5 ErrMin= 4.18D-07
+ ErrMax= 4.18D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.36D-11 BMatP= 4.32D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.668D-02-0.495D-01-0.346D-01 0.137D+00 0.940D+00
+ Coeff:      0.668D-02-0.495D-01-0.346D-01 0.137D+00 0.940D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.05D-08 MaxDP=2.52D-06 DE=-3.38D-10 OVMax= 4.91D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943627346047     Delta-E=       -0.000000000069 Rises=F Damp=F
+ DIIS: error= 2.59D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943627346047     IErMin= 6 ErrMin= 2.59D-07
+ ErrMax= 2.59D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.23D-11 BMatP= 5.36D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.198D-02 0.305D-01-0.565D-01-0.251D+00 0.352D+00 0.926D+00
+ Coeff:     -0.198D-02 0.305D-01-0.565D-01-0.251D+00 0.352D+00 0.926D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.41D-08 MaxDP=2.33D-06 DE=-6.93D-11 OVMax= 5.09D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943627346078     Delta-E=       -0.000000000031 Rises=F Damp=F
+ DIIS: error= 1.92D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943627346078     IErMin= 7 ErrMin= 1.92D-07
+ ErrMax= 1.92D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.90D-12 BMatP= 2.23D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.141D-02 0.127D-01-0.494D-03-0.560D-01-0.135D+00 0.963D-01
+ Coeff-Com:  0.108D+01
+ Coeff:     -0.141D-02 0.127D-01-0.494D-03-0.560D-01-0.135D+00 0.963D-01
+ Coeff:      0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.48D-08 MaxDP=2.18D-06 DE=-3.12D-11 OVMax= 4.95D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943627346098     Delta-E=       -0.000000000020 Rises=F Damp=F
+ DIIS: error= 1.89D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943627346098     IErMin= 8 ErrMin= 1.89D-07
+ ErrMax= 1.89D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.88D-12 BMatP= 4.90D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.619D-04-0.370D-02 0.142D-01 0.449D-01-0.131D+00-0.212D+00
+ Coeff-Com:  0.383D+00 0.904D+00
+ Coeff:      0.619D-04-0.370D-02 0.142D-01 0.449D-01-0.131D+00-0.212D+00
+ Coeff:      0.383D+00 0.904D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.72D-08 MaxDP=1.97D-06 DE=-2.02D-11 OVMax= 4.44D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943627346104     Delta-E=       -0.000000000006 Rises=F Damp=F
+ DIIS: error= 1.81D-07 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943627346104     IErMin= 9 ErrMin= 1.81D-07
+ ErrMax= 1.81D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.87D-12 BMatP= 2.88D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.573D-03-0.546D-02 0.147D-02 0.262D-01 0.379D-01-0.649D-01
+ Coeff-Com: -0.350D+00 0.369D-01 0.132D+01
+ Coeff:      0.573D-03-0.546D-02 0.147D-02 0.262D-01 0.379D-01-0.649D-01
+ Coeff:     -0.350D+00 0.369D-01 0.132D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.48D-08 MaxDP=2.75D-06 DE=-5.91D-12 OVMax= 6.21D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943627346112     Delta-E=       -0.000000000008 Rises=F Damp=F
+ DIIS: error= 1.73D-07 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943627346112     IErMin=10 ErrMin= 1.73D-07
+ ErrMax= 1.73D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.54D-12 BMatP= 1.87D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.171D-03 0.295D-02-0.633D-02-0.246D-01 0.405D-01 0.101D+00
+ Coeff-Com: -0.387D-01-0.399D+00-0.410D+00 0.173D+01
+ Coeff:     -0.171D-03 0.295D-02-0.633D-02-0.246D-01 0.405D-01 0.101D+00
+ Coeff:     -0.387D-01-0.399D+00-0.410D+00 0.173D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.53D-08 MaxDP=3.70D-06 DE=-7.50D-12 OVMax= 8.36D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943627346128     Delta-E=       -0.000000000016 Rises=F Damp=F
+ DIIS: error= 1.62D-07 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943627346128     IErMin=11 ErrMin= 1.62D-07
+ ErrMax= 1.62D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.35D-12 BMatP= 1.54D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.536D-03 0.526D-02-0.244D-02-0.261D-01-0.292D-01 0.714D-01
+ Coeff-Com:  0.314D+00-0.751D-01-0.122D+01 0.210D+00 0.175D+01
+ Coeff:     -0.536D-03 0.526D-02-0.244D-02-0.261D-01-0.292D-01 0.714D-01
+ Coeff:      0.314D+00-0.751D-01-0.122D+01 0.210D+00 0.175D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.77D-08 MaxDP=5.57D-06 DE=-1.59D-11 OVMax= 1.26D-05
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943627346150     Delta-E=       -0.000000000022 Rises=F Damp=F
+ DIIS: error= 1.47D-07 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943627346150     IErMin=12 ErrMin= 1.47D-07
+ ErrMax= 1.47D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.11D-12 BMatP= 1.35D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.399D-03-0.585D-02 0.962D-02 0.441D-01-0.530D-01-0.170D+00
+ Coeff-Com: -0.495D-01 0.612D+00 0.101D+01-0.272D+01-0.497D+00 0.282D+01
+ Coeff:      0.399D-03-0.585D-02 0.962D-02 0.441D-01-0.530D-01-0.170D+00
+ Coeff:     -0.495D-01 0.612D+00 0.101D+01-0.272D+01-0.497D+00 0.282D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.47D-07 MaxDP=1.22D-05 DE=-2.18D-11 OVMax= 2.76D-05
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943627346180     Delta-E=       -0.000000000030 Rises=F Damp=F
+ DIIS: error= 1.14D-07 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943627346180     IErMin=13 ErrMin= 1.14D-07
+ ErrMax= 1.14D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.22D-13 BMatP= 1.11D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.393D-03-0.323D-02-0.124D-02 0.114D-01 0.523D-01-0.138D-01
+ Coeff-Com: -0.325D+00-0.157D+00 0.106D+01 0.519D+00-0.175D+01-0.685D+00
+ Coeff-Com:  0.228D+01
+ Coeff:      0.393D-03-0.323D-02-0.124D-02 0.114D-01 0.523D-01-0.138D-01
+ Coeff:     -0.325D+00-0.157D+00 0.106D+01 0.519D+00-0.175D+01-0.685D+00
+ Coeff:      0.228D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.79D-07 MaxDP=1.49D-05 DE=-3.02D-11 OVMax= 3.36D-05
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943627346203     Delta-E=       -0.000000000023 Rises=F Damp=F
+ DIIS: error= 7.24D-08 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943627346203     IErMin=14 ErrMin= 7.24D-08
+ ErrMax= 7.24D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.64D-13 BMatP= 7.22D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.370D-03 0.556D-02-0.102D-01-0.429D-01 0.624D-01 0.169D+00
+ Coeff-Com: -0.316D-02-0.645D+00-0.782D+00 0.267D+01 0.212D+00-0.269D+01
+ Coeff-Com:  0.235D+00 0.182D+01
+ Coeff:     -0.370D-03 0.556D-02-0.102D-01-0.429D-01 0.624D-01 0.169D+00
+ Coeff:     -0.316D-02-0.645D+00-0.782D+00 0.267D+01 0.212D+00-0.269D+01
+ Coeff:      0.235D+00 0.182D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.77D-07 MaxDP=1.47D-05 DE=-2.30D-11 OVMax= 3.32D-05
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943627346222     Delta-E=       -0.000000000019 Rises=F Damp=F
+ DIIS: error= 2.93D-08 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943627346222     IErMin=15 ErrMin= 2.93D-08
+ ErrMax= 2.93D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.97D-14 BMatP= 3.64D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.253D-03 0.252D-02-0.132D-02-0.127D-01-0.139D-01 0.359D-01
+ Coeff-Com:  0.142D+00-0.318D-01-0.594D+00 0.141D+00 0.821D+00-0.388D-02
+ Coeff-Com: -0.105D+01 0.217D+00 0.135D+01
+ Coeff:     -0.253D-03 0.252D-02-0.132D-02-0.127D-01-0.139D-01 0.359D-01
+ Coeff:      0.142D+00-0.318D-01-0.594D+00 0.141D+00 0.821D+00-0.388D-02
+ Coeff:     -0.105D+01 0.217D+00 0.135D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.49D-08 MaxDP=7.01D-06 DE=-1.93D-11 OVMax= 1.59D-05
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943627346228     Delta-E=       -0.000000000006 Rises=F Damp=F
+ DIIS: error= 7.86D-09 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943627346228     IErMin=16 ErrMin= 7.86D-09
+ ErrMax= 7.86D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.68D-14 BMatP= 9.97D-14
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-6.79D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com: -0.540D-03 0.203D-02 0.672D-02-0.187D-01-0.276D-01 0.294D-01
+ Coeff-Com:  0.151D+00 0.586D-01-0.604D+00 0.817D-01 0.662D+00-0.233D+00
+ Coeff-Com: -0.415D+00 0.216D+00 0.109D+01
+ Coeff:     -0.540D-03 0.203D-02 0.672D-02-0.187D-01-0.276D-01 0.294D-01
+ Coeff:      0.151D+00 0.586D-01-0.604D+00 0.817D-01 0.662D+00-0.233D+00
+ Coeff:     -0.415D+00 0.216D+00 0.109D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.43D-08 MaxDP=2.01D-06 DE=-5.68D-12 OVMax= 4.54D-06
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943627346222     Delta-E=        0.000000000005 Rises=F Damp=F
+ DIIS: error= 2.34D-09 at cycle  17 NSaved=  16.
+ NSaved=16 IEnMin=15 EnMin= -668.943627346228     IErMin=16 ErrMin= 2.34D-09
+ ErrMax= 2.34D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.95D-15 BMatP= 1.68D-14
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Large coefficients: NSaved= 16 BigCof=    0.00 CofMax=   10.00 Det=-6.21D-15
+ Inversion failed.  Reducing to 15 matrices.
+ Coeff-Com:  0.718D-04 0.531D-03-0.128D-02-0.767D-03-0.709D-02 0.154D-01
+ Coeff-Com:  0.341D-01-0.578D-01-0.651D-01 0.803D-01 0.810D-01-0.910D-01
+ Coeff-Com: -0.136D+00 0.237D+00 0.911D+00
+ Coeff:      0.718D-04 0.531D-03-0.128D-02-0.767D-03-0.709D-02 0.154D-01
+ Coeff:      0.341D-01-0.578D-01-0.651D-01 0.803D-01 0.810D-01-0.910D-01
+ Coeff:     -0.136D+00 0.237D+00 0.911D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.48D-09 MaxDP=2.83D-07 DE= 5.46D-12 OVMax= 6.45D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627346     A.U. after   17 cycles
+            NFock= 17  Conv=0.35D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650255385350D+02 PE=-2.333718446368D+03 EE= 6.192815280348D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:05:59 2024, MaxMem=  4294967296 cpu:      1081.2
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:05:59 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:05:59 2024, MaxMem=  4294967296 cpu:         1.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:05:59 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:       114.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.04353912D-01-4.89618204D-02 1.12647451D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000013461   -0.000003610    0.000013703
+      2        6          -0.000022908   -0.000020651   -0.000048208
+      3        6          -0.000026894    0.000031435    0.000038139
+      4        6           0.000033689    0.000019985    0.000008947
+      5        6          -0.000039441    0.000007423    0.000020753
+      6        6           0.000052579   -0.000005489   -0.000032139
+      7        6           0.000008491    0.000015061    0.000017449
+      8        6          -0.000016020   -0.000027509   -0.000054506
+      9        1           0.000006606   -0.000004811    0.000004793
+     10        1          -0.000002978   -0.000005836   -0.000000260
+     11        1          -0.000003540    0.000005829    0.000004758
+     12        1          -0.000015670   -0.000005095    0.000010191
+     13        1           0.000011859   -0.000010736    0.000008962
+     14        1          -0.000006032    0.000013129    0.000006694
+     15        1           0.000011233   -0.000010578   -0.000001503
+     16        1          -0.000004436    0.000001452    0.000002227
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000054506 RMS     0.000020579
+ Leave Link  716 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000062322 RMS     0.000014626
+ Search for a local minimum.
+ Step number  76 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .14626D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   76
+ ITU=  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0  1
+ ITU=  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1  1
+ ITU=  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0 -1
+ ITU=  0  0  0  1  0  0  1  0  0  0  0  0  0  1  0
+     Eigenvalues ---   -0.62033  -0.00029   0.00000   0.00000   0.00045
+     Eigenvalues ---    0.00113   0.00550   0.00895   0.01081   0.01350
+     Eigenvalues ---    0.01744   0.02144   0.02535   0.03248   0.04231
+     Eigenvalues ---    0.04409   0.08228   0.08580   0.10100   0.10369
+     Eigenvalues ---    0.10682   0.11106   0.11443   0.12032   0.14435
+     Eigenvalues ---    0.14877   0.16373   0.18725   0.21051   0.27759
+     Eigenvalues ---    0.28676   0.33143   0.33702   0.34655   0.35533
+     Eigenvalues ---    0.38049   0.38269   0.38330   0.38587   0.38814
+     Eigenvalues ---    0.39932   0.47295
+ Eigenvalue     1 is  -6.20D-01 should be greater than     0.000000 Eigenvector:
+                          R7        R1        R14       A8        R12
+   1                    0.45902  -0.36453   0.30608   0.25098  -0.24197
+                          R6        R10       A9        A16       D5
+   1                   -0.22806   0.22352  -0.22213  -0.18901  -0.14731
+ Eigenvalue     2 is  -2.91D-04 should be greater than     0.000000 Eigenvector:
+                          D1        D3        D2        R2        A1
+   1                    0.50643   0.49841   0.49453   0.26381   0.16044
+                          D15       D25       D5        D29       D17
+   1                    0.12191   0.11615  -0.10365  -0.10169   0.10064
+ Eigenvalue     3 is   1.41D-11 Eigenvector:
+                          A1        R2        D6        D2        D8
+   1                    0.63795   0.55037   0.20328  -0.18986   0.18210
+                          D3        D1        D4        D15       D14
+   1                   -0.17897  -0.16686   0.16529   0.14445   0.13354
+ Eigenvalue     4 is   1.90D-07 Eigenvector:
+                          R2        A1        D3        D1        D2
+   1                    0.74998  -0.62939  -0.08130  -0.08045  -0.08001
+                          D6        D4        D8        D7        D5
+   1                   -0.07269  -0.07026  -0.06683  -0.04397  -0.04154
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-6.20329689D-01 EMin=-6.20329676D-01
+ I=     1 Eig=   -6.20D-01 Dot1=  5.32D-05
+ I=     1 Stepn=  6.00D-01 RXN=   6.00D-01 EDone=F
+ I=     2 Eig=   -2.91D-04 Dot1= -6.86D-06
+ I=     2 Stepn= -3.00D-01 RXN=   6.71D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  6.01D-05.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  6.00D-01 in eigenvector direction(s).  Step.Grad=  1.51D-05.
+ Quartic linear search produced a step of -0.01577.
+ Maximum step size (   0.383) exceeded in Quadratic search.
+    -- Step size not scaled.
+ Iteration  1 RMS(Cart)=  0.19576075 RMS(Int)=  0.01402568
+ Iteration  2 RMS(Cart)=  0.01700081 RMS(Int)=  0.00079861
+ Iteration  3 RMS(Cart)=  0.00013025 RMS(Int)=  0.00079547
+ Iteration  4 RMS(Cart)=  0.00000009 RMS(Int)=  0.00079547
+ ITry= 1 IFail=0 DXMaxC= 1.15D+00 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43823  -0.00003   0.00012  -0.19571  -0.19559   3.24264
+    R2        9.48030  -0.00001  -0.00150  -0.08259  -0.08409   9.39621
+    R3        2.81378   0.00003  -0.00008   0.05294   0.05287   2.86665
+    R4        2.10333   0.00000  -0.00002  -0.06365  -0.06366   2.03967
+    R5        2.08077   0.00001  -0.00001   0.00688   0.00687   2.08764
+    R6        2.79915   0.00003   0.00001  -0.12375  -0.12432   2.67482
+    R7        2.80665   0.00004  -0.00004   0.24629   0.24645   3.05310
+    R8        2.78858   0.00000   0.00000   0.00563   0.00569   2.79427
+    R9        2.08096   0.00000   0.00001  -0.03210  -0.03209   2.04887
+   R10        2.80915   0.00004  -0.00003   0.12312   0.12288   2.93203
+   R11        2.07879   0.00002  -0.00002   0.02406   0.02404   2.10283
+   R12        2.65206   0.00001  -0.00003  -0.12469  -0.12449   2.52757
+   R13        2.06675   0.00000   0.00000  -0.00812  -0.00812   2.05863
+   R14        2.62591   0.00004   0.00000   0.16004   0.16034   2.78625
+   R15        2.06744   0.00001  -0.00001   0.01578   0.01577   2.08321
+   R16        2.06701   0.00000   0.00000   0.00888   0.00888   2.07589
+    A1        1.73230  -0.00006   0.00035  -0.05006  -0.04972   1.68259
+    A2        1.99304  -0.00001  -0.00006  -0.00720  -0.00838   1.98466
+    A3        1.80173   0.00000  -0.00005   0.03723   0.03639   1.83812
+    A4        1.90083   0.00000  -0.00001  -0.03025  -0.03111   1.86972
+    A5        1.95350   0.00001   0.00000   0.04740   0.04696   2.00046
+    A6        1.95244   0.00000   0.00006  -0.02844  -0.02893   1.92350
+    A7        1.85143   0.00000   0.00006  -0.01542  -0.01476   1.83668
+    A8        2.13171   0.00003   0.00007   0.13677   0.13664   2.26835
+    A9        2.09844  -0.00003   0.00012  -0.12267  -0.12087   1.97757
+   A10        1.97437   0.00000  -0.00001  -0.01789  -0.01807   1.95631
+   A11        1.96542   0.00000  -0.00006   0.03405   0.03240   1.99783
+   A12        2.06561  -0.00001  -0.00002   0.02455   0.02441   2.09002
+   A13        2.06630   0.00001  -0.00006  -0.03461  -0.03402   2.03228
+   A14        1.96803   0.00001  -0.00002   0.07626   0.07619   2.04422
+   A15        2.07729   0.00000   0.00000  -0.00367  -0.00322   2.07407
+   A16        2.06962  -0.00001   0.00004  -0.10339  -0.10386   1.96576
+   A17        2.06891  -0.00001   0.00005  -0.05160  -0.05237   2.01654
+   A18        2.11094   0.00000  -0.00001   0.04348   0.04329   2.15422
+   A19        2.10117   0.00001  -0.00003   0.00522   0.00519   2.10636
+   A20        2.13540   0.00001  -0.00003   0.05031   0.05028   2.18568
+   A21        2.07207  -0.00001   0.00002  -0.00686  -0.00691   2.06516
+   A22        2.07264   0.00000   0.00001  -0.04454  -0.04455   2.02809
+   A23        2.08221  -0.00001  -0.00003  -0.05096  -0.05105   2.03116
+   A24        2.09055   0.00000   0.00003   0.01134   0.01107   2.10163
+   A25        2.10985   0.00001  -0.00001   0.04084   0.04055   2.15040
+    D1       -0.44967   0.00000  -0.00486  -0.08729  -0.09229  -0.54196
+    D2       -2.57457  -0.00001  -0.00479  -0.16662  -0.17176  -2.74633
+    D3        1.74662  -0.00001  -0.00483  -0.15466  -0.15900   1.58762
+    D4        2.39152  -0.00001  -0.00114  -0.03538  -0.03553   2.35599
+    D5       -1.19444  -0.00001  -0.00064  -0.05124  -0.05289  -1.24733
+    D6       -1.85261   0.00000  -0.00125   0.04125   0.04144  -1.81117
+    D7        0.84462   0.00000  -0.00075   0.02539   0.02407   0.86869
+    D8        0.22256   0.00000  -0.00113   0.03448   0.03391   0.25647
+    D9        2.91979   0.00000  -0.00064   0.01862   0.01655   2.93634
+   D10        1.87090   0.00000   0.00030  -0.00034  -0.00117   1.86973
+   D11       -1.89737   0.00000   0.00007   0.02240   0.02231  -1.87506
+   D12       -0.85496   0.00001  -0.00019   0.04255   0.04042  -0.81454
+   D13        1.65995   0.00002  -0.00042   0.06529   0.06390   1.72386
+   D14       -2.27616  -0.00001  -0.00026  -0.01551  -0.01857  -2.29473
+   D15        0.90157  -0.00001  -0.00017  -0.05455  -0.05663   0.84494
+   D16        0.45848  -0.00001   0.00021   0.01046   0.01101   0.46949
+   D17       -2.64697   0.00000   0.00030  -0.02858  -0.02705  -2.67402
+   D18        0.88748  -0.00001   0.00002  -0.02271  -0.02483   0.86264
+   D19       -1.65533   0.00000  -0.00004   0.06084   0.05958  -1.59575
+   D20       -1.62717  -0.00001   0.00023  -0.06861  -0.06935  -1.69653
+   D21        2.11320   0.00000   0.00017   0.01493   0.01506   2.12827
+   D22       -0.52481   0.00000   0.00011   0.04004   0.03993  -0.48488
+   D23        2.54639  -0.00001   0.00021  -0.00702  -0.00724   2.53916
+   D24        2.02087   0.00000   0.00015  -0.00618  -0.00657   2.01430
+   D25       -1.19112   0.00000   0.00025  -0.05324  -0.05374  -1.24485
+   D26        0.12759   0.00000  -0.00012   0.00995   0.01029   0.13789
+   D27       -3.09927   0.00000  -0.00019  -0.00751  -0.00743  -3.10670
+   D28       -2.94402   0.00001  -0.00022   0.05512   0.05438  -2.88963
+   D29        0.11230   0.00001  -0.00029   0.03767   0.03666   0.14897
+   D30       -0.09411   0.00000  -0.00004  -0.03935  -0.03950  -0.13361
+   D31        3.01093  -0.00001  -0.00014  -0.00052  -0.00097   3.00996
+   D32        3.13278   0.00000   0.00002  -0.02366  -0.02376   3.10902
+   D33       -0.04536  -0.00001  -0.00007   0.01517   0.01476  -0.03060
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000062     0.000450     YES
+ RMS     Force            0.000015     0.000300     YES
+ Maximum Displacement     1.150046     0.001800     NO
+ RMS     Displacement     0.198698     0.001200     NO
+ Predicted change in Energy=-8.937308D-02
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.804511   -1.560658   -0.984175
+      2          6           0       -1.487451   -1.513377    0.114703
+      3          6           0       -0.671473   -0.237089    0.034405
+      4          6           0       -0.173396    0.590245    1.069272
+      5          6           0        1.287606    0.497901    1.277566
+      6          6           0        2.190648    0.626749    0.022472
+      7          6           0        1.634734    0.238016   -1.130283
+      8          6           0        0.218550   -0.130927   -1.309788
+      9          1           0       -3.674369    3.334804   -1.018409
+     10          1           0       -0.927871   -2.417279   -0.071890
+     11          1           0       -1.906082   -1.635452    1.129729
+     12          1           0       -0.626383    1.558794    1.248825
+     13          1           0        1.679311   -0.239650    2.012984
+     14          1           0        3.170695    1.102264    0.034549
+     15          1           0        2.247019    0.278499   -2.046106
+     16          1           0       -0.231519   -0.329870   -2.291926
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.715929   0.000000
+     3  C    2.709093   1.516963   0.000000
+     4  C    3.970616   2.657663   1.415456   0.000000
+     5  C    5.108674   3.619175   2.433855   1.478661   0.000000
+     6  C    5.545241   4.256413   2.989665   2.585696   1.551563
+     7  C    4.792021   3.790172   2.626940   2.869049   2.446585
+     8  C    3.359919   2.617400   1.615632   2.516672   2.869269
+     9  H    4.972260   5.437961   4.783746   4.914044   6.159604
+    10  H    2.255624   1.079345   2.197786   3.304041   3.902261
+    11  H    2.298120   1.104732   2.163194   2.821273   3.843526
+    12  H    4.411519   3.386134   2.168420   1.084215   2.188533
+    13  H    5.552718   3.905667   3.072616   2.238714   1.112768
+    14  H    6.620576   5.342876   4.068921   3.537762   2.335888
+    15  H    5.479794   4.671850   3.621043   3.957420   3.466325
+    16  H    3.137728   2.961404   2.369385   3.485347   3.966639
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.337535   0.000000
+     8  C    2.497631   1.474421   0.000000
+     9  H    6.543349   6.147291   5.220250   0.000000
+    10  H    4.358919   3.838975   2.841493   6.444037   0.000000
+    11  H    4.809029   4.599447   3.567758   5.696032   1.735522
+    12  H    3.210656   3.537975   3.180498   4.193421   4.200516
+    13  H    2.230303   3.179667   3.631316   7.115332   3.985746
+    14  H    1.089382   2.112566   3.470325   7.276528   5.403402
+    15  H    2.098445   1.102390   2.196470   6.742403   4.609195
+    16  H    3.484028   2.270421   1.098516   5.186992   3.125819
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.443111   0.000000
+    13  H    3.947587   3.022344   0.000000
+    14  H    5.870960   4.012567   2.817652   0.000000
+    15  H    5.567529   4.555455   4.131221   2.420928   0.000000
+    16  H    4.026962   4.032355   4.710803   4.363319   2.563921
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6661256      0.9293834      0.8407677
+ Leave Link  202 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.0880086256 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071051139 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.0809035118 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2725 LenP2D=    7930.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.25D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:06:06 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:06:07 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.021890    0.030892   -0.064520
+         Rot=    0.999779    0.015327    0.014362   -0.000117 Ang=   2.41 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0267 S= 3.0038
+ Leave Link  401 at Sun Aug 11 02:06:07 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.887936614629
+ DIIS: error= 5.79D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.887936614629     IErMin= 1 ErrMin= 5.79D-03
+ ErrMax= 5.79D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.57D-02 BMatP= 5.57D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.707 Goal=     0.100 Shift=    0.000
+ T=  509. Gap= 0.324 NK=4 IS=   37 IE=   46 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.735 Goal=     0.100 Shift=    0.000
+ T=  509. Gap= 0.235 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.707 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=1.37D-03 MaxDP=1.85D-02              OVMax= 5.95D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.912526355914     Delta-E=       -0.024589741286 Rises=F Damp=F
+ DIIS: error= 3.13D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.912526355914     IErMin= 2 ErrMin= 3.13D-03
+ ErrMax= 3.13D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.48D-03 BMatP= 5.57D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.350D-01 0.965D+00
+ Coeff:      0.350D-01 0.965D+00
+ Gap=     0.329 Goal=     0.100 Shift=    0.000
+ T=  410. Gap= 0.330 NK=4 IS=   37 IE=   46 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ T=  410. Gap= 0.235 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.235 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=5.57D-04 MaxDP=2.32D-02 DE=-2.46D-02 OVMax= 3.54D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.915308972382     Delta-E=       -0.002782616468 Rises=F Damp=F
+ DIIS: error= 1.94D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.915308972382     IErMin= 3 ErrMin= 1.94D-03
+ ErrMax= 1.94D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.39D-03 BMatP= 6.48D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.890D-01 0.419D+00 0.670D+00
+ Coeff:     -0.890D-01 0.419D+00 0.670D+00
+ Gap=     0.330 Goal=     0.100 Shift=    0.000
+ T=  228. Gap= 0.330 NK=4 IS=   37 IE=   46 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ T=  228. Gap= 0.235 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.235 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.71D-04 MaxDP=8.20D-03 DE=-2.78D-03 OVMax= 2.83D-02
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.916765472931     Delta-E=       -0.001456500549 Rises=F Damp=F
+ DIIS: error= 8.37D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.916765472931     IErMin= 4 ErrMin= 8.37D-04
+ ErrMax= 8.37D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.41D-04 BMatP= 3.39D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.849D-02-0.768D-01 0.842D-01 0.100D+01
+ Coeff:     -0.849D-02-0.768D-01 0.842D-01 0.100D+01
+ Gap=     0.332 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=1.96D-04 MaxDP=7.94D-03 DE=-1.46D-03 OVMax= 1.72D-02
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.917241028509     Delta-E=       -0.000475555578 Rises=F Damp=F
+ DIIS: error= 8.14D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.917241028509     IErMin= 5 ErrMin= 8.14D-04
+ ErrMax= 8.14D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.31D-04 BMatP= 3.41D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.222D-01-0.138D+00-0.147D+00 0.272D+00 0.991D+00
+ Coeff:      0.222D-01-0.138D+00-0.147D+00 0.272D+00 0.991D+00
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=1.43D-04 MaxDP=4.79D-03 DE=-4.76D-04 OVMax= 1.75D-02
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.917493495564     Delta-E=       -0.000252467055 Rises=F Damp=F
+ DIIS: error= 3.62D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.917493495564     IErMin= 6 ErrMin= 3.62D-04
+ ErrMax= 3.62D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.41D-05 BMatP= 1.31D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.661D-02 0.130D-01-0.472D-01-0.374D+00 0.122D+00 0.128D+01
+ Coeff:      0.661D-02 0.130D-01-0.472D-01-0.374D+00 0.122D+00 0.128D+01
+ Gap=     0.334 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=1.39D-04 MaxDP=5.11D-03 DE=-2.52D-04 OVMax= 1.47D-02
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.917622429172     Delta-E=       -0.000128933608 Rises=F Damp=F
+ DIIS: error= 2.25D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.917622429172     IErMin= 7 ErrMin= 2.25D-04
+ ErrMax= 2.25D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.17D-05 BMatP= 4.41D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.382D-02 0.376D-01 0.275D-01-0.150D+00-0.195D+00 0.270D+00
+ Coeff-Com:  0.101D+01
+ Coeff:     -0.382D-02 0.376D-01 0.275D-01-0.150D+00-0.195D+00 0.270D+00
+ Coeff:      0.101D+01
+ Gap=     0.334 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=6.39D-05 MaxDP=2.75D-03 DE=-1.29D-04 OVMax= 6.58D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.917655590771     Delta-E=       -0.000033161599 Rises=F Damp=F
+ DIIS: error= 2.09D-04 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.917655590771     IErMin= 8 ErrMin= 2.09D-04
+ ErrMax= 2.09D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.83D-06 BMatP= 1.17D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.202D-02-0.442D-03 0.158D-01 0.877D-01-0.426D-01-0.335D+00
+ Coeff-Com:  0.122D+00 0.116D+01
+ Coeff:     -0.202D-02-0.442D-03 0.158D-01 0.877D-01-0.426D-01-0.335D+00
+ Coeff:      0.122D+00 0.116D+01
+ Gap=     0.334 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=4.57D-05 MaxDP=2.90D-03 DE=-3.32D-05 OVMax= 6.69D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.917674408327     Delta-E=       -0.000018817557 Rises=F Damp=F
+ DIIS: error= 1.99D-04 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.917674408327     IErMin= 9 ErrMin= 1.99D-04
+ ErrMax= 1.99D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.86D-06 BMatP= 4.83D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.134D-02-0.116D-01-0.963D-02 0.373D-01 0.595D-01-0.619D-01
+ Coeff-Com: -0.297D+00-0.401D-01 0.132D+01
+ Coeff:      0.134D-02-0.116D-01-0.963D-02 0.373D-01 0.595D-01-0.619D-01
+ Coeff:     -0.297D+00-0.401D-01 0.132D+01
+ Gap=     0.334 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=4.27D-05 MaxDP=3.27D-03 DE=-1.88D-05 OVMax= 7.42D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.917690392734     Delta-E=       -0.000015984407 Rises=F Damp=F
+ DIIS: error= 1.90D-04 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.917690392734     IErMin=10 ErrMin= 1.90D-04
+ ErrMax= 1.90D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.20D-06 BMatP= 2.86D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.578D-03 0.170D-02-0.478D-02-0.391D-01 0.557D-02 0.138D+00
+ Coeff-Com:  0.332D-02-0.427D+00-0.215D+00 0.154D+01
+ Coeff:      0.578D-03 0.170D-02-0.478D-02-0.391D-01 0.557D-02 0.138D+00
+ Coeff:      0.332D-02-0.427D+00-0.215D+00 0.154D+01
+ Gap=     0.334 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=4.79D-05 MaxDP=3.86D-03 DE=-1.60D-05 OVMax= 8.81D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.917707137052     Delta-E=       -0.000016744318 Rises=F Damp=F
+ DIIS: error= 1.77D-04 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.917707137052     IErMin=11 ErrMin= 1.77D-04
+ ErrMax= 1.77D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.88D-06 BMatP= 2.20D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.113D-02 0.760D-02 0.828D-02-0.127D-01-0.453D-01 0.499D-02
+ Coeff-Com:  0.212D+00 0.161D+00-0.918D+00-0.339D+00 0.192D+01
+ Coeff:     -0.113D-02 0.760D-02 0.828D-02-0.127D-01-0.453D-01 0.499D-02
+ Coeff:      0.212D+00 0.161D+00-0.918D+00-0.339D+00 0.192D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.235 Goal=     0.100 Shift=    0.000
+ RMSDP=6.99D-05 MaxDP=5.72D-03 DE=-1.67D-05 OVMax= 1.30D-02
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.917729581737     Delta-E=       -0.000022444685 Rises=F Damp=F
+ DIIS: error= 1.59D-04 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.917729581737     IErMin=12 ErrMin= 1.59D-04
+ ErrMax= 1.59D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.56D-06 BMatP= 1.88D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.547D-03-0.383D-02 0.487D-02 0.590D-01-0.232D-02-0.195D+00
+ Coeff-Com: -0.450D-01 0.584D+00 0.395D+00-0.191D+01-0.425D+00 0.254D+01
+ Coeff:     -0.547D-03-0.383D-02 0.487D-02 0.590D-01-0.232D-02-0.195D+00
+ Coeff:     -0.450D-01 0.584D+00 0.395D+00-0.191D+01-0.425D+00 0.254D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=1.37D-04 MaxDP=1.12D-02 DE=-2.24D-05 OVMax= 2.56D-02
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.917766896185     Delta-E=       -0.000037314448 Rises=F Damp=F
+ DIIS: error= 1.21D-04 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.917766896185     IErMin=13 ErrMin= 1.21D-04
+ ErrMax= 1.21D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.05D-06 BMatP= 1.56D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.154D-02-0.144D-01-0.103D-01 0.503D-01 0.715D-01-0.110D+00
+ Coeff-Com: -0.358D+00 0.106D-01 0.157D+01-0.184D+00-0.311D+01 0.907D+00
+ Coeff-Com:  0.218D+01
+ Coeff:      0.154D-02-0.144D-01-0.103D-01 0.503D-01 0.715D-01-0.110D+00
+ Coeff:     -0.358D+00 0.106D-01 0.157D+01-0.184D+00-0.311D+01 0.907D+00
+ Coeff:      0.218D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=2.40D-04 MaxDP=1.92D-02 DE=-3.73D-05 OVMax= 4.47D-02
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.917809862826     Delta-E=       -0.000042966641 Rises=F Damp=F
+ DIIS: error= 5.94D-05 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.917809862826     IErMin=14 ErrMin= 5.94D-05
+ ErrMax= 5.94D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.03D-07 BMatP= 1.05D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.711D-03-0.434D-02-0.478D-02 0.181D-02 0.259D-01 0.132D-01
+ Coeff-Com: -0.106D+00-0.190D+00 0.492D+00 0.508D+00-0.100D+01-0.461D+00
+ Coeff-Com:  0.806D+00 0.920D+00
+ Coeff:      0.711D-03-0.434D-02-0.478D-02 0.181D-02 0.259D-01 0.132D-01
+ Coeff:     -0.106D+00-0.190D+00 0.492D+00 0.508D+00-0.100D+01-0.461D+00
+ Coeff:      0.806D+00 0.920D+00
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.98D-05 MaxDP=5.56D-03 DE=-4.30D-05 OVMax= 1.30D-02
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.917817160444     Delta-E=       -0.000007297618 Rises=F Damp=F
+ DIIS: error= 4.13D-05 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.917817160444     IErMin=15 ErrMin= 4.13D-05
+ ErrMax= 4.13D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.18D-07 BMatP= 5.03D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.475D-03 0.310D-02 0.339D-02-0.381D-02-0.179D-01-0.922D-03
+ Coeff-Com:  0.893D-01 0.697D-01-0.345D+00-0.238D+00 0.679D+00 0.808D-01
+ Coeff-Com: -0.651D+00-0.810D+00 0.214D+01
+ Coeff:     -0.475D-03 0.310D-02 0.339D-02-0.381D-02-0.179D-01-0.922D-03
+ Coeff:      0.893D-01 0.697D-01-0.345D+00-0.238D+00 0.679D+00 0.808D-01
+ Coeff:     -0.651D+00-0.810D+00 0.214D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=1.22D-04 MaxDP=9.58D-03 DE=-7.30D-06 OVMax= 2.27D-02
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.917823849380     Delta-E=       -0.000006688936 Rises=F Damp=F
+ DIIS: error= 1.33D-05 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.917823849380     IErMin=16 ErrMin= 1.33D-05
+ ErrMax= 1.33D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.08D-08 BMatP= 2.18D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.115D-03-0.395D-03 0.820D-03 0.107D-01-0.178D-02-0.335D-01
+ Coeff-Com: -0.401D-02 0.111D+00 0.272D-01-0.368D+00-0.224D-01 0.453D+00
+ Coeff-Com: -0.119D+00-0.861D+00 0.865D+00 0.943D+00
+ Coeff:     -0.115D-03-0.395D-03 0.820D-03 0.107D-01-0.178D-02-0.335D-01
+ Coeff:     -0.401D-02 0.111D+00 0.272D-01-0.368D+00-0.224D-01 0.453D+00
+ Coeff:     -0.119D+00-0.861D+00 0.865D+00 0.943D+00
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=3.87D-05 MaxDP=3.02D-03 DE=-6.69D-06 OVMax= 7.24D-03
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.917824412958     Delta-E=       -0.000000563578 Rises=F Damp=F
+ DIIS: error= 7.59D-06 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.917824412958     IErMin=17 ErrMin= 7.59D-06
+ ErrMax= 7.59D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.17D-09 BMatP= 7.08D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.905D-04-0.134D-02-0.627D-03 0.742D-02 0.484D-02-0.200D-01
+ Coeff-Com: -0.298D-01 0.385D-01 0.142D+00-0.136D+00-0.256D+00 0.233D+00
+ Coeff-Com:  0.172D+00-0.186D+00-0.166D+00 0.184D+00 0.101D+01
+ Coeff:      0.905D-04-0.134D-02-0.627D-03 0.742D-02 0.484D-02-0.200D-01
+ Coeff:     -0.298D-01 0.385D-01 0.142D+00-0.136D+00-0.256D+00 0.233D+00
+ Coeff:      0.172D+00-0.186D+00-0.166D+00 0.184D+00 0.101D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=5.87D-06 MaxDP=4.67D-04 DE=-5.64D-07 OVMax= 1.09D-03
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.917824434593     Delta-E=       -0.000000021635 Rises=F Damp=F
+ DIIS: error= 1.29D-06 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.917824434593     IErMin=18 ErrMin= 1.29D-06
+ ErrMax= 1.29D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.04D-10 BMatP= 9.17D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.339D-04-0.202D-03-0.269D-03-0.855D-07 0.137D-02 0.549D-03
+ Coeff-Com: -0.544D-02-0.749D-02 0.211D-01 0.263D-01-0.505D-01-0.201D-01
+ Coeff-Com:  0.417D-01 0.485D-01-0.661D-01-0.508D-01 0.538D-01 0.101D+01
+ Coeff:      0.339D-04-0.202D-03-0.269D-03-0.855D-07 0.137D-02 0.549D-03
+ Coeff:     -0.544D-02-0.749D-02 0.211D-01 0.263D-01-0.505D-01-0.201D-01
+ Coeff:      0.417D-01 0.485D-01-0.661D-01-0.508D-01 0.538D-01 0.101D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=2.24D-06 MaxDP=1.68D-04 DE=-2.16D-08 OVMax= 4.16D-04
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.917824436423     Delta-E=       -0.000000001830 Rises=F Damp=F
+ DIIS: error= 7.50D-07 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.917824436423     IErMin=19 ErrMin= 7.50D-07
+ ErrMax= 7.50D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.10D-10 BMatP= 3.04D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.818D-05 0.120D-03 0.598D-04-0.683D-03-0.368D-03 0.179D-02
+ Coeff-Com:  0.262D-02-0.369D-02-0.122D-01 0.129D-01 0.219D-01-0.199D-01
+ Coeff-Com: -0.138D-01 0.250D-01 0.527D-03-0.342D-01-0.132D+00 0.965D-01
+ Coeff-Com:  0.106D+01
+ Coeff:     -0.818D-05 0.120D-03 0.598D-04-0.683D-03-0.368D-03 0.179D-02
+ Coeff:      0.262D-02-0.369D-02-0.122D-01 0.129D-01 0.219D-01-0.199D-01
+ Coeff:     -0.138D-01 0.250D-01 0.527D-03-0.342D-01-0.132D+00 0.965D-01
+ Coeff:      0.106D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=2.83D-07 MaxDP=1.89D-05 DE=-1.83D-09 OVMax= 4.81D-05
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.917824436568     Delta-E=       -0.000000000145 Rises=F Damp=F
+ DIIS: error= 2.44D-07 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.917824436568     IErMin=20 ErrMin= 2.44D-07
+ ErrMax= 2.44D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.33D-11 BMatP= 1.10D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.717D-05 0.697D-04 0.513D-04-0.245D-03-0.299D-03 0.576D-03
+ Coeff-Com:  0.160D-02-0.168D-03-0.758D-02 0.122D-02 0.144D-01-0.475D-02
+ Coeff-Com: -0.117D-01-0.964D-03 0.184D-01 0.845D-03-0.592D-01-0.109D+00
+ Coeff-Com:  0.391D+00 0.766D+00
+ Coeff:     -0.717D-05 0.697D-04 0.513D-04-0.245D-03-0.299D-03 0.576D-03
+ Coeff:      0.160D-02-0.168D-03-0.758D-02 0.122D-02 0.144D-01-0.475D-02
+ Coeff:     -0.117D-01-0.964D-03 0.184D-01 0.845D-03-0.592D-01-0.109D+00
+ Coeff:      0.391D+00 0.766D+00
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=6.68D-08 MaxDP=2.63D-06 DE=-1.45D-10 OVMax= 9.92D-06
+
+ Cycle  21  Pass 1  IDiag  1:
+ E= -668.917824436579     Delta-E=       -0.000000000011 Rises=F Damp=F
+ DIIS: error= 1.50D-07 at cycle  21 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.917824436579     IErMin=20 ErrMin= 1.50D-07
+ ErrMax= 1.50D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.04D-12 BMatP= 2.33D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.112D-04-0.115D-05 0.973D-04 0.167D-04-0.281D-03-0.252D-03
+ Coeff-Com:  0.819D-03 0.122D-02-0.260D-02-0.192D-02 0.355D-02 0.112D-02
+ Coeff-Com: -0.428D-02-0.176D-04 0.584D-02 0.216D-01-0.414D-01-0.153D+00
+ Coeff-Com:  0.392D-01 0.113D+01
+ Coeff:     -0.112D-04-0.115D-05 0.973D-04 0.167D-04-0.281D-03-0.252D-03
+ Coeff:      0.819D-03 0.122D-02-0.260D-02-0.192D-02 0.355D-02 0.112D-02
+ Coeff:     -0.428D-02-0.176D-04 0.584D-02 0.216D-01-0.414D-01-0.153D+00
+ Coeff:      0.392D-01 0.113D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=3.51D-08 MaxDP=2.23D-06 DE=-1.11D-11 OVMax= 5.68D-06
+
+ Cycle  22  Pass 1  IDiag  1:
+ E= -668.917824436582     Delta-E=       -0.000000000003 Rises=F Damp=F
+ DIIS: error= 4.71D-08 at cycle  22 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.917824436582     IErMin=20 ErrMin= 4.71D-08
+ ErrMax= 4.71D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.37D-13 BMatP= 2.04D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.217D-06-0.681D-05 0.356D-05 0.870D-05-0.264D-04-0.773D-04
+ Coeff-Com:  0.201D-03 0.253D-03-0.448D-03-0.226D-03 0.692D-03 0.884D-03
+ Coeff-Com: -0.214D-02-0.113D-02 0.424D-02 0.155D-01-0.261D-01-0.133D+00
+ Coeff-Com: -0.667D-01 0.121D+01
+ Coeff:     -0.217D-06-0.681D-05 0.356D-05 0.870D-05-0.264D-04-0.773D-04
+ Coeff:      0.201D-03 0.253D-03-0.448D-03-0.226D-03 0.692D-03 0.884D-03
+ Coeff:     -0.214D-02-0.113D-02 0.424D-02 0.155D-01-0.261D-01-0.133D+00
+ Coeff:     -0.667D-01 0.121D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=1.42D-08 MaxDP=7.31D-07 DE=-2.73D-12 OVMax= 2.01D-06
+
+ Cycle  23  Pass 1  IDiag  1:
+ E= -668.917824436577     Delta-E=        0.000000000005 Rises=F Damp=F
+ DIIS: error= 1.59D-08 at cycle  23 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.917824436582     IErMin=20 ErrMin= 1.59D-08
+ ErrMax= 1.59D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.60D-14 BMatP= 3.37D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.414D-05 0.393D-05 0.128D-04-0.644D-06-0.671D-04-0.246D-04
+ Coeff-Com:  0.256D-03 0.410D-04-0.383D-03 0.178D-05 0.666D-03-0.310D-03
+ Coeff-Com: -0.761D-03-0.164D-02 0.663D-02 0.237D-01-0.299D-01-0.151D+00
+ Coeff-Com:  0.610D-01 0.109D+01
+ Coeff:     -0.414D-05 0.393D-05 0.128D-04-0.644D-06-0.671D-04-0.246D-04
+ Coeff:      0.256D-03 0.410D-04-0.383D-03 0.178D-05 0.666D-03-0.310D-03
+ Coeff:     -0.761D-03-0.164D-02 0.663D-02 0.237D-01-0.299D-01-0.151D+00
+ Coeff:      0.610D-01 0.109D+01
+ Gap=     0.333 Goal=     0.100 Shift=    0.000
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ RMSDP=4.41D-09 MaxDP=1.89D-07 DE= 5.00D-12 OVMax= 4.21D-07
+
+ SCF Done:  E(UwB97XD) =  -668.917824437     A.U. after   23 cycles
+            NFock= 23  Conv=0.44D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0296 S= 3.0042
+ <L.S>= 0.000000000000E+00
+ KE= 6.650133436452D+02 PE=-2.332932916958D+03 EE= 6.189208453647D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0296,   after    12.0002
+ Leave Link  502 at Sun Aug 11 02:07:37 2024, MaxMem=  4294967296 cpu:      1434.3
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:07:37 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2725 LenP2D=    7930.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:07:37 2024, MaxMem=  4294967296 cpu:         1.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:07:37 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:       113.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 5.34155276D-01-1.29873878D-01 1.45684914D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.034629385   -0.001293334   -0.029989440
+      2        6           0.018620229    0.029006329    0.036990449
+      3        6           0.009769879   -0.026167915   -0.074394950
+      4        6           0.022520261    0.006206060    0.019289800
+      5        6           0.029918198   -0.007062080   -0.007472373
+      6        6          -0.024920681    0.009031540    0.049847682
+      7        6          -0.045951140   -0.017713178   -0.051419122
+      8        6           0.013972002    0.008425734    0.044543631
+      9        1          -0.000014283    0.000015758   -0.000008868
+     10        1           0.015510085   -0.015914775   -0.001727284
+     11        1           0.002674486   -0.001558987    0.002087695
+     12        1          -0.005687367    0.011083538    0.001419758
+     13        1          -0.004451011    0.007716532   -0.000864989
+     14        1           0.002972986   -0.002271864    0.005530140
+     15        1          -0.003384121   -0.000793538    0.002181864
+     16        1           0.003079864    0.001290181    0.003986006
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.074394950 RMS     0.022469185
+ Leave Link  716 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.045836189 RMS     0.012495281
+ Search for a local minimum.
+ Step number  77 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .12495D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   77
+                                                     76
+ ITU=  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0  0
+ ITU=  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1  1
+ ITU=  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0  0
+ ITU= -1  0  0  0  1  0  0  1  0  0  0  0  0  0  1
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99917.
+ Iteration  1 RMS(Cart)=  0.18603161 RMS(Int)=  0.01452644
+ Iteration  2 RMS(Cart)=  0.02214305 RMS(Int)=  0.00010280
+ Iteration  3 RMS(Cart)=  0.00014626 RMS(Int)=  0.00000066
+ Iteration  4 RMS(Cart)=  0.00000001 RMS(Int)=  0.00000066
+ ITry= 1 IFail=0 DXMaxC= 1.15D+00 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=T
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.24264   0.04584   0.19543   0.00000   0.19543   3.43807
+    R2        9.39621   0.00002   0.08402   0.00000   0.08402   9.48023
+    R3        2.86665  -0.00940  -0.05282   0.00000  -0.05282   2.81382
+    R4        2.03967   0.02167   0.06361   0.00000   0.06361   2.10328
+    R5        2.08764   0.00108  -0.00686   0.00000  -0.00686   2.08078
+    R6        2.67482   0.03374   0.12422   0.00000   0.12422   2.79904
+    R7        3.05310  -0.04374  -0.24625   0.00000  -0.24625   2.80686
+    R8        2.79427  -0.00471  -0.00568   0.00000  -0.00568   2.78858
+    R9        2.04887   0.01251   0.03206   0.00000   0.03206   2.08093
+   R10        2.93203  -0.03241  -0.12277   0.00000  -0.12277   2.80925
+   R11        2.10283  -0.00725  -0.02402   0.00000  -0.02402   2.07881
+   R12        2.52757   0.04007   0.12439   0.00000   0.12439   2.65196
+   R13        2.05863   0.00174   0.00811   0.00000   0.00811   2.06674
+   R14        2.78625  -0.04150  -0.16020   0.00000  -0.16020   2.62605
+   R15        2.08321  -0.00372  -0.01576   0.00000  -0.01576   2.06746
+   R16        2.07589  -0.00506  -0.00888   0.00000  -0.00888   2.06702
+    A1        1.68259   0.00013   0.04968   0.00000   0.04968   1.73226
+    A2        1.98466   0.00206   0.00837   0.00000   0.00837   1.99303
+    A3        1.83812   0.00292  -0.03636   0.00000  -0.03636   1.80176
+    A4        1.86972   0.00179   0.03109   0.00000   0.03109   1.90081
+    A5        2.00046  -0.00595  -0.04692   0.00000  -0.04692   1.95354
+    A6        1.92350  -0.00019   0.02891   0.00000   0.02891   1.95241
+    A7        1.83668  -0.00028   0.01474   0.00000   0.01474   1.85142
+    A8        2.26835  -0.01213  -0.13652   0.00000  -0.13652   2.13183
+    A9        1.97757   0.01032   0.12077   0.00000   0.12077   2.09834
+   A10        1.95631   0.00161   0.01805   0.00000   0.01805   1.97436
+   A11        1.99783   0.00193  -0.03238   0.00000  -0.03238   1.96545
+   A12        2.09002  -0.00308  -0.02439   0.00000  -0.02439   2.06563
+   A13        2.03228   0.00167   0.03399   0.00000   0.03399   2.06627
+   A14        2.04422  -0.01716  -0.07613   0.00000  -0.07613   1.96809
+   A15        2.07407   0.00476   0.00322   0.00000   0.00322   2.07729
+   A16        1.96576   0.00989   0.10378   0.00000   0.10378   2.06954
+   A17        2.01654   0.01069   0.05233   0.00000   0.05233   2.06887
+   A18        2.15422  -0.01026  -0.04325   0.00000  -0.04325   2.11097
+   A19        2.10636  -0.00009  -0.00519   0.00000  -0.00519   2.10118
+   A20        2.18568  -0.00456  -0.05023   0.00000  -0.05023   2.13544
+   A21        2.06516   0.00413   0.00690   0.00000   0.00690   2.07206
+   A22        2.02809   0.00054   0.04451   0.00000   0.04451   2.07260
+   A23        2.03116   0.00574   0.05100   0.00000   0.05100   2.08216
+   A24        2.10163  -0.00163  -0.01107   0.00000  -0.01106   2.09056
+   A25        2.15040  -0.00411  -0.04051   0.00000  -0.04051   2.10988
+    D1       -0.54196  -0.00214   0.09221   0.00000   0.09221  -0.44975
+    D2       -2.74633   0.00193   0.17162   0.00000   0.17162  -2.57471
+    D3        1.58762   0.00021   0.15887   0.00000   0.15887   1.74649
+    D4        2.35599   0.00049   0.03550   0.00000   0.03549   2.39148
+    D5       -1.24733   0.00143   0.05284   0.00000   0.05284  -1.19448
+    D6       -1.81117   0.00138  -0.04140   0.00000  -0.04140  -1.85258
+    D7        0.86869   0.00232  -0.02405   0.00000  -0.02405   0.84464
+    D8        0.25647  -0.00309  -0.03388   0.00000  -0.03388   0.22259
+    D9        2.93634  -0.00215  -0.01654   0.00000  -0.01653   2.91980
+   D10        1.86973  -0.00236   0.00117   0.00000   0.00117   1.87090
+   D11       -1.87506  -0.00082  -0.02229   0.00000  -0.02229  -1.89735
+   D12       -0.81454  -0.00516  -0.04039   0.00000  -0.04038  -0.85493
+   D13        1.72386  -0.00362  -0.06385   0.00000  -0.06385   1.66001
+   D14       -2.29473   0.00152   0.01855   0.00000   0.01856  -2.27618
+   D15        0.84494   0.00229   0.05658   0.00000   0.05658   0.90152
+   D16        0.46949  -0.00202  -0.01100   0.00000  -0.01100   0.45849
+   D17       -2.67402  -0.00125   0.02702   0.00000   0.02702  -2.64700
+   D18        0.86264  -0.00248   0.02481   0.00000   0.02481   0.88746
+   D19       -1.59575  -0.00234  -0.05954   0.00000  -0.05953  -1.65528
+   D20       -1.69653  -0.00225   0.06930   0.00000   0.06930  -1.62723
+   D21        2.12827  -0.00211  -0.01505   0.00000  -0.01505   2.11322
+   D22       -0.48488  -0.00081  -0.03990   0.00000  -0.03990  -0.52477
+   D23        2.53916   0.00253   0.00723   0.00000   0.00723   2.54639
+   D24        2.01430  -0.00206   0.00656   0.00000   0.00656   2.02086
+   D25       -1.24485   0.00128   0.05369   0.00000   0.05369  -1.19116
+   D26        0.13789  -0.00025  -0.01029   0.00000  -0.01029   0.12760
+   D27       -3.10670   0.00121   0.00742   0.00000   0.00742  -3.09928
+   D28       -2.88963  -0.00273  -0.05434   0.00000  -0.05434  -2.94397
+   D29        0.14897  -0.00126  -0.03663   0.00000  -0.03663   0.11234
+   D30       -0.13361   0.00198   0.03947   0.00000   0.03947  -0.09415
+   D31        3.00996   0.00118   0.00097   0.00000   0.00097   3.01093
+   D32        3.10902   0.00034   0.02374   0.00000   0.02374   3.13276
+   D33       -0.03060  -0.00046  -0.01475   0.00000  -0.01475  -0.04535
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.045836     0.000450     NO
+ RMS     Force            0.012495     0.000300     NO
+ Maximum Displacement     1.151160     0.001800     NO
+ RMS     Displacement     0.198533     0.001200     NO
+ Predicted change in Energy=-4.438988D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.889960   -1.572651   -0.909020
+      2          6           0       -1.432697   -1.488338    0.176936
+      3          6           0       -0.617677   -0.253463    0.009667
+      4          6           0       -0.075100    0.495427    1.166688
+      5          6           0        1.383322    0.328391    1.317222
+      6          6           0        2.125851    0.594414    0.057125
+      7          6           0        1.488728    0.330179   -1.165031
+      8          6           0        0.147978   -0.026834   -1.242771
+      9          1           0       -3.645312    3.334547   -1.627577
+     10          1           0       -0.860347   -2.403888   -0.093183
+     11          1           0       -1.756498   -1.627796    1.220069
+     12          1           0       -0.517984    1.473657    1.410659
+     13          1           0        1.764174   -0.446543    1.998805
+     14          1           0        3.120747    1.048241    0.075629
+     15          1           0        2.046303    0.486730   -2.093228
+     16          1           0       -0.356023   -0.109102   -2.210063
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819347   0.000000
+     3  C    2.783435   1.489011   0.000000
+     4  C    4.063120   2.599616   1.481190   0.000000
+     5  C    5.179869   3.539875   2.460132   1.475654   0.000000
+     6  C    5.548690   4.124981   2.871949   2.466802   1.486594
+     7  C    4.781131   3.693589   2.481430   2.812432   2.484490
+     8  C    3.424910   2.578778   1.485325   2.475482   2.864581
+     9  H    5.016720   5.604655   4.972017   5.349293   6.557131
+    10  H    2.340059   1.113005   2.166517   3.257287   3.806395
+    11  H    2.412632   1.101100   2.156566   2.708879   3.700618
+    12  H    4.504128   3.336493   2.226131   1.101182   2.221559
+    13  H    5.602189   3.824203   3.109207   2.227702   1.100058
+    14  H    6.630777   5.213286   3.959116   3.421908   2.253527
+    15  H    5.478147   4.599780   3.473736   3.889406   3.477899
+    16  H    3.202425   2.959609   2.239755   3.441921   3.957077
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403357   0.000000
+     8  C    2.446970   1.389645   0.000000
+     9  H    6.607033   5.966452   5.082913   0.000000
+    10  H    4.234358   3.760603   2.826422   6.560491   0.000000
+    11  H    4.622043   4.478153   3.500813   6.025077   1.769191
+    12  H    3.097577   3.459568   3.120204   4.740672   4.173022
+    13  H    2.232604   3.269408   3.646377   7.530593   3.885322
+    14  H    1.093673   2.172173   3.425102   7.342184   5.272078
+    15  H    2.154517   1.094051   2.142583   6.381331   4.561191
+    16  H    3.434353   2.165218   1.093818   4.797649   3.162526
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.345034   0.000000
+    13  H    3.794327   3.039955   0.000000
+    14  H    5.679651   3.899186   2.788060   0.000000
+    15  H    5.469044   4.452731   4.206582   2.484686   0.000000
+    16  H    4.004194   3.954869   4.724794   4.318769   2.477870
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6870854      0.9256736      0.8388269
+ Leave Link  202 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4740643129 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071839955 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4668803174 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.000006    0.000074   -0.000049
+         Rot=    1.000000    0.000136    0.000050    0.000108 Ang=   0.02 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=    -0.020069   -0.032763    0.064103
+         Rot=    0.999782   -0.015193   -0.014310    0.000226 Ang=  -2.39 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 8.35D-04
+ Max alpha theta=  8.765 degrees.
+ Max  beta theta= 11.743 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:07:44 2024, MaxMem=  4294967296 cpu:         2.3
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943627369283
+ DIIS: error= 1.03D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943627369283     IErMin= 1 ErrMin= 1.03D-06
+ ErrMax= 1.03D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.55D-10 BMatP= 9.55D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    79.052 Goal=     0.100 Shift=    0.000
+ Gap=    76.921 Goal=     0.100 Shift=    0.000
+ RMSDP=1.86D-07 MaxDP=3.26D-06              OVMax= 8.14D-06
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943627369592     Delta-E=       -0.000000000309 Rises=F Damp=F
+ DIIS: error= 2.50D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943627369592     IErMin= 2 ErrMin= 2.50D-07
+ ErrMax= 2.50D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.45D-11 BMatP= 9.55D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.821D-02 0.101D+01
+ Coeff:     -0.821D-02 0.101D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.18D-08 MaxDP=2.00D-06 DE=-3.09D-10 OVMax= 4.55D-06
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943627369626     Delta-E=       -0.000000000034 Rises=F Damp=F
+ DIIS: error= 2.15D-07 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943627369626     IErMin= 3 ErrMin= 2.15D-07
+ ErrMax= 2.15D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.54D-11 BMatP= 6.45D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.634D-01 0.471D+00 0.593D+00
+ Coeff:     -0.634D-01 0.471D+00 0.593D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.27D-08 MaxDP=8.32D-07 DE=-3.43D-11 OVMax= 2.68D-06
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943627369649     Delta-E=       -0.000000000023 Rises=F Damp=F
+ DIIS: error= 8.38D-08 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943627369649     IErMin= 4 ErrMin= 8.38D-08
+ ErrMax= 8.38D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.82D-12 BMatP= 4.54D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.728D-03-0.157D+00 0.830D-02 0.115D+01
+ Coeff:      0.728D-03-0.157D+00 0.830D-02 0.115D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.40D-08 MaxDP=7.69D-07 DE=-2.30D-11 OVMax= 1.87D-06
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943627369642     Delta-E=        0.000000000007 Rises=F Damp=F
+ DIIS: error= 6.71D-08 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 4 EnMin= -668.943627369649     IErMin= 5 ErrMin= 6.71D-08
+ ErrMax= 6.71D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.29D-12 BMatP= 3.82D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.124D-01-0.139D+00-0.111D+00 0.337D+00 0.900D+00
+ Coeff:      0.124D-01-0.139D+00-0.111D+00 0.337D+00 0.900D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.27D-08 MaxDP=4.32D-07 DE= 6.59D-12 OVMax= 1.41D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943627369642     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 3.84D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 4 EnMin= -668.943627369649     IErMin= 6 ErrMin= 3.84D-08
+ ErrMax= 3.84D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.03D-13 BMatP= 1.29D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.534D-03 0.601D-01 0.473D-02-0.423D+00 0.336D-02 0.136D+01
+ Coeff:     -0.534D-03 0.601D-01 0.473D-02-0.423D+00 0.336D-02 0.136D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.24D-08 MaxDP=4.91D-07 DE=-2.27D-13 OVMax= 1.29D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943627369640     Delta-E=        0.000000000002 Rises=F Damp=F
+ DIIS: error= 2.32D-08 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 4 EnMin= -668.943627369649     IErMin= 7 ErrMin= 2.32D-08
+ ErrMax= 2.32D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.05D-13 BMatP= 4.03D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.283D-02 0.363D-01 0.283D-01-0.108D+00-0.198D+00 0.377D-01
+ Coeff-Com:  0.121D+01
+ Coeff:     -0.283D-02 0.363D-01 0.283D-01-0.108D+00-0.198D+00 0.377D-01
+ Coeff:      0.121D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.01D-09 MaxDP=2.80D-07 DE= 2.27D-12 OVMax= 6.99D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627370     A.U. after    7 cycles
+            NFock=  7  Conv=0.70D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650254007728D+02 PE=-2.333716624369D+03 EE= 6.192807159096D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:08:13 2024, MaxMem=  4294967296 cpu:       450.7
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:08:13 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:08:13 2024, MaxMem=  4294967296 cpu:         1.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:08:13 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:       114.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.04276347D-01-4.91284135D-02 1.12734893D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000008773   -0.000005080   -0.000004021
+      2        6          -0.000011333    0.000003462   -0.000021598
+      3        6          -0.000011192    0.000020823   -0.000035982
+      4        6           0.000049730    0.000020469    0.000020580
+      5        6          -0.000012716    0.000003219    0.000007708
+      6        6           0.000026543   -0.000006529    0.000007393
+      7        6          -0.000040861    0.000003696   -0.000014668
+      8        6           0.000002198   -0.000023971   -0.000005039
+      9        1           0.000006600   -0.000004806    0.000004790
+     10        1           0.000008767   -0.000017614   -0.000003459
+     11        1          -0.000000903    0.000004464    0.000005931
+     12        1          -0.000020009    0.000003607    0.000012123
+     13        1           0.000008513   -0.000003510    0.000008511
+     14        1          -0.000003488    0.000010455    0.000010932
+     15        1           0.000008438   -0.000011566    0.000000557
+     16        1          -0.000001512    0.000002881    0.000006241
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000049730 RMS     0.000015268
+ Leave Link  716 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000062292 RMS     0.000012811
+ Search for a local minimum.
+ Step number  78 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .12811D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   78
+ ITU=  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1  0
+ ITU=  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1 -1
+ ITU=  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1  0
+ ITU=  0 -1  0  0  0  1  0  0  1  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.00099   0.00000   0.00000   0.00017   0.00043
+     Eigenvalues ---    0.00422   0.00561   0.00901   0.01097   0.01790
+     Eigenvalues ---    0.01889   0.02314   0.02828   0.03379   0.04428
+     Eigenvalues ---    0.07910   0.08084   0.09120   0.10058   0.10261
+     Eigenvalues ---    0.10969   0.11285   0.11768   0.13024   0.14481
+     Eigenvalues ---    0.14771   0.17498   0.18350   0.23513   0.24353
+     Eigenvalues ---    0.27929   0.33231   0.34038   0.34518   0.35913
+     Eigenvalues ---    0.38085   0.38223   0.38465   0.38590   0.39091
+     Eigenvalues ---    0.39968   0.47596
+ Eigenvalue     1 is  -9.86D-04 should be greater than     0.000000 Eigenvector:
+                          D3        D25       D2        D14       D1
+   1                   -0.26827  -0.26632  -0.26514  -0.26194  -0.26083
+                          D11       D15       D7        D10       D23
+   1                    0.25931  -0.24434   0.22777   0.22701  -0.21929
+ RFO step:  Lambda=-9.85952799D-04 EMin=-9.85520665D-04
+ I=     1 Eig=   -9.86D-04 Dot1=  1.23D-05
+ I=     1 Stepn=  6.00D-01 RXN=   6.00D-01 EDone=F
+ Mixed    1 eigenvectors in step.  Raw Step.Grad=  1.23D-05.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  6.00D-01 in eigenvector direction(s).  Step.Grad=  2.89D-06.
+ Quartic linear search produced a step of -0.01085.
+ Iteration  1 RMS(Cart)=  0.11099745 RMS(Int)=  0.00571832
+ Iteration  2 RMS(Cart)=  0.01122522 RMS(Int)=  0.00039232
+ Iteration  3 RMS(Cart)=  0.00005121 RMS(Int)=  0.00039015
+ Iteration  4 RMS(Cart)=  0.00000001 RMS(Int)=  0.00039015
+ ITry= 1 IFail=0 DXMaxC= 4.12D-01 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43807   0.00000   0.00000   0.00572   0.00572   3.44379
+    R2        9.48023  -0.00001   0.00000  -0.09460  -0.09460   9.38563
+    R3        2.81382   0.00002   0.00000   0.01278   0.01278   2.82661
+    R4        2.10328   0.00002   0.00000   0.01323   0.01323   2.11650
+    R5        2.08078   0.00001   0.00000   0.00540   0.00540   2.08618
+    R6        2.79904   0.00005   0.00000   0.02139   0.02130   2.82034
+    R7        2.80686  -0.00002   0.00000  -0.03098  -0.03120   2.77566
+    R8        2.78858   0.00000   0.00000   0.00759   0.00763   2.79621
+    R9        2.08093   0.00001   0.00000   0.00730   0.00730   2.08824
+   R10        2.80925   0.00001   0.00000  -0.00873  -0.00850   2.80075
+   R11        2.07881   0.00001   0.00000   0.00030   0.00030   2.07911
+   R12        2.65196   0.00004   0.00000   0.04138   0.04151   2.69347
+   R13        2.06674   0.00000   0.00000   0.00201   0.00201   2.06875
+   R14        2.62605  -0.00001   0.00000  -0.04255  -0.04263   2.58342
+   R15        2.06746   0.00000   0.00000   0.00065   0.00065   2.06810
+   R16        2.06702   0.00000   0.00000   0.00062   0.00062   2.06763
+    A1        1.73226  -0.00006   0.00000  -0.03043  -0.03043   1.70183
+    A2        1.99303  -0.00001   0.00000  -0.00062  -0.00059   1.99244
+    A3        1.80176   0.00001   0.00000   0.01240   0.01238   1.81413
+    A4        1.90081   0.00000   0.00000   0.02379   0.02380   1.92461
+    A5        1.95354   0.00001   0.00000  -0.00441  -0.00450   1.94904
+    A6        1.95241   0.00000   0.00000  -0.01740  -0.01747   1.93494
+    A7        1.85142   0.00000   0.00000  -0.01181  -0.01207   1.83935
+    A8        2.13183   0.00002   0.00000  -0.00465  -0.00504   2.12679
+    A9        2.09834  -0.00002   0.00000   0.01340   0.01331   2.11165
+   A10        1.97436   0.00001   0.00000   0.01600   0.01444   1.98880
+   A11        1.96545   0.00000   0.00000   0.01111   0.00993   1.97538
+   A12        2.06563  -0.00001   0.00000  -0.01426  -0.01387   2.05176
+   A13        2.06627   0.00001   0.00000   0.01274   0.01327   2.07953
+   A14        1.96809  -0.00001   0.00000  -0.01309  -0.01334   1.95475
+   A15        2.07729   0.00001   0.00000  -0.00623  -0.00654   2.07075
+   A16        2.06954   0.00000   0.00000   0.00294   0.00284   2.07238
+   A17        2.06887   0.00000   0.00000  -0.00862  -0.00960   2.05927
+   A18        2.11097  -0.00001   0.00000  -0.00209  -0.00274   2.10823
+   A19        2.10118   0.00001   0.00000   0.00616   0.00536   2.10654
+   A20        2.13544   0.00001   0.00000   0.00083   0.00017   2.13561
+   A21        2.07206  -0.00001   0.00000  -0.00723  -0.00697   2.06510
+   A22        2.07260   0.00000   0.00000   0.00769   0.00794   2.08054
+   A23        2.08216  -0.00001   0.00000   0.02102   0.02008   2.10225
+   A24        2.09056   0.00000   0.00000  -0.02063  -0.02018   2.07038
+   A25        2.10988   0.00001   0.00000  -0.00073  -0.00030   2.10959
+    D1       -0.44975   0.00000   0.00000  -0.15650  -0.15650  -0.60625
+    D2       -2.57471   0.00000   0.00000  -0.15909  -0.15902  -2.73373
+    D3        1.74649  -0.00001   0.00000  -0.16096  -0.16102   1.58547
+    D4        2.39148  -0.00001   0.00000   0.05390   0.05412   2.44560
+    D5       -1.19448  -0.00001   0.00000   0.12422   0.12398  -1.07050
+    D6       -1.85258   0.00000   0.00000   0.06634   0.06649  -1.78609
+    D7        0.84464   0.00000   0.00000   0.13666   0.13635   0.98099
+    D8        0.22259   0.00000   0.00000   0.03642   0.03674   0.25933
+    D9        2.91980   0.00000   0.00000   0.10675   0.10661   3.02641
+   D10        1.87090  -0.00001   0.00000   0.13621   0.13614   2.00704
+   D11       -1.89735   0.00000   0.00000   0.15559   0.15536  -1.74200
+   D12       -0.85493   0.00000   0.00000   0.07057   0.07064  -0.78429
+   D13        1.66001   0.00001   0.00000   0.08995   0.08985   1.74986
+   D14       -2.27618  -0.00001   0.00000  -0.15717  -0.15782  -2.43400
+   D15        0.90152   0.00000   0.00000  -0.14660  -0.14704   0.75448
+   D16        0.45849  -0.00001   0.00000  -0.09771  -0.09780   0.36069
+   D17       -2.64700   0.00000   0.00000  -0.08715  -0.08702  -2.73402
+   D18        0.88746  -0.00001   0.00000   0.00105   0.00104   0.88850
+   D19       -1.65528   0.00000   0.00000   0.02599   0.02614  -1.62914
+   D20       -1.62723  -0.00001   0.00000  -0.00778  -0.00788  -1.63511
+   D21        2.11322  -0.00001   0.00000   0.01717   0.01722   2.13044
+   D22       -0.52477   0.00000   0.00000  -0.05796  -0.05744  -0.58222
+   D23        2.54639   0.00000   0.00000  -0.13157  -0.13091   2.41548
+   D24        2.02086   0.00000   0.00000  -0.08618  -0.08609   1.93478
+   D25       -1.19116   0.00000   0.00000  -0.15979  -0.15955  -1.35071
+   D26        0.12760   0.00000   0.00000   0.03726   0.03766   0.16526
+   D27       -3.09928   0.00001   0.00000   0.05563   0.05564  -3.04364
+   D28       -2.94397   0.00001   0.00000   0.11079   0.11138  -2.83259
+   D29        0.11234   0.00001   0.00000   0.12915   0.12937   0.24171
+   D30       -0.09415   0.00000   0.00000   0.04441   0.04447  -0.04968
+   D31        3.01093  -0.00001   0.00000   0.03331   0.03304   3.04397
+   D32        3.13276   0.00000   0.00000   0.02674   0.02703  -3.12340
+   D33       -0.04535  -0.00001   0.00000   0.01564   0.01560  -0.02975
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000062     0.000450     YES
+ RMS     Force            0.000013     0.000300     YES
+ Maximum Displacement     0.412433     0.001800     NO
+ RMS     Displacement     0.107392     0.001200     NO
+ Predicted change in Energy=-1.899074D-04
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.846022   -1.539485   -1.058181
+      2          6           0       -1.494219   -1.470934    0.162059
+      3          6           0       -0.579566   -0.298938   -0.002804
+      4          6           0       -0.044869    0.454005    1.169636
+      5          6           0        1.423754    0.343320    1.312384
+      6          6           0        2.129990    0.662993    0.049194
+      7          6           0        1.493700    0.317935   -1.178657
+      8          6           0        0.197813   -0.113811   -1.235212
+      9          1           0       -3.587870    3.353278   -1.480370
+     10          1           0       -0.953007   -2.441153    0.020019
+     11          1           0       -1.901948   -1.510318    1.187206
+     12          1           0       -0.541481    1.404409    1.436542
+     13          1           0        1.832597   -0.444757    1.962197
+     14          1           0        3.043336    1.266491    0.055005
+     15          1           0        2.048593    0.465381   -2.110348
+     16          1           0       -0.295291   -0.285446   -2.196743
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.822376   0.000000
+     3  C    2.790986   1.495776   0.000000
+     4  C    4.096783   2.611746   1.492461   0.000000
+     5  C    5.234073   3.623443   2.481030   1.479690   0.000000
+     6  C    5.553187   4.207288   2.875710   2.455418   1.482095
+     7  C    4.722045   3.731652   2.462030   2.810727   2.492151
+     8  C    3.365831   2.580139   1.468815   2.482862   2.863938
+     9  H    4.966659   5.509444   4.956993   5.289723   6.478866
+    10  H    2.357759   1.120005   2.174641   3.244731   3.882331
+    11  H    2.435958   1.103957   2.152268   2.703260   3.809454
+    12  H    4.494559   3.286277   2.230372   1.105047   2.236845
+    13  H    5.675437   3.919342   3.114646   2.227286   1.100216
+    14  H    6.617947   5.300411   3.947066   3.382240   2.248620
+    15  H    5.392940   4.632997   3.454438   3.891145   3.481438
+    16  H    3.061889   2.899440   2.212321   3.455721   3.957833
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.425323   0.000000
+     8  C    2.446718   1.367086   0.000000
+     9  H    6.501625   5.926777   5.139281   0.000000
+    10  H    4.375093   3.877598   2.883836   6.539809   0.000000
+    11  H    4.719626   4.524405   3.496761   5.797660   1.768975
+    12  H    3.100192   3.487355   3.160667   4.646176   4.118767
+    13  H    2.230500   3.249848   3.606309   7.460415   3.939193
+    14  H    1.094735   2.196144   3.415683   7.119336   5.451477
+    15  H    2.170091   1.094393   2.127607   6.364474   4.689989
+    16  H    3.438860   2.145008   1.094145   4.959292   3.161280
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.226247   0.000000
+    13  H    3.960158   3.054828   0.000000
+    14  H    5.783457   3.844291   2.834015   0.000000
+    15  H    5.512170   4.491178   4.178591   2.513969   0.000000
+    16  H    3.941163   4.014596   4.674406   4.315705   2.462722
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.7136604      0.9251958      0.8333120
+ Leave Link  202 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.2058654026 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071236553 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.1987417473 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7939.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.03D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:08:20 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.028409   -0.002879   -0.050973
+         Rot=    0.999954   -0.003989    0.008615    0.001029 Ang=  -1.09 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:08:21 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.926372636857
+ DIIS: error= 6.08D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.926372636857     IErMin= 1 ErrMin= 6.08D-03
+ ErrMax= 6.08D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.95D-02 BMatP= 2.95D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.703 Goal=     0.100 Shift=    0.000
+ T=  538. Gap= 0.317 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.745 Goal=     0.100 Shift=    0.000
+ T=  538. Gap= 0.236 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.703 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=9.60D-04 MaxDP=2.49D-02              OVMax= 3.41D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.940510247623     Delta-E=       -0.014137610766 Rises=F Damp=F
+ DIIS: error= 1.69D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.940510247623     IErMin= 2 ErrMin= 1.69D-03
+ ErrMax= 1.69D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.72D-03 BMatP= 2.95D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.184D+00 0.118D+01
+ Coeff:     -0.184D+00 0.118D+01
+ Gap=     0.318 Goal=     0.100 Shift=    0.000
+ T=  373. Gap= 0.318 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.236 Goal=     0.100 Shift=    0.000
+ T=  373. Gap= 0.236 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.236 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=3.81D-04 MaxDP=8.46D-03 DE=-1.41D-02 OVMax= 2.78D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.942075948511     Delta-E=       -0.001565700888 Rises=F Damp=F
+ DIIS: error= 8.53D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.942075948511     IErMin= 3 ErrMin= 8.53D-04
+ ErrMax= 8.53D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.45D-04 BMatP= 1.72D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.850D-01 0.376D+00 0.709D+00
+ Coeff:     -0.850D-01 0.376D+00 0.709D+00
+ Gap=     0.318 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.27D-04 MaxDP=3.84D-03 DE=-1.57D-03 OVMax= 1.31D-02
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.942349752005     Delta-E=       -0.000273803495 Rises=F Damp=F
+ DIIS: error= 4.55D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.942349752005     IErMin= 4 ErrMin= 4.55D-04
+ ErrMax= 4.55D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.27D-04 BMatP= 4.45D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.330D-01-0.257D+00 0.194D+00 0.103D+01
+ Coeff:      0.330D-01-0.257D+00 0.194D+00 0.103D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.47D-04 MaxDP=4.91D-03 DE=-2.74D-04 OVMax= 1.41D-02
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.942544081640     Delta-E=       -0.000194329635 Rises=F Damp=F
+ DIIS: error= 3.93D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.942544081640     IErMin= 5 ErrMin= 3.93D-04
+ ErrMax= 3.93D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.29D-05 BMatP= 1.27D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.154D-01-0.731D-01-0.968D-01 0.220D-01 0.113D+01
+ Coeff:      0.154D-01-0.731D-01-0.968D-01 0.220D-01 0.113D+01
+ Gap=     0.318 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.08D-05 MaxDP=2.76D-03 DE=-1.94D-04 OVMax= 9.80D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.942625886450     Delta-E=       -0.000081804810 Rises=F Damp=F
+ DIIS: error= 1.85D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.942625886450     IErMin= 6 ErrMin= 1.85D-04
+ ErrMax= 1.85D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.76D-05 BMatP= 3.29D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.105D-01 0.105D+00-0.132D+00-0.556D+00 0.463D+00 0.113D+01
+ Coeff:     -0.105D-01 0.105D+00-0.132D+00-0.556D+00 0.463D+00 0.113D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.63D-05 MaxDP=3.48D-03 DE=-8.18D-05 OVMax= 9.39D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.942678735582     Delta-E=       -0.000052849132 Rises=F Damp=F
+ DIIS: error= 1.37D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.942678735582     IErMin= 7 ErrMin= 1.37D-04
+ ErrMax= 1.37D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.62D-06 BMatP= 1.76D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.504D-02 0.239D-01 0.426D-01-0.174D-01-0.378D+00 0.694D-02
+ Coeff-Com:  0.133D+01
+ Coeff:     -0.504D-02 0.239D-01 0.426D-01-0.174D-01-0.378D+00 0.694D-02
+ Coeff:      0.133D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.75D-05 MaxDP=2.11D-03 DE=-5.28D-05 OVMax= 5.95D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.942696745768     Delta-E=       -0.000018010186 Rises=F Damp=F
+ DIIS: error= 1.22D-04 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.942696745768     IErMin= 8 ErrMin= 1.22D-04
+ ErrMax= 1.22D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.71D-06 BMatP= 4.62D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.168D-02-0.230D-01 0.493D-01 0.144D+00-0.226D+00-0.309D+00
+ Coeff-Com:  0.364D+00 0.999D+00
+ Coeff:      0.168D-02-0.230D-01 0.493D-01 0.144D+00-0.226D+00-0.309D+00
+ Coeff:      0.364D+00 0.999D+00
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.83D-05 MaxDP=1.57D-03 DE=-1.80D-05 OVMax= 3.60D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.942702713155     Delta-E=       -0.000005967387 Rises=F Damp=F
+ DIIS: error= 1.17D-04 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.942702713155     IErMin= 9 ErrMin= 1.17D-04
+ ErrMax= 1.17D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.42D-07 BMatP= 1.71D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.155D-02-0.102D-01-0.128D-02 0.309D-01 0.508D-01-0.628D-01
+ Coeff-Com: -0.261D+00 0.198D+00 0.105D+01
+ Coeff:      0.155D-02-0.102D-01-0.128D-02 0.309D-01 0.508D-01-0.628D-01
+ Coeff:     -0.261D+00 0.198D+00 0.105D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.91D-05 MaxDP=1.45D-03 DE=-5.97D-06 OVMax= 3.25D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.942706475611     Delta-E=       -0.000003762456 Rises=F Damp=F
+ DIIS: error= 1.13D-04 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.942706475611     IErMin=10 ErrMin= 1.13D-04
+ ErrMax= 1.13D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.45D-07 BMatP= 8.42D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.788D-03 0.859D-02-0.140D-01-0.482D-01 0.575D-01 0.102D+00
+ Coeff-Com: -0.652D-01-0.305D+00-0.144D+00 0.141D+01
+ Coeff:     -0.788D-03 0.859D-02-0.140D-01-0.482D-01 0.575D-01 0.102D+00
+ Coeff:     -0.652D-01-0.305D+00-0.144D+00 0.141D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.07D-05 MaxDP=1.71D-03 DE=-3.76D-06 OVMax= 3.83D-03
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.942710469400     Delta-E=       -0.000003993789 Rises=F Damp=F
+ DIIS: error= 1.09D-04 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.942710469400     IErMin=11 ErrMin= 1.09D-04
+ ErrMax= 1.09D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.73D-07 BMatP= 6.45D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.817D-03 0.501D-02 0.221D-02-0.130D-01-0.371D-01 0.265D-01
+ Coeff-Com:  0.156D+00-0.554D-01-0.565D+00-0.332D+00 0.181D+01
+ Coeff:     -0.817D-03 0.501D-02 0.221D-02-0.130D-01-0.371D-01 0.265D-01
+ Coeff:      0.156D+00-0.554D-01-0.565D+00-0.332D+00 0.181D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.15D-05 MaxDP=2.62D-03 DE=-3.99D-06 OVMax= 5.89D-03
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.942716215324     Delta-E=       -0.000005745923 Rises=F Damp=F
+ DIIS: error= 1.03D-04 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.942716215324     IErMin=12 ErrMin= 1.03D-04
+ ErrMax= 1.03D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.02D-07 BMatP= 5.73D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.165D-02-0.169D-01 0.237D-01 0.898D-01-0.923D-01-0.188D+00
+ Coeff-Com:  0.443D-01 0.603D+00 0.490D+00-0.263D+01-0.514D+00 0.319D+01
+ Coeff:      0.165D-02-0.169D-01 0.237D-01 0.898D-01-0.923D-01-0.188D+00
+ Coeff:      0.443D-01 0.603D+00 0.490D+00-0.263D+01-0.514D+00 0.319D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.22D-05 MaxDP=7.66D-03 DE=-5.75D-06 OVMax= 1.73D-02
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.942730715236     Delta-E=       -0.000014499912 Rises=F Damp=F
+ DIIS: error= 8.18D-05 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.942730715236     IErMin=13 ErrMin= 8.18D-05
+ ErrMax= 8.18D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.41D-07 BMatP= 5.02D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.132D-02-0.924D-02 0.102D-02 0.324D-01 0.310D-01-0.609D-01
+ Coeff-Com: -0.210D+00 0.192D+00 0.815D+00-0.437D-01-0.242D+01 0.607D+00
+ Coeff-Com:  0.207D+01
+ Coeff:      0.132D-02-0.924D-02 0.102D-02 0.324D-01 0.310D-01-0.609D-01
+ Coeff:     -0.210D+00 0.192D+00 0.815D+00-0.437D-01-0.242D+01 0.607D+00
+ Coeff:      0.207D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.31D-04 MaxDP=1.08D-02 DE=-1.45D-05 OVMax= 2.46D-02
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.942745409891     Delta-E=       -0.000014694656 Rises=F Damp=F
+ DIIS: error= 5.03D-05 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.942745409891     IErMin=14 ErrMin= 5.03D-05
+ ErrMax= 5.03D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.71D-07 BMatP= 3.41D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.722D-03 0.880D-02-0.158D-01-0.533D-01 0.746D-01 0.118D+00
+ Coeff-Com: -0.111D+00-0.346D+00-0.833D-01 0.182D+01-0.420D+00-0.204D+01
+ Coeff-Com:  0.605D+00 0.145D+01
+ Coeff:     -0.722D-03 0.880D-02-0.158D-01-0.533D-01 0.746D-01 0.118D+00
+ Coeff:     -0.111D+00-0.346D+00-0.833D-01 0.182D+01-0.420D+00-0.204D+01
+ Coeff:      0.605D+00 0.145D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.08D-04 MaxDP=8.83D-03 DE=-1.47D-05 OVMax= 2.02D-02
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.942752243537     Delta-E=       -0.000006833646 Rises=F Damp=F
+ DIIS: error= 2.35D-05 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.942752243537     IErMin=15 ErrMin= 2.35D-05
+ ErrMax= 2.35D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.46D-08 BMatP= 1.71D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.311D-05-0.134D-02 0.602D-02 0.112D-01-0.353D-01-0.223D-01
+ Coeff-Com:  0.770D-01 0.865D-01-0.159D+00-0.589D+00 0.665D+00 0.494D+00
+ Coeff-Com: -0.739D+00-0.402D+00 0.161D+01
+ Coeff:      0.311D-05-0.134D-02 0.602D-02 0.112D-01-0.353D-01-0.223D-01
+ Coeff:      0.770D-01 0.865D-01-0.159D+00-0.589D+00 0.665D+00 0.494D+00
+ Coeff:     -0.739D+00-0.402D+00 0.161D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.47D-05 MaxDP=4.42D-03 DE=-6.83D-06 OVMax= 1.02D-02
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.942753889770     Delta-E=       -0.000001646233 Rises=F Damp=F
+ DIIS: error= 1.06D-05 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.942753889770     IErMin=16 ErrMin= 1.06D-05
+ ErrMax= 1.06D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.24D-08 BMatP= 6.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.350D-03-0.383D-02 0.617D-02 0.212D-01-0.251D-01-0.463D-01
+ Coeff-Com:  0.223D-01 0.143D+00 0.824D-01-0.673D+00-0.220D-01 0.765D+00
+ Coeff-Com: -0.173D+00-0.575D+00 0.370D+00 0.111D+01
+ Coeff:      0.350D-03-0.383D-02 0.617D-02 0.212D-01-0.251D-01-0.463D-01
+ Coeff:      0.223D-01 0.143D+00 0.824D-01-0.673D+00-0.220D-01 0.765D+00
+ Coeff:     -0.173D+00-0.575D+00 0.370D+00 0.111D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.06D-05 MaxDP=3.29D-03 DE=-1.65D-06 OVMax= 7.60D-03
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.942754302895     Delta-E=       -0.000000413125 Rises=F Damp=F
+ DIIS: error= 3.11D-06 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.942754302895     IErMin=17 ErrMin= 3.11D-06
+ ErrMax= 3.11D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.37D-09 BMatP= 1.24D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.137D-03-0.120D-02 0.113D-02 0.573D-02-0.252D-02-0.122D-01
+ Coeff-Com: -0.808D-02 0.360D-01 0.643D-01-0.121D+00-0.157D+00 0.181D+00
+ Coeff-Com:  0.109D+00-0.104D+00-0.196D+00 0.292D+00 0.914D+00
+ Coeff:      0.137D-03-0.120D-02 0.113D-02 0.573D-02-0.252D-02-0.122D-01
+ Coeff:     -0.808D-02 0.360D-01 0.643D-01-0.121D+00-0.157D+00 0.181D+00
+ Coeff:      0.109D+00-0.104D+00-0.196D+00 0.292D+00 0.914D+00
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.39D-06 MaxDP=2.66D-04 DE=-4.13D-07 OVMax= 6.27D-04
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.942754307870     Delta-E=       -0.000000004975 Rises=F Damp=F
+ DIIS: error= 5.93D-07 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.942754307870     IErMin=18 ErrMin= 5.93D-07
+ ErrMax= 5.93D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-10 BMatP= 2.37D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.625D-05 0.172D-03-0.544D-03-0.135D-02 0.306D-02 0.301D-02
+ Coeff-Com: -0.632D-02-0.912D-02 0.832D-02 0.627D-01-0.508D-01-0.573D-01
+ Coeff-Com:  0.602D-01 0.507D-01-0.102D+00-0.584D-01 0.140D+00 0.958D+00
+ Coeff:     -0.625D-05 0.172D-03-0.544D-03-0.135D-02 0.306D-02 0.301D-02
+ Coeff:     -0.632D-02-0.912D-02 0.832D-02 0.627D-01-0.508D-01-0.573D-01
+ Coeff:      0.602D-01 0.507D-01-0.102D+00-0.584D-01 0.140D+00 0.958D+00
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.07D-07 MaxDP=6.43D-05 DE=-4.98D-09 OVMax= 1.50D-04
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.942754308189     Delta-E=       -0.000000000319 Rises=F Damp=F
+ DIIS: error= 2.62D-07 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.942754308189     IErMin=19 ErrMin= 2.62D-07
+ ErrMax= 2.62D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.78D-11 BMatP= 1.33D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.162D-04 0.170D-03-0.257D-03-0.951D-03 0.105D-02 0.204D-02
+ Coeff-Com: -0.774D-03-0.596D-02-0.512D-02 0.286D-01 0.470D-02-0.345D-01
+ Coeff-Com:  0.233D-02 0.229D-01 0.689D-04-0.413D-01-0.615D-01 0.202D+00
+ Coeff-Com:  0.886D+00
+ Coeff:     -0.162D-04 0.170D-03-0.257D-03-0.951D-03 0.105D-02 0.204D-02
+ Coeff:     -0.774D-03-0.596D-02-0.512D-02 0.286D-01 0.470D-02-0.345D-01
+ Coeff:      0.233D-02 0.229D-01 0.689D-04-0.413D-01-0.615D-01 0.202D+00
+ Coeff:      0.886D+00
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.00D-07 MaxDP=1.63D-05 DE=-3.19D-10 OVMax= 3.72D-05
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.942754308209     Delta-E=       -0.000000000020 Rises=F Damp=F
+ DIIS: error= 1.46D-07 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.942754308209     IErMin=20 ErrMin= 1.46D-07
+ ErrMax= 1.46D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.00D-12 BMatP= 1.78D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.411D-06-0.218D-04 0.743D-04 0.202D-03-0.464D-03-0.431D-03
+ Coeff-Com:  0.995D-03 0.139D-02-0.178D-02-0.965D-02 0.976D-02 0.797D-02
+ Coeff-Com: -0.105D-01-0.667D-02 0.171D-01 0.457D-02-0.278D-01-0.153D+00
+ Coeff-Com:  0.637D-01 0.110D+01
+ Coeff:      0.411D-06-0.218D-04 0.743D-04 0.202D-03-0.464D-03-0.431D-03
+ Coeff:      0.995D-03 0.139D-02-0.178D-02-0.965D-02 0.976D-02 0.797D-02
+ Coeff:     -0.105D-01-0.667D-02 0.171D-01 0.457D-02-0.278D-01-0.153D+00
+ Coeff:      0.637D-01 0.110D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.80D-08 MaxDP=7.79D-07 DE=-1.96D-11 OVMax= 4.18D-06
+
+ Cycle  21  Pass 1  IDiag  1:
+ E= -668.942754308210     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 4.96D-08 at cycle  21 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.942754308210     IErMin=20 ErrMin= 4.96D-08
+ ErrMax= 4.96D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.67D-13 BMatP= 3.00D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.474D-05 0.119D-04 0.498D-04-0.646D-04-0.114D-03 0.576D-04
+ Coeff-Com:  0.380D-03 0.284D-03-0.181D-02-0.451D-03 0.238D-02 0.154D-03
+ Coeff-Com: -0.132D-02-0.149D-02 0.275D-02 0.111D-01-0.744D-02-0.107D+00
+ Coeff-Com: -0.120D+00 0.122D+01
+ Coeff:     -0.474D-05 0.119D-04 0.498D-04-0.646D-04-0.114D-03 0.576D-04
+ Coeff:      0.380D-03 0.284D-03-0.181D-02-0.451D-03 0.238D-02 0.154D-03
+ Coeff:     -0.132D-02-0.149D-02 0.275D-02 0.111D-01-0.744D-02-0.107D+00
+ Coeff:     -0.120D+00 0.122D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.54D-08 MaxDP=1.68D-06 DE=-1.59D-12 OVMax= 4.46D-06
+
+ Cycle  22  Pass 1  IDiag  1:
+ E= -668.942754308217     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 1.39D-08 at cycle  22 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.942754308217     IErMin=20 ErrMin= 1.39D-08
+ ErrMax= 1.39D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.40D-14 BMatP= 3.67D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.373D-05-0.960D-05 0.353D-04 0.211D-04-0.896D-04-0.910D-04
+ Coeff-Com:  0.180D-03 0.952D-03-0.912D-03-0.960D-03 0.985D-03 0.827D-03
+ Coeff-Com: -0.162D-02-0.645D-03 0.439D-02 0.195D-01 0.216D-03-0.131D+00
+ Coeff-Com: -0.202D+00 0.131D+01
+ Coeff:     -0.373D-05-0.960D-05 0.353D-04 0.211D-04-0.896D-04-0.910D-04
+ Coeff:      0.180D-03 0.952D-03-0.912D-03-0.960D-03 0.985D-03 0.827D-03
+ Coeff:     -0.162D-02-0.645D-03 0.439D-02 0.195D-01 0.216D-03-0.131D+00
+ Coeff:     -0.202D+00 0.131D+01
+ Gap=     0.317 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.10D-09 MaxDP=3.40D-07 DE=-6.59D-12 OVMax= 9.58D-07
+
+ SCF Done:  E(UwB97XD) =  -668.942754308     A.U. after   22 cycles
+            NFock= 22  Conv=0.71D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0206 S= 3.0029
+ <L.S>= 0.000000000000E+00
+ KE= 6.650066100941D+02 PE=-2.333161213008D+03 EE= 6.190131068587D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0206,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:09:47 2024, MaxMem=  4294967296 cpu:      1379.4
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:09:47 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7939.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:09:47 2024, MaxMem=  4294967296 cpu:         1.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:09:47 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:09:54 2024, MaxMem=  4294967296 cpu:       114.0
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 5.20927625D-01-4.54747068D-02 1.46647357D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.001833644   -0.000549119    0.002999986
+      2        6           0.003830482    0.000128330    0.000242687
+      3        6          -0.001619119   -0.002132689    0.009230756
+      4        6          -0.003221782   -0.000339892   -0.001837891
+      5        6          -0.005004270   -0.000359177   -0.000852595
+      6        6           0.001176795    0.001483693   -0.001512267
+      7        6           0.011375642    0.002566974    0.001663545
+      8        6          -0.007275322   -0.000322450   -0.004530119
+      9        1           0.000006583   -0.000002543    0.000003769
+     10        1          -0.002471339    0.002921934   -0.000645731
+     11        1          -0.001163256   -0.000320999   -0.002456985
+     12        1           0.002500197   -0.001491646   -0.000725052
+     13        1          -0.000096931   -0.000559478   -0.000162116
+     14        1          -0.000145290   -0.000696583   -0.001052202
+     15        1          -0.000472223    0.000080030    0.000024249
+     16        1           0.000746187   -0.000406387   -0.000390032
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.011375642 RMS     0.002931065
+ Leave Link  716 at Sun Aug 11 02:09:54 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.008937211 RMS     0.001821855
+ Search for a local minimum.
+ Step number  79 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .18219D-02 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   79
+                                                     78
+ ITU=  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0  1
+ ITU=  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1  1
+ ITU= -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0 -1
+ ITU=  0  0 -1  0  0  0  1  0  0  1  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99365.
+ Iteration  1 RMS(Cart)=  0.10323748 RMS(Int)=  0.00513131
+ Iteration  2 RMS(Cart)=  0.01099905 RMS(Int)=  0.00004276
+ Iteration  3 RMS(Cart)=  0.00005132 RMS(Int)=  0.00000246
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000246
+ ITry= 1 IFail=0 DXMaxC= 4.10D-01 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=T
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.44379  -0.00336  -0.00569   0.00000  -0.00569   3.43810
+    R2        9.38563   0.00000   0.09400   0.00000   0.09400   9.47963
+    R3        2.82661  -0.00294  -0.01270   0.00000  -0.01270   2.81390
+    R4        2.11650  -0.00364  -0.01314   0.00000  -0.01314   2.10336
+    R5        2.08618  -0.00184  -0.00537   0.00000  -0.00537   2.08081
+    R6        2.82034  -0.00497  -0.02117   0.00000  -0.02116   2.79918
+    R7        2.77566   0.00565   0.03100   0.00000   0.03100   2.80666
+    R8        2.79621  -0.00211  -0.00758   0.00000  -0.00758   2.78863
+    R9        2.08824  -0.00258  -0.00726   0.00000  -0.00726   2.08098
+   R10        2.80075   0.00239   0.00845   0.00000   0.00844   2.80920
+   R11        2.07911   0.00027  -0.00030   0.00000  -0.00030   2.07881
+   R12        2.69347  -0.00274  -0.04125   0.00000  -0.04125   2.65222
+   R13        2.06875  -0.00051  -0.00199   0.00000  -0.00199   2.06676
+   R14        2.58342   0.00894   0.04236   0.00000   0.04236   2.62578
+   R15        2.06810  -0.00025  -0.00064   0.00000  -0.00064   2.06746
+   R16        2.06763   0.00007  -0.00061   0.00000  -0.00061   2.06702
+    A1        1.70183  -0.00006   0.03024   0.00000   0.03024   1.73207
+    A2        1.99244   0.00148   0.00059   0.00000   0.00059   1.99303
+    A3        1.81413  -0.00117  -0.01230   0.00000  -0.01230   1.80184
+    A4        1.92461  -0.00233  -0.02365   0.00000  -0.02365   1.90096
+    A5        1.94904   0.00023   0.00447   0.00000   0.00447   1.95351
+    A6        1.93494   0.00119   0.01736   0.00000   0.01736   1.95230
+    A7        1.83935   0.00034   0.01200   0.00000   0.01200   1.85135
+    A8        2.12679  -0.00028   0.00501   0.00000   0.00501   2.13180
+    A9        2.11165   0.00012  -0.01323   0.00000  -0.01323   2.09842
+   A10        1.98880   0.00016  -0.01435   0.00000  -0.01434   1.97446
+   A11        1.97538  -0.00027  -0.00986   0.00000  -0.00986   1.96552
+   A12        2.05176   0.00145   0.01378   0.00000   0.01378   2.06554
+   A13        2.07953  -0.00119  -0.01318   0.00000  -0.01318   2.06635
+   A14        1.95475   0.00331   0.01325   0.00000   0.01326   1.96801
+   A15        2.07075  -0.00153   0.00650   0.00000   0.00650   2.07725
+   A16        2.07238  -0.00104  -0.00282   0.00000  -0.00282   2.06956
+   A17        2.05927  -0.00094   0.00954   0.00000   0.00955   2.06882
+   A18        2.10823   0.00154   0.00272   0.00000   0.00272   2.11096
+   A19        2.10654  -0.00057  -0.00533   0.00000  -0.00533   2.10121
+   A20        2.13561  -0.00166  -0.00017   0.00000  -0.00016   2.13545
+   A21        2.06510   0.00116   0.00692   0.00000   0.00692   2.07202
+   A22        2.08054   0.00049  -0.00789   0.00000  -0.00789   2.07265
+   A23        2.10225  -0.00087  -0.01996   0.00000  -0.01995   2.08230
+   A24        2.07038   0.00118   0.02005   0.00000   0.02005   2.09043
+   A25        2.10959  -0.00028   0.00029   0.00000   0.00029   2.10988
+    D1       -0.60625  -0.00017   0.15551   0.00000   0.15551  -0.45074
+    D2       -2.73373  -0.00050   0.15801   0.00000   0.15801  -2.57572
+    D3        1.58547   0.00068   0.16000   0.00000   0.16000   1.74547
+    D4        2.44560  -0.00044  -0.05377   0.00000  -0.05377   2.39183
+    D5       -1.07050  -0.00040  -0.12319   0.00000  -0.12319  -1.19370
+    D6       -1.78609  -0.00077  -0.06606   0.00000  -0.06607  -1.85216
+    D7        0.98099  -0.00073  -0.13549   0.00000  -0.13548   0.84551
+    D8        0.25933   0.00057  -0.03651   0.00000  -0.03651   0.22282
+    D9        3.02641   0.00061  -0.10593   0.00000  -0.10593   2.92048
+   D10        2.00704  -0.00001  -0.13528   0.00000  -0.13528   1.87176
+   D11       -1.74200  -0.00048  -0.15437   0.00000  -0.15437  -1.89637
+   D12       -0.78429  -0.00005  -0.07019   0.00000  -0.07019  -0.85448
+   D13        1.74986  -0.00052  -0.08928   0.00000  -0.08928   1.66058
+   D14       -2.43400   0.00074   0.15682   0.00000   0.15683  -2.27717
+   D15        0.75448  -0.00010   0.14611   0.00000   0.14611   0.90059
+   D16        0.36069   0.00070   0.09718   0.00000   0.09718   0.45787
+   D17       -2.73402  -0.00015   0.08647   0.00000   0.08647  -2.64755
+   D18        0.88850   0.00135  -0.00103   0.00000  -0.00103   0.88746
+   D19       -1.62914   0.00055  -0.02598   0.00000  -0.02598  -1.65512
+   D20       -1.63511   0.00083   0.00783   0.00000   0.00783  -1.62728
+   D21        2.13044   0.00002  -0.01711   0.00000  -0.01711   2.11333
+   D22       -0.58222  -0.00051   0.05708   0.00000   0.05707  -0.52514
+   D23        2.41548  -0.00037   0.13007   0.00000   0.13007   2.54555
+   D24        1.93478   0.00010   0.08554   0.00000   0.08554   2.02032
+   D25       -1.35071   0.00024   0.15854   0.00000   0.15853  -1.19217
+   D26        0.16526  -0.00013  -0.03742   0.00000  -0.03742   0.12784
+   D27       -3.04364  -0.00013  -0.05529   0.00000  -0.05529  -3.09893
+   D28       -2.83259  -0.00046  -0.11068   0.00000  -0.11068  -2.94327
+   D29        0.24171  -0.00046  -0.12855   0.00000  -0.12855   0.11316
+   D30       -0.04968  -0.00049  -0.04419   0.00000  -0.04419  -0.09386
+   D31        3.04397   0.00042  -0.03283   0.00000  -0.03282   3.01114
+   D32       -3.12340  -0.00051  -0.02686   0.00000  -0.02686   3.13293
+   D33       -0.02975   0.00039  -0.01550   0.00000  -0.01550  -0.04525
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.008937     0.000450     NO
+ RMS     Force            0.001822     0.000300     NO
+ Maximum Displacement     0.409667     0.001800     NO
+ RMS     Displacement     0.106691     0.001200     NO
+ Predicted change in Energy=-3.920855D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:09:54 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.889734   -1.572448   -0.909979
+      2          6           0       -1.433102   -1.488274    0.176866
+      3          6           0       -0.617451   -0.253766    0.009578
+      4          6           0       -0.074927    0.495164    1.166691
+      5          6           0        1.383569    0.328504    1.317177
+      6          6           0        2.125876    0.594874    0.057058
+      7          6           0        1.488742    0.330112   -1.165138
+      8          6           0        0.148268   -0.027412   -1.242747
+      9          1           0       -3.644758    3.334769   -1.626529
+     10          1           0       -0.860882   -2.404197   -0.092448
+     11          1           0       -1.757465   -1.627117    1.219925
+     12          1           0       -0.518167    1.473225    1.410800
+     13          1           0        1.764606   -0.446508    1.998570
+     14          1           0        3.120323    1.049705    0.075482
+     15          1           0        2.046292    0.486605   -2.093362
+     16          1           0       -0.355682   -0.110266   -2.210018
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819367   0.000000
+     3  C    2.783483   1.489054   0.000000
+     4  C    4.063338   2.599695   1.481262   0.000000
+     5  C    5.180247   3.540427   2.460271   1.475680   0.000000
+     6  C    5.548764   4.125552   2.871983   2.466730   1.486564
+     7  C    4.780783   3.693869   2.481314   2.812423   2.484543
+     8  C    3.424519   2.578788   1.485221   2.475538   2.864586
+     9  H    5.016402   5.604053   4.971823   5.348751   6.556455
+    10  H    2.340171   1.113050   2.166570   3.257215   3.806870
+    11  H    2.412781   1.101118   2.156540   2.708845   3.701352
+    12  H    4.504050   3.336192   2.226157   1.101206   2.221654
+    13  H    5.602703   3.824816   3.109250   2.227700   1.100059
+    14  H    6.630807   5.213952   3.959082   3.421677   2.253498
+    15  H    5.477631   4.600029   3.473620   3.889420   3.477927
+    16  H    3.201483   2.959215   2.239581   3.442024   3.957097
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403496   0.000000
+     8  C    2.446970   1.389502   0.000000
+     9  H    6.606187   5.966043   5.083169   0.000000
+    10  H    4.235269   3.761362   2.826779   6.560419   0.000000
+    11  H    4.622753   4.478519   3.500804   6.023661   1.769191
+    12  H    3.097593   3.459746   3.120474   4.739862   4.172722
+    13  H    2.232591   3.269295   3.646138   7.529982   3.885626
+    14  H    1.093680   2.172328   3.425057   7.340619   5.273295
+    15  H    2.154614   1.094053   2.142488   6.381068   4.562023
+    16  H    3.434383   2.165088   1.093821   4.798620   3.162506
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.344311   0.000000
+    13  H    3.795407   3.040049   0.000000
+    14  H    5.680488   3.898853   2.788349   0.000000
+    15  H    5.469393   4.452979   4.206418   2.484856   0.000000
+    16  H    4.003790   3.955271   4.724499   4.318755   2.477770
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6873037      0.9256628      0.8387845
+ Leave Link  202 at Sun Aug 11 02:09:55 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4716604857 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071835897 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4644768960 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:09:55 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7945.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:09:55 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:09:55 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000145   -0.000026   -0.000342
+         Rot=    1.000000   -0.000026    0.000052    0.000006 Ang=  -0.01 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=    -0.027393    0.003201    0.051086
+         Rot=    0.999955    0.003962   -0.008563   -0.001023 Ang=   1.09 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 6.35D-03
+ Max alpha theta=  6.463 degrees.
+ Max  beta theta=  7.496 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:09:55 2024, MaxMem=  4294967296 cpu:         2.3
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943627403654
+ DIIS: error= 3.03D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943627403654     IErMin= 1 ErrMin= 3.03D-06
+ ErrMax= 3.03D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.06D-08 BMatP= 1.06D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    80.105 Goal=     0.100 Shift=    0.000
+ Gap=    81.049 Goal=     0.100 Shift=    0.000
+ RMSDP=6.76D-07 MaxDP=1.21D-05              OVMax= 2.29D-05
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943627407455     Delta-E=       -0.000000003801 Rises=F Damp=F
+ DIIS: error= 6.30D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943627407455     IErMin= 2 ErrMin= 6.30D-07
+ ErrMax= 6.30D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.13D-10 BMatP= 1.06D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.823D-01 0.108D+01
+ Coeff:     -0.823D-01 0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.02D-07 MaxDP=4.42D-06 DE=-3.80D-09 OVMax= 1.05D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943627407817     Delta-E=       -0.000000000362 Rises=F Damp=F
+ DIIS: error= 4.94D-07 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943627407817     IErMin= 3 ErrMin= 4.94D-07
+ ErrMax= 4.94D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.00D-10 BMatP= 5.13D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.631D-01 0.377D+00 0.686D+00
+ Coeff:     -0.631D-01 0.377D+00 0.686D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.73D-08 MaxDP=2.46D-06 DE=-3.62D-10 OVMax= 4.96D-06
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943627407919     Delta-E=       -0.000000000102 Rises=F Damp=F
+ DIIS: error= 2.54D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943627407919     IErMin= 4 ErrMin= 2.54D-07
+ ErrMax= 2.54D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.45D-11 BMatP= 2.00D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.156D-01-0.231D+00 0.526D-01 0.116D+01
+ Coeff:      0.156D-01-0.231D+00 0.526D-01 0.116D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.77D-08 MaxDP=2.35D-06 DE=-1.02D-10 OVMax= 6.18D-06
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943627407973     Delta-E=       -0.000000000053 Rises=F Damp=F
+ DIIS: error= 1.45D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943627407973     IErMin= 5 ErrMin= 1.45D-07
+ ErrMax= 1.45D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.63D-12 BMatP= 3.45D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.980D-02-0.557D-01-0.106D+00-0.342D-01 0.119D+01
+ Coeff:      0.980D-02-0.557D-01-0.106D+00-0.342D-01 0.119D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.79D-08 MaxDP=1.41D-06 DE=-5.32D-11 OVMax= 3.75D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943627407980     Delta-E=       -0.000000000008 Rises=F Damp=F
+ DIIS: error= 9.51D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943627407980     IErMin= 6 ErrMin= 9.51D-08
+ ErrMax= 9.51D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.98D-12 BMatP= 6.63D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.242D-02 0.534D-01-0.318D-01-0.322D+00 0.210D+00 0.109D+01
+ Coeff:     -0.242D-02 0.534D-01-0.318D-01-0.322D+00 0.210D+00 0.109D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.14D-08 MaxDP=8.94D-07 DE=-7.73D-12 OVMax= 2.53D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943627407980     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 3.46D-08 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 6 EnMin= -668.943627407980     IErMin= 7 ErrMin= 3.46D-08
+ ErrMax= 3.46D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.41D-13 BMatP= 1.98D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.294D-02 0.279D-01 0.160D-01-0.798D-01-0.219D+00 0.291D+00
+ Coeff-Com:  0.967D+00
+ Coeff:     -0.294D-02 0.279D-01 0.160D-01-0.798D-01-0.219D+00 0.291D+00
+ Coeff:      0.967D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.08D-08 MaxDP=4.46D-07 DE= 0.00D+00 OVMax= 1.07D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943627407984     Delta-E=       -0.000000000004 Rises=F Damp=F
+ DIIS: error= 2.64D-08 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943627407984     IErMin= 8 ErrMin= 2.64D-08
+ ErrMax= 2.64D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.48D-13 BMatP= 5.41D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.185D-03-0.964D-02 0.105D-01 0.709D-01-0.806D-01-0.246D+00
+ Coeff-Com:  0.129D+00 0.113D+01
+ Coeff:      0.185D-03-0.964D-02 0.105D-01 0.709D-01-0.806D-01-0.246D+00
+ Coeff:      0.129D+00 0.113D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.65D-09 MaxDP=2.43D-07 DE=-4.09D-12 OVMax= 7.45D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627408     A.U. after    8 cycles
+            NFock=  8  Conv=0.67D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650252293891D+02 PE=-2.333711655634D+03 EE= 6.192783219410D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:10:27 2024, MaxMem=  4294967296 cpu:       513.9
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:10:27 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7945.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:10:27 2024, MaxMem=  4294967296 cpu:         1.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:10:27 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:       114.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.03796109D-01-4.91010565D-02 1.12971071D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000005182   -0.000008314    0.000012973
+      2        6           0.000015498    0.000005929   -0.000021553
+      3        6          -0.000024029    0.000004500    0.000032672
+      4        6           0.000028001    0.000019115    0.000003616
+      5        6          -0.000046935    0.000001850    0.000006099
+      6        6           0.000030210    0.000004930   -0.000013765
+      7        6           0.000024176    0.000010151    0.000005949
+      8        6          -0.000027964   -0.000018954   -0.000037984
+      9        1           0.000006593   -0.000004782    0.000004781
+     10        1          -0.000008605   -0.000000235   -0.000005127
+     11        1          -0.000008787    0.000003406   -0.000009575
+     12        1          -0.000003972   -0.000006090    0.000007364
+     13        1           0.000007561   -0.000007774    0.000006804
+     14        1          -0.000004026    0.000003191    0.000003591
+     15        1           0.000004198   -0.000007616    0.000000815
+     16        1           0.000002897    0.000000692    0.000003341
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000046935 RMS     0.000015333
+ Leave Link  716 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000062189 RMS     0.000011667
+ Search for a local minimum.
+ Step number  80 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .11667D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   76
+                                                     79   78   80
+ ITU=  0  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1  0
+ ITU=  1  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1  1
+ ITU=  1 -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1  0
+ ITU= -1  0  0 -1  0  0  0  1  0  0  1  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.00000   0.00000   0.00003   0.00030   0.00147
+     Eigenvalues ---    0.00295   0.00666   0.00941   0.01080   0.01843
+     Eigenvalues ---    0.01899   0.02314   0.02628   0.03528   0.03986
+     Eigenvalues ---    0.07076   0.08119   0.09146   0.09987   0.10445
+     Eigenvalues ---    0.10998   0.11140   0.12139   0.13271   0.14348
+     Eigenvalues ---    0.14735   0.16923   0.18732   0.22215   0.27199
+     Eigenvalues ---    0.28048   0.32785   0.33366   0.34514   0.35608
+     Eigenvalues ---    0.38068   0.38279   0.38449   0.38594   0.38817
+     Eigenvalues ---    0.39914   0.49471
+ RFO step:  Lambda=-5.67912740D-05 EMin= 1.02629016D-12
+ Quartic linear search produced a step of -0.00972.
+ Maximum step size (   0.383) exceeded in Quadratic search.
+    -- Step size scaled by   0.433
+ Iteration  1 RMS(Cart)=  0.17253961 RMS(Int)=  0.02850637
+ Iteration  2 RMS(Cart)=  0.18147566 RMS(Int)=  0.01330940
+ Iteration  3 RMS(Cart)=  0.04852706 RMS(Int)=  0.00078372
+ Iteration  4 RMS(Cart)=  0.00078326 RMS(Int)=  0.00007846
+ Iteration  5 RMS(Cart)=  0.00000018 RMS(Int)=  0.00007846
+ ITry= 1 IFail=0 DXMaxC= 2.45D+00 DCOld= 1.00D+10 DXMaxT= 3.83D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43810  -0.00002   0.00000   0.00878   0.00878   3.44688
+    R2        9.47963  -0.00001   0.00001   0.01030   0.01031   9.48993
+    R3        2.81390   0.00000   0.00000  -0.00503  -0.00503   2.80888
+    R4        2.10336   0.00000   0.00000  -0.00072  -0.00072   2.10264
+    R5        2.08081  -0.00001   0.00000  -0.00108  -0.00108   2.07973
+    R6        2.79918   0.00001   0.00000  -0.00226  -0.00221   2.79697
+    R7        2.80666   0.00002   0.00000  -0.00200  -0.00195   2.80471
+    R8        2.78863  -0.00002   0.00000   0.00176   0.00175   2.79038
+    R9        2.08098   0.00000   0.00000   0.00049   0.00049   2.08147
+   R10        2.80920   0.00002   0.00000   0.00055   0.00051   2.80971
+   R11        2.07881   0.00001   0.00000  -0.00039  -0.00039   2.07842
+   R12        2.65222   0.00001   0.00000   0.00234   0.00229   2.65451
+   R13        2.06676   0.00000   0.00000  -0.00012  -0.00012   2.06664
+   R14        2.62578   0.00004   0.00000  -0.00356  -0.00356   2.62222
+   R15        2.06746   0.00000   0.00000  -0.00030  -0.00030   2.06716
+   R16        2.06702   0.00000   0.00000   0.00011   0.00011   2.06713
+    A1        1.73207  -0.00006   0.00000  -0.38196  -0.38196   1.35011
+    A2        1.99303   0.00000   0.00000  -0.00683  -0.00685   1.98618
+    A3        1.80184   0.00000   0.00000  -0.00719  -0.00721   1.79462
+    A4        1.90096  -0.00001   0.00000   0.00424   0.00425   1.90521
+    A5        1.95351   0.00001   0.00000   0.00067   0.00063   1.95414
+    A6        1.95230   0.00000   0.00000   0.00429   0.00429   1.95659
+    A7        1.85135   0.00000   0.00000   0.00488   0.00488   1.85622
+    A8        2.13180   0.00002   0.00000   0.00955   0.00918   2.14097
+    A9        2.09842  -0.00003   0.00000   0.00522   0.00480   2.10322
+   A10        1.97446   0.00001   0.00000   0.00240   0.00221   1.97667
+   A11        1.96552   0.00000   0.00000  -0.00259  -0.00250   1.96302
+   A12        2.06554   0.00000   0.00000  -0.00097  -0.00104   2.06450
+   A13        2.06635   0.00000   0.00000  -0.00448  -0.00456   2.06179
+   A14        1.96801   0.00001   0.00000  -0.00137  -0.00138   1.96663
+   A15        2.07725   0.00000   0.00000  -0.00167  -0.00168   2.07557
+   A16        2.06956  -0.00001   0.00000  -0.00017  -0.00015   2.06941
+   A17        2.06882  -0.00001   0.00000   0.00040   0.00037   2.06919
+   A18        2.11096   0.00000   0.00000   0.00023   0.00024   2.11120
+   A19        2.10121   0.00001   0.00000  -0.00097  -0.00096   2.10025
+   A20        2.13545   0.00000   0.00000  -0.00090  -0.00089   2.13455
+   A21        2.07202   0.00000   0.00000   0.00012   0.00012   2.07214
+   A22        2.07265   0.00000   0.00000   0.00073   0.00073   2.07338
+   A23        2.08230  -0.00001   0.00000  -0.00015  -0.00005   2.08224
+   A24        2.09043   0.00001   0.00000  -0.00027  -0.00032   2.09012
+   A25        2.10988   0.00001   0.00000   0.00045   0.00040   2.11028
+    D1       -0.45074   0.00000   0.00001  -0.01063  -0.01059  -0.46133
+    D2       -2.57572  -0.00001   0.00001  -0.00282  -0.00284  -2.57857
+    D3        1.74547   0.00000   0.00001  -0.00665  -0.00663   1.73883
+    D4        2.39183  -0.00001   0.00000  -0.07612  -0.07620   2.31563
+    D5       -1.19370  -0.00001  -0.00001  -0.02948  -0.02942  -1.22312
+    D6       -1.85216  -0.00001   0.00000  -0.08954  -0.08961  -1.94177
+    D7        0.84551  -0.00001  -0.00001  -0.04290  -0.04284   0.80266
+    D8        0.22282   0.00000   0.00000  -0.07994  -0.08000   0.14282
+    D9        2.92048   0.00000  -0.00001  -0.03330  -0.03323   2.88725
+   D10        1.87176  -0.00001  -0.00001   0.04172   0.04172   1.91348
+   D11       -1.89637   0.00000  -0.00001   0.02816   0.02819  -1.86818
+   D12       -0.85448   0.00000   0.00000  -0.00242  -0.00244  -0.85692
+   D13        1.66058   0.00001  -0.00001  -0.01598  -0.01597   1.64461
+   D14       -2.27717   0.00000   0.00001  -0.04396  -0.04387  -2.32105
+   D15        0.90059   0.00000   0.00001  -0.04491  -0.04485   0.85574
+   D16        0.45787   0.00000   0.00001   0.00041   0.00040   0.45827
+   D17       -2.64755   0.00000   0.00001  -0.00055  -0.00058  -2.64813
+   D18        0.88746   0.00000   0.00000   0.00185   0.00193   0.88939
+   D19       -1.65512   0.00000   0.00000   0.00695   0.00700  -1.64812
+   D20       -1.62728  -0.00001   0.00000   0.01404   0.01406  -1.61322
+   D21        2.11333  -0.00001   0.00000   0.01915   0.01913   2.13246
+   D22       -0.52514   0.00000   0.00000  -0.00139  -0.00138  -0.52652
+   D23        2.54555   0.00000   0.00001  -0.00694  -0.00694   2.53862
+   D24        2.02032   0.00000   0.00001  -0.00704  -0.00700   2.01331
+   D25       -1.19217   0.00000   0.00001  -0.01258  -0.01256  -1.20474
+   D26        0.12784   0.00000   0.00000  -0.00116  -0.00118   0.12666
+   D27       -3.09893   0.00000   0.00000  -0.00180  -0.00181  -3.10074
+   D28       -2.94327   0.00000  -0.00001   0.00430   0.00430  -2.93897
+   D29        0.11316   0.00000  -0.00001   0.00366   0.00366   0.11682
+   D30       -0.09386   0.00000   0.00000   0.00245   0.00244  -0.09142
+   D31        3.01114   0.00000   0.00000   0.00341   0.00342   3.01456
+   D32        3.13293   0.00000   0.00000   0.00312   0.00310   3.13603
+   D33       -0.04525   0.00000   0.00000   0.00407   0.00408  -0.04117
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000062     0.000450     YES
+ RMS     Force            0.000012     0.000300     YES
+ Maximum Displacement     2.447479     0.001800     NO
+ RMS     Displacement     0.396027     0.001200     NO
+ Predicted change in Energy=-2.432002D-05
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.871873   -1.799592   -0.941998
+      2          6           0       -1.437277   -1.586258    0.164095
+      3          6           0       -0.679106   -0.329835   -0.072427
+      4          6           0       -0.267413    0.573549    1.025337
+      5          6           0        1.190998    0.553866    1.255597
+      6          6           0        1.971308    0.765361    0.007773
+      7          6           0        1.423168    0.327678   -1.209264
+      8          6           0        0.126663   -0.157132   -1.306818
+      9          1           0       -2.349608    3.192048   -0.769362
+     10          1           0       -0.823613   -2.489277   -0.050389
+     11          1           0       -1.769955   -1.678720    1.209071
+     12          1           0       -0.798346    1.531814    1.139636
+     13          1           0        1.599213   -0.119530    2.023436
+     14          1           0        2.917674    1.313257    0.022021
+     15          1           0        2.011414    0.446729   -2.123814
+     16          1           0       -0.317739   -0.380987   -2.280968
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.824012   0.000000
+     3  C    2.779311   1.486394   0.000000
+     4  C    4.035520   2.602900   1.480095   0.000000
+     5  C    5.184122   3.560806   2.458021   1.476607   0.000000
+     6  C    5.562145   4.144032   2.868899   2.466596   1.486835
+     7  C    4.800426   3.705593   2.478766   2.812821   2.486083
+     8  C    3.438312   2.579127   1.484188   2.475508   2.864315
+     9  H    5.021856   4.953373   3.959792   3.796448   4.857608
+    10  H    2.337948   1.112668   2.164384   3.293547   3.876207
+    11  H    2.419903   1.100545   2.156775   2.713690   3.708619
+    12  H    4.441958   3.329007   2.224647   1.101465   2.219756
+    13  H    5.622012   3.850807   3.102839   2.227297   1.099854
+    14  H    6.643645   5.233829   3.955439   3.420320   2.253840
+    15  H    5.503557   4.610969   3.471331   3.889253   3.479222
+    16  H    3.213858   2.946928   2.238495   3.441704   3.956960
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.404708   0.000000
+     8  C    2.445784   1.387618   0.000000
+     9  H    5.016280   4.757307   4.199737   0.000000
+    10  H    4.290412   3.785004   2.814345   5.926469   0.000000
+    11  H    4.627494   4.479958   3.498870   5.289100   1.771667
+    12  H    3.088616   3.449986   3.113410   2.967670   4.193564
+    13  H    2.232573   3.268232   3.641485   5.861695   3.973227
+    14  H    1.093618   2.172780   3.423097   5.648044   5.334954
+    15  H    2.155644   1.093896   2.141125   5.328211   4.577838
+    16  H    3.433976   2.163680   1.093880   4.379501   3.110672
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.355053   0.000000
+    13  H    3.800732   3.042422   0.000000
+    14  H    5.686377   3.886597   2.792289   0.000000
+    15  H    5.470321   4.440976   4.205977   2.485314   0.000000
+    16  H    3.996676   3.948459   4.719212   4.317652   2.476845
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.9094190      0.9370851      0.8411092
+ Leave Link  202 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       381.5569987062 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0074016862 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      381.5495970200 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2736 LenP2D=    8030.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.08D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         3.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=    -0.133036   -0.018089   -0.094326
+         Rot=    0.999419    0.021963    0.009752   -0.024152 Ang=   3.90 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0261 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:10:35 2024, MaxMem=  4294967296 cpu:         1.6
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.934750722434
+ DIIS: error= 4.94D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.934750722434     IErMin= 1 ErrMin= 4.94D-03
+ ErrMax= 4.94D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.54D-02 BMatP= 1.54D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.703 Goal=     0.100 Shift=    0.000
+ T=  414. Gap= 0.319 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ T=  414. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.703 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=6.43D-04 MaxDP=1.25D-02              OVMax= 2.04D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.942299375353     Delta-E=       -0.007548652919 Rises=F Damp=F
+ DIIS: error= 1.37D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.942299375353     IErMin= 2 ErrMin= 1.37D-03
+ ErrMax= 1.37D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.42D-04 BMatP= 1.54D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.223D+00 0.122D+01
+ Coeff:     -0.223D+00 0.122D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ T=  248. Gap= 0.319 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ T=  248. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.237 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.38D-04 MaxDP=4.48D-03 DE=-7.55D-03 OVMax= 9.72D-03
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943021001466     Delta-E=       -0.000721626112 Rises=F Damp=F
+ DIIS: error= 2.99D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943021001466     IErMin= 3 ErrMin= 2.99D-04
+ ErrMax= 2.99D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.48D-05 BMatP= 8.42D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.150D-01-0.300D-01 0.104D+01
+ Coeff:     -0.150D-01-0.300D-01 0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.99D-05 MaxDP=2.28D-03 DE=-7.22D-04 OVMax= 3.03D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943070459396     Delta-E=       -0.000049457930 Rises=F Damp=F
+ DIIS: error= 2.03D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943070459396     IErMin= 4 ErrMin= 2.03D-04
+ ErrMax= 2.03D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.37D-05 BMatP= 6.48D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.323D-01-0.231D+00 0.482D+00 0.716D+00
+ Coeff:      0.323D-01-0.231D+00 0.482D+00 0.716D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.15D-05 MaxDP=1.07D-03 DE=-4.95D-05 OVMax= 2.18D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943086799171     Delta-E=       -0.000016339776 Rises=F Damp=F
+ DIIS: error= 1.54D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943086799171     IErMin= 5 ErrMin= 1.54D-04
+ ErrMax= 1.54D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.54D-06 BMatP= 3.37D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.129D-01-0.784D-01 0.675D-01 0.249D+00 0.749D+00
+ Coeff:      0.129D-01-0.784D-01 0.675D-01 0.249D+00 0.749D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.35D-05 MaxDP=3.93D-04 DE=-1.63D-05 OVMax= 7.23D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943089057569     Delta-E=       -0.000002258398 Rises=F Damp=F
+ DIIS: error= 3.37D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943089057569     IErMin= 6 ErrMin= 3.37D-05
+ ErrMax= 3.37D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.17D-07 BMatP= 4.54D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.425D-02 0.383D-01-0.135D+00-0.113D+00 0.172D+00 0.104D+01
+ Coeff:     -0.425D-02 0.383D-01-0.135D+00-0.113D+00 0.172D+00 0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.24D-05 MaxDP=3.47D-04 DE=-2.26D-06 OVMax= 8.06D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943090151453     Delta-E=       -0.000001093883 Rises=F Damp=F
+ DIIS: error= 2.94D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943090151453     IErMin= 7 ErrMin= 2.94D-05
+ ErrMax= 2.94D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.48D-07 BMatP= 7.17D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.559D-03 0.475D-02-0.158D-01-0.151D-01 0.509D-01-0.444D-01
+ Coeff-Com:  0.102D+01
+ Coeff:     -0.559D-03 0.475D-02-0.158D-01-0.151D-01 0.509D-01-0.444D-01
+ Coeff:      0.102D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.26D-06 MaxDP=2.52D-04 DE=-1.09D-06 OVMax= 5.73D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943090433505     Delta-E=       -0.000000282053 Rises=F Damp=F
+ DIIS: error= 2.82D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943090433505     IErMin= 8 ErrMin= 2.82D-05
+ ErrMax= 2.82D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.01D-07 BMatP= 1.48D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.224D-03-0.264D-02 0.127D-01 0.742D-02 0.538D-01-0.310D+00
+ Coeff-Com:  0.612D-01 0.118D+01
+ Coeff:      0.224D-03-0.264D-02 0.127D-01 0.742D-02 0.538D-01-0.310D+00
+ Coeff:      0.612D-01 0.118D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.96D-06 MaxDP=3.34D-04 DE=-2.82D-07 OVMax= 7.54D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943090714601     Delta-E=       -0.000000281096 Rises=F Damp=F
+ DIIS: error= 2.79D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943090714601     IErMin= 9 ErrMin= 2.79D-05
+ ErrMax= 2.79D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.05D-08 BMatP= 1.01D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.180D-03 0.317D-02-0.195D-01-0.779D-02 0.939D-01 0.989D-01
+ Coeff-Com: -0.782D+00 0.155D+00 0.146D+01
+ Coeff:     -0.180D-03 0.317D-02-0.195D-01-0.779D-02 0.939D-01 0.989D-01
+ Coeff:     -0.782D+00 0.155D+00 0.146D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.15D-06 MaxDP=4.62D-04 DE=-2.81D-07 OVMax= 1.06D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943090989763     Delta-E=       -0.000000275162 Rises=F Damp=F
+ DIIS: error= 1.53D-04 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943090989763     IErMin= 9 ErrMin= 2.79D-05
+ ErrMax= 1.53D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.90D-06 BMatP= 8.05D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.497D-03 0.511D-02-0.214D-01-0.140D-01 0.186D-01 0.258D+00
+ Coeff-Com: -0.600D+00-0.458D+00 0.169D+01 0.127D+00
+ Coeff:     -0.497D-03 0.511D-02-0.214D-01-0.140D-01 0.186D-01 0.258D+00
+ Coeff:     -0.600D+00-0.458D+00 0.169D+01 0.127D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.33D-06 MaxDP=1.00D-04 DE=-2.75D-07 OVMax= 2.32D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943091091026     Delta-E=       -0.000000101262 Rises=F Damp=F
+ DIIS: error= 6.06D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943091091026     IErMin= 9 ErrMin= 2.79D-05
+ ErrMax= 6.06D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.46D-07 BMatP= 8.05D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.742D-03 0.726D-02-0.290D-01-0.202D-01 0.114D-01 0.356D+00
+ Coeff-Com: -0.589D+00-0.669D+00 0.154D+01-0.665D-01 0.457D+00
+ Coeff:     -0.742D-03 0.726D-02-0.290D-01-0.202D-01 0.114D-01 0.356D+00
+ Coeff:     -0.589D+00-0.669D+00 0.154D+01-0.665D-01 0.457D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.07D-06 MaxDP=1.63D-04 DE=-1.01D-07 OVMax= 3.75D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943091185147     Delta-E=       -0.000000094121 Rises=F Damp=F
+ DIIS: error= 6.17D-05 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943091185147     IErMin= 9 ErrMin= 2.79D-05
+ ErrMax= 6.17D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.93D-07 BMatP= 8.05D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.465D-03 0.451D-02-0.180D-01-0.124D-01-0.563D-02 0.258D+00
+ Coeff-Com: -0.400D+00-0.565D+00 0.120D+01-0.196D+00 0.405D+00 0.326D+00
+ Coeff:     -0.465D-03 0.451D-02-0.180D-01-0.124D-01-0.563D-02 0.258D+00
+ Coeff:     -0.400D+00-0.565D+00 0.120D+01-0.196D+00 0.405D+00 0.326D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.08D-06 MaxDP=8.60D-05 DE=-9.41D-08 OVMax= 1.99D-04
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943091238954     Delta-E=       -0.000000053808 Rises=F Damp=F
+ DIIS: error= 2.49D-05 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943091238954     IErMin=13 ErrMin= 2.49D-05
+ ErrMax= 2.49D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.55D-08 BMatP= 8.05D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.320D-03 0.237D-02-0.617D-02-0.714D-02-0.222D-01 0.896D-01
+ Coeff-Com:  0.174D+00-0.308D+00-0.423D+00 0.285D+00-0.530D+00-0.386D+00
+ Coeff-Com:  0.213D+01
+ Coeff:     -0.320D-03 0.237D-02-0.617D-02-0.714D-02-0.222D-01 0.896D-01
+ Coeff:      0.174D+00-0.308D+00-0.423D+00 0.285D+00-0.530D+00-0.386D+00
+ Coeff:      0.213D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.75D-06 MaxDP=6.22D-04 DE=-5.38D-08 OVMax= 1.43D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943091548175     Delta-E=       -0.000000309221 Rises=F Damp=F
+ DIIS: error= 1.05D-04 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943091548175     IErMin=13 ErrMin= 2.49D-05
+ ErrMax= 1.05D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.14D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.716D-05-0.248D-03 0.161D-02 0.720D-03-0.133D-01-0.385D-02
+ Coeff-Com:  0.163D+00-0.110D+00-0.490D+00 0.154D+00-0.288D+00-0.763D+00
+ Coeff-Com:  0.208D+01 0.274D+00
+ Coeff:      0.716D-05-0.248D-03 0.161D-02 0.720D-03-0.133D-01-0.385D-02
+ Coeff:      0.163D+00-0.110D+00-0.490D+00 0.154D+00-0.288D+00-0.763D+00
+ Coeff:      0.208D+01 0.274D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.77D-06 MaxDP=1.44D-04 DE=-3.09D-07 OVMax= 3.30D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943091613331     Delta-E=       -0.000000065155 Rises=F Damp=F
+ DIIS: error= 1.23D-04 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943091613331     IErMin=13 ErrMin= 2.49D-05
+ ErrMax= 1.23D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.29D-06 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.613D-04 0.359D-03-0.439D-03-0.110D-02-0.226D-01 0.392D-01
+ Coeff-Com:  0.176D+00-0.223D+00-0.429D+00-0.395D-01-0.226D-01-0.659D+00
+ Coeff-Com:  0.185D+01 0.124D+00 0.207D+00
+ Coeff:     -0.613D-04 0.359D-03-0.439D-03-0.110D-02-0.226D-01 0.392D-01
+ Coeff:      0.176D+00-0.223D+00-0.429D+00-0.395D-01-0.226D-01-0.659D+00
+ Coeff:      0.185D+01 0.124D+00 0.207D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.54D-07 MaxDP=6.87D-05 DE=-6.52D-08 OVMax= 1.58D-04
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943091657227     Delta-E=       -0.000000043897 Rises=F Damp=F
+ DIIS: error= 6.67D-05 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943091657227     IErMin=13 ErrMin= 2.49D-05
+ ErrMax= 6.67D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.98D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.865D-05-0.127D-03 0.533D-03 0.581D-03-0.170D-01 0.248D-01
+ Coeff-Com:  0.125D+00-0.167D+00-0.294D+00-0.181D+00 0.458D+00-0.731D+00
+ Coeff-Com:  0.124D+01-0.390D+00 0.353D+00 0.574D+00
+ Coeff:      0.865D-05-0.127D-03 0.533D-03 0.581D-03-0.170D-01 0.248D-01
+ Coeff:      0.125D+00-0.167D+00-0.294D+00-0.181D+00 0.458D+00-0.731D+00
+ Coeff:      0.124D+01-0.390D+00 0.353D+00 0.574D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.36D-06 MaxDP=1.11D-04 DE=-4.39D-08 OVMax= 2.55D-04
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943091715527     Delta-E=       -0.000000058300 Rises=F Damp=F
+ DIIS: error= 2.67D-05 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943091715527     IErMin=13 ErrMin= 2.49D-05
+ ErrMax= 2.67D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.70D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.239D-04 0.425D-03-0.258D-02-0.256D-03-0.279D-01 0.973D-01
+ Coeff-Com:  0.589D-01-0.264D+00 0.448D+00-0.126D+01 0.449D+01-0.537D+00
+ Coeff-Com: -0.446D+01-0.410D+01 0.139D+01 0.336D+01 0.180D+01
+ Coeff:     -0.239D-04 0.425D-03-0.258D-02-0.256D-03-0.279D-01 0.973D-01
+ Coeff:      0.589D-01-0.264D+00 0.448D+00-0.126D+01 0.449D+01-0.537D+00
+ Coeff:     -0.446D+01-0.410D+01 0.139D+01 0.336D+01 0.180D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.65D-05 MaxDP=1.35D-03 DE=-5.83D-08 OVMax= 3.11D-03
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943092258028     Delta-E=       -0.000000542501 Rises=F Damp=F
+ DIIS: error= 2.24D-05 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943092258028     IErMin=18 ErrMin= 2.24D-05
+ ErrMax= 2.24D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.01D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.384D-03 0.397D-02-0.174D-01-0.106D-01-0.810D-01 0.453D+00
+ Coeff-Com: -0.436D+00-0.125D+01 0.198D+01-0.167D+01 0.464D+01 0.308D+01
+ Coeff-Com: -0.710D+01-0.106D+01 0.370D+00-0.522D+00 0.183D+00 0.244D+01
+ Coeff:     -0.384D-03 0.397D-02-0.174D-01-0.106D-01-0.810D-01 0.453D+00
+ Coeff:     -0.436D+00-0.125D+01 0.198D+01-0.167D+01 0.464D+01 0.308D+01
+ Coeff:     -0.710D+01-0.106D+01 0.370D+00-0.522D+00 0.183D+00 0.244D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.19D-05 MaxDP=1.79D-03 DE=-5.43D-07 OVMax= 4.13D-03
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943092837129     Delta-E=       -0.000000579101 Rises=F Damp=F
+ DIIS: error= 5.04D-05 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943092837129     IErMin=18 ErrMin= 2.24D-05
+ ErrMax= 5.04D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.52D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.457D-04-0.182D-03-0.868D-03 0.160D-02-0.267D-01 0.938D-01
+ Coeff-Com: -0.146D+00-0.189D+00 0.993D+00-0.121D+01 0.398D+01 0.109D+01
+ Coeff-Com: -0.636D+01-0.179D+01 0.982D+00 0.507D+00 0.675D+00 0.167D+01
+ Coeff-Com:  0.733D+00
+ Coeff:      0.457D-04-0.182D-03-0.868D-03 0.160D-02-0.267D-01 0.938D-01
+ Coeff:     -0.146D+00-0.189D+00 0.993D+00-0.121D+01 0.398D+01 0.109D+01
+ Coeff:     -0.636D+01-0.179D+01 0.982D+00 0.507D+00 0.675D+00 0.167D+01
+ Coeff:      0.733D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.85D-05 MaxDP=2.33D-03 DE=-5.79D-07 OVMax= 5.36D-03
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.943093275494     Delta-E=       -0.000000438365 Rises=F Damp=F
+ DIIS: error= 5.52D-05 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093275494     IErMin=18 ErrMin= 2.24D-05
+ ErrMax= 5.52D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.25D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.974D-04 0.110D-02-0.547D-02-0.239D-02 0.989D-03 0.859D-01
+ Coeff-Com: -0.285D+00-0.113D+00 0.735D+00-0.417D-01 0.221D+00 0.143D+01
+ Coeff-Com: -0.223D+01 0.207D+00-0.978D-01-0.636D+00-0.719D-01 0.143D+01
+ Coeff-Com: -0.864D+00 0.123D+01
+ Coeff:     -0.974D-04 0.110D-02-0.547D-02-0.239D-02 0.989D-03 0.859D-01
+ Coeff:     -0.285D+00-0.113D+00 0.735D+00-0.417D-01 0.221D+00 0.143D+01
+ Coeff:     -0.223D+01 0.207D+00-0.978D-01-0.636D+00-0.719D-01 0.143D+01
+ Coeff:     -0.864D+00 0.123D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.27D-06 MaxDP=3.48D-04 DE=-4.38D-07 OVMax= 8.02D-04
+
+ Cycle  21  Pass 1  IDiag  1:
+ E= -668.943093328403     Delta-E=       -0.000000052909 Rises=F Damp=F
+ DIIS: error= 3.51D-05 at cycle  21 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093328403     IErMin=17 ErrMin= 2.24D-05
+ ErrMax= 3.51D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.65D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.219D-03-0.190D-02-0.131D-02 0.384D-01-0.480D-01-0.277D+00
+ Coeff-Com:  0.236D+00-0.822D-01 0.130D+01-0.472D+01 0.212D+01 0.313D+01
+ Coeff-Com:  0.274D+01-0.141D+01-0.240D+01-0.947D+00 0.620D+00-0.125D+01
+ Coeff-Com: -0.177D+00 0.213D+01
+ Coeff:      0.219D-03-0.190D-02-0.131D-02 0.384D-01-0.480D-01-0.277D+00
+ Coeff:      0.236D+00-0.822D-01 0.130D+01-0.472D+01 0.212D+01 0.313D+01
+ Coeff:      0.274D+01-0.141D+01-0.240D+01-0.947D+00 0.620D+00-0.125D+01
+ Coeff:     -0.177D+00 0.213D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.54D-05 MaxDP=1.26D-03 DE=-5.29D-08 OVMax= 2.90D-03
+
+ Cycle  22  Pass 1  IDiag  1:
+ E= -668.943093411016     Delta-E=       -0.000000082613 Rises=F Damp=F
+ DIIS: error= 5.56D-05 at cycle  22 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093411016     IErMin=16 ErrMin= 2.24D-05
+ ErrMax= 5.56D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.26D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.209D-04-0.405D-03 0.297D-01-0.652D-01-0.140D+00 0.287D+00
+ Coeff-Com: -0.990D-01 0.577D+00-0.304D+01 0.246D+01 0.697D+00 0.122D+01
+ Coeff-Com: -0.807D+00-0.133D+01-0.184D+00 0.563D+00-0.296D+00 0.663D-01
+ Coeff-Com:  0.139D+00 0.932D+00
+ Coeff:      0.209D-04-0.405D-03 0.297D-01-0.652D-01-0.140D+00 0.287D+00
+ Coeff:     -0.990D-01 0.577D+00-0.304D+01 0.246D+01 0.697D+00 0.122D+01
+ Coeff:     -0.807D+00-0.133D+01-0.184D+00 0.563D+00-0.296D+00 0.663D-01
+ Coeff:      0.139D+00 0.932D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.23D-06 MaxDP=1.00D-04 DE=-8.26D-08 OVMax= 2.29D-04
+
+ Cycle  23  Pass 1  IDiag  1:
+ E= -668.943093422173     Delta-E=       -0.000000011158 Rises=F Damp=F
+ DIIS: error= 5.61D-05 at cycle  23 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093422173     IErMin=15 ErrMin= 2.24D-05
+ ErrMax= 5.61D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.44D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.451D-03 0.143D-01-0.322D-01-0.972D-01 0.187D+00 0.842D-01
+ Coeff-Com: -0.963D-02-0.205D+01 0.279D+01-0.638D+00 0.717D+00-0.532D+00
+ Coeff-Com: -0.950D+00 0.966D-01 0.564D+00 0.195D-01 0.953D-01-0.524D+00
+ Coeff-Com:  0.225D+00 0.104D+01
+ Coeff:     -0.451D-03 0.143D-01-0.322D-01-0.972D-01 0.187D+00 0.842D-01
+ Coeff:     -0.963D-02-0.205D+01 0.279D+01-0.638D+00 0.717D+00-0.532D+00
+ Coeff:     -0.950D+00 0.966D-01 0.564D+00 0.195D-01 0.953D-01-0.524D+00
+ Coeff:      0.225D+00 0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.84D-07 MaxDP=6.20D-05 DE=-1.12D-08 OVMax= 1.41D-04
+
+ Cycle  24  Pass 1  IDiag  1:
+ E= -668.943093430976     Delta-E=       -0.000000008803 Rises=F Damp=F
+ DIIS: error= 6.41D-05 at cycle  24 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093430976     IErMin=14 ErrMin= 2.24D-05
+ ErrMax= 6.41D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.68D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.157D-01-0.351D-01-0.103D+00 0.196D+00 0.914D-01-0.139D-01
+ Coeff-Com: -0.201D+01 0.282D+01-0.752D+00 0.653D+00-0.513D+00-0.907D+00
+ Coeff-Com:  0.126D+00 0.568D+00 0.426D-01 0.974D-01-0.561D+00 0.244D+00
+ Coeff-Com:  0.108D+01-0.427D-01
+ Coeff:      0.157D-01-0.351D-01-0.103D+00 0.196D+00 0.914D-01-0.139D-01
+ Coeff:     -0.201D+01 0.282D+01-0.752D+00 0.653D+00-0.513D+00-0.907D+00
+ Coeff:      0.126D+00 0.568D+00 0.426D-01 0.974D-01-0.561D+00 0.244D+00
+ Coeff:      0.108D+01-0.427D-01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.20D-08 MaxDP=3.01D-06 DE=-8.80D-09 OVMax= 6.94D-06
+
+ Cycle  25  Pass 1  IDiag  1:
+ E= -668.943093429815     Delta-E=        0.000000001161 Rises=F Damp=F
+ DIIS: error= 6.75D-05 at cycle  25 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943093430976     IErMin=13 ErrMin= 2.24D-05
+ ErrMax= 6.75D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.97D-07 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.639D-02-0.953D-01 0.459D-01 0.252D+00-0.276D+00-0.143D+01
+ Coeff-Com:  0.244D+01-0.770D+00 0.813D+00-0.500D+00-0.950D+00-0.119D-01
+ Coeff-Com:  0.626D+00 0.131D-01 0.468D-01-0.371D+00 0.995D-02 0.718D+00
+ Coeff-Com:  0.147D+01-0.104D+01
+ Coeff:      0.639D-02-0.953D-01 0.459D-01 0.252D+00-0.276D+00-0.143D+01
+ Coeff:      0.244D+01-0.770D+00 0.813D+00-0.500D+00-0.950D+00-0.119D-01
+ Coeff:      0.626D+00 0.131D-01 0.468D-01-0.371D+00 0.995D-02 0.718D+00
+ Coeff:      0.147D+01-0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.33D-07 MaxDP=1.32D-05 DE= 1.16D-09 OVMax= 3.11D-05
+
+ Cycle  26  Pass 1  IDiag  1:
+ E= -668.943093440947     Delta-E=       -0.000000011132 Rises=F Damp=F
+ DIIS: error= 3.01D-05 at cycle  26 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093440947     IErMin=12 ErrMin= 2.24D-05
+ ErrMax= 3.01D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.31D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.537D-01 0.290D-01 0.138D+00-0.253D-01-0.564D+00 0.141D+01
+ Coeff-Com: -0.986D+00 0.598D+00-0.449D+00-0.400D+00-0.700D-01 0.457D+00
+ Coeff-Com:  0.850D-01-0.268D+00 0.121D-01 0.328D+00-0.556D-01 0.604D+00
+ Coeff-Com: -0.692D+00 0.907D+00
+ Coeff:     -0.537D-01 0.290D-01 0.138D+00-0.253D-01-0.564D+00 0.141D+01
+ Coeff:     -0.986D+00 0.598D+00-0.449D+00-0.400D+00-0.700D-01 0.457D+00
+ Coeff:      0.850D-01-0.268D+00 0.121D-01 0.328D+00-0.556D-01 0.604D+00
+ Coeff:     -0.692D+00 0.907D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.90D-07 MaxDP=4.80D-05 DE=-1.11D-08 OVMax= 1.10D-04
+
+ Cycle  27  Pass 1  IDiag  1:
+ E= -668.943093443283     Delta-E=       -0.000000002336 Rises=F Damp=F
+ DIIS: error= 2.71D-05 at cycle  27 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093443283     IErMin=11 ErrMin= 2.24D-05
+ ErrMax= 2.71D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.03D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.141D-01 0.379D-01-0.442D-02 0.302D-01 0.866D+00-0.121D+01
+ Coeff-Com:  0.233D+00-0.281D+00 0.114D-01 0.171D-01 0.340D+00 0.185D+00
+ Coeff-Com: -0.355D+00 0.202D-02 0.485D+00-0.371D+00 0.744D+00-0.110D+01
+ Coeff-Com:  0.710D+00 0.645D+00
+ Coeff:      0.141D-01 0.379D-01-0.442D-02 0.302D-01 0.866D+00-0.121D+01
+ Coeff:      0.233D+00-0.281D+00 0.114D-01 0.171D-01 0.340D+00 0.185D+00
+ Coeff:     -0.355D+00 0.202D-02 0.485D+00-0.371D+00 0.744D+00-0.110D+01
+ Coeff:      0.710D+00 0.645D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.73D-07 MaxDP=1.06D-05 DE=-2.34D-09 OVMax= 2.49D-05
+
+ Cycle  28  Pass 1  IDiag  1:
+ E= -668.943093446663     Delta-E=       -0.000000003379 Rises=F Damp=F
+ DIIS: error= 1.39D-05 at cycle  28 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093446663     IErMin=20 ErrMin= 1.39D-05
+ ErrMax= 1.39D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.47D-08 BMatP= 3.55D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.541D-01-0.390D-01 0.156D+00 0.390D+00-0.761D+00-0.353D-02
+ Coeff-Com: -0.320D-02-0.760D-01 0.544D-01 0.248D+00 0.183D+00-0.194D+00
+ Coeff-Com: -0.177D+00 0.631D+00-0.264D+00 0.168D+01-0.200D+01 0.820D+00
+ Coeff-Com: -0.194D+01 0.224D+01
+ Coeff:      0.541D-01-0.390D-01 0.156D+00 0.390D+00-0.761D+00-0.353D-02
+ Coeff:     -0.320D-02-0.760D-01 0.544D-01 0.248D+00 0.183D+00-0.194D+00
+ Coeff:     -0.177D+00 0.631D+00-0.264D+00 0.168D+01-0.200D+01 0.820D+00
+ Coeff:     -0.194D+01 0.224D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.43D-07 MaxDP=6.19D-06 DE=-3.38D-09 OVMax= 1.20D-05
+
+ Cycle  29  Pass 1  IDiag  1:
+ E= -668.943093448664     Delta-E=       -0.000000002002 Rises=F Damp=F
+ DIIS: error= 1.96D-05 at cycle  29 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093448664     IErMin=19 ErrMin= 1.39D-05
+ ErrMax= 1.96D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.45D-08 BMatP= 2.47D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.696D-01 0.326D-01 0.116D+00-0.301D+00 0.674D-01 0.221D-01
+ Coeff-Com: -0.619D-01 0.346D-01 0.597D-01-0.372D-01-0.108D+00 0.832D-01
+ Coeff-Com:  0.265D+00-0.441D+00 0.127D+01-0.128D+01 0.464D+00-0.554D+00
+ Coeff-Com:  0.196D+00 0.110D+01
+ Coeff:      0.696D-01 0.326D-01 0.116D+00-0.301D+00 0.674D-01 0.221D-01
+ Coeff:     -0.619D-01 0.346D-01 0.597D-01-0.372D-01-0.108D+00 0.832D-01
+ Coeff:      0.265D+00-0.441D+00 0.127D+01-0.128D+01 0.464D+00-0.554D+00
+ Coeff:      0.196D+00 0.110D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.03D-07 MaxDP=1.09D-05 DE=-2.00D-09 OVMax= 2.58D-05
+
+ Cycle  30  Pass 1  IDiag  1:
+ E= -668.943093447615     Delta-E=        0.000000001049 Rises=F Damp=F
+ DIIS: error= 4.55D-05 at cycle  30 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943093448664     IErMin=18 ErrMin= 1.39D-05
+ ErrMax= 4.55D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.86D-07 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.735D-01-0.274D+00 0.278D+00-0.272D+00-0.213D+00 0.444D+00
+ Coeff-Com: -0.256D-01 0.289D-01-0.505D-01 0.116D+00-0.175D+00-0.395D-01
+ Coeff-Com:  0.585D-01 0.539D+00-0.582D+00 0.719D-01 0.916D-01-0.346D+00
+ Coeff-Com:  0.239D+00 0.104D+01
+ Coeff:      0.735D-01-0.274D+00 0.278D+00-0.272D+00-0.213D+00 0.444D+00
+ Coeff:     -0.256D-01 0.289D-01-0.505D-01 0.116D+00-0.175D+00-0.395D-01
+ Coeff:      0.585D-01 0.539D+00-0.582D+00 0.719D-01 0.916D-01-0.346D+00
+ Coeff:      0.239D+00 0.104D+01
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.38D-07 MaxDP=1.81D-05 DE= 1.05D-09 OVMax= 4.13D-05
+
+ Cycle  31  Pass 1  IDiag  1:
+ E= -668.943093448168     Delta-E=       -0.000000000554 Rises=F Damp=F
+ DIIS: error= 3.81D-05 at cycle  31 NSaved=  20.
+ NSaved=20 IEnMin=18 EnMin= -668.943093448664     IErMin=17 ErrMin= 1.39D-05
+ ErrMax= 3.81D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.34D-07 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.169D+00 0.270D+00-0.251D+00-0.881D-01 0.226D+00 0.148D-01
+ Coeff-Com:  0.195D-01-0.427D-01 0.811D-01-0.960D-01 0.442D-01 0.473D-01
+ Coeff-Com:  0.258D+00-0.291D+00-0.473D-01 0.124D-01-0.206D+00 0.309D+00
+ Coeff-Com:  0.490D+00 0.417D+00
+ Coeff:     -0.169D+00 0.270D+00-0.251D+00-0.881D-01 0.226D+00 0.148D-01
+ Coeff:      0.195D-01-0.427D-01 0.811D-01-0.960D-01 0.442D-01 0.473D-01
+ Coeff:      0.258D+00-0.291D+00-0.473D-01 0.124D-01-0.206D+00 0.309D+00
+ Coeff:      0.490D+00 0.417D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.47D-08 MaxDP=3.26D-06 DE=-5.54D-10 OVMax= 8.36D-06
+
+ Cycle  32  Pass 1  IDiag  1:
+ E= -668.943093450183     Delta-E=       -0.000000002015 Rises=F Damp=F
+ DIIS: error= 4.20D-06 at cycle  32 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093450183     IErMin=20 ErrMin= 4.20D-06
+ ErrMax= 4.20D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.50D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.150D-01-0.676D-01-0.176D-01 0.922D-01 0.683D-02-0.299D-01
+ Coeff-Com: -0.133D-01 0.773D-02 0.788D-02 0.227D-01-0.568D-01-0.308D-01
+ Coeff-Com:  0.230D-01-0.801D-01 0.191D+00-0.647D-01 0.405D-01-0.133D-01
+ Coeff-Com:  0.179D+00 0.789D+00
+ Coeff:      0.150D-01-0.676D-01-0.176D-01 0.922D-01 0.683D-02-0.299D-01
+ Coeff:     -0.133D-01 0.773D-02 0.788D-02 0.227D-01-0.568D-01-0.308D-01
+ Coeff:      0.230D-01-0.801D-01 0.191D+00-0.647D-01 0.405D-01-0.133D-01
+ Coeff:      0.179D+00 0.789D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.10D-08 MaxDP=1.08D-06 DE=-2.01D-09 OVMax= 2.54D-06
+
+ Cycle  33  Pass 1  IDiag  1:
+ E= -668.943093450209     Delta-E=       -0.000000000026 Rises=F Damp=F
+ DIIS: error= 3.29D-06 at cycle  33 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093450209     IErMin=20 ErrMin= 3.29D-06
+ ErrMax= 3.29D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.64D-10 BMatP= 1.50D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.222D-01-0.378D-02 0.378D-01 0.333D-02-0.179D-01-0.316D-02
+ Coeff-Com: -0.292D-03 0.971D-02 0.186D-02-0.358D-01-0.507D-03-0.413D-03
+ Coeff-Com: -0.109D-01 0.945D-01-0.464D-01 0.519D-02 0.400D-01-0.936D-01
+ Coeff-Com:  0.129D+00 0.914D+00
+ Coeff:     -0.222D-01-0.378D-02 0.378D-01 0.333D-02-0.179D-01-0.316D-02
+ Coeff:     -0.292D-03 0.971D-02 0.186D-02-0.358D-01-0.507D-03-0.413D-03
+ Coeff:     -0.109D-01 0.945D-01-0.464D-01 0.519D-02 0.400D-01-0.936D-01
+ Coeff:      0.129D+00 0.914D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.66D-08 MaxDP=1.29D-06 DE=-2.57D-11 OVMax= 2.89D-06
+
+ Cycle  34  Pass 1  IDiag  1:
+ E= -668.943093450212     Delta-E=       -0.000000000003 Rises=F Damp=F
+ DIIS: error= 1.97D-06 at cycle  34 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943093450212     IErMin=20 ErrMin= 1.97D-06
+ ErrMax= 1.97D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.04D-10 BMatP= 8.64D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.411D-02-0.635D-02 0.359D-02-0.582D-03 0.658D-03 0.443D-02
+ Coeff-Com: -0.128D-01 0.414D-02 0.767D-02-0.723D-02 0.457D-02-0.122D-01
+ Coeff-Com:  0.192D-01 0.113D-01 0.846D-02 0.171D-01-0.575D-01 0.270D-02
+ Coeff-Com:  0.109D+00 0.900D+00
+ Coeff:      0.411D-02-0.635D-02 0.359D-02-0.582D-03 0.658D-03 0.443D-02
+ Coeff:     -0.128D-01 0.414D-02 0.767D-02-0.723D-02 0.457D-02-0.122D-01
+ Coeff:      0.192D-01 0.113D-01 0.846D-02 0.171D-01-0.575D-01 0.270D-02
+ Coeff:      0.109D+00 0.900D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.45D-08 MaxDP=5.50D-07 DE=-2.96D-12 OVMax= 1.39D-06
+
+ Cycle  35  Pass 1  IDiag  1:
+ E= -668.943093450207     Delta-E=        0.000000000005 Rises=F Damp=F
+ DIIS: error= 4.72D-06 at cycle  35 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943093450212     IErMin=19 ErrMin= 1.97D-06
+ ErrMax= 4.72D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.87D-09 BMatP= 2.04D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.542D-03 0.290D-03-0.489D-04 0.820D-03 0.300D-02-0.485D-02
+ Coeff-Com: -0.179D-02 0.101D-01 0.544D-03-0.353D-02 0.446D-02-0.276D-01
+ Coeff-Com:  0.994D-02 0.208D-01-0.126D-01-0.544D-01-0.419D-01-0.101D+00
+ Coeff-Com:  0.636D+00 0.562D+00
+ Coeff:     -0.542D-03 0.290D-03-0.489D-04 0.820D-03 0.300D-02-0.485D-02
+ Coeff:     -0.179D-02 0.101D-01 0.544D-03-0.353D-02 0.446D-02-0.276D-01
+ Coeff:      0.994D-02 0.208D-01-0.126D-01-0.544D-01-0.419D-01-0.101D+00
+ Coeff:      0.636D+00 0.562D+00
+ Gap=     0.319 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.04D-09 MaxDP=2.96D-07 DE= 4.55D-12 OVMax= 5.91D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943093450     A.U. after   35 cycles
+            NFock= 35  Conv=0.60D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0258 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650314677311D+02 PE=-2.335893674835D+03 EE= 6.203695166334D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0258,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:14:10 2024, MaxMem=  4294967296 cpu:      3426.0
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:14:10 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2736 LenP2D=    8030.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:14:11 2024, MaxMem=  4294967296 cpu:         2.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:14:11 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:14:23 2024, MaxMem=  4294967296 cpu:       203.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 5.98306928D-01-6.85502425D-03 1.21304097D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000127201   -0.000119577    0.000547865
+      2        6          -0.000116766   -0.000219332   -0.001063401
+      3        6          -0.000074368   -0.000091244   -0.000024833
+      4        6           0.000699975    0.000497719    0.000464196
+      5        6          -0.000338410    0.000041452   -0.000019212
+      6        6           0.000115268    0.000088465    0.000161544
+      7        6           0.000311817    0.000085701   -0.000126474
+      8        6          -0.000398383   -0.000386500   -0.000227608
+      9        1          -0.000348360    0.000410749   -0.000304497
+     10        1          -0.000006054    0.000078964    0.000177443
+     11        1          -0.000304058    0.000004887    0.000069794
+     12        1           0.000150893   -0.000448157    0.000244082
+     13        1           0.000092907   -0.000062125    0.000110050
+     14        1           0.000020977    0.000076578    0.000075464
+     15        1           0.000093036   -0.000056689   -0.000053848
+     16        1          -0.000025677    0.000099108   -0.000030565
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001063401 RMS     0.000288639
+ Leave Link  716 at Sun Aug 11 02:14:23 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.004748092 RMS     0.000693961
+ Search for a local minimum.
+ Step number  81 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .69396D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   53   55   69   70   71
+                                                     72   73   74   76   78
+                                                     80   81
+ DE=  5.34D-04 DEPred=-2.43D-05 R=-2.20D+01
+ Trust test=-2.20D+01 RLast= 4.22D-01 DXMaxT set to 1.92D-01
+ ITU= -1  0  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1 -1
+ ITU=  0  1  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1  1
+ ITU=  1  1 -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1  1
+ ITU=  0 -1  0  0 -1  0  0  0  1  0  0  1  0  0  0
+     Eigenvalues ---    0.00000   0.00000   0.00003   0.00134   0.00273
+     Eigenvalues ---    0.00653   0.00892   0.01073   0.01194   0.01797
+     Eigenvalues ---    0.01891   0.02275   0.02629   0.03519   0.03949
+     Eigenvalues ---    0.07074   0.08076   0.08928   0.09986   0.10445
+     Eigenvalues ---    0.10974   0.11142   0.11917   0.13325   0.14425
+     Eigenvalues ---    0.14644   0.17002   0.18736   0.22148   0.27204
+     Eigenvalues ---    0.27889   0.32777   0.33338   0.34503   0.35583
+     Eigenvalues ---    0.37896   0.38281   0.38421   0.38594   0.38719
+     Eigenvalues ---    0.39899   0.49371
+ Eigenvalue     1 is   1.86D-12 Eigenvector:
+                          R2        D2        D3        D1        A1
+   1                   -0.67737   0.42698   0.42414   0.41565   0.04878
+                          D15       D5        D17       D31       D21
+   1                   -0.02457   0.02194  -0.01791   0.01699   0.01535
+ Eigenvalue     2 is   3.55D-09 Eigenvector:
+                          D6        D8        D4        D15       D14
+   1                    0.43878   0.41375   0.39725   0.30250   0.29231
+                          D10       A1        D21       D11       D7
+   1                   -0.28276  -0.18127  -0.17708  -0.17425   0.13864
+ Eigenvalue     3 is   3.36D-05 Eigenvector:
+                          R2        D2        D3        D1        A1
+   1                   -0.72602  -0.39403  -0.39214  -0.37891   0.06444
+                          D17       D31       D7        D4        D10
+   1                    0.04669  -0.03620   0.03581  -0.03387   0.03239
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    81   80
+ RFO step:  Lambda=-2.36578061D-04.
+ NNeg= 0 NP= 2 Switch=  2.50D-03 Rises=T DC= -5.34D-04 SmlDif=  1.00D-05
+ RMS Error=  0.5118504684D-02 NUsed= 2 EDIIS=F
+ DidBck=T Rises=T RFO-DIIS coefs:    0.01280    0.98720
+ Iteration  1 RMS(Cart)=  0.19438447 RMS(Int)=  0.02885919
+ Iteration  2 RMS(Cart)=  0.20196530 RMS(Int)=  0.01394976
+ Iteration  3 RMS(Cart)=  0.01309981 RMS(Int)=  0.00014712
+ Iteration  4 RMS(Cart)=  0.00005763 RMS(Int)=  0.00014656
+ Iteration  5 RMS(Cart)=  0.00000000 RMS(Int)=  0.00014656
+ ITry= 1 IFail=0 DXMaxC= 2.52D+00 DCOld= 1.00D+10 DXMaxT= 1.92D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.44688  -0.00001  -0.00867  -0.00243  -0.01110   3.43579
+    R2        9.48993   0.00036  -0.01018  -0.01000  -0.02018   9.46976
+    R3        2.80888   0.00011   0.00496   0.00128   0.00625   2.81512
+    R4        2.10264  -0.00010   0.00071   0.00016   0.00087   2.10351
+    R5        2.07973   0.00016   0.00107   0.00003   0.00110   2.08083
+    R6        2.79697   0.00070   0.00218   0.00195   0.00422   2.80120
+    R7        2.80471   0.00015   0.00193   0.00039   0.00240   2.80711
+    R8        2.79038  -0.00022  -0.00173  -0.00253  -0.00425   2.78613
+    R9        2.08147  -0.00044  -0.00048  -0.00067  -0.00115   2.08032
+   R10        2.80971   0.00007  -0.00050  -0.00037  -0.00096   2.80875
+   R11        2.07842   0.00015   0.00038   0.00052   0.00091   2.07933
+   R12        2.65451   0.00038  -0.00226  -0.00095  -0.00331   2.65120
+   R13        2.06664   0.00006   0.00011  -0.00013  -0.00001   2.06663
+   R14        2.62222   0.00058   0.00352   0.00219   0.00569   2.62790
+   R15        2.06716   0.00009   0.00029  -0.00004   0.00025   2.06742
+   R16        2.06713   0.00002  -0.00011  -0.00052  -0.00063   2.06650
+    A1        1.35011   0.00475   0.37707  -0.01758   0.35949   1.70960
+    A2        1.98618   0.00272   0.00676   0.00464   0.01139   1.99757
+    A3        1.79462  -0.00089   0.00712   0.00124   0.00834   1.80296
+    A4        1.90521  -0.00099  -0.00419  -0.00445  -0.00863   1.89658
+    A5        1.95414  -0.00058  -0.00062  -0.00028  -0.00094   1.95319
+    A6        1.95659  -0.00060  -0.00423  -0.00040  -0.00462   1.95197
+    A7        1.85622   0.00017  -0.00481  -0.00106  -0.00587   1.85035
+    A8        2.14097  -0.00050  -0.00906  -0.00493  -0.01471   2.12626
+    A9        2.10322   0.00033  -0.00473  -0.00524  -0.01072   2.09250
+   A10        1.97667   0.00009  -0.00218  -0.00044  -0.00298   1.97369
+   A11        1.96302   0.00004   0.00247   0.00097   0.00359   1.96661
+   A12        2.06450   0.00009   0.00103   0.00242   0.00327   2.06778
+   A13        2.06179  -0.00005   0.00451   0.00475   0.00907   2.07086
+   A14        1.96663   0.00007   0.00136   0.00103   0.00238   1.96901
+   A15        2.07557   0.00006   0.00166   0.00308   0.00470   2.08027
+   A16        2.06941  -0.00011   0.00015   0.00044   0.00058   2.06999
+   A17        2.06919   0.00004  -0.00037  -0.00008  -0.00052   2.06867
+   A18        2.11120  -0.00010  -0.00023  -0.00066  -0.00088   2.11032
+   A19        2.10025   0.00006   0.00095   0.00110   0.00207   2.10232
+   A20        2.13455   0.00000   0.00088   0.00056   0.00146   2.13601
+   A21        2.07214  -0.00002  -0.00012  -0.00032  -0.00045   2.07169
+   A22        2.07338   0.00002  -0.00072  -0.00004  -0.00077   2.07261
+   A23        2.08224  -0.00018   0.00005  -0.00084  -0.00059   2.08165
+   A24        2.09012   0.00011   0.00031   0.00145   0.00166   2.09178
+   A25        2.11028   0.00007  -0.00039  -0.00066  -0.00116   2.10912
+    D1       -0.46133  -0.00007   0.01046  -0.02483  -0.01434  -0.47568
+    D2       -2.57857  -0.00023   0.00281  -0.02778  -0.02500  -2.60357
+    D3        1.73883   0.00039   0.00655  -0.02542  -0.01888   1.71996
+    D4        2.31563   0.00038   0.07522   0.03715   0.11221   2.42784
+    D5       -1.22312   0.00013   0.02905   0.00463   0.03382  -1.18930
+    D6       -1.94177   0.00065   0.08847   0.04163   0.12995  -1.81182
+    D7        0.80266   0.00039   0.04229   0.00911   0.05156   0.85422
+    D8        0.14282   0.00004   0.07898   0.03980   0.11863   0.26145
+    D9        2.88725  -0.00021   0.03281   0.00727   0.04024   2.92749
+   D10        1.91348  -0.00009  -0.04118  -0.03046  -0.07170   1.84178
+   D11       -1.86818   0.00002  -0.02783  -0.01700  -0.04481  -1.91299
+   D12       -0.85692   0.00008   0.00241   0.00085   0.00324  -0.85369
+   D13        1.64461   0.00019   0.01577   0.01431   0.03013   1.67473
+   D14       -2.32105   0.00018   0.04331   0.03113   0.07452  -2.24653
+   D15        0.85574   0.00024   0.04428   0.03290   0.07723   0.93297
+   D16        0.45827  -0.00018  -0.00040   0.00061   0.00020   0.45847
+   D17       -2.64813  -0.00012   0.00057   0.00238   0.00291  -2.64522
+   D18        0.88939  -0.00001  -0.00190  -0.00152  -0.00327   0.88612
+   D19       -1.64812   0.00000  -0.00691  -0.00872  -0.01554  -1.66366
+   D20       -1.61322  -0.00018  -0.01388  -0.01403  -0.02789  -1.64112
+   D21        2.13246  -0.00016  -0.01889  -0.02123  -0.04016   2.09229
+   D22       -0.52652  -0.00012   0.00136   0.00094   0.00232  -0.52420
+   D23        2.53862  -0.00006   0.00685   0.00636   0.01320   2.55181
+   D24        2.01331  -0.00007   0.00691   0.00911   0.01606   2.02938
+   D25       -1.20474  -0.00001   0.01240   0.01453   0.02694  -1.17780
+   D26        0.12666   0.00004   0.00116   0.00070   0.00184   0.12850
+   D27       -3.10074   0.00008   0.00179   0.00341   0.00518  -3.09556
+   D28       -2.93897  -0.00001  -0.00424  -0.00461  -0.00886  -2.94783
+   D29        0.11682   0.00002  -0.00361  -0.00190  -0.00551   0.11130
+   D30       -0.09142   0.00004  -0.00241  -0.00203  -0.00447  -0.09589
+   D31        3.01456  -0.00002  -0.00337  -0.00378  -0.00715   3.00741
+   D32        3.13603   0.00001  -0.00307  -0.00473  -0.00783   3.12820
+   D33       -0.04117  -0.00005  -0.00403  -0.00648  -0.01051  -0.05168
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004748     0.000450     NO
+ RMS     Force            0.000694     0.000300     NO
+ Maximum Displacement     2.520567     0.001800     NO
+ RMS     Displacement     0.397793     0.001200     NO
+ Predicted change in Energy=-9.750707D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:14:23 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.868098   -1.603276   -0.928496
+      2          6           0       -1.428432   -1.474029    0.174359
+      3          6           0       -0.627045   -0.230542   -0.000921
+      4          6           0       -0.077476    0.514896    1.156488
+      5          6           0        1.376752    0.329587    1.313370
+      6          6           0        2.128631    0.579844    0.055907
+      7          6           0        1.493566    0.319185   -1.167625
+      8          6           0        0.147219   -0.018851   -1.250837
+      9          1           0       -3.683435    3.297813   -1.581540
+     10          1           0       -0.838002   -2.386202   -0.067270
+     11          1           0       -1.768674   -1.598928    1.214126
+     12          1           0       -0.514756    1.493943    1.405759
+     13          1           0        1.747957   -0.442077    2.004366
+     14          1           0        3.131352    1.015782    0.078158
+     15          1           0        2.058829    0.460668   -2.093563
+     16          1           0       -0.352879   -0.094843   -2.220357
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.818139   0.000000
+     3  C    2.786954   1.489700   0.000000
+     4  C    4.076932   2.597206   1.482329   0.000000
+     5  C    5.175005   3.524122   2.460957   1.474358   0.000000
+     6  C    5.540971   4.109151   2.872926   2.466253   1.486326
+     7  C    4.772541   3.681659   2.482013   2.812113   2.483765
+     8  C    3.421468   2.575152   1.485459   2.476003   2.865017
+     9  H    5.011179   5.562256   4.928403   5.314543   6.541893
+    10  H    2.340079   1.113127   2.166974   3.239190   3.766539
+    11  H    2.408232   1.101126   2.156882   2.707715   3.690898
+    12  H    4.536489   3.340660   2.228275   1.100856   2.223075
+    13  H    5.590887   3.808319   3.115535   2.228654   1.100334
+    14  H    6.623158   5.196157   3.960446   3.422026   2.252828
+    15  H    5.467345   4.587758   3.474312   3.889675   3.477011
+    16  H    3.204778   2.965406   2.240419   3.442487   3.957145
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.402954   0.000000
+     8  C    2.447857   1.390627   0.000000
+     9  H    6.621835   5.987061   5.077749   0.000000
+    10  H    4.196846   3.737126   2.824154   6.534334   0.000000
+    11  H    4.612755   4.471477   3.499048   5.954841   1.768595
+    12  H    3.105668   3.469254   3.127981   4.713643   4.162912
+    13  H    2.232875   3.271966   3.652099   7.506365   3.841677
+    14  H    1.093612   2.172456   3.426623   7.375879   5.229763
+    15  H    2.153902   1.094030   2.143450   6.425352   4.538961
+    16  H    3.434308   2.165416   1.093546   4.796958   3.181423
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.342886   0.000000
+    13  H    3.785429   3.037494   0.000000
+    14  H    5.668985   3.909638   2.783777   0.000000
+    15  H    5.461916   4.465003   4.207685   2.484920   0.000000
+    16  H    4.007795   3.962217   4.731001   4.319321   2.478106
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6798195      0.9273063      0.8407030
+ Leave Link  202 at Sun Aug 11 02:14:23 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.5798700752 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071964377 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.5726736375 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:14:24 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7947.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:14:24 2024, MaxMem=  4294967296 cpu:         5.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:14:24 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.138896    0.005538    0.080359
+         Rot=    0.999522   -0.020083   -0.007518    0.022250 Ang=  -3.54 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0258 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:14:24 2024, MaxMem=  4294967296 cpu:         2.4
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.932313779545
+ DIIS: error= 5.99D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.932313779545     IErMin= 1 ErrMin= 5.99D-03
+ ErrMax= 5.99D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.11D-02 BMatP= 2.11D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ T=  529. Gap= 0.320 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.736 Goal=     0.100 Shift=    0.000
+ T=  529. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.701 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=7.81D-04 MaxDP=1.47D-02              OVMax= 2.42D-02
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.942532577838     Delta-E=       -0.010218798293 Rises=F Damp=F
+ DIIS: error= 1.78D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.942532577838     IErMin= 2 ErrMin= 1.78D-03
+ ErrMax= 1.78D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.14D-03 BMatP= 2.11D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.217D+00 0.122D+01
+ Coeff:     -0.217D+00 0.122D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ T=  369. Gap= 0.321 NK=4 IS=   37 IE=   45 IFin=   36
+          NO(<0.9)=   0  NV(>0.1)=   0     36.00e < EF      0.00e >EF  Err=0.0D+00
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ T=  369. Gap= 0.237 NK=4 IS=   31 IE=   35 IFin=   30
+          NO(<0.9)=   0  NV(>0.1)=   0     30.00e < EF      0.00e >EF  Err=0.0D+00
+ GapD=    0.237 DampG=1.000 DampE=1.000 DampFc=1.0000 IDamp=-1.
+ RMSDP=2.87D-04 MaxDP=5.57D-03 DE=-1.02D-02 OVMax= 1.15D-02
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943509230803     Delta-E=       -0.000976652964 Rises=F Damp=F
+ DIIS: error= 3.93D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943509230803     IErMin= 3 ErrMin= 3.93D-04
+ ErrMax= 3.93D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.00D-04 BMatP= 1.14D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.269D-01 0.349D-01 0.992D+00
+ Coeff:     -0.269D-01 0.349D-01 0.992D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.57D-05 MaxDP=2.75D-03 DE=-9.77D-04 OVMax= 4.19D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943579221336     Delta-E=       -0.000069990533 Rises=F Damp=F
+ DIIS: error= 2.49D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943579221336     IErMin= 4 ErrMin= 2.49D-04
+ ErrMax= 2.49D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.21D-05 BMatP= 1.00D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.302D-01-0.226D+00 0.462D+00 0.733D+00
+ Coeff:      0.302D-01-0.226D+00 0.462D+00 0.733D+00
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.54D-05 MaxDP=1.34D-03 DE=-7.00D-05 OVMax= 3.19D-03
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943605809864     Delta-E=       -0.000026588528 Rises=F Damp=F
+ DIIS: error= 9.39D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943605809864     IErMin= 5 ErrMin= 9.39D-05
+ ErrMax= 9.39D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.99D-06 BMatP= 5.21D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.740D-02-0.349D-01-0.580D-01 0.976D-01 0.988D+00
+ Coeff:      0.740D-02-0.349D-01-0.580D-01 0.976D-01 0.988D+00
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.38D-05 MaxDP=6.77D-04 DE=-2.66D-05 OVMax= 1.51D-03
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943610160749     Delta-E=       -0.000004350885 Rises=F Damp=F
+ DIIS: error= 4.62D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943610160749     IErMin= 6 ErrMin= 4.62D-05
+ ErrMax= 4.62D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-06 BMatP= 3.99D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.422D-02 0.393D-01-0.130D+00-0.134D+00 0.373D+00 0.856D+00
+ Coeff:     -0.422D-02 0.393D-01-0.130D+00-0.134D+00 0.373D+00 0.856D+00
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.32D-05 MaxDP=3.94D-04 DE=-4.35D-06 OVMax= 1.00D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943611686611     Delta-E=       -0.000001525862 Rises=F Damp=F
+ DIIS: error= 3.08D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943611686611     IErMin= 7 ErrMin= 3.08D-05
+ ErrMax= 3.08D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.33D-07 BMatP= 1.33D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.514D-03 0.652D-05 0.246D-01 0.122D-02-0.193D+00-0.996D-01
+ Coeff-Com:  0.127D+01
+ Coeff:     -0.514D-03 0.652D-05 0.246D-01 0.122D-02-0.193D+00-0.996D-01
+ Coeff:      0.127D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.45D-06 MaxDP=3.78D-04 DE=-1.53D-06 OVMax= 8.47D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943612388624     Delta-E=       -0.000000702013 Rises=F Damp=F
+ DIIS: error= 3.04D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943612388624     IErMin= 8 ErrMin= 3.04D-05
+ ErrMax= 3.04D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.10D-07 BMatP= 2.33D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.149D-02-0.133D-01 0.419D-01 0.447D-01-0.105D+00-0.272D+00
+ Coeff-Com: -0.721D-01 0.137D+01
+ Coeff:      0.149D-02-0.133D-01 0.419D-01 0.447D-01-0.105D+00-0.272D+00
+ Coeff:     -0.721D-01 0.137D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.00D-06 MaxDP=4.62D-04 DE=-7.02D-07 OVMax= 1.03D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943612877593     Delta-E=       -0.000000488969 Rises=F Damp=F
+ DIIS: error= 2.94D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943612877593     IErMin= 9 ErrMin= 2.94D-05
+ ErrMax= 2.94D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.76D-08 BMatP= 1.10D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.110D-03 0.546D-03-0.101D-01-0.140D-02 0.745D-01 0.275D-01
+ Coeff-Com: -0.445D+00 0.274D-01 0.133D+01
+ Coeff:      0.110D-03 0.546D-03-0.101D-01-0.140D-02 0.745D-01 0.275D-01
+ Coeff:     -0.445D+00 0.274D-01 0.133D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.79D-06 MaxDP=4.66D-04 DE=-4.89D-07 OVMax= 1.06D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943613211984     Delta-E=       -0.000000334391 Rises=F Damp=F
+ DIIS: error= 2.75D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943613211984     IErMin=10 ErrMin= 2.75D-05
+ ErrMax= 2.75D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.02D-08 BMatP= 5.76D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.482D-03 0.460D-02-0.163D-01-0.155D-01 0.514D-01 0.951D-01
+ Coeff-Com: -0.358D-01-0.516D+00 0.288D+00 0.114D+01
+ Coeff:     -0.482D-03 0.460D-02-0.163D-01-0.155D-01 0.514D-01 0.951D-01
+ Coeff:     -0.358D-01-0.516D+00 0.288D+00 0.114D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.43D-06 MaxDP=4.17D-04 DE=-3.34D-07 OVMax= 9.55D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943613456882     Delta-E=       -0.000000244899 Rises=F Damp=F
+ DIIS: error= 2.58D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943613456882     IErMin=11 ErrMin= 2.58D-05
+ ErrMax= 2.58D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.32D-08 BMatP= 4.02D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.322D-04-0.262D-03 0.364D-02 0.826D-03-0.257D-01-0.137D-01
+ Coeff-Com:  0.162D+00-0.307D-01-0.403D+00-0.585D-01 0.137D+01
+ Coeff:     -0.322D-04-0.262D-03 0.364D-02 0.826D-03-0.257D-01-0.137D-01
+ Coeff:      0.162D+00-0.307D-01-0.403D+00-0.585D-01 0.137D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.27D-06 MaxDP=4.28D-04 DE=-2.45D-07 OVMax= 9.78D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943613687565     Delta-E=       -0.000000230683 Rises=F Damp=F
+ DIIS: error= 2.43D-05 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943613687565     IErMin=12 ErrMin= 2.43D-05
+ ErrMax= 2.43D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.00D-08 BMatP= 3.32D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.446D-03-0.420D-02 0.146D-01 0.154D-01-0.438D-01-0.938D-01
+ Coeff-Com: -0.141D-01 0.567D+00-0.204D+00-0.134D+01-0.194D+00 0.230D+01
+ Coeff:      0.446D-03-0.420D-02 0.146D-01 0.154D-01-0.438D-01-0.938D-01
+ Coeff:     -0.141D-01 0.567D+00-0.204D+00-0.134D+01-0.194D+00 0.230D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.18D-05 MaxDP=9.70D-04 DE=-2.31D-07 OVMax= 2.21D-03
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943614166188     Delta-E=       -0.000000478622 Rises=F Damp=F
+ DIIS: error= 2.12D-05 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943614166188     IErMin=13 ErrMin= 2.12D-05
+ ErrMax= 2.12D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.43D-08 BMatP= 3.00D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.175D-04 0.924D-03-0.920D-02-0.190D-02 0.551D-01 0.409D-01
+ Coeff-Com: -0.353D+00 0.746D-01 0.774D+00 0.215D+00-0.257D+01-0.233D+00
+ Coeff-Com:  0.300D+01
+ Coeff:      0.175D-04 0.924D-03-0.920D-02-0.190D-02 0.551D-01 0.409D-01
+ Coeff:     -0.353D+00 0.746D-01 0.774D+00 0.215D+00-0.257D+01-0.233D+00
+ Coeff:      0.300D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.90D-05 MaxDP=2.38D-03 DE=-4.79D-07 OVMax= 5.42D-03
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943615097180     Delta-E=       -0.000000930992 Rises=F Damp=F
+ DIIS: error= 1.43D-05 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943615097180     IErMin=14 ErrMin= 1.43D-05
+ ErrMax= 1.43D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-08 BMatP= 2.43D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.491D-03 0.513D-02-0.211D-01-0.176D-01 0.745D-01 0.133D+00
+ Coeff-Com: -0.171D+00-0.572D+00 0.587D+00 0.162D+01-0.993D+00-0.266D+01
+ Coeff-Com:  0.119D+01 0.183D+01
+ Coeff:     -0.491D-03 0.513D-02-0.211D-01-0.176D-01 0.745D-01 0.133D+00
+ Coeff:     -0.171D+00-0.572D+00 0.587D+00 0.162D+01-0.993D+00-0.266D+01
+ Coeff:      0.119D+01 0.183D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.92D-05 MaxDP=3.22D-03 DE=-9.31D-07 OVMax= 7.33D-03
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943615806798     Delta-E=       -0.000000709618 Rises=F Damp=F
+ DIIS: error= 5.29D-06 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943615806798     IErMin=15 ErrMin= 5.29D-06
+ ErrMax= 5.29D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.29D-09 BMatP= 1.33D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.135D-03 0.979D-03-0.171D-02-0.349D-02-0.510D-02 0.206D-01
+ Coeff-Com:  0.954D-01-0.173D+00-0.134D+00 0.237D+00 0.665D+00-0.225D+00
+ Coeff-Com: -0.983D+00 0.229D+00 0.128D+01
+ Coeff:     -0.135D-03 0.979D-03-0.171D-02-0.349D-02-0.510D-02 0.206D-01
+ Coeff:      0.954D-01-0.173D+00-0.134D+00 0.237D+00 0.665D+00-0.225D+00
+ Coeff:     -0.983D+00 0.229D+00 0.128D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.72D-05 MaxDP=1.42D-03 DE=-7.10D-07 OVMax= 3.22D-03
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943615918745     Delta-E=       -0.000000111947 Rises=F Damp=F
+ DIIS: error= 1.45D-06 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943615918745     IErMin=16 ErrMin= 1.45D-06
+ ErrMax= 1.45D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.01D-10 BMatP= 3.29D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.104D-03-0.119D-02 0.544D-02 0.404D-02-0.223D-01-0.307D-01
+ Coeff-Com:  0.711D-01 0.112D+00-0.194D+00-0.366D+00 0.400D+00 0.664D+00
+ Coeff-Com: -0.554D+00-0.423D+00 0.308D+00 0.103D+01
+ Coeff:      0.104D-03-0.119D-02 0.544D-02 0.404D-02-0.223D-01-0.307D-01
+ Coeff:      0.711D-01 0.112D+00-0.194D+00-0.366D+00 0.400D+00 0.664D+00
+ Coeff:     -0.554D+00-0.423D+00 0.308D+00 0.103D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.36D-06 MaxDP=4.45D-04 DE=-1.12D-07 OVMax= 1.00D-03
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943615928418     Delta-E=       -0.000000009673 Rises=F Damp=F
+ DIIS: error= 6.61D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943615928418     IErMin=17 ErrMin= 6.61D-07
+ ErrMax= 6.61D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.01D-10 BMatP= 7.01D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.403D-04-0.360D-03 0.112D-02 0.129D-02-0.212D-02-0.907D-02
+ Coeff-Com: -0.841D-02 0.535D-01-0.111D-01-0.964D-01-0.371D-01 0.122D+00
+ Coeff-Com:  0.724D-01-0.858D-01-0.182D+00 0.182D+00 0.999D+00
+ Coeff:      0.403D-04-0.360D-03 0.112D-02 0.129D-02-0.212D-02-0.907D-02
+ Coeff:     -0.841D-02 0.535D-01-0.111D-01-0.964D-01-0.371D-01 0.122D+00
+ Coeff:      0.724D-01-0.858D-01-0.182D+00 0.182D+00 0.999D+00
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.16D-06 MaxDP=9.63D-05 DE=-9.67D-09 OVMax= 2.16D-04
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943615928915     Delta-E=       -0.000000000497 Rises=F Damp=F
+ DIIS: error= 3.07D-07 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943615928915     IErMin=18 ErrMin= 3.07D-07
+ ErrMax= 3.07D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.70D-11 BMatP= 1.01D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.896D-05 0.109D-03-0.543D-03-0.360D-03 0.252D-02 0.234D-02
+ Coeff-Com: -0.896D-02-0.581D-02 0.196D-01 0.273D-01-0.431D-01-0.634D-01
+ Coeff-Com:  0.691D-01 0.369D-01-0.562D-01-0.820D-01 0.160D+00 0.942D+00
+ Coeff:     -0.896D-05 0.109D-03-0.543D-03-0.360D-03 0.252D-02 0.234D-02
+ Coeff:     -0.896D-02-0.581D-02 0.196D-01 0.273D-01-0.431D-01-0.634D-01
+ Coeff:      0.691D-01 0.369D-01-0.562D-01-0.820D-01 0.160D+00 0.942D+00
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.87D-07 MaxDP=1.53D-05 DE=-4.97D-10 OVMax= 3.42D-05
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943615928942     Delta-E=       -0.000000000026 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943615928942     IErMin=19 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.06D-12 BMatP= 1.70D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.493D-05 0.390D-04-0.859D-04-0.159D-03-0.397D-04 0.983D-03
+ Coeff-Com:  0.315D-02-0.826D-02-0.353D-03 0.961D-02 0.146D-01-0.100D-01
+ Coeff-Com: -0.229D-01 0.898D-02 0.425D-01-0.408D-01-0.257D+00 0.837D-01
+ Coeff-Com:  0.118D+01
+ Coeff:     -0.493D-05 0.390D-04-0.859D-04-0.159D-03-0.397D-04 0.983D-03
+ Coeff:      0.315D-02-0.826D-02-0.353D-03 0.961D-02 0.146D-01-0.100D-01
+ Coeff:     -0.229D-01 0.898D-02 0.425D-01-0.408D-01-0.257D+00 0.837D-01
+ Coeff:      0.118D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.47D-08 MaxDP=4.02D-06 DE=-2.64D-11 OVMax= 8.72D-06
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.943615928956     Delta-E=       -0.000000000015 Rises=F Damp=F
+ DIIS: error= 4.86D-08 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=20 EnMin= -668.943615928956     IErMin=20 ErrMin= 4.86D-08
+ ErrMax= 4.86D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.29D-13 BMatP= 4.06D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.179D-05-0.208D-04 0.987D-04 0.659D-04-0.422D-03-0.469D-03
+ Coeff-Com:  0.139D-02 0.137D-02-0.317D-02-0.586D-02 0.691D-02 0.128D-01
+ Coeff-Com: -0.122D-01-0.594D-02 0.989D-02 0.789D-02-0.447D-01-0.113D+00
+ Coeff-Com:  0.110D+00 0.104D+01
+ Coeff:      0.179D-05-0.208D-04 0.987D-04 0.659D-04-0.422D-03-0.469D-03
+ Coeff:      0.139D-02 0.137D-02-0.317D-02-0.586D-02 0.691D-02 0.128D-01
+ Coeff:     -0.122D-01-0.594D-02 0.989D-02 0.789D-02-0.447D-01-0.113D+00
+ Coeff:      0.110D+00 0.104D+01
+ Gap=     0.321 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.88D-09 MaxDP=2.60D-07 DE=-1.48D-11 OVMax= 8.82D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943615929     A.U. after   20 cycles
+            NFock= 20  Conv=0.89D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0262 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650247222259D+02 PE=-2.333927142843D+03 EE= 6.193861310509D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0262,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:16:15 2024, MaxMem=  4294967296 cpu:      1767.5
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:16:15 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2724 LenP2D=    7947.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:16:15 2024, MaxMem=  4294967296 cpu:         2.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:16:15 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:16:25 2024, MaxMem=  4294967296 cpu:       156.0
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.07611615D-01-3.98279920D-02 1.25416952D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000115522    0.000224673   -0.000223637
+      2        6          -0.000546285   -0.000323028    0.000334221
+      3        6           0.000198476    0.000071532    0.000236791
+      4        6          -0.000846194   -0.000478462   -0.000311401
+      5        6           0.000527877    0.000068917    0.000182912
+      6        6          -0.000172442   -0.000139919   -0.000365030
+      7        6           0.000274614   -0.000058381    0.000429750
+      8        6           0.000337262    0.000487278    0.000094817
+      9        1           0.000004499   -0.000002044    0.000003504
+     10        1           0.000095920   -0.000016204    0.000057063
+     11        1           0.000215226   -0.000003454    0.000158663
+     12        1           0.000056529    0.000133537   -0.000153444
+     13        1          -0.000143593    0.000031817   -0.000182156
+     14        1           0.000036046   -0.000005062   -0.000119494
+     15        1          -0.000043639    0.000129620   -0.000040899
+     16        1          -0.000109819   -0.000120821   -0.000101660
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000846194 RMS     0.000256197
+ Leave Link  716 at Sun Aug 11 02:16:25 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000668436 RMS     0.000172790
+ Search for a local minimum.
+ Step number  82 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .17279D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   47   48   50   51   52
+                                                     53   54   55   56   57
+                                                     58   59   60   61   62
+                                                     63   64   65   66   67
+                                                     68   69   70   71   72
+                                                     73   74   75   77   76
+                                                     78   80   81   82
+ DE= -5.22D-04 DEPred=-9.75D-04 R= 5.36D-01
+ TightC=F SS=  1.41D+00  RLast= 4.52D-01 DXNew= 3.2215D-01 1.3571D+00
+ Trust test= 5.36D-01 RLast= 4.52D-01 DXMaxT set to 3.22D-01
+ ITU=  1 -1  0  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0 -1
+ ITU= -1  0  1  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1  1
+ ITU=  1  1  1 -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0 -1
+ ITU=  1  0 -1  0  0 -1  0  0  0  1  0  0  1  0  0
+     Eigenvalues ---    0.00000   0.00000   0.00009   0.00145   0.00313
+     Eigenvalues ---    0.00662   0.00962   0.01086   0.01181   0.01745
+     Eigenvalues ---    0.01839   0.02105   0.02356   0.03407   0.03976
+     Eigenvalues ---    0.07099   0.08204   0.08926   0.09980   0.10393
+     Eigenvalues ---    0.11039   0.11272   0.12130   0.13971   0.14277
+     Eigenvalues ---    0.15800   0.17646   0.18437   0.21696   0.26330
+     Eigenvalues ---    0.28245   0.31614   0.33472   0.34357   0.35059
+     Eigenvalues ---    0.37869   0.38225   0.38446   0.38594   0.38693
+     Eigenvalues ---    0.39656   0.48289
+ Eigenvalue     1 is   4.52D-12 Eigenvector:
+                          R2        D2        D3        D1        D4
+   1                    0.65938  -0.43332  -0.43103  -0.41706  -0.06905
+                          D8        D6        D5        D11       A1
+   1                   -0.05341  -0.04362  -0.04082   0.03240  -0.03046
+ Eigenvalue     2 is   3.67D-09 Eigenvector:
+                          R2        D6        D2        D3        D1
+   1                   -0.50399   0.33764  -0.32307  -0.31294  -0.30478
+                          D4        D8        D7        D5        D9
+   1                    0.29578   0.28970   0.19736   0.15551   0.14942
+ Eigenvalue     3 is   9.12D-05 Eigenvector:
+                          R2        D6        D4        D8        D3
+   1                    0.55084   0.35311   0.34934   0.32724   0.22585
+                          D2        D1        D7        D5        A1
+   1                    0.22006   0.21588   0.18278   0.17901  -0.16178
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    82   81   80
+ RFO step:  Lambda=-6.14891556D-06.
+ NNeg= 0 NP= 3 Switch=  2.50D-03 Rises=F DC= -5.34D-04 SmlDif=  1.00D-05
+ RMS Error=  0.7094216565D-03 NUsed= 3 EDIIS=F
+ DidBck=T Rises=F RFO-DIIS coefs:    0.05324    0.01293    0.93383
+ Iteration  1 RMS(Cart)=  0.02109922 RMS(Int)=  0.00017406
+ Iteration  2 RMS(Cart)=  0.00032081 RMS(Int)=  0.00000350
+ Iteration  3 RMS(Cart)=  0.00000005 RMS(Int)=  0.00000350
+ ITry= 1 IFail=0 DXMaxC= 6.74D-02 DCOld= 1.00D+10 DXMaxT= 3.22D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43579   0.00002   0.00231  -0.00027   0.00204   3.43782
+    R2        9.46976   0.00000   0.00948  -0.01853  -0.00905   9.46070
+    R3        2.81512   0.00020  -0.00122   0.00013  -0.00109   2.81404
+    R4        2.10351   0.00005  -0.00015  -0.00018  -0.00033   2.10318
+    R5        2.08083   0.00008  -0.00003   0.00018   0.00015   2.08098
+    R6        2.80120  -0.00060  -0.00194   0.00031  -0.00163   2.79957
+    R7        2.80711   0.00021  -0.00045   0.00019  -0.00026   2.80685
+    R8        2.78613   0.00047   0.00239  -0.00013   0.00225   2.78839
+    R9        2.08032   0.00006   0.00063   0.00005   0.00068   2.08100
+   R10        2.80875   0.00009   0.00043  -0.00007   0.00036   2.80911
+   R11        2.07933  -0.00019  -0.00050   0.00000  -0.00050   2.07883
+   R12        2.65120  -0.00054   0.00100  -0.00003   0.00096   2.65216
+   R13        2.06663   0.00003   0.00012   0.00005   0.00016   2.06679
+   R14        2.62790  -0.00005  -0.00206   0.00025  -0.00180   2.62610
+   R15        2.06742   0.00003   0.00004   0.00005   0.00008   2.06750
+   R16        2.06650   0.00015   0.00049   0.00009   0.00058   2.06709
+    A1        1.70960  -0.00005   0.01634   0.00326   0.01960   1.72920
+    A2        1.99757  -0.00067  -0.00439   0.00021  -0.00418   1.99339
+    A3        1.80296   0.00024  -0.00116   0.00075  -0.00040   1.80255
+    A4        1.89658   0.00046   0.00421  -0.00057   0.00363   1.90021
+    A5        1.95319   0.00007   0.00031   0.00017   0.00047   1.95367
+    A6        1.95197   0.00004   0.00037  -0.00035   0.00002   1.95199
+    A7        1.85035  -0.00008   0.00101  -0.00017   0.00084   1.85118
+    A8        2.12626  -0.00007   0.00536   0.00038   0.00573   2.13199
+    A9        2.09250   0.00028   0.00567   0.00069   0.00635   2.09885
+   A10        1.97369  -0.00017   0.00075  -0.00004   0.00070   1.97440
+   A11        1.96661   0.00000  -0.00107   0.00000  -0.00107   1.96555
+   A12        2.06778   0.00001  -0.00213  -0.00021  -0.00234   2.06543
+   A13        2.07086  -0.00008  -0.00433   0.00018  -0.00415   2.06671
+   A14        1.96901   0.00002  -0.00097   0.00003  -0.00093   1.96808
+   A15        2.08027  -0.00011  -0.00288  -0.00002  -0.00290   2.07737
+   A16        2.06999   0.00006  -0.00041  -0.00005  -0.00045   2.06953
+   A17        2.06867  -0.00004   0.00014   0.00019   0.00034   2.06901
+   A18        2.11032   0.00015   0.00061  -0.00008   0.00053   2.11085
+   A19        2.10232  -0.00011  -0.00106  -0.00012  -0.00118   2.10114
+   A20        2.13601   0.00000  -0.00054  -0.00004  -0.00058   2.13543
+   A21        2.07169   0.00002   0.00032   0.00000   0.00031   2.07200
+   A22        2.07261  -0.00003   0.00005   0.00001   0.00006   2.07267
+   A23        2.08165   0.00018   0.00061  -0.00015   0.00046   2.08212
+   A24        2.09178  -0.00017  -0.00128   0.00001  -0.00127   2.09051
+   A25        2.10912  -0.00001   0.00072   0.00009   0.00081   2.10994
+    D1       -0.47568  -0.00002   0.02347  -0.02487  -0.00140  -0.47707
+    D2       -2.60357   0.00011   0.02633  -0.02570   0.00063  -2.60294
+    D3        1.71996  -0.00010   0.02407  -0.02563  -0.00156   1.71839
+    D4        2.42784   0.00006  -0.03509  -0.00579  -0.04088   2.38696
+    D5       -1.18930   0.00012  -0.00454  -0.00325  -0.00779  -1.19709
+    D6       -1.81182  -0.00004  -0.03935  -0.00456  -0.04391  -1.85573
+    D7        0.85422   0.00002  -0.00881  -0.00202  -0.01082   0.84340
+    D8        0.26145  -0.00006  -0.03760  -0.00490  -0.04251   0.21894
+    D9        2.92749  -0.00001  -0.00706  -0.00236  -0.00942   2.91807
+   D10        1.84178   0.00019   0.02892   0.00234   0.03126   1.87304
+   D11       -1.91299   0.00005   0.01610   0.00235   0.01845  -1.89454
+   D12       -0.85369   0.00003  -0.00078  -0.00022  -0.00100  -0.85468
+   D13        1.67473  -0.00011  -0.01360  -0.00021  -0.01381   1.66092
+   D14       -2.24653   0.00003  -0.02958  -0.00204  -0.03163  -2.27815
+   D15        0.93297  -0.00004  -0.03123  -0.00083  -0.03206   0.90091
+   D16        0.45847   0.00010  -0.00057   0.00038  -0.00019   0.45828
+   D17       -2.64522   0.00002  -0.00221   0.00159  -0.00062  -2.64584
+   D18        0.88612   0.00003   0.00130  -0.00017   0.00113   0.88725
+   D19       -1.66366   0.00006   0.00818  -0.00011   0.00807  -1.65559
+   D20       -1.64112   0.00014   0.01328  -0.00002   0.01326  -1.62785
+   D21        2.09229   0.00016   0.02016   0.00004   0.02020   2.11249
+   D22       -0.52420   0.00010  -0.00091   0.00030  -0.00061  -0.52480
+   D23        2.55181   0.00005  -0.00602   0.00012  -0.00590   2.54591
+   D24        2.02938   0.00002  -0.00867   0.00026  -0.00841   2.02097
+   D25       -1.17780  -0.00004  -0.01377   0.00007  -0.01370  -1.19150
+   D26        0.12850  -0.00003  -0.00064  -0.00015  -0.00079   0.12771
+   D27       -3.09556  -0.00008  -0.00321  -0.00051  -0.00372  -3.09928
+   D28       -2.94783   0.00001   0.00437   0.00003   0.00441  -2.94342
+   D29        0.11130  -0.00003   0.00180  -0.00032   0.00148   0.11278
+   D30       -0.09589  -0.00001   0.00195  -0.00023   0.00172  -0.09417
+   D31        3.00741   0.00006   0.00358  -0.00146   0.00211   3.00952
+   D32        3.12820   0.00003   0.00451   0.00013   0.00464   3.13284
+   D33       -0.05168   0.00010   0.00614  -0.00111   0.00503  -0.04665
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000668     0.000450     NO
+ RMS     Force            0.000173     0.000300     YES
+ Maximum Displacement     0.067376     0.001800     NO
+ RMS     Displacement     0.021153     0.001200     NO
+ Predicted change in Energy=-1.529233D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:16:25 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.886591   -1.572352   -0.918241
+      2          6           0       -1.434030   -1.483085    0.173386
+      3          6           0       -0.614010   -0.252318   -0.000603
+      4          6           0       -0.078763    0.508042    1.152702
+      5          6           0        1.378230    0.341020    1.315561
+      6          6           0        2.130126    0.592881    0.058200
+      7          6           0        1.501672    0.316438   -1.165865
+      8          6           0        0.161065   -0.039832   -1.249719
+      9          1           0       -3.691038    3.326546   -1.564457
+     10          1           0       -0.863242   -2.402957   -0.084888
+     11          1           0       -1.763668   -1.611720    1.216193
+     12          1           0       -0.522791    1.488968    1.383571
+     13          1           0        1.753314   -0.427003    2.008099
+     14          1           0        3.125228    1.046212    0.079222
+     15          1           0        2.066312    0.462628   -2.091505
+     16          1           0       -0.336305   -0.130497   -2.219730
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819217   0.000000
+     3  C    2.783733   1.489125   0.000000
+     4  C    4.062110   2.600076   1.481469   0.000000
+     5  C    5.180690   3.541289   2.460357   1.475550   0.000000
+     6  C    5.550596   4.126271   2.871951   2.466643   1.486519
+     7  C    4.783899   3.694621   2.481416   2.812515   2.484616
+     8  C    3.427346   2.579251   1.485322   2.475744   2.864821
+     9  H    5.006389   5.589878   4.972123   5.326862   6.550217
+    10  H    2.340582   1.112955   2.166672   3.258980   3.809837
+    11  H    2.412118   1.101206   2.156451   2.708565   3.700620
+    12  H    4.500840   3.335866   2.226282   1.101216   2.221776
+    13  H    5.603928   3.826310   3.109602   2.227671   1.100071
+    14  H    6.632780   5.214695   3.959098   3.421629   2.253404
+    15  H    5.481691   4.600861   3.473780   3.889510   3.477979
+    16  H    3.205741   2.959983   2.239751   3.441999   3.957302
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403464   0.000000
+     8  C    2.447076   1.389672   0.000000
+     9  H    6.632639   6.015302   5.125452   0.000000
+    10  H    4.237425   3.762504   2.826728   6.558412   0.000000
+    11  H    4.621996   4.478218   3.500879   5.986088   1.769078
+    12  H    3.097991   3.460187   3.120753   4.701633   4.173650
+    13  H    2.232545   3.269568   3.646716   7.516200   3.889905
+    14  H    1.093699   2.172268   3.425178   7.373133   5.275565
+    15  H    2.154593   1.094075   2.142671   6.451890   4.562935
+    16  H    3.434462   2.165304   1.093855   4.861560   3.162165
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.343958   0.000000
+    13  H    3.794712   3.040005   0.000000
+    14  H    5.679667   3.899410   2.788023   0.000000
+    15  H    5.469236   4.453423   4.206681   2.484739   0.000000
+    16  H    4.004617   3.954898   4.725353   4.318801   2.478066
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6898698      0.9245455      0.8386428
+ Leave Link  202 at Sun Aug 11 02:16:25 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4299365534 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071820466 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4227545068 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:16:25 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2723 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:16:26 2024, MaxMem=  4294967296 cpu:         5.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:16:26 2024, MaxMem=  4294967296 cpu:         0.5
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000009    0.004547    0.003666
+         Rot=    0.999997    0.000245   -0.000512    0.002268 Ang=   0.27 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0262 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:16:26 2024, MaxMem=  4294967296 cpu:         2.5
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.942887219037
+ DIIS: error= 1.48D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.942887219037     IErMin= 1 ErrMin= 1.48D-03
+ ErrMax= 1.48D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.41D-03 BMatP= 1.41D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.740 Goal=     0.100 Shift=    0.000
+ GapD=    0.701 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.14D-04 MaxDP=3.70D-03              OVMax= 6.11D-03
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943553343573     Delta-E=       -0.000666124535 Rises=F Damp=F
+ DIIS: error= 4.28D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943553343573     IErMin= 2 ErrMin= 4.28D-04
+ ErrMax= 4.28D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.30D-05 BMatP= 1.41D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.206D+00 0.121D+01
+ Coeff:     -0.206D+00 0.121D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.28D-05 MaxDP=2.13D-03 DE=-6.66D-04 OVMax= 3.27D-03
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943618875558     Delta-E=       -0.000065531985 Rises=F Damp=F
+ DIIS: error= 1.27D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943618875558     IErMin= 3 ErrMin= 1.27D-04
+ ErrMax= 1.27D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.61D-06 BMatP= 7.30D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.218D-01-0.220D-03 0.102D+01
+ Coeff:     -0.218D-01-0.220D-03 0.102D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.95D-05 MaxDP=7.72D-04 DE=-6.55D-05 OVMax= 1.30D-03
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943624665500     Delta-E=       -0.000005789942 Rises=F Damp=F
+ DIIS: error= 6.98D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943624665500     IErMin= 4 ErrMin= 6.98D-05
+ ErrMax= 6.98D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.28D-06 BMatP= 6.61D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.287D-01-0.225D+00 0.451D+00 0.745D+00
+ Coeff:      0.287D-01-0.225D+00 0.451D+00 0.745D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.70D-05 MaxDP=5.18D-04 DE=-5.79D-06 OVMax= 9.60D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943626752376     Delta-E=       -0.000002086876 Rises=F Damp=F
+ DIIS: error= 4.44D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943626752376     IErMin= 5 ErrMin= 4.44D-05
+ ErrMax= 4.44D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.69D-07 BMatP= 3.28D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.613D-02-0.218D-01-0.107D+00 0.695D-01 0.105D+01
+ Coeff:      0.613D-02-0.218D-01-0.107D+00 0.695D-01 0.105D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.75D-06 MaxDP=2.48D-04 DE=-2.09D-06 OVMax= 6.02D-04
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943627300531     Delta-E=       -0.000000548155 Rises=F Damp=F
+ DIIS: error= 2.21D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943627300531     IErMin= 6 ErrMin= 2.21D-05
+ ErrMax= 2.21D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.45D-07 BMatP= 3.69D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.543D-02 0.527D-01-0.166D+00-0.177D+00 0.421D+00 0.875D+00
+ Coeff:     -0.543D-02 0.527D-01-0.166D+00-0.177D+00 0.421D+00 0.875D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.85D-06 MaxDP=1.60D-04 DE=-5.48D-07 OVMax= 3.86D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943627505123     Delta-E=       -0.000000204592 Rises=F Damp=F
+ DIIS: error= 1.17D-05 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943627505123     IErMin= 7 ErrMin= 1.17D-05
+ ErrMax= 1.17D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.85D-08 BMatP= 1.45D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.670D-03-0.199D-02 0.444D-01 0.450D-02-0.277D+00-0.116D+00
+ Coeff-Com:  0.135D+01
+ Coeff:     -0.670D-03-0.199D-02 0.444D-01 0.450D-02-0.277D+00-0.116D+00
+ Coeff:      0.135D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.18D-06 MaxDP=1.04D-04 DE=-2.05D-07 OVMax= 3.19D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943627587907     Delta-E=       -0.000000082784 Rises=F Damp=F
+ DIIS: error= 5.37D-06 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943627587907     IErMin= 8 ErrMin= 5.37D-06
+ ErrMax= 5.37D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.04D-08 BMatP= 2.85D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.157D-02-0.166D-01 0.602D-01 0.562D-01-0.180D+00-0.301D+00
+ Coeff-Com:  0.279D+00 0.110D+01
+ Coeff:      0.157D-02-0.166D-01 0.602D-01 0.562D-01-0.180D+00-0.301D+00
+ Coeff:      0.279D+00 0.110D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.10D-06 MaxDP=7.51D-05 DE=-8.28D-08 OVMax= 1.93D-04
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943627618013     Delta-E=       -0.000000030107 Rises=F Damp=F
+ DIIS: error= 5.27D-06 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943627618013     IErMin= 9 ErrMin= 5.27D-06
+ ErrMax= 5.27D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.56D-09 BMatP= 1.04D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.496D-03-0.260D-02-0.142D-02 0.948D-02 0.485D-01-0.288D-01
+ Coeff-Com: -0.321D+00 0.175D+00 0.112D+01
+ Coeff:      0.496D-03-0.260D-02-0.142D-02 0.948D-02 0.485D-01-0.288D-01
+ Coeff:     -0.321D+00 0.175D+00 0.112D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.33D-06 MaxDP=6.32D-05 DE=-3.01D-08 OVMax= 1.46D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943627630697     Delta-E=       -0.000000012684 Rises=F Damp=F
+ DIIS: error= 4.93D-06 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943627630697     IErMin=10 ErrMin= 4.93D-06
+ ErrMax= 4.93D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.65D-09 BMatP= 3.56D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.433D-03 0.485D-02-0.190D-01-0.167D-01 0.641D-01 0.871D-01
+ Coeff-Com: -0.117D+00-0.342D+00 0.116D+00 0.122D+01
+ Coeff:     -0.433D-03 0.485D-02-0.190D-01-0.167D-01 0.641D-01 0.871D-01
+ Coeff:     -0.117D+00-0.342D+00 0.116D+00 0.122D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.03D-06 MaxDP=6.68D-05 DE=-1.27D-08 OVMax= 1.54D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943627638907     Delta-E=       -0.000000008209 Rises=F Damp=F
+ DIIS: error= 4.50D-06 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943627638907     IErMin=11 ErrMin= 4.50D-06
+ ErrMax= 4.50D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.06D-09 BMatP= 1.65D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.815D-04 0.194D-03 0.209D-02-0.100D-02-0.174D-01-0.290D-02
+ Coeff-Com:  0.992D-01-0.211D-01-0.309D+00-0.769D-01 0.133D+01
+ Coeff:     -0.815D-04 0.194D-03 0.209D-02-0.100D-02-0.174D-01-0.290D-02
+ Coeff:      0.992D-01-0.211D-01-0.309D+00-0.769D-01 0.133D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.38D-07 MaxDP=6.54D-05 DE=-8.21D-09 OVMax= 1.50D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943627645239     Delta-E=       -0.000000006332 Rises=F Damp=F
+ DIIS: error= 4.23D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943627645239     IErMin=12 ErrMin= 4.23D-06
+ ErrMax= 4.23D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.91D-10 BMatP= 1.06D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.171D-03-0.192D-02 0.765D-02 0.690D-02-0.259D-01-0.360D-01
+ Coeff-Com:  0.479D-01 0.142D+00-0.507D-01-0.514D+00 0.200D-01 0.140D+01
+ Coeff:      0.171D-03-0.192D-02 0.765D-02 0.690D-02-0.259D-01-0.360D-01
+ Coeff:      0.479D-01 0.142D+00-0.507D-01-0.514D+00 0.200D-01 0.140D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=9.36D-07 MaxDP=7.66D-05 DE=-6.33D-09 OVMax= 1.74D-04
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943627651953     Delta-E=       -0.000000006714 Rises=F Damp=F
+ DIIS: error= 3.94D-06 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943627651953     IErMin=13 ErrMin= 3.94D-06
+ ErrMax= 3.94D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.91D-10 BMatP= 8.91D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.883D-05 0.482D-03-0.434D-02-0.909D-03 0.226D-01 0.140D-01
+ Coeff-Com: -0.103D+00-0.142D-01 0.278D+00 0.169D+00-0.111D+01-0.265D+00
+ Coeff-Com:  0.201D+01
+ Coeff:      0.883D-05 0.482D-03-0.434D-02-0.909D-03 0.226D-01 0.140D-01
+ Coeff:     -0.103D+00-0.142D-01 0.278D+00 0.169D+00-0.111D+01-0.265D+00
+ Coeff:      0.201D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.57D-06 MaxDP=1.30D-04 DE=-6.71D-09 OVMax= 2.94D-04
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943627662392     Delta-E=       -0.000000010439 Rises=F Damp=F
+ DIIS: error= 3.56D-06 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943627662392     IErMin=14 ErrMin= 3.56D-06
+ ErrMax= 3.56D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.67D-10 BMatP= 7.91D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.360D-03 0.418D-02-0.176D-01-0.144D-01 0.610D-01 0.815D-01
+ Coeff-Com: -0.136D+00-0.290D+00 0.197D+00 0.107D+01-0.336D+00-0.271D+01
+ Coeff-Com:  0.321D+00 0.277D+01
+ Coeff:     -0.360D-03 0.418D-02-0.176D-01-0.144D-01 0.610D-01 0.815D-01
+ Coeff:     -0.136D+00-0.290D+00 0.197D+00 0.107D+01-0.336D+00-0.271D+01
+ Coeff:      0.321D+00 0.277D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=4.01D-06 MaxDP=3.32D-04 DE=-1.04D-08 OVMax= 7.52D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943627684482     Delta-E=       -0.000000022090 Rises=F Damp=F
+ DIIS: error= 2.62D-06 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943627684482     IErMin=15 ErrMin= 2.62D-06
+ ErrMax= 2.62D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.94D-10 BMatP= 6.67D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.814D-04 0.137D-03 0.268D-02-0.972D-03-0.201D-01-0.510D-02
+ Coeff-Com:  0.115D+00-0.185D-01-0.335D+00-0.103D+00 0.137D+01 0.158D+00
+ Coeff-Com: -0.298D+01 0.459D+00 0.235D+01
+ Coeff:     -0.814D-04 0.137D-03 0.268D-02-0.972D-03-0.201D-01-0.510D-02
+ Coeff:      0.115D+00-0.185D-01-0.335D+00-0.103D+00 0.137D+01 0.158D+00
+ Coeff:     -0.298D+01 0.459D+00 0.235D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.87D-06 MaxDP=5.70D-04 DE=-2.21D-08 OVMax= 1.29D-03
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943627706649     Delta-E=       -0.000000022167 Rises=F Damp=F
+ DIIS: error= 9.94D-07 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943627706649     IErMin=16 ErrMin= 9.94D-07
+ ErrMax= 9.94D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.02D-10 BMatP= 3.94D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.125D-03-0.177D-02 0.885D-02 0.597D-02-0.347D-01-0.390D-01
+ Coeff-Com:  0.104D+00 0.121D+00-0.209D+00-0.506D+00 0.602D+00 0.137D+01
+ Coeff-Com: -0.128D+01-0.111D+01 0.864D+00 0.110D+01
+ Coeff:      0.125D-03-0.177D-02 0.885D-02 0.597D-02-0.347D-01-0.390D-01
+ Coeff:      0.104D+00 0.121D+00-0.209D+00-0.506D+00 0.602D+00 0.137D+01
+ Coeff:     -0.128D+01-0.111D+01 0.864D+00 0.110D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.33D-06 MaxDP=2.76D-04 DE=-2.22D-08 OVMax= 6.24D-04
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943627710271     Delta-E=       -0.000000003622 Rises=F Damp=F
+ DIIS: error= 2.25D-07 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=17 EnMin= -668.943627710271     IErMin=17 ErrMin= 2.25D-07
+ ErrMax= 2.25D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.34D-11 BMatP= 1.02D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.371D-04-0.280D-03 0.631D-03 0.103D-02 0.243D-03-0.538D-02
+ Coeff-Com: -0.122D-01 0.223D-01 0.501D-01-0.484D-01-0.262D+00 0.226D+00
+ Coeff-Com:  0.479D+00-0.278D+00-0.422D+00 0.171D+00 0.108D+01
+ Coeff:      0.371D-04-0.280D-03 0.631D-03 0.103D-02 0.243D-03-0.538D-02
+ Coeff:     -0.122D-01 0.223D-01 0.501D-01-0.484D-01-0.262D+00 0.226D+00
+ Coeff:      0.479D+00-0.278D+00-0.422D+00 0.171D+00 0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.57D-07 MaxDP=6.26D-05 DE=-3.62D-09 OVMax= 1.42D-04
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943627710444     Delta-E=       -0.000000000173 Rises=F Damp=F
+ DIIS: error= 4.98D-08 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=18 EnMin= -668.943627710444     IErMin=18 ErrMin= 4.98D-08
+ ErrMax= 4.98D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.27D-12 BMatP= 1.34D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.191D-04 0.264D-03-0.133D-02-0.951D-03 0.538D-02 0.554D-02
+ Coeff-Com: -0.151D-01-0.184D-01 0.323D-01 0.770D-01-0.107D+00-0.186D+00
+ Coeff-Com:  0.191D+00 0.163D+00-0.141D+00-0.146D+00 0.307D-02 0.114D+01
+ Coeff:     -0.191D-04 0.264D-03-0.133D-02-0.951D-03 0.538D-02 0.554D-02
+ Coeff:     -0.151D-01-0.184D-01 0.323D-01 0.770D-01-0.107D+00-0.186D+00
+ Coeff:      0.191D+00 0.163D+00-0.141D+00-0.146D+00 0.307D-02 0.114D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.25D-07 MaxDP=1.03D-05 DE=-1.73D-10 OVMax= 2.32D-05
+
+ Cycle  19  Pass 1  IDiag  1:
+ E= -668.943627710456     Delta-E=       -0.000000000012 Rises=F Damp=F
+ DIIS: error= 1.64D-08 at cycle  19 NSaved=  19.
+ NSaved=19 IEnMin=19 EnMin= -668.943627710456     IErMin=19 ErrMin= 1.64D-08
+ ErrMax= 1.64D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.41D-13 BMatP= 1.27D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.476D-05 0.431D-04-0.134D-03-0.164D-03 0.307D-03 0.787D-03
+ Coeff-Com:  0.381D-03-0.352D-02-0.285D-02 0.953D-02 0.191D-01-0.305D-01
+ Coeff-Com: -0.380D-01 0.352D-01 0.340D-01-0.228D-01-0.106D+00 0.649D-01
+ Coeff-Com:  0.104D+01
+ Coeff:     -0.476D-05 0.431D-04-0.134D-03-0.164D-03 0.307D-03 0.787D-03
+ Coeff:      0.381D-03-0.352D-02-0.285D-02 0.953D-02 0.191D-01-0.305D-01
+ Coeff:     -0.380D-01 0.352D-01 0.340D-01-0.228D-01-0.106D+00 0.649D-01
+ Coeff:      0.104D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.39D-08 MaxDP=1.09D-06 DE=-1.18D-11 OVMax= 2.46D-06
+
+ Cycle  20  Pass 1  IDiag  1:
+ E= -668.943627710455     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 5.30D-09 at cycle  20 NSaved=  20.
+ NSaved=20 IEnMin=19 EnMin= -668.943627710456     IErMin=20 ErrMin= 5.30D-09
+ ErrMax= 5.30D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.76D-14 BMatP= 1.41D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.169D-05-0.293D-04 0.168D-03 0.103D-03-0.747D-03-0.642D-03
+ Coeff-Com:  0.239D-02 0.189D-02-0.563D-02-0.945D-02 0.208D-01 0.209D-01
+ Coeff-Com: -0.381D-01-0.164D-01 0.302D-01 0.158D-01-0.271D-01-0.160D+00
+ Coeff-Com:  0.250D+00 0.916D+00
+ Coeff:      0.169D-05-0.293D-04 0.168D-03 0.103D-03-0.747D-03-0.642D-03
+ Coeff:      0.239D-02 0.189D-02-0.563D-02-0.945D-02 0.208D-01 0.209D-01
+ Coeff:     -0.381D-01-0.164D-01 0.302D-01 0.158D-01-0.271D-01-0.160D+00
+ Coeff:      0.250D+00 0.916D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.29D-09 MaxDP=1.07D-07 DE= 4.55D-13 OVMax= 2.45D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627710     A.U. after   20 cycles
+            NFock= 20  Conv=0.23D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650244840428D+02 PE=-2.333627893058D+03 EE= 6.192370267979D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:18:02 2024, MaxMem=  4294967296 cpu:      1529.5
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:18:02 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2723 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:18:02 2024, MaxMem=  4294967296 cpu:         2.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:18:02 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:       154.3
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.03689788D-01-4.96409172D-02 1.16571183D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.000012477   -0.000000718   -0.000069724
+      2        6           0.000079602    0.000078713    0.000146306
+      3        6           0.000009477    0.000014721    0.000045355
+      4        6          -0.000076746   -0.000038905   -0.000072269
+      5        6          -0.000017505   -0.000005832    0.000032905
+      6        6           0.000046140   -0.000001451   -0.000052824
+      7        6          -0.000057541   -0.000006088    0.000006867
+      8        6          -0.000012231    0.000019454    0.000022179
+      9        1           0.000007161   -0.000004628    0.000004396
+     10        1          -0.000011188   -0.000018743   -0.000040738
+     11        1           0.000019829    0.000000681   -0.000044213
+     12        1           0.000017838   -0.000001981   -0.000002610
+     13        1           0.000001932   -0.000003971   -0.000000110
+     14        1          -0.000012525   -0.000005047   -0.000001914
+     15        1          -0.000007541   -0.000004833    0.000013127
+     16        1           0.000025776   -0.000021373    0.000013267
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000146306 RMS     0.000038559
+ Leave Link  716 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000094106 RMS     0.000029410
+ Search for a local minimum.
+ Step number  83 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .29410D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   77
+                                                     76   79   78   80   81
+                                                     82   83
+ DE= -1.18D-05 DEPred=-1.53D-05 R= 7.70D-01
+ TightC=F SS=  1.41D+00  RLast= 1.04D-01 DXNew= 5.4179D-01 3.1288D-01
+ Trust test= 7.70D-01 RLast= 1.04D-01 DXMaxT set to 3.22D-01
+ ITU=  1  1 -1  0  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0  0
+ ITU= -1 -1  0  1  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1  1
+ ITU=  1  1  1  1 -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0
+ ITU= -1  1  0 -1  0  0 -1  0  0  0  1  0  0  1  0
+     Eigenvalues ---    0.00000   0.00000   0.00009   0.00048   0.00251
+     Eigenvalues ---    0.00516   0.00790   0.01041   0.01190   0.01430
+     Eigenvalues ---    0.01721   0.01970   0.02213   0.03656   0.04087
+     Eigenvalues ---    0.07476   0.07976   0.08383   0.09324   0.10473
+     Eigenvalues ---    0.10954   0.11341   0.12912   0.14171   0.14279
+     Eigenvalues ---    0.15855   0.17712   0.19143   0.20988   0.27297
+     Eigenvalues ---    0.30148   0.32211   0.33503   0.34265   0.35178
+     Eigenvalues ---    0.38082   0.38251   0.38450   0.38597   0.39629
+     Eigenvalues ---    0.39905   0.46296
+ Eigenvalue     1 is   2.08D-12 Eigenvector:
+                          R2        D2        D3        D1        A1
+   1                    0.72996  -0.39237  -0.39010  -0.38534  -0.06540
+                          D6        D8        D4        D7        D15
+   1                    0.04575   0.03809   0.03373   0.02569   0.02478
+ Eigenvalue     2 is   1.41D-08 Eigenvector:
+                          R2        D1        D4        D3        D2
+   1                    0.55909   0.34050  -0.31865   0.29380   0.29335
+                          D8        D6        D5        D9        D7
+   1                   -0.27304  -0.25558  -0.20095  -0.15534  -0.13788
+ Eigenvalue     3 is   8.99D-05 Eigenvector:
+                          R2        D4        D6        D8        D3
+   1                    0.36870   0.36422   0.36072   0.33795   0.30347
+                          D2        D1        D5        D7        D9
+   1                    0.29296   0.27665   0.22830   0.22479   0.20202
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    83   82   81   80
+ RFO step:  Lambda=-7.73175542D-07.
+ NNeg= 0 NP= 4 Switch=  2.50D-03 Rises=F DC= -5.34D-04 SmlDif=  1.00D-05
+ RMS Error=  0.6522522783D-03 NUsed= 4 EDIIS=F
+ DidBck=T Rises=F RFO-DIIS coefs:    0.03418    0.03986    0.01287    0.91309
+ Iteration  1 RMS(Cart)=  0.00237454 RMS(Int)=  0.00000279
+ Iteration  2 RMS(Cart)=  0.00000348 RMS(Int)=  0.00000245
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000245
+ ITry= 1 IFail=0 DXMaxC= 9.82D-03 DCOld= 1.00D+10 DXMaxT= 3.22D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43782   0.00004   0.00029   0.00036   0.00065   3.43848
+    R2        9.46070  -0.00001   0.01801  -0.01826  -0.00025   9.46046
+    R3        2.81404  -0.00009  -0.00015  -0.00010  -0.00025   2.81379
+    R4        2.10318   0.00002   0.00017  -0.00003   0.00014   2.10332
+    R5        2.08098  -0.00005  -0.00017  -0.00003  -0.00020   2.08078
+    R6        2.79957  -0.00009  -0.00033  -0.00020  -0.00052   2.79905
+    R7        2.80685  -0.00005  -0.00019  -0.00011  -0.00030   2.80655
+    R8        2.78839   0.00002   0.00016   0.00007   0.00022   2.78861
+    R9        2.08100  -0.00001  -0.00004   0.00000  -0.00003   2.08096
+   R10        2.80911   0.00004   0.00007   0.00006   0.00013   2.80925
+   R11        2.07883   0.00000  -0.00001   0.00000  -0.00001   2.07882
+   R12        2.65216  -0.00003   0.00005  -0.00002   0.00003   2.65219
+   R13        2.06679  -0.00001  -0.00004  -0.00001  -0.00005   2.06674
+   R14        2.62610  -0.00007  -0.00027  -0.00001  -0.00028   2.62582
+   R15        2.06750  -0.00002  -0.00005  -0.00001  -0.00006   2.06744
+   R16        2.06709  -0.00002  -0.00008  -0.00002  -0.00010   2.06698
+    A1        1.72920  -0.00007  -0.00304   0.00238  -0.00065   1.72854
+    A2        1.99339  -0.00009  -0.00026  -0.00021  -0.00047   1.99292
+    A3        1.80255  -0.00001  -0.00074  -0.00007  -0.00081   1.80174
+    A4        1.90021   0.00005   0.00060  -0.00003   0.00057   1.90078
+    A5        1.95367   0.00003  -0.00016   0.00015  -0.00001   1.95366
+    A6        1.95199   0.00003   0.00034   0.00007   0.00042   1.95241
+    A7        1.85118   0.00000   0.00018   0.00010   0.00028   1.85146
+    A8        2.13199   0.00004  -0.00029  -0.00011  -0.00038   2.13161
+    A9        2.09885  -0.00007  -0.00058  -0.00005  -0.00062   2.09823
+   A10        1.97440   0.00003   0.00006   0.00005   0.00011   1.97451
+   A11        1.96555  -0.00002  -0.00001   0.00003   0.00001   1.96556
+   A12        2.06543   0.00001   0.00018   0.00015   0.00033   2.06577
+   A13        2.06671   0.00000  -0.00023  -0.00005  -0.00027   2.06643
+   A14        1.96808   0.00000  -0.00005  -0.00002  -0.00006   1.96802
+   A15        2.07737   0.00000  -0.00002  -0.00002  -0.00004   2.07733
+   A16        2.06953   0.00000   0.00004  -0.00010  -0.00006   2.06947
+   A17        2.06901  -0.00002  -0.00018   0.00004  -0.00014   2.06886
+   A18        2.11085   0.00002   0.00008   0.00000   0.00008   2.11093
+   A19        2.10114   0.00001   0.00011  -0.00002   0.00009   2.10122
+   A20        2.13543   0.00001   0.00003  -0.00001   0.00003   2.13545
+   A21        2.07200   0.00000   0.00000   0.00003   0.00003   2.07203
+   A22        2.07267  -0.00001  -0.00001  -0.00001  -0.00002   2.07265
+   A23        2.08212   0.00001   0.00015  -0.00006   0.00009   2.08220
+   A24        2.09051   0.00001  -0.00003   0.00010   0.00007   2.09058
+   A25        2.10994  -0.00002  -0.00008  -0.00002  -0.00010   2.10984
+    D1       -0.47707  -0.00002   0.02430  -0.02354   0.00077  -0.47631
+    D2       -2.60294   0.00001   0.02514  -0.02355   0.00159  -2.60135
+    D3        1.71839   0.00000   0.02505  -0.02362   0.00143   1.71982
+    D4        2.38696   0.00002   0.00515  -0.00112   0.00403   2.39099
+    D5       -1.19709   0.00003   0.00307  -0.00142   0.00166  -1.19543
+    D6       -1.85573  -0.00003   0.00391  -0.00126   0.00265  -1.85308
+    D7        0.84340  -0.00003   0.00183  -0.00155   0.00028   0.84368
+    D8        0.21894   0.00001   0.00426  -0.00098   0.00329   0.22222
+    D9        2.91807   0.00001   0.00218  -0.00127   0.00091   2.91898
+   D10        1.87304  -0.00002  -0.00189  -0.00043  -0.00233   1.87071
+   D11       -1.89454  -0.00002  -0.00206  -0.00027  -0.00233  -1.89687
+   D12       -0.85468   0.00000   0.00020  -0.00014   0.00006  -0.85463
+   D13        1.66092  -0.00001   0.00003   0.00002   0.00005   1.66097
+   D14       -2.27815   0.00000   0.00160   0.00070   0.00230  -2.27585
+   D15        0.90091  -0.00002   0.00041   0.00017   0.00057   0.90148
+   D16        0.45828   0.00001  -0.00037   0.00040   0.00003   0.45831
+   D17       -2.64584   0.00000  -0.00157  -0.00014  -0.00170  -2.64754
+   D18        0.88725  -0.00001   0.00018  -0.00021  -0.00004   0.88721
+   D19       -1.65559   0.00000   0.00020   0.00004   0.00025  -1.65534
+   D20       -1.62785  -0.00001   0.00019  -0.00046  -0.00027  -1.62813
+   D21        2.11249   0.00000   0.00021  -0.00020   0.00002   2.11251
+   D22       -0.52480   0.00000  -0.00031   0.00026  -0.00004  -0.52485
+   D23        2.54591   0.00000  -0.00019   0.00061   0.00042   2.54634
+   D24        2.02097   0.00000  -0.00036   0.00003  -0.00032   2.02064
+   D25       -1.19150   0.00000  -0.00024   0.00038   0.00014  -1.19136
+   D26        0.12771   0.00000   0.00014   0.00003   0.00017   0.12788
+   D27       -3.09928   0.00001   0.00045   0.00019   0.00064  -3.09864
+   D28       -2.94342   0.00000   0.00002  -0.00031  -0.00029  -2.94371
+   D29        0.11278   0.00001   0.00034  -0.00016   0.00017   0.11295
+   D30       -0.09417   0.00000   0.00025  -0.00034  -0.00009  -0.09426
+   D31        3.00952   0.00002   0.00146   0.00020   0.00166   3.01118
+   D32        3.13284   0.00000  -0.00007  -0.00049  -0.00056   3.13229
+   D33       -0.04665   0.00001   0.00115   0.00005   0.00119  -0.04546
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000094     0.000450     YES
+ RMS     Force            0.000029     0.000300     YES
+ Maximum Displacement     0.009819     0.001800     NO
+ RMS     Displacement     0.002374     0.001200     NO
+ Predicted change in Energy=-5.096802D-07
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.884500   -1.573803   -0.919675
+      2          6           0       -1.433310   -1.482434    0.174175
+      3          6           0       -0.615033   -0.250626    0.000469
+      4          6           0       -0.078457    0.507890    1.154015
+      5          6           0        1.378645    0.339571    1.315639
+      6          6           0        2.129768    0.592247    0.057896
+      7          6           0        1.499987    0.317486   -1.165881
+      8          6           0        0.159145   -0.037515   -1.248909
+      9          1           0       -3.689054    3.324447   -1.569653
+     10          1           0       -0.861207   -2.401533   -0.084257
+     11          1           0       -1.763546   -1.611746    1.216597
+     12          1           0       -0.521325    1.488920    1.386584
+     13          1           0        1.753607   -0.429677    2.006875
+     14          1           0        3.125366    1.044439    0.078552
+     15          1           0        2.064035    0.463618   -2.091854
+     16          1           0       -0.338614   -0.128312   -2.218646
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819563   0.000000
+     3  C    2.783512   1.488994   0.000000
+     4  C    4.062944   2.599443   1.481192   0.000000
+     5  C    5.179964   3.539736   2.460235   1.475669   0.000000
+     6  C    5.548900   4.124724   2.871875   2.466749   1.486590
+     7  C    4.781350   3.693196   2.481216   2.812411   2.484584
+     8  C    3.425251   2.578540   1.485164   2.475472   2.864660
+     9  H    5.006259   5.588866   4.969510   5.328017   6.551028
+    10  H    2.340251   1.113028   2.166606   3.257416   3.806612
+    11  H    2.412807   1.101100   2.156548   2.708560   3.700109
+    12  H    4.503742   3.336255   2.226233   1.101199   2.221693
+    13  H    5.602300   3.824072   3.109370   2.227749   1.100067
+    14  H    6.630998   5.213037   3.959025   3.421840   2.253500
+    15  H    5.478420   4.599286   3.473524   3.889460   3.477953
+    16  H    3.202858   2.959324   2.239607   3.441987   3.957153
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403477   0.000000
+     8  C    2.446976   1.389524   0.000000
+     9  H    6.631178   6.010905   5.119990   0.000000
+    10  H    4.234248   3.760081   2.825971   6.556674   0.000000
+    11  H    4.621479   4.477587   3.500523   5.986382   1.769238
+    12  H    3.098019   3.460207   3.120715   4.705636   4.173070
+    13  H    2.232565   3.269398   3.646400   7.517152   3.885654
+    14  H    1.093673   2.172311   3.425091   7.372336   5.272001
+    15  H    2.154598   1.094043   2.142498   6.446322   4.560326
+    16  H    3.434349   2.165064   1.093800   4.854708   3.161685
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.344568   0.000000
+    13  H    3.793704   3.039916   0.000000
+    14  H    5.679078   3.899598   2.788041   0.000000
+    15  H    5.468396   4.453634   4.206415   2.484842   0.000000
+    16  H    4.003985   3.955566   4.724748   4.318752   2.477737
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6888686      0.9251066      0.8390280
+ Leave Link  202 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       380.4690103838 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn= 300590 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0071840405 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      380.4618263434 Hartrees.
+ Leave Link  301 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2723 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  1.07D-03  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=      300590 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   164   164   164   164   164 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         5.8
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sun Aug 11 02:18:12 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000129    0.000020    0.000195
+         Rot=    1.000000   -0.000178    0.000022   -0.000181 Ang=  -0.03 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ Leave Link  401 at Sun Aug 11 02:18:13 2024, MaxMem=  4294967296 cpu:         2.5
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302289774.
+ IVT=       90270 IEndB=       90270 NGot=  4294967296 MDV=  3994923503
+ LenX=  3994923503 LenY=  3994896166
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Dynamic level shift is on during FON iterations.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -668.943622513100
+ DIIS: error= 1.04D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -668.943622513100     IErMin= 1 ErrMin= 1.04D-04
+ ErrMax= 1.04D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.06D-05 BMatP= 1.06D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.701 Goal=     0.100 Shift=    0.000
+ Gap=     0.739 Goal=     0.100 Shift=    0.000
+ RMSDP=1.78D-05 MaxDP=2.88D-04              OVMax= 4.94D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -668.943627337551     Delta-E=       -0.000004824451 Rises=F Damp=F
+ DIIS: error= 2.66D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -668.943627337551     IErMin= 2 ErrMin= 2.66D-05
+ ErrMax= 2.66D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.37D-07 BMatP= 1.06D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.194D+00 0.119D+01
+ Coeff:     -0.194D+00 0.119D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.64D-06 MaxDP=1.49D-04 DE=-4.82D-06 OVMax= 3.06D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -668.943627795833     Delta-E=       -0.000000458282 Rises=F Damp=F
+ DIIS: error= 1.34D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -668.943627795833     IErMin= 3 ErrMin= 1.34D-05
+ ErrMax= 1.34D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.97D-08 BMatP= 5.37D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.503D-01 0.178D+00 0.872D+00
+ Coeff:     -0.503D-01 0.178D+00 0.872D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.13D-06 MaxDP=5.20D-05 DE=-4.58D-07 OVMax= 1.22D-04
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -668.943627843120     Delta-E=       -0.000000047287 Rises=F Damp=F
+ DIIS: error= 9.40D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -668.943627843120     IErMin= 4 ErrMin= 9.40D-06
+ ErrMax= 9.40D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.53D-08 BMatP= 6.97D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.301D-01-0.235D+00 0.310D+00 0.895D+00
+ Coeff:      0.301D-01-0.235D+00 0.310D+00 0.895D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.62D-06 MaxDP=4.31D-05 DE=-4.73D-08 OVMax= 1.07D-04
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -668.943627864112     Delta-E=       -0.000000020992 Rises=F Damp=F
+ DIIS: error= 4.88D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -668.943627864112     IErMin= 5 ErrMin= 4.88D-06
+ ErrMax= 4.88D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.91D-09 BMatP= 2.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.782D-02-0.327D-01-0.981D-01 0.406D-01 0.108D+01
+ Coeff:      0.782D-02-0.327D-01-0.981D-01 0.406D-01 0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=7.57D-07 MaxDP=2.25D-05 DE=-2.10D-08 OVMax= 6.02D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -668.943627868810     Delta-E=       -0.000000004698 Rises=F Damp=F
+ DIIS: error= 2.55D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -668.943627868810     IErMin= 6 ErrMin= 2.55D-06
+ ErrMax= 2.55D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.19D-09 BMatP= 2.91D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.445D-02 0.460D-01-0.118D+00-0.211D+00 0.450D+00 0.838D+00
+ Coeff:     -0.445D-02 0.460D-01-0.118D+00-0.211D+00 0.450D+00 0.838D+00
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.99D-07 MaxDP=1.88D-05 DE=-4.70D-09 OVMax= 4.37D-05
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -668.943627870618     Delta-E=       -0.000000001808 Rises=F Damp=F
+ DIIS: error= 2.13D-06 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -668.943627870618     IErMin= 7 ErrMin= 2.13D-06
+ ErrMax= 2.13D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.09D-10 BMatP= 1.19D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.203D-02 0.129D-01-0.517D-02-0.439D-01-0.886D-01 0.125D+00
+ Coeff-Com:  0.100D+01
+ Coeff:     -0.203D-02 0.129D-01-0.517D-02-0.439D-01-0.886D-01 0.125D+00
+ Coeff:      0.100D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.64D-07 MaxDP=1.93D-05 DE=-1.81D-09 OVMax= 4.44D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -668.943627871609     Delta-E=       -0.000000000991 Rises=F Damp=F
+ DIIS: error= 1.97D-06 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -668.943627871609     IErMin= 8 ErrMin= 1.97D-06
+ ErrMax= 1.97D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.17D-10 BMatP= 3.09D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.927D-03-0.113D-01 0.361D-01 0.554D-01-0.160D+00-0.237D+00
+ Coeff-Com:  0.259D+00 0.106D+01
+ Coeff:      0.927D-03-0.113D-01 0.361D-01 0.554D-01-0.160D+00-0.237D+00
+ Coeff:      0.259D+00 0.106D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.89D-07 MaxDP=2.30D-05 DE=-9.91D-10 OVMax= 5.23D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -668.943627872592     Delta-E=       -0.000000000984 Rises=F Damp=F
+ DIIS: error= 1.87D-06 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -668.943627872592     IErMin= 9 ErrMin= 1.87D-06
+ ErrMax= 1.87D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.77D-10 BMatP= 2.17D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.627D-03-0.421D-02 0.310D-02 0.156D-01 0.213D-01-0.518D-01
+ Coeff-Com: -0.294D+00 0.406D-01 0.127D+01
+ Coeff:      0.627D-03-0.421D-02 0.310D-02 0.156D-01 0.213D-01-0.518D-01
+ Coeff:     -0.294D+00 0.406D-01 0.127D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.27D-07 MaxDP=2.69D-05 DE=-9.84D-10 OVMax= 6.10D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -668.943627873648     Delta-E=       -0.000000001056 Rises=F Damp=F
+ DIIS: error= 1.78D-06 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -668.943627873648     IErMin=10 ErrMin= 1.78D-06
+ ErrMax= 1.78D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.59D-10 BMatP= 1.77D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.986D-03 0.114D-01-0.355D-01-0.543D-01 0.152D+00 0.228D+00
+ Coeff-Com: -0.208D+00-0.100D+01-0.198D+00 0.211D+01
+ Coeff:     -0.986D-03 0.114D-01-0.355D-01-0.543D-01 0.152D+00 0.228D+00
+ Coeff:     -0.208D+00-0.100D+01-0.198D+00 0.211D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=6.95D-07 MaxDP=5.74D-05 DE=-1.06D-09 OVMax= 1.30D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -668.943627875732     Delta-E=       -0.000000002083 Rises=F Damp=F
+ DIIS: error= 1.61D-06 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -668.943627875732     IErMin=11 ErrMin= 1.61D-06
+ ErrMax= 1.61D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.33D-10 BMatP= 1.59D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.890D-03 0.474D-02 0.217D-02-0.124D-01-0.796D-01 0.309D-01
+ Coeff-Com:  0.573D+00 0.217D+00-0.248D+01-0.368D+00 0.311D+01
+ Coeff:     -0.890D-03 0.474D-02 0.217D-02-0.124D-01-0.796D-01 0.309D-01
+ Coeff:      0.573D+00 0.217D+00-0.248D+01-0.368D+00 0.311D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.86D-06 MaxDP=1.54D-04 DE=-2.08D-09 OVMax= 3.49D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -668.943627880302     Delta-E=       -0.000000004570 Rises=F Damp=F
+ DIIS: error= 1.17D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=12 EnMin= -668.943627880302     IErMin=12 ErrMin= 1.17D-06
+ ErrMax= 1.17D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.93D-11 BMatP= 1.33D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.102D-02-0.135D-01 0.482D-01 0.714D-01-0.232D+00-0.298D+00
+ Coeff-Com:  0.439D+00 0.153D+01-0.568D+00-0.296D+01 0.942D+00 0.204D+01
+ Coeff:      0.102D-02-0.135D-01 0.482D-01 0.714D-01-0.232D+00-0.298D+00
+ Coeff:      0.439D+00 0.153D+01-0.568D+00-0.296D+01 0.942D+00 0.204D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=2.73D-06 MaxDP=2.26D-04 DE=-4.57D-09 OVMax= 5.11D-04
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -668.943627884392     Delta-E=       -0.000000004090 Rises=F Damp=F
+ DIIS: error= 5.16D-07 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=13 EnMin= -668.943627884392     IErMin=13 ErrMin= 5.16D-07
+ ErrMax= 5.16D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.64D-11 BMatP= 7.93D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.668D-03-0.553D-02 0.105D-01 0.246D-01-0.171D-01-0.900D-01
+ Coeff-Com: -0.192D+00 0.298D+00 0.107D+01-0.553D+00-0.131D+01 0.537D+00
+ Coeff-Com:  0.122D+01
+ Coeff:      0.668D-03-0.553D-02 0.105D-01 0.246D-01-0.171D-01-0.900D-01
+ Coeff:     -0.192D+00 0.298D+00 0.107D+01-0.553D+00-0.131D+01 0.537D+00
+ Coeff:      0.122D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.37D-06 MaxDP=1.14D-04 DE=-4.09D-09 OVMax= 2.57D-04
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -668.943627885276     Delta-E=       -0.000000000884 Rises=F Damp=F
+ DIIS: error= 1.90D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -668.943627885276     IErMin=14 ErrMin= 1.90D-07
+ ErrMax= 1.90D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.25D-12 BMatP= 2.64D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.403D-03 0.533D-02-0.196D-01-0.283D-01 0.938D-01 0.118D+00
+ Coeff-Com: -0.185D+00-0.604D+00 0.236D+00 0.117D+01-0.399D+00-0.760D+00
+ Coeff-Com: -0.110D-02 0.138D+01
+ Coeff:     -0.403D-03 0.533D-02-0.196D-01-0.283D-01 0.938D-01 0.118D+00
+ Coeff:     -0.185D+00-0.604D+00 0.236D+00 0.117D+01-0.399D+00-0.760D+00
+ Coeff:     -0.110D-02 0.138D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=5.52D-07 MaxDP=4.57D-05 DE=-8.84D-10 OVMax= 1.03D-04
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -668.943627885428     Delta-E=       -0.000000000152 Rises=F Damp=F
+ DIIS: error= 9.05D-08 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=15 EnMin= -668.943627885428     IErMin=15 ErrMin= 9.05D-08
+ ErrMax= 9.05D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.66D-12 BMatP= 8.25D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.245D-03 0.225D-02-0.515D-02-0.104D-01 0.143D-01 0.413D-01
+ Coeff-Com:  0.370D-01-0.153D+00-0.287D+00 0.270D+00 0.354D+00-0.224D+00
+ Coeff-Com: -0.381D+00 0.970D-01 0.124D+01
+ Coeff:     -0.245D-03 0.225D-02-0.515D-02-0.104D-01 0.143D-01 0.413D-01
+ Coeff:      0.370D-01-0.153D+00-0.287D+00 0.270D+00 0.354D+00-0.224D+00
+ Coeff:     -0.381D+00 0.970D-01 0.124D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.85D-07 MaxDP=1.52D-05 DE=-1.52D-10 OVMax= 3.43D-05
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -668.943627885453     Delta-E=       -0.000000000025 Rises=F Damp=F
+ DIIS: error= 5.95D-08 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=16 EnMin= -668.943627885453     IErMin=16 ErrMin= 5.95D-08
+ ErrMax= 5.95D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.97D-13 BMatP= 2.66D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.122D-03-0.178D-02 0.720D-02 0.100D-01-0.368D-01-0.386D-01
+ Coeff-Com:  0.773D-01 0.223D+00-0.130D+00-0.448D+00 0.220D+00 0.278D+00
+ Coeff-Com: -0.566D-01-0.572D+00 0.223D+00 0.124D+01
+ Coeff:      0.122D-03-0.178D-02 0.720D-02 0.100D-01-0.368D-01-0.386D-01
+ Coeff:      0.773D-01 0.223D+00-0.130D+00-0.448D+00 0.220D+00 0.278D+00
+ Coeff:     -0.566D-01-0.572D+00 0.223D+00 0.124D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=8.48D-08 MaxDP=6.78D-06 DE=-2.55D-11 OVMax= 1.53D-05
+
+ Cycle  17  Pass 1  IDiag  1:
+ E= -668.943627885448     Delta-E=        0.000000000005 Rises=F Damp=F
+ DIIS: error= 1.92D-08 at cycle  17 NSaved=  17.
+ NSaved=17 IEnMin=16 EnMin= -668.943627885453     IErMin=17 ErrMin= 1.92D-08
+ ErrMax= 1.92D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.04D-13 BMatP= 7.97D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.425D-04-0.369D-03 0.694D-03 0.174D-02-0.191D-02-0.534D-02
+ Coeff-Com: -0.119D-01 0.215D-01 0.627D-01-0.389D-01-0.738D-01 0.309D-01
+ Coeff-Com:  0.806D-01-0.199D-02-0.259D+00-0.335D-01 0.123D+01
+ Coeff:      0.425D-04-0.369D-03 0.694D-03 0.174D-02-0.191D-02-0.534D-02
+ Coeff:     -0.119D-01 0.215D-01 0.627D-01-0.389D-01-0.738D-01 0.309D-01
+ Coeff:      0.806D-01-0.199D-02-0.259D+00-0.335D-01 0.123D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=1.77D-08 MaxDP=1.31D-06 DE= 5.46D-12 OVMax= 2.96D-06
+
+ Cycle  18  Pass 1  IDiag  1:
+ E= -668.943627885448     Delta-E=       -0.000000000001 Rises=F Damp=F
+ DIIS: error= 6.30D-09 at cycle  18 NSaved=  18.
+ NSaved=18 IEnMin=16 EnMin= -668.943627885453     IErMin=18 ErrMin= 6.30D-09
+ ErrMax= 6.30D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.26D-14 BMatP= 1.04D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.150D-04 0.244D-03-0.106D-02-0.138D-02 0.544D-02 0.580D-02
+ Coeff-Com: -0.137D-01-0.320D-01 0.262D-01 0.647D-01-0.401D-01-0.406D-01
+ Coeff-Com:  0.162D-01 0.875D-01-0.595D-01-0.186D+00 0.874D-01 0.108D+01
+ Coeff:     -0.150D-04 0.244D-03-0.106D-02-0.138D-02 0.544D-02 0.580D-02
+ Coeff:     -0.137D-01-0.320D-01 0.262D-01 0.647D-01-0.401D-01-0.406D-01
+ Coeff:      0.162D-01 0.875D-01-0.595D-01-0.186D+00 0.874D-01 0.108D+01
+ Gap=     0.320 Goal=     0.100 Shift=    0.000
+ Gap=     0.237 Goal=     0.100 Shift=    0.000
+ RMSDP=3.93D-09 MaxDP=2.69D-07 DE=-9.09D-13 OVMax= 6.09D-07
+
+ SCF Done:  E(UwB97XD) =  -668.943627885     A.U. after   18 cycles
+            NFock= 18  Conv=0.39D-08     -V/T= 2.0059
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0260 S= 3.0037
+ <L.S>= 0.000000000000E+00
+ KE= 6.650253788612D+02 PE=-2.333706401700D+03 EE= 6.192755686103D+02
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation    12.0260,   after    12.0001
+ Leave Link  502 at Sun Aug 11 02:19:36 2024, MaxMem=  4294967296 cpu:      1323.0
+ (Enter /usr/local/g09/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Sun Aug 11 02:19:36 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2723 LenP2D=    7944.
+ LDataN:  DoStor=T MaxTD1= 5 Len=  102
+ Leave Link  701 at Sun Aug 11 02:19:36 2024, MaxMem=  4294967296 cpu:         2.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Sun Aug 11 02:19:36 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Leave Link  703 at Sun Aug 11 02:19:45 2024, MaxMem=  4294967296 cpu:       140.1
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 6.03708938D-01-4.95392078D-02 1.16896548D-01
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.000044147   -0.000006366    0.000035262
+      2        6          -0.000067732   -0.000016849   -0.000054952
+      3        6          -0.000030089   -0.000016685    0.000040311
+      4        6           0.000044537    0.000042059    0.000043829
+      5        6          -0.000040172    0.000007956   -0.000009083
+      6        6           0.000022376   -0.000006599   -0.000028034
+      7        6           0.000053916    0.000010276    0.000037271
+      8        6          -0.000011783   -0.000020729   -0.000059374
+      9        1           0.000007024   -0.000004488    0.000004384
+     10        1          -0.000000597    0.000004168   -0.000003129
+     11        1          -0.000008290    0.000002055    0.000000736
+     12        1          -0.000005707   -0.000004743   -0.000003346
+     13        1           0.000000771   -0.000008534    0.000003986
+     14        1          -0.000002818    0.000008264    0.000001518
+     15        1           0.000005989    0.000006796   -0.000003760
+     16        1          -0.000011572    0.000003416   -0.000005618
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000067732 RMS     0.000025775
+ Leave Link  716 at Sun Aug 11 02:19:45 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000064538 RMS     0.000017811
+ Search for a local minimum.
+ Step number  84 out of a maximum of   84
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .17811D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   46   47   48   50   51
+                                                     52   53   54   55   56
+                                                     57   58   59   60   61
+                                                     62   63   64   65   66
+                                                     67   68   69   70   71
+                                                     72   73   74   75   77
+                                                     76   79   78   80   81
+                                                     82   83   84
+ DE= -1.75D-07 DEPred=-5.10D-07 R= 3.43D-01
+ Trust test= 3.43D-01 RLast= 8.46D-03 DXMaxT set to 3.22D-01
+ ITU=  0  1  1 -1  0  0  0  0  0  0  1  0  1 -1  1  1  0  0  0  0
+ ITU=  0 -1 -1  0  1  0  0  1  1 -1  1  1  1  1  1  0  1  1  1  1
+ ITU=  1  1  1  1  1 -1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+ ITU=  0 -1  1  0 -1  0  0 -1  0  0  0  1  0  0  1
+     Eigenvalues ---    0.00000   0.00000   0.00003   0.00108   0.00207
+     Eigenvalues ---    0.00462   0.00772   0.01110   0.01168   0.01491
+     Eigenvalues ---    0.01637   0.02120   0.02900   0.03622   0.04529
+     Eigenvalues ---    0.05476   0.07698   0.08864   0.09217   0.10300
+     Eigenvalues ---    0.10950   0.11291   0.11465   0.13246   0.14267
+     Eigenvalues ---    0.16078   0.16991   0.18149   0.22568   0.23487
+     Eigenvalues ---    0.28054   0.32208   0.33405   0.33721   0.35455
+     Eigenvalues ---    0.38083   0.38224   0.38371   0.38593   0.38987
+     Eigenvalues ---    0.39729   0.44754
+ Eigenvalue     1 is   1.50D-12 Eigenvector:
+                          R2        D3        D2        D1        A1
+   1                    0.86800   0.28194   0.28125   0.27880  -0.07804
+                          D11       D13       D4        D15       D6
+   1                   -0.02173  -0.01780   0.01776   0.01755   0.01722
+ Eigenvalue     2 is   3.20D-08 Eigenvector:
+                          D6        D8        D2        D4        D1
+   1                   -0.37860  -0.34533   0.33642  -0.33160   0.31739
+                          D3        R2        D7        D9        D5
+   1                    0.31649  -0.26487  -0.26096  -0.22769  -0.21396
+ Eigenvalue     3 is   3.46D-05 Eigenvector:
+                          R2        D3        D1        D2        D6
+   1                    0.41250  -0.39377  -0.37921  -0.37751  -0.28844
+                          D8        D4        D7        D9        D5
+   1                   -0.26295  -0.26251  -0.20340  -0.17791  -0.17747
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    84   83   82   81   80
+ RFO step:  Lambda=-9.72497465D-08.
+ NNeg= 0 NP= 5 Switch=  2.50D-03 Rises=F DC= -5.34D-04 SmlDif=  1.00D-05
+ RMS Error=  0.1244255504D-03 NUsed= 5 EDIIS=F
+ DidBck=T Rises=F RFO-DIIS coefs:    0.23479    0.12326    0.05712    0.01277    0.57207
+ Iteration  1 RMS(Cart)=  0.00837369 RMS(Int)=  0.00003419
+ Iteration  2 RMS(Cart)=  0.00006145 RMS(Int)=  0.00000315
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000315
+ ITry= 1 IFail=0 DXMaxC= 4.24D-02 DCOld= 1.00D+10 DXMaxT= 3.22D-01 DXLimC= 3.00D+00 Rises=F
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43848  -0.00006  -0.00034  -0.00051  -0.00085   3.43763
+    R2        9.46046  -0.00001   0.01190  -0.02085  -0.00895   9.45151
+    R3        2.81379   0.00003   0.00011   0.00019   0.00030   2.81409
+    R4        2.10332   0.00000   0.00001  -0.00002  -0.00001   2.10331
+    R5        2.08078   0.00000   0.00003   0.00000   0.00003   2.08081
+    R6        2.79905   0.00005   0.00024  -0.00032  -0.00009   2.79896
+    R7        2.80655   0.00006   0.00011   0.00055   0.00066   2.80721
+    R8        2.78861  -0.00002  -0.00014   0.00007  -0.00006   2.78855
+    R9        2.08096   0.00000  -0.00002  -0.00013  -0.00015   2.08081
+   R10        2.80925   0.00002  -0.00007   0.00060   0.00053   2.80978
+   R11        2.07882   0.00001   0.00002   0.00014   0.00016   2.07898
+   R12        2.65219  -0.00002  -0.00001   0.00012   0.00011   2.65230
+   R13        2.06674   0.00000   0.00001  -0.00004  -0.00003   2.06671
+   R14        2.62582   0.00006   0.00008   0.00007   0.00015   2.62597
+   R15        2.06744   0.00001   0.00001   0.00005   0.00006   2.06750
+   R16        2.06698   0.00001   0.00001  -0.00003  -0.00002   2.06696
+    A1        1.72854  -0.00006  -0.00382   0.00077  -0.00305   1.72550
+    A2        1.99292   0.00000   0.00030   0.00019   0.00048   1.99341
+    A3        1.80174   0.00000   0.00013   0.00017   0.00030   1.80204
+    A4        1.90078  -0.00001  -0.00015  -0.00022  -0.00038   1.90041
+    A5        1.95366   0.00000  -0.00010   0.00006  -0.00005   1.95361
+    A6        1.95241   0.00000  -0.00008  -0.00003  -0.00012   1.95229
+    A7        1.85146   0.00000  -0.00011  -0.00017  -0.00028   1.85119
+    A8        2.13161   0.00003  -0.00003   0.00011   0.00009   2.13170
+    A9        2.09823  -0.00002  -0.00007  -0.00053  -0.00058   2.09764
+   A10        1.97451  -0.00001  -0.00006   0.00024   0.00019   1.97470
+   A11        1.96556   0.00000   0.00000   0.00009   0.00009   1.96565
+   A12        2.06577   0.00000  -0.00007   0.00026   0.00019   2.06596
+   A13        2.06643   0.00000   0.00018   0.00009   0.00028   2.06671
+   A14        1.96802   0.00002   0.00004   0.00018   0.00022   1.96824
+   A15        2.07733  -0.00001   0.00010  -0.00008   0.00002   2.07735
+   A16        2.06947  -0.00001   0.00009  -0.00030  -0.00022   2.06925
+   A17        2.06886   0.00000  -0.00002  -0.00057  -0.00058   2.06828
+   A18        2.11093   0.00000  -0.00003   0.00026   0.00023   2.11117
+   A19        2.10122   0.00000   0.00003   0.00026   0.00029   2.10151
+   A20        2.13545   0.00001   0.00001   0.00018   0.00019   2.13564
+   A21        2.07203  -0.00001  -0.00003  -0.00004  -0.00007   2.07197
+   A22        2.07265   0.00000   0.00001  -0.00010  -0.00009   2.07256
+   A23        2.08220  -0.00001   0.00001   0.00017   0.00018   2.08238
+   A24        2.09058   0.00000  -0.00003  -0.00009  -0.00012   2.09046
+   A25        2.10984   0.00001   0.00000  -0.00004  -0.00004   2.10980
+    D1       -0.47631   0.00000   0.01476  -0.02792  -0.01316  -0.48947
+    D2       -2.60135   0.00000   0.01463  -0.02821  -0.01358  -2.61493
+    D3        1.71982   0.00000   0.01475  -0.02801  -0.01326   1.70656
+    D4        2.39099   0.00000   0.00112   0.00379   0.00492   2.39591
+    D5       -1.19543   0.00000   0.00079   0.00339   0.00417  -1.19126
+    D6       -1.85308   0.00000   0.00142   0.00418   0.00561  -1.84747
+    D7        0.84368   0.00000   0.00109   0.00377   0.00485   0.84854
+    D8        0.22222   0.00000   0.00116   0.00398   0.00514   0.22736
+    D9        2.91898   0.00000   0.00083   0.00357   0.00439   2.92337
+   D10        1.87071   0.00000  -0.00022   0.00065   0.00043   1.87115
+   D11       -1.89687   0.00000   0.00002   0.00134   0.00137  -1.89551
+   D12       -0.85463   0.00000   0.00010   0.00121   0.00132  -0.85331
+   D13        1.66097   0.00001   0.00035   0.00190   0.00225   1.66322
+   D14       -2.27585  -0.00001   0.00006  -0.00119  -0.00113  -2.27698
+   D15        0.90148  -0.00001   0.00063  -0.00246  -0.00183   0.89965
+   D16        0.45831   0.00000  -0.00025  -0.00157  -0.00182   0.45649
+   D17       -2.64754   0.00000   0.00033  -0.00285  -0.00252  -2.65006
+   D18        0.88721   0.00001   0.00011   0.00040   0.00051   0.88772
+   D19       -1.65534   0.00000  -0.00029   0.00083   0.00054  -1.65480
+   D20       -1.62813   0.00001  -0.00003  -0.00036  -0.00039  -1.62851
+   D21        2.11251   0.00000  -0.00043   0.00007  -0.00036   2.11215
+   D22       -0.52485   0.00000  -0.00015  -0.00139  -0.00154  -0.52639
+   D23        2.54634  -0.00001  -0.00029  -0.00218  -0.00246   2.54387
+   D24        2.02064   0.00000   0.00026  -0.00174  -0.00148   2.01916
+   D25       -1.19136   0.00000   0.00012  -0.00252  -0.00240  -1.19376
+   D26        0.12788   0.00000  -0.00003   0.00101   0.00099   0.12887
+   D27       -3.09864  -0.00001  -0.00009   0.00154   0.00144  -3.09720
+   D28       -2.94371   0.00000   0.00012   0.00179   0.00190  -2.94181
+   D29        0.11295   0.00000   0.00005   0.00231   0.00236   0.11532
+   D30       -0.09426   0.00000   0.00018   0.00051   0.00069  -0.09357
+   D31        3.01118  -0.00001  -0.00040   0.00180   0.00140   3.01258
+   D32        3.13229   0.00000   0.00025  -0.00002   0.00024   3.13252
+   D33       -0.04546   0.00000  -0.00033   0.00128   0.00095  -0.04451
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000065     0.000450     YES
+ RMS     Force            0.000018     0.000300     YES
+ Maximum Displacement     0.042384     0.001800     NO
+ RMS     Displacement     0.008381     0.001200     NO
+ Predicted change in Energy=-3.607486D-07
+ Optimization stopped.
+    -- Number of steps exceeded,  NStep=  84
+    -- Flag reset to prevent archiving.
+                           ----------------------------
+                           ! Non-Optimized Parameters !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.8191         -DE/DX =   -0.0001              !
+ ! R2    R(1,9)                  5.0015         -DE/DX =    0.0                 !
+ ! R3    R(2,3)                  1.4892         -DE/DX =    0.0                 !
+ ! R4    R(2,10)                 1.113          -DE/DX =    0.0                 !
+ ! R5    R(2,11)                 1.1011         -DE/DX =    0.0                 !
+ ! R6    R(3,4)                  1.4811         -DE/DX =    0.0                 !
+ ! R7    R(3,8)                  1.4855         -DE/DX =    0.0001              !
+ ! R8    R(4,5)                  1.4756         -DE/DX =    0.0                 !
+ ! R9    R(4,12)                 1.1011         -DE/DX =    0.0                 !
+ ! R10   R(5,6)                  1.4869         -DE/DX =    0.0                 !
+ ! R11   R(5,13)                 1.1002         -DE/DX =    0.0                 !
+ ! R12   R(6,7)                  1.4035         -DE/DX =    0.0                 !
+ ! R13   R(6,14)                 1.0937         -DE/DX =    0.0                 !
+ ! R14   R(7,8)                  1.3896         -DE/DX =    0.0001              !
+ ! R15   R(7,15)                 1.0941         -DE/DX =    0.0                 !
+ ! R16   R(8,16)                 1.0938         -DE/DX =    0.0                 !
+ ! A1    A(2,1,9)               98.8637         -DE/DX =   -0.0001              !
+ ! A2    A(1,2,3)              114.2139         -DE/DX =    0.0                 !
+ ! A3    A(1,2,10)             103.2495         -DE/DX =    0.0                 !
+ ! A4    A(1,2,11)             108.8853         -DE/DX =    0.0                 !
+ ! A5    A(3,2,10)             111.9335         -DE/DX =    0.0                 !
+ ! A6    A(3,2,11)             111.858          -DE/DX =    0.0                 !
+ ! A7    A(10,2,11)            106.0652         -DE/DX =    0.0                 !
+ ! A8    A(2,3,4)              122.1374         -DE/DX =    0.0                 !
+ ! A9    A(2,3,8)              120.1861         -DE/DX =    0.0                 !
+ ! A10   A(4,3,8)              113.1419         -DE/DX =    0.0                 !
+ ! A11   A(3,4,5)              112.6234         -DE/DX =    0.0                 !
+ ! A12   A(3,4,12)             118.3708         -DE/DX =    0.0                 !
+ ! A13   A(5,4,12)             118.4138         -DE/DX =    0.0                 !
+ ! A14   A(4,5,6)              112.7717         -DE/DX =    0.0                 !
+ ! A15   A(4,5,13)             119.0234         -DE/DX =    0.0                 !
+ ! A16   A(6,5,13)             118.5596         -DE/DX =    0.0                 !
+ ! A17   A(5,6,7)              118.5037         -DE/DX =    0.0                 !
+ ! A18   A(5,6,14)             120.961          -DE/DX =    0.0                 !
+ ! A19   A(7,6,14)             120.4079         -DE/DX =    0.0                 !
+ ! A20   A(6,7,8)              122.3633         -DE/DX =    0.0                 !
+ ! A21   A(6,7,15)             118.7149         -DE/DX =    0.0                 !
+ ! A22   A(8,7,15)             118.749          -DE/DX =    0.0                 !
+ ! A23   A(3,8,7)              119.3116         -DE/DX =    0.0                 !
+ ! A24   A(3,8,16)             119.7747         -DE/DX =    0.0                 !
+ ! A25   A(7,8,16)             120.8827         -DE/DX =    0.0                 !
+ ! D1    D(9,1,2,3)            -28.0448         -DE/DX =    0.0                 !
+ ! D2    D(9,1,2,10)          -149.8243         -DE/DX =    0.0                 !
+ ! D3    D(9,1,2,11)            97.7787         -DE/DX =    0.0                 !
+ ! D4    D(1,2,3,4)            137.2758         -DE/DX =    0.0                 !
+ ! D5    D(1,2,3,8)            -68.2544         -DE/DX =    0.0                 !
+ ! D6    D(10,2,3,4)          -105.8523         -DE/DX =    0.0                 !
+ ! D7    D(10,2,3,8)            48.6176         -DE/DX =    0.0                 !
+ ! D8    D(11,2,3,4)            13.0269         -DE/DX =    0.0                 !
+ ! D9    D(11,2,3,8)           167.4968         -DE/DX =    0.0                 !
+ ! D10   D(2,3,4,5)            107.2088         -DE/DX =    0.0                 !
+ ! D11   D(2,3,4,12)          -108.6047         -DE/DX =    0.0                 !
+ ! D12   D(8,3,4,5)            -48.8911         -DE/DX =    0.0                 !
+ ! D13   D(8,3,4,12)            95.2954         -DE/DX =    0.0                 !
+ ! D14   D(2,3,8,7)           -130.4614         -DE/DX =    0.0                 !
+ ! D15   D(2,3,8,16)            51.5462         -DE/DX =    0.0                 !
+ ! D16   D(4,3,8,7)             26.1551         -DE/DX =    0.0                 !
+ ! D17   D(4,3,8,16)          -151.8373         -DE/DX =    0.0                 !
+ ! D18   D(3,4,5,6)             50.8627         -DE/DX =    0.0                 !
+ ! D19   D(3,4,5,13)           -94.8131         -DE/DX =    0.0                 !
+ ! D20   D(12,4,5,6)           -93.307          -DE/DX =    0.0                 !
+ ! D21   D(12,4,5,13)          121.0173         -DE/DX =    0.0                 !
+ ! D22   D(4,5,6,7)            -30.16           -DE/DX =    0.0                 !
+ ! D23   D(4,5,6,14)           145.7532         -DE/DX =    0.0                 !
+ ! D24   D(13,5,6,7)           115.6893         -DE/DX =    0.0                 !
+ ! D25   D(13,5,6,14)          -68.3976         -DE/DX =    0.0                 !
+ ! D26   D(5,6,7,8)              7.3835         -DE/DX =    0.0                 !
+ ! D27   D(5,6,7,15)          -177.4563         -DE/DX =    0.0                 !
+ ! D28   D(14,6,7,8)          -168.5531         -DE/DX =    0.0                 !
+ ! D29   D(14,6,7,15)            6.6071         -DE/DX =    0.0                 !
+ ! D30   D(6,7,8,3)             -5.3611         -DE/DX =    0.0                 !
+ ! D31   D(6,7,8,16)           172.6084         -DE/DX =    0.0                 !
+ ! D32   D(15,7,8,3)           179.4803         -DE/DX =    0.0                 !
+ ! D33   D(15,7,8,16)           -2.5502         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Largest change from initial coordinates is atom    9       0.420 Angstoms.
+ Leave Link  103 at Sun Aug 11 02:19:45 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -2.884500   -1.573803   -0.919675
+      2          6           0       -1.433310   -1.482434    0.174175
+      3          6           0       -0.615033   -0.250626    0.000469
+      4          6           0       -0.078457    0.507890    1.154015
+      5          6           0        1.378645    0.339571    1.315639
+      6          6           0        2.129768    0.592247    0.057896
+      7          6           0        1.499987    0.317486   -1.165881
+      8          6           0        0.159145   -0.037515   -1.248909
+      9          1           0       -3.689054    3.324447   -1.569653
+     10          1           0       -0.861207   -2.401533   -0.084257
+     11          1           0       -1.763546   -1.611746    1.216597
+     12          1           0       -0.521325    1.488920    1.386584
+     13          1           0        1.753607   -0.429677    2.006875
+     14          1           0        3.125366    1.044439    0.078552
+     15          1           0        2.064035    0.463618   -2.091854
+     16          1           0       -0.338614   -0.128312   -2.218646
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.819563   0.000000
+     3  C    2.783512   1.488994   0.000000
+     4  C    4.062944   2.599443   1.481192   0.000000
+     5  C    5.179964   3.539736   2.460235   1.475669   0.000000
+     6  C    5.548900   4.124724   2.871875   2.466749   1.486590
+     7  C    4.781350   3.693196   2.481216   2.812411   2.484584
+     8  C    3.425251   2.578540   1.485164   2.475472   2.864660
+     9  H    5.006259   5.588866   4.969510   5.328017   6.551028
+    10  H    2.340251   1.113028   2.166606   3.257416   3.806612
+    11  H    2.412807   1.101100   2.156548   2.708560   3.700109
+    12  H    4.503742   3.336255   2.226233   1.101199   2.221693
+    13  H    5.602300   3.824072   3.109370   2.227749   1.100067
+    14  H    6.630998   5.213037   3.959025   3.421840   2.253500
+    15  H    5.478420   4.599286   3.473524   3.889460   3.477953
+    16  H    3.202858   2.959324   2.239607   3.441987   3.957153
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.403477   0.000000
+     8  C    2.446976   1.389524   0.000000
+     9  H    6.631178   6.010905   5.119990   0.000000
+    10  H    4.234248   3.760081   2.825971   6.556674   0.000000
+    11  H    4.621479   4.477587   3.500523   5.986382   1.769238
+    12  H    3.098019   3.460207   3.120715   4.705636   4.173070
+    13  H    2.232565   3.269398   3.646400   7.517152   3.885654
+    14  H    1.093673   2.172311   3.425091   7.372336   5.272001
+    15  H    2.154598   1.094043   2.142498   6.446322   4.560326
+    16  H    3.434349   2.165064   1.093800   4.854708   3.161685
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    3.344568   0.000000
+    13  H    3.793704   3.039916   0.000000
+    14  H    5.679078   3.899598   2.788041   0.000000
+    15  H    5.468396   4.453634   4.206415   2.484842   0.000000
+    16  H    4.003985   3.955566   4.724748   4.318752   2.477737
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.6888686      0.9251066      0.8390280
+ Leave Link  202 at Sun Aug 11 02:19:45 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 1 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Alpha  occ. eigenvalues --  -89.01758 -10.34238 -10.32387 -10.32250 -10.32152
+ Alpha  occ. eigenvalues --  -10.32039 -10.31819 -10.31667  -8.06872  -6.02914
+ Alpha  occ. eigenvalues --   -6.02044  -6.01093  -0.96570  -0.90128  -0.85143
+ Alpha  occ. eigenvalues --   -0.83136  -0.74059  -0.70140  -0.67524  -0.60394
+ Alpha  occ. eigenvalues --   -0.59231  -0.55722  -0.52790  -0.51160  -0.50621
+ Alpha  occ. eigenvalues --   -0.48502  -0.47913  -0.45145  -0.43339  -0.39985
+ Alpha  occ. eigenvalues --   -0.36334  -0.33493  -0.31710  -0.30762  -0.28678
+ Alpha  occ. eigenvalues --   -0.22071
+ Alpha virt. eigenvalues --    0.09921   0.13050   0.15522   0.17110   0.18468
+ Alpha virt. eigenvalues --    0.19123   0.19707   0.20594   0.22564   0.27990
+ Alpha virt. eigenvalues --    0.31964   0.32510   0.35318   0.37527   0.40965
+ Alpha virt. eigenvalues --    0.43469   0.44641   0.46171   0.48987   0.50122
+ Alpha virt. eigenvalues --    0.50838   0.51993   0.54860   0.55894   0.56071
+ Alpha virt. eigenvalues --    0.58058   0.59024   0.60051   0.61588   0.64348
+ Alpha virt. eigenvalues --    0.64370   0.65628   0.66926   0.68900   0.69873
+ Alpha virt. eigenvalues --    0.70654   0.71146   0.72377   0.73284   0.73916
+ Alpha virt. eigenvalues --    0.75073   0.75899   0.76032   0.77293   0.78650
+ Alpha virt. eigenvalues --    0.79379   0.81151   0.81778   0.83459   0.84833
+ Alpha virt. eigenvalues --    0.86891   0.87332   0.91380   0.93356   0.94122
+ Alpha virt. eigenvalues --    1.03647   1.06555   1.10464   1.13763   1.21177
+ Alpha virt. eigenvalues --    1.31457   1.34807   1.36145   1.41683   1.44393
+ Alpha virt. eigenvalues --    1.44398   1.44412   1.49469   1.52110   1.55128
+ Alpha virt. eigenvalues --    1.62053   1.66622   1.69064   1.70058   1.73322
+ Alpha virt. eigenvalues --    1.76383   1.77697   1.79477   1.80120   1.82916
+ Alpha virt. eigenvalues --    1.83747   1.85901   1.86966   1.88711   1.91327
+ Alpha virt. eigenvalues --    1.95724   1.99092   2.01565   2.03722   2.04819
+ Alpha virt. eigenvalues --    2.06628   2.10896   2.12000   2.13973   2.15150
+ Alpha virt. eigenvalues --    2.20629   2.21440   2.27040   2.31095   2.32317
+ Alpha virt. eigenvalues --    2.37565   2.41383   2.46816   2.49305   2.52745
+ Alpha virt. eigenvalues --    2.56760   2.58757   2.65795   2.73548   2.79471
+ Alpha virt. eigenvalues --    2.81047   2.83435   2.87333   2.91648   2.95367
+ Alpha virt. eigenvalues --    2.99761   3.03282   3.06635   3.16390   3.43513
+  Beta  occ. eigenvalues --  -89.01195 -10.34243 -10.31693 -10.31230 -10.31223
+  Beta  occ. eigenvalues --  -10.31145 -10.31122 -10.30967  -8.06303  -6.01558
+  Beta  occ. eigenvalues --   -6.01170  -6.00669  -0.93209  -0.87780  -0.81502
+  Beta  occ. eigenvalues --   -0.79085  -0.70205  -0.66669  -0.64479  -0.58242
+  Beta  occ. eigenvalues --   -0.56705  -0.53715  -0.50238  -0.48858  -0.48252
+  Beta  occ. eigenvalues --   -0.45293  -0.45132  -0.42734  -0.37833  -0.30979
+  Beta virt. eigenvalues --   -0.07288  -0.04364  -0.02431   0.01662   0.06628
+  Beta virt. eigenvalues --    0.13610   0.14877   0.16292   0.18290   0.19718
+  Beta virt. eigenvalues --    0.20044   0.20447   0.22444   0.23129   0.30078
+  Beta virt. eigenvalues --    0.33954   0.34837   0.38210   0.40454   0.42589
+  Beta virt. eigenvalues --    0.44560   0.45444   0.46708   0.48253   0.50747
+  Beta virt. eigenvalues --    0.51407   0.53219   0.57116   0.57634   0.58627
+  Beta virt. eigenvalues --    0.61328   0.61932   0.62394   0.65101   0.66996
+  Beta virt. eigenvalues --    0.67260   0.67670   0.70624   0.71854   0.71966
+  Beta virt. eigenvalues --    0.72873   0.73005   0.74206   0.74517   0.75456
+  Beta virt. eigenvalues --    0.77090   0.77744   0.78933   0.79925   0.80786
+  Beta virt. eigenvalues --    0.81105   0.82829   0.83495   0.84752   0.86862
+  Beta virt. eigenvalues --    0.88282   0.88782   0.92848   0.94646   0.95507
+  Beta virt. eigenvalues --    1.05215   1.07822   1.12703   1.15220   1.22694
+  Beta virt. eigenvalues --    1.32545   1.32808   1.35599   1.38208   1.43432
+  Beta virt. eigenvalues --    1.51877   1.54894   1.57002   1.64010   1.68293
+  Beta virt. eigenvalues --    1.70757   1.72073   1.75052   1.79148   1.79213
+  Beta virt. eigenvalues --    1.82036   1.82586   1.85198   1.86676   1.89332
+  Beta virt. eigenvalues --    1.89799   1.91335   1.93228   1.97853   2.00926
+  Beta virt. eigenvalues --    2.02625   2.05134   2.06908   2.08849   2.13769
+  Beta virt. eigenvalues --    2.14237   2.16347   2.18449   2.18710   2.19623
+  Beta virt. eigenvalues --    2.22721   2.24022   2.26217   2.30270   2.34048
+  Beta virt. eigenvalues --    2.35896   2.40498   2.43246   2.48949   2.51605
+  Beta virt. eigenvalues --    2.56079   2.59882   2.61774   2.68489   2.76053
+  Beta virt. eigenvalues --    2.80918   2.83088   2.84951   2.89327   2.93299
+  Beta virt. eigenvalues --    2.97020   3.02067   3.05885   3.07758   3.17791
+  Beta virt. eigenvalues --    3.44698
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  S   15.915859   0.273377  -0.094361   0.001770  -0.000119  -0.000083
+     2  C    0.273377   4.876790   0.318588  -0.046524  -0.003007   0.000163
+     3  C   -0.094361   0.318588   5.558939   0.351070  -0.078999  -0.043338
+     4  C    0.001770  -0.046524   0.351070   5.125107   0.365259  -0.046045
+     5  C   -0.000119  -0.003007  -0.078999   0.365259   5.218929   0.298934
+     6  C   -0.000083   0.000163  -0.043338  -0.046045   0.298934   5.086510
+     7  C    0.000945   0.001877  -0.023320  -0.027675  -0.027085   0.460398
+     8  C   -0.002456  -0.063454   0.268127  -0.037043  -0.040651  -0.028212
+     9  H    0.000026  -0.000009   0.000025  -0.000014   0.000000   0.000000
+    10  H   -0.032416   0.350516  -0.025475   0.002529   0.002391   0.000010
+    11  H   -0.027796   0.386554  -0.030060   0.001595   0.000369   0.000003
+    12  H    0.000112   0.003963  -0.041731   0.402241  -0.039924   0.000876
+    13  H   -0.000002   0.000657  -0.001345  -0.039199   0.401358  -0.036827
+    14  H    0.000000  -0.000004  -0.000170   0.005613  -0.049562   0.415952
+    15  H   -0.000003  -0.000165   0.008988  -0.000260   0.008501  -0.050091
+    16  H    0.013472  -0.002880  -0.059925   0.006490  -0.000250   0.007963
+               7          8          9         10         11         12
+     1  S    0.000945  -0.002456   0.000026  -0.032416  -0.027796   0.000112
+     2  C    0.001877  -0.063454  -0.000009   0.350516   0.386554   0.003963
+     3  C   -0.023320   0.268127   0.000025  -0.025475  -0.030060  -0.041731
+     4  C   -0.027675  -0.037043  -0.000014   0.002529   0.001595   0.402241
+     5  C   -0.027085  -0.040651   0.000000   0.002391   0.000369  -0.039924
+     6  C    0.460398  -0.028212   0.000000   0.000010   0.000003   0.000876
+     7  C    4.775347   0.496751  -0.000002   0.000915  -0.000036  -0.000461
+     8  C    0.496751   5.030811   0.000007   0.005525   0.007634   0.002736
+     9  H   -0.000002   0.000007   0.999878   0.000000   0.000000   0.000039
+    10  H    0.000915   0.005525   0.000000   0.610716  -0.009086  -0.000368
+    11  H   -0.000036   0.007634   0.000000  -0.009086   0.582243   0.000596
+    12  H   -0.000461   0.002736   0.000039  -0.000368   0.000596   0.584652
+    13  H    0.000833   0.000774   0.000000   0.000009   0.000009   0.004069
+    14  H   -0.034944   0.008120   0.000000   0.000004   0.000000  -0.000015
+    15  H    0.424345  -0.049500   0.000000  -0.000052   0.000008   0.000001
+    16  H   -0.032125   0.417138   0.000015  -0.000964   0.000112   0.000040
+              13         14         15         16
+     1  S   -0.000002   0.000000  -0.000003   0.013472
+     2  C    0.000657  -0.000004  -0.000165  -0.002880
+     3  C   -0.001345  -0.000170   0.008988  -0.059925
+     4  C   -0.039199   0.005613  -0.000260   0.006490
+     5  C    0.401358  -0.049562   0.008501  -0.000250
+     6  C   -0.036827   0.415952  -0.050091   0.007963
+     7  C    0.000833  -0.034944   0.424345  -0.032125
+     8  C    0.000774   0.008120  -0.049500   0.417138
+     9  H    0.000000   0.000000   0.000000   0.000015
+    10  H    0.000009   0.000004  -0.000052  -0.000964
+    11  H    0.000009   0.000000   0.000008   0.000112
+    12  H    0.004069  -0.000015   0.000001   0.000040
+    13  H    0.595929   0.000029  -0.000199   0.000008
+    14  H    0.000029   0.615066  -0.009966  -0.000203
+    15  H   -0.000199  -0.009966   0.642275  -0.010426
+    16  H    0.000008  -0.000203  -0.010426   0.617742
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  S    1.132528  -0.009425  -0.043378   0.000259  -0.000279   0.000008
+     2  C   -0.009425  -0.017202  -0.004316  -0.029726   0.000246  -0.000704
+     3  C   -0.043378  -0.004316   1.232345  -0.040601  -0.088116   0.000807
+     4  C    0.000259  -0.029726  -0.040601   1.101785  -0.044908  -0.038896
+     5  C   -0.000279   0.000246  -0.088116  -0.044908   1.176785  -0.064134
+     6  C    0.000008  -0.000704   0.000807  -0.038896  -0.064134   0.829198
+     7  C   -0.000215  -0.000762  -0.019800  -0.010474  -0.021632  -0.004353
+     8  C    0.004152  -0.028692  -0.077712  -0.027067   0.003670  -0.038379
+     9  H    0.000011  -0.000009   0.000023  -0.000014   0.000000   0.000000
+    10  H   -0.032749  -0.001602  -0.022075   0.001976   0.002555  -0.000197
+    11  H   -0.006117  -0.000667  -0.004826   0.008613   0.000586   0.000047
+    12  H    0.000177   0.003342  -0.033547   0.028788  -0.028631  -0.001215
+    13  H   -0.000001   0.000508   0.000359  -0.023902   0.023132  -0.027853
+    14  H   -0.000001   0.000025  -0.001015   0.002420  -0.011608   0.014986
+    15  H    0.000007   0.000020   0.000905  -0.000773   0.001274  -0.004219
+    16  H    0.000535   0.003236  -0.011205   0.001793  -0.001167  -0.000240
+               7          8          9         10         11         12
+     1  S   -0.000215   0.004152   0.000011  -0.032749  -0.006117   0.000177
+     2  C   -0.000762  -0.028692  -0.000009  -0.001602  -0.000667   0.003342
+     3  C   -0.019800  -0.077712   0.000023  -0.022075  -0.004826  -0.033547
+     4  C   -0.010474  -0.027067  -0.000014   0.001976   0.008613   0.028788
+     5  C   -0.021632   0.003670   0.000000   0.002555   0.000586  -0.028631
+     6  C   -0.004353  -0.038379   0.000000  -0.000197   0.000047  -0.001215
+     7  C   -0.017145   0.012043  -0.000002   0.001325  -0.000002   0.000372
+     8  C    0.012043   0.711040   0.000005   0.005598   0.002298  -0.001978
+     9  H   -0.000002   0.000005   0.999869   0.000000   0.000000   0.000038
+    10  H    0.001325   0.005598   0.000000   0.136138  -0.004564  -0.000368
+    11  H   -0.000002   0.002298   0.000000  -0.004564   0.028313  -0.000108
+    12  H    0.000372  -0.001978   0.000038  -0.000368  -0.000108   0.052226
+    13  H   -0.001735  -0.000358   0.000000  -0.000102  -0.000033   0.001859
+    14  H   -0.012557  -0.000124   0.000000   0.000007  -0.000001   0.000209
+    15  H    0.003671  -0.004965   0.000000  -0.000036   0.000003   0.000088
+    16  H   -0.009406   0.012325   0.000012  -0.001830  -0.000087   0.000215
+              13         14         15         16
+     1  S   -0.000001  -0.000001   0.000007   0.000535
+     2  C    0.000508   0.000025   0.000020   0.003236
+     3  C    0.000359  -0.001015   0.000905  -0.011205
+     4  C   -0.023902   0.002420  -0.000773   0.001793
+     5  C    0.023132  -0.011608   0.001274  -0.001167
+     6  C   -0.027853   0.014986  -0.004219  -0.000240
+     7  C   -0.001735  -0.012557   0.003671  -0.009406
+     8  C   -0.000358  -0.000124  -0.004965   0.012325
+     9  H    0.000000   0.000000   0.000000   0.000012
+    10  H   -0.000102   0.000007  -0.000036  -0.001830
+    11  H   -0.000033  -0.000001   0.000003  -0.000087
+    12  H    0.001859   0.000209   0.000088   0.000215
+    13  H    0.035396   0.002067   0.000030   0.000041
+    14  H    0.002067  -0.008446   0.000654   0.000001
+    15  H    0.000030   0.000654   0.009814   0.000260
+    16  H    0.000041   0.000001   0.000260  -0.006890
+ Mulliken charges and spin densities:
+               1          2
+     1  S   -0.048327   1.045512
+     2  C   -0.096441  -0.085729
+     3  C   -0.107012   0.887848
+     4  C   -0.064915   0.929272
+     5  C   -0.056144   0.947774
+     6  C   -0.066212   0.664855
+     7  C   -0.015763  -0.080671
+     8  C   -0.016309   0.571857
+     9  H    0.000036   0.999932
+    10  H    0.095746   0.084076
+    11  H    0.087854   0.023454
+    12  H    0.083174   0.021466
+    13  H    0.073896   0.009409
+    14  H    0.050080  -0.013382
+    15  H    0.036542   0.006733
+    16  H    0.043794  -0.012407
+ Sum of Mulliken charges =   0.00000   6.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  S   -0.048327   1.045512
+     2  C    0.087160   0.021802
+     3  C   -0.106977   1.887780
+     4  C    0.018259   0.950738
+     5  C    0.017752   0.957183
+     6  C   -0.016132   0.651473
+     7  C    0.020779  -0.073938
+     8  C    0.027485   0.559450
+ Electronic spatial extent (au):  <R**2>=           1501.7567
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              1.5345    Y=             -0.1259    Z=              0.2971  Tot=              1.5680
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -58.8651   YY=            -56.0975   ZZ=            -55.2319
+   XY=             -1.7939   XZ=             -2.9831   YZ=             -1.1027
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -2.1336   YY=              0.6340   ZZ=              1.4996
+   XY=             -1.7939   XZ=             -2.9831   YZ=             -1.1027
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             93.5157  YYY=             48.2189  ZZZ=             29.5013  XYY=             26.9356
+  XXY=             31.1901  XXZ=             16.3195  XZZ=             26.4577  YZZ=             14.5301
+  YYZ=             13.9710  XYZ=             -1.0897
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=          -1272.0410 YYYY=           -487.0810 ZZZZ=           -402.3504 XXXY=           -239.6331
+ XXXZ=           -132.2073 YYYX=           -228.0385 YYYZ=            -35.0725 ZZZX=           -123.9865
+ ZZZY=            -46.5144 XXYY=           -317.9293 XXZZ=           -273.4820 YYZZ=           -147.9130
+ XXYZ=            -23.8081 YYXZ=            -40.3173 ZZXY=            -70.3136
+ N-N= 3.804618263434D+02 E-N=-2.333706401295D+03  KE= 6.650253788612D+02
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  S(33)              0.19093      10.93014       3.90014       3.64590
+     2  C(13)              0.01159       2.17241       0.77517       0.72464
+     3  C(13)              0.21434      40.15892      14.32970      13.39558
+     4  C(13)              0.19105      35.79583      12.77284      11.94020
+     5  C(13)              0.23945      44.86541      16.00909      14.96549
+     6  C(13)              0.13446      25.19245       8.98929       8.40330
+     7  C(13)             -0.00275      -0.51564      -0.18399      -0.17200
+     8  C(13)              0.09844      18.44430       6.58138       6.15236
+     9  H(1)               0.26657     198.58810      70.86117      66.24186
+    10  H(1)               0.03784      28.18691      10.05779       9.40214
+    11  H(1)               0.00971       7.23406       2.58129       2.41302
+    12  H(1)               0.01843      13.72692       4.89811       4.57881
+    13  H(1)               0.01275       9.49663       3.38863       3.16773
+    14  H(1)              -0.00084      -0.62717      -0.22379      -0.20920
+    15  H(1)               0.00244       1.81515       0.64769       0.60547
+    16  H(1)              -0.00113      -0.84550      -0.30170      -0.28203
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom       -0.459673      0.884863     -0.425190
+     2   Atom       -0.001486      0.041273     -0.039787
+     3   Atom        0.421968     -0.024315     -0.397653
+     4   Atom       -0.283163     -0.123076      0.406240
+     5   Atom       -0.351786      0.461779     -0.109993
+     6   Atom       -0.153814      0.471703     -0.317888
+     7   Atom        0.009994     -0.039570      0.029576
+     8   Atom       -0.279272      0.542553     -0.263281
+     9   Atom        0.000478      0.002668     -0.003146
+    10   Atom       -0.005197      0.027919     -0.022722
+    11   Atom       -0.001386      0.000095      0.001291
+    12   Atom       -0.028172      0.058368     -0.030196
+    13   Atom       -0.036134      0.024678      0.011456
+    14   Atom        0.058783     -0.005633     -0.053149
+    15   Atom        0.003482     -0.019495      0.016013
+    16   Atom       -0.027706     -0.018862      0.046568
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom       -1.730323     -1.281711      2.292946
+     2   Atom        0.041473     -0.012385      0.038053
+     3   Atom       -0.680352      0.312911     -0.156010
+     4   Atom        0.316697     -0.397675     -0.626253
+     5   Atom        0.323776      0.215298      0.680301
+     6   Atom       -0.409853     -0.025135     -0.056690
+     7   Atom        0.055458      0.035623     -0.041225
+     8   Atom       -0.167190     -0.043584      0.039199
+     9   Atom       -0.004754      0.002530     -0.002669
+    10   Atom        0.002749      0.008701      0.005059
+    11   Atom        0.025536     -0.003039     -0.015337
+    12   Atom       -0.053019     -0.029901      0.023592
+    13   Atom       -0.030700      0.054898     -0.047815
+    14   Atom        0.032795     -0.010406     -0.004936
+    15   Atom        0.004230     -0.014119      0.000027
+    16   Atom       -0.001239      0.032003      0.006307
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -2.1553   -88.366   -31.531   -29.476 -0.0259 -0.6113  0.7910
+     1 S(33)  Bbb    -1.5677   -64.274   -22.934   -21.439  0.8887  0.3482  0.2982
+              Bcc     3.7230   152.640    54.466    50.915 -0.4577  0.7107  0.5343
+
+              Baa    -0.0675    -9.058    -3.232    -3.022  0.4243 -0.4389  0.7921
+     2 C(13)  Bbb    -0.0056    -0.751    -0.268    -0.250  0.7913 -0.2456 -0.5599
+              Bcc     0.0731     9.809     3.500     3.272  0.4403  0.8643  0.2431
+
+              Baa    -0.5582   -74.909   -26.729   -24.987  0.5819  0.5727 -0.5774
+     3 C(13)  Bbb    -0.4419   -59.294   -21.157   -19.778  0.1872  0.5966  0.7804
+              Bcc     1.0001   134.202    47.887    44.765  0.7914 -0.5622  0.2399
+
+              Baa    -0.5598   -75.117   -26.804   -25.056 -0.4317  0.8276  0.3588
+     4 C(13)  Bbb    -0.4589   -61.579   -21.973   -20.541  0.8258  0.2026  0.5263
+              Bcc     1.0187   136.696    48.777    45.597 -0.3628 -0.5235  0.7709
+
+              Baa    -0.5620   -75.420   -26.912   -25.157 -0.0012 -0.5532  0.8331
+     5 C(13)  Bbb    -0.4617   -61.955   -22.107   -20.666  0.9623 -0.2273 -0.1495
+              Bcc     1.0237   137.375    49.019    45.823  0.2720  0.8015  0.5326
+
+              Baa    -0.3892   -52.222   -18.634   -17.420  0.7307  0.3850  0.5638
+     6 C(13)  Bbb    -0.2869   -38.502   -13.738   -12.843 -0.5208 -0.2197  0.8249
+              Bcc     0.6761    90.724    32.373    30.262 -0.4415  0.8964 -0.0400
+
+              Baa    -0.0984   -13.200    -4.710    -4.403 -0.5179  0.7616  0.3896
+     7 C(13)  Bbb     0.0416     5.584     1.993     1.863  0.5838  0.6475 -0.4898
+              Bcc     0.0568     7.615     2.717     2.540  0.6253  0.0262  0.7799
+
+              Baa    -0.3310   -44.418   -15.849   -14.816  0.8681  0.1448  0.4748
+     8 C(13)  Bbb    -0.2469   -33.128   -11.821   -11.050 -0.4570 -0.1404  0.8783
+              Bcc     0.5779    77.545    27.670    25.866 -0.1939  0.9794  0.0557
+
+              Baa    -0.0045    -2.381    -0.850    -0.794 -0.3889  0.0842  0.9174
+     9 H(1)   Bbb    -0.0032    -1.723    -0.615    -0.575  0.7016  0.6724  0.2357
+              Bcc     0.0077     4.104     1.464     1.369 -0.5971  0.7354 -0.3205
+
+              Baa    -0.0266   -14.168    -5.055    -4.726 -0.3690 -0.0675  0.9270
+    10 H(1)   Bbb    -0.0023    -1.206    -0.430    -0.402  0.9230 -0.1439  0.3569
+              Bcc     0.0288    15.374     5.486     5.128  0.1093  0.9873  0.1154
+
+              Baa    -0.0289   -15.407    -5.498    -5.139 -0.6312  0.7152  0.3000
+    11 H(1)   Bbb    -0.0021    -1.112    -0.397    -0.371  0.5073  0.0881  0.8572
+              Bcc     0.0310    16.519     5.894     5.510  0.5867  0.6933 -0.4185
+
+              Baa    -0.0642   -34.279   -12.232   -11.434  0.8064  0.2451  0.5383
+    12 H(1)   Bbb    -0.0289   -15.411    -5.499    -5.141 -0.3943 -0.4554  0.7982
+              Bcc     0.0931    49.691    17.731    16.575 -0.4408  0.8559  0.2706
+
+              Baa    -0.0722   -38.510   -13.741   -12.846  0.8338 -0.0082 -0.5520
+    13 H(1)   Bbb    -0.0219   -11.665    -4.162    -3.891  0.3551  0.7735  0.5249
+              Bcc     0.0940    50.175    17.904    16.737  0.4227 -0.6337  0.6479
+
+              Baa    -0.0542   -28.920   -10.319    -9.647  0.0775  0.0488  0.9958
+    14 H(1)   Bbb    -0.0194   -10.342    -3.690    -3.450 -0.3885  0.9213 -0.0149
+              Bcc     0.0736    39.262    14.010    13.096  0.9182  0.3857 -0.0904
+
+              Baa    -0.0205   -10.920    -3.897    -3.643 -0.2227  0.9710 -0.0869
+    15 H(1)   Bbb    -0.0048    -2.584    -0.922    -0.862  0.8053  0.2335  0.5449
+              Bcc     0.0253    13.505     4.819     4.505 -0.5494 -0.0514  0.8340
+
+              Baa    -0.0401   -21.412    -7.640    -7.142  0.9225  0.1581 -0.3520
+    16 H(1)   Bbb    -0.0187    -9.984    -3.562    -3.330 -0.1728  0.9849 -0.0104
+              Bcc     0.0588    31.395    11.203    10.472  0.3451  0.0705  0.9359
+
+
+ ---------------------------------------------------------------------------------
+
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Sun Aug 11 02:19:45 2024, MaxMem=  4294967296 cpu:         2.9
+ (Enter /usr/local/g09/l9999.exe)
+
+
+ TRUTH, IN SCIENCE, CAN BE DEFINED AS THE WORKING HYPOTHESIS
+ BEST FITTED TO OPEN THE WAY TO THE NEXT BETTER ONE.
+
+                              -- KONRAD LORENZ
+ Error termination request processed by link 9999.
+ Error termination via Lnk1e in /usr/local/g09/l9999.exe at Sun Aug 11 02:19:45 2024.
+ Job cpu time:       1 days 15 hours  9 minutes 56.4 seconds.
+ File lengths (MBytes):  RWF=     94 Int=      0 D2E=      0 Chk=      4 Scr=      1
+channel 17: open failed: connect failed: open failed
+channel 14: open failed: connect failed: open failed
+channel 7: open failed: connect failed: open failed
+channel 7: open failed: connect failed: open failed
+channel 7: open failed: connect failed: open failed
+cat input.gjf
+%chk=check.chk
+%mem=32768mb
+%NProcShared=16
+
+#P opt=(calcfc) guess=INDO uwb97xd/def2svp   IOp(2/9=2000)      nosymm scf=(NDamp=30,NoDIIS,xqc,Fermi,Noincfock,NoVarAcc) int=grid=300590
+
+rxn_1557_SC[C]1[CH][CH][CH][CH][CH]1
+
+0 7
+S      -3.14253253    0.19398865   -0.19065599
+C      -1.83205167   -1.05954109   -0.13850994
+C      -0.48704070   -0.40853004   -0.07594324
+C       0.07307724    0.00529552    1.21009842
+C       1.39406091    0.61158443    1.27145254
+C       2.16042313    0.81489440    0.05328128
+C       1.60818289    0.41206692   -1.22942420
+C       0.28904358   -0.19784716   -1.29744298
+H      -2.65948100    0.86910792   -1.24360755
+H      -1.92165913   -1.69198033   -1.02801183
+H      -1.99618314   -1.70281591    0.73237729
+H      -0.52118123   -0.06575720    2.11363703
+H       1.78008491    0.96840309    2.21824610
+H       3.12508962    1.30483696    0.09720293
+H       2.16961292    0.58960442   -2.13824458
+H      -0.11393763   -0.48033978   -2.26252914
+
+
+cd ..
+cd conformer2
+ls
+debug_log.txt  err.txt  final_time  initial_time  input.gjf  input.log  output.out  out.txt  submit.sh
+channel 16: open failed: connect failed: open failed
+channel 17: open failed: connect failed: open failed
+cat input.log
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /usr/local/g09/l1.exe "/gtmp/calvin.p/scratch/g09/491074.zeus-master/Gau-2890310.inp" -scrdir="/gtmp/calvin.p/scratch/g09/491074.zeus-master/"
+ Entering Link 1 = /usr/local/g09/l1.exe PID=   2890311.
+
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+
+ The following legend is applicable only to US Government
+ contracts under FAR:
+
+                    RESTRICTED RIGHTS LEGEND
+
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+
+
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria,
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci,
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian,
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada,
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima,
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr.,
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers,
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand,
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi,
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross,
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann,
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski,
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth,
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels,
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski,
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                10-Aug-2024
+ ******************************************
+ %chk=check.chk
+ %mem=32768mb
+ %NProcShared=16
+ Will use up to   16 processors via shared memory.
+ ----------------------------------------------------------------------
+ #P opt=(calcfc) guess=INDO uwb97xd/def2svp IOp(2/9=2000) nosymm scf=(N
+ Damp=30,NoDIIS,xqc)
+ ----------------------------------------------------------------------
+ 1/10=4,14=-1,18=20,19=15,26=3,38=1/1,3;
+ 2/9=2000,12=2,15=1,17=6,18=5,40=1/2;
+ 3/5=43,7=101,11=2,16=1,25=1,30=1,71=2,74=-58,116=2,140=1/1,2,3;
+ 4/5=4,11=3/1;
+ 5/5=2,8=3,13=1,18=-1,22=1,38=5,93=30/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1,31=1/1,2,10;
+ 10/6=1,13=1,31=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/10=1,18=20,25=1,30=1/1,2,3,16;
+ 1/10=4,14=-1,18=20,19=15,26=3/3(2);
+ 2/9=2000,15=1/2;
+ 99//99;
+ 2/9=2000,15=1/2;
+ 3/5=43,7=101,11=2,16=1,25=1,30=1,71=1,74=-58,116=2/1,2,3;
+ 4/5=5,11=3,16=3,69=1/1;
+ 5/5=2,8=3,13=1,18=-1,22=1,38=5,93=30/2,8;
+ 7/30=1/1,2,3,16;
+ 1/14=-1,18=20,19=15,26=3/3(-5);
+ 2/9=2000,15=1/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ Leave Link    1 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         0.5
+ (Enter /usr/local/g09/l101.exe)
+ ------------------------------------
+ rxn_1557_SC[C]1[CH][CH][CH][CH][CH]1
+ ------------------------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 7
+ S                    -3.09771   0.22702  -0.32636
+ C                    -1.82766  -1.05066  -0.11753
+ C                    -2.1396   -1.91336   1.06268
+ C                    -2.94728  -3.12173   0.90074
+ C                    -3.19313  -3.99489   2.03853
+ C                    -2.65688  -3.65647   3.34684
+ C                    -1.87525  -2.44304   3.52124
+ C                    -1.6261   -1.56595   2.38718
+ H                    -2.55376   0.79953  -1.40907
+ H                    -0.85548  -0.56065   0.00167
+ H                    -1.77694  -1.6461   -1.03532
+ H                    -3.45714  -3.31578  -0.03547
+ H                    -3.86639  -4.83675   1.93453
+ H                    -2.92599  -4.25257   4.20993
+ H                    -1.5729   -2.13614   4.51483
+ H                    -1.15487  -0.60473   2.55479
+
+ NAtoms=     16 NQM=       16 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          32          12          12          12          12          12          12          12           1           1
+ AtmWgt=  31.9720718  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000   1.0078250   1.0078250
+ NucSpn=           0           0           0           0           0           0           0           0           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460
+ AtZNuc=  16.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   1.0000000   1.0000000
+
+  Atom        11          12          13          14          15          16
+ IAtWgt=           1           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         4.8
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.8136         calculate D2E/DX2 analytically  !
+ ! R2    R(1,9)                  1.3401         calculate D2E/DX2 analytically  !
+ ! R3    R(2,3)                  1.4948         calculate D2E/DX2 analytically  !
+ ! R4    R(2,10)                 1.0952         calculate D2E/DX2 analytically  !
+ ! R5    R(2,11)                 1.0952         calculate D2E/DX2 analytically  !
+ ! R6    R(3,4)                  1.4624         calculate D2E/DX2 analytically  !
+ ! R7    R(3,8)                  1.4624         calculate D2E/DX2 analytically  !
+ ! R8    R(4,5)                  1.4551         calculate D2E/DX2 analytically  !
+ ! R9    R(4,12)                 1.0836         calculate D2E/DX2 analytically  !
+ ! R10   R(5,6)                  1.4539         calculate D2E/DX2 analytically  !
+ ! R11   R(5,13)                 1.083          calculate D2E/DX2 analytically  !
+ ! R12   R(6,7)                  1.4539         calculate D2E/DX2 analytically  !
+ ! R13   R(6,14)                 1.0829         calculate D2E/DX2 analytically  !
+ ! R14   R(7,8)                  1.4551         calculate D2E/DX2 analytically  !
+ ! R15   R(7,15)                 1.083          calculate D2E/DX2 analytically  !
+ ! R16   R(8,16)                 1.0836         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,9)               96.301          calculate D2E/DX2 analytically  !
+ ! A2    A(1,2,3)              110.5709         calculate D2E/DX2 analytically  !
+ ! A3    A(1,2,10)             108.5996         calculate D2E/DX2 analytically  !
+ ! A4    A(1,2,11)             108.6            calculate D2E/DX2 analytically  !
+ ! A5    A(3,2,10)             110.9491         calculate D2E/DX2 analytically  !
+ ! A6    A(3,2,11)             110.9486         calculate D2E/DX2 analytically  !
+ ! A7    A(10,2,11)            107.059          calculate D2E/DX2 analytically  !
+ ! A8    A(2,3,4)              120.3109         calculate D2E/DX2 analytically  !
+ ! A9    A(2,3,8)              120.3112         calculate D2E/DX2 analytically  !
+ ! A10   A(4,3,8)              119.3735         calculate D2E/DX2 analytically  !
+ ! A11   A(3,4,5)              120.1678         calculate D2E/DX2 analytically  !
+ ! A12   A(3,4,12)             120.2338         calculate D2E/DX2 analytically  !
+ ! A13   A(5,4,12)             119.2494         calculate D2E/DX2 analytically  !
+ ! A14   A(4,5,6)              120.1081         calculate D2E/DX2 analytically  !
+ ! A15   A(4,5,13)             119.7621         calculate D2E/DX2 analytically  !
+ ! A16   A(6,5,13)             119.78           calculate D2E/DX2 analytically  !
+ ! A17   A(5,6,7)              120.0337         calculate D2E/DX2 analytically  !
+ ! A18   A(5,6,14)             119.8297         calculate D2E/DX2 analytically  !
+ ! A19   A(7,6,14)             119.8296         calculate D2E/DX2 analytically  !
+ ! A20   A(6,7,8)              120.1081         calculate D2E/DX2 analytically  !
+ ! A21   A(6,7,15)             119.7799         calculate D2E/DX2 analytically  !
+ ! A22   A(8,7,15)             119.7622         calculate D2E/DX2 analytically  !
+ ! A23   A(3,8,7)              120.1677         calculate D2E/DX2 analytically  !
+ ! A24   A(3,8,16)             120.2342         calculate D2E/DX2 analytically  !
+ ! A25   A(7,8,16)             119.2494         calculate D2E/DX2 analytically  !
+ ! D1    D(9,1,2,3)           -179.9974         calculate D2E/DX2 analytically  !
+ ! D2    D(9,1,2,10)            58.0492         calculate D2E/DX2 analytically  !
+ ! D3    D(9,1,2,11)           -58.0442         calculate D2E/DX2 analytically  !
+ ! D4    D(1,2,3,4)             90.3734         calculate D2E/DX2 analytically  !
+ ! D5    D(1,2,3,8)            -90.3892         calculate D2E/DX2 analytically  !
+ ! D6    D(10,2,3,4)          -149.0648         calculate D2E/DX2 analytically  !
+ ! D7    D(10,2,3,8)            30.1726         calculate D2E/DX2 analytically  !
+ ! D8    D(11,2,3,4)           -30.1886         calculate D2E/DX2 analytically  !
+ ! D9    D(11,2,3,8)           149.0488         calculate D2E/DX2 analytically  !
+ ! D10   D(2,3,4,5)            176.9201         calculate D2E/DX2 analytically  !
+ ! D11   D(2,3,4,12)            -9.9126         calculate D2E/DX2 analytically  !
+ ! D12   D(8,3,4,5)             -2.3244         calculate D2E/DX2 analytically  !
+ ! D13   D(8,3,4,12)           170.8429         calculate D2E/DX2 analytically  !
+ ! D14   D(2,3,8,7)           -176.919          calculate D2E/DX2 analytically  !
+ ! D15   D(2,3,8,16)             9.9116         calculate D2E/DX2 analytically  !
+ ! D16   D(4,3,8,7)              2.3255         calculate D2E/DX2 analytically  !
+ ! D17   D(4,3,8,16)          -170.8439         calculate D2E/DX2 analytically  !
+ ! D18   D(3,4,5,6)              1.1235         calculate D2E/DX2 analytically  !
+ ! D19   D(3,4,5,13)           174.3182         calculate D2E/DX2 analytically  !
+ ! D20   D(12,4,5,6)          -172.1108         calculate D2E/DX2 analytically  !
+ ! D21   D(12,4,5,13)            1.0839         calculate D2E/DX2 analytically  !
+ ! D22   D(4,5,6,7)              0.0978         calculate D2E/DX2 analytically  !
+ ! D23   D(4,5,6,14)           173.7245         calculate D2E/DX2 analytically  !
+ ! D24   D(13,5,6,7)          -173.0956         calculate D2E/DX2 analytically  !
+ ! D25   D(13,5,6,14)            0.5311         calculate D2E/DX2 analytically  !
+ ! D26   D(5,6,7,8)             -0.0967         calculate D2E/DX2 analytically  !
+ ! D27   D(5,6,7,15)           173.0982         calculate D2E/DX2 analytically  !
+ ! D28   D(14,6,7,8)          -173.7234         calculate D2E/DX2 analytically  !
+ ! D29   D(14,6,7,15)           -0.5285         calculate D2E/DX2 analytically  !
+ ! D30   D(6,7,8,3)             -1.1257         calculate D2E/DX2 analytically  !
+ ! D31   D(6,7,8,16)           172.1107         calculate D2E/DX2 analytically  !
+ ! D32   D(15,7,8,3)          -174.3219         calculate D2E/DX2 analytically  !
+ ! D33   D(15,7,8,16)           -1.0854         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06
+ Number of steps in this run=     84 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0       -3.097707    0.227023   -0.326361
+      2          6           0       -1.827656   -1.050664   -0.117526
+      3          6           0       -2.139602   -1.913365    1.062678
+      4          6           0       -2.947277   -3.121725    0.900738
+      5          6           0       -3.193127   -3.994893    2.038535
+      6          6           0       -2.656878   -3.656473    3.346845
+      7          6           0       -1.875251   -2.443044    3.521240
+      8          6           0       -1.626100   -1.565953    2.387185
+      9          1           0       -2.553758    0.799527   -1.409069
+     10          1           0       -0.855480   -0.560646    0.001672
+     11          1           0       -1.776939   -1.646101   -1.035315
+     12          1           0       -3.457144   -3.315784   -0.035467
+     13          1           0       -3.866390   -4.836747    1.934528
+     14          1           0       -2.925991   -4.252567    4.209932
+     15          1           0       -1.572900   -2.136139    4.514826
+     16          1           0       -1.154867   -0.604729    2.554792
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  S    0.000000
+     2  C    1.813594   0.000000
+     3  C    2.725556   1.494807   0.000000
+     4  C    3.569666   2.565094   1.462429   0.000000
+     5  C    4.840084   3.896357   2.528828   1.455145   0.000000
+     6  C    5.363610   4.413584   2.919489   2.520659   1.453879
+     7  C    4.840216   3.896359   2.528827   2.911508   2.518621
+     8  C    3.569835   2.565097   1.462428   2.524967   2.911509
+     9  H    1.340112   2.370340   3.693351   4.567963   5.939801
+    10  H    2.399085   1.095195   2.145822   3.426815   4.626820
+    11  H    2.399091   1.095196   2.145817   2.701011   4.119584
+    12  H    3.572855   2.791547   2.215540   1.083560   2.198266
+    13  H    5.598594   4.764639   3.505436   2.203359   1.082967
+    14  H    6.377631   5.494126   3.999435   3.497145   2.202890
+    15  H    5.598810   4.764646   3.505439   3.990228   3.494585
+    16  H    3.573162   2.791557   2.215544   3.504839   3.989266
+                    6          7          8          9         10
+     6  C    0.000000
+     7  C    1.453880   0.000000
+     8  C    2.520661   1.455145   0.000000
+     9  H    6.518074   5.939915   4.568105   0.000000
+    10  H    4.900956   4.119553   2.700957   2.593146   0.000000
+    11  H    4.900940   4.626768   3.426759   2.593113   1.761431
+    12  H    3.492352   3.989263   3.504835   4.431555   3.789567
+    13  H    2.202408   3.494582   3.990225   6.683579   5.575532
+    14  H    1.082899   2.202891   3.497145   7.565408   5.968815
+    15  H    2.202409   1.082968   2.203362   6.683768   4.833780
+    16  H    3.492353   2.198267   1.083561   4.431820   2.570992
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.571114   0.000000
+    13  H    4.833839   2.522239   0.000000
+    14  H    5.968803   4.379851   2.530431   0.000000
+    15  H    5.575467   5.064297   4.383072   2.530432   0.000000
+    16  H    3.789498   4.399970   5.064293   4.379851   2.522242
+                   16
+    16  H    0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C7H8S(7)
+ Framework group  C1[X(C7H8S)]
+ Deg. of freedom    42
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):      3.9816211      0.9669950      0.8561000
+ Leave Link  202 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2SVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+   156 basis functions,   268 primitive gaussians,   164 cartesian basis functions
+    36 alpha electrons       30 beta electrons
+       nuclear repulsion energy       385.6752275082 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   16 NActive=   16 NUniq=   16 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0074942444 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      385.6677332637 Hartrees.
+ Leave Link  301 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2775 NPrTT=   10291 LenC2=    2731 LenP2D=    8006.
+ LDataN:  DoStor=T MaxTD1= 4 Len=   56
+ NBasis=   156 RedAO= T EigKep=  4.62D-04  NBF=   156
+ NBsUse=   156 1.00D-06 EigRej= -1.00D+00 NBFU=   156
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   163   163   163   163   163 MxSgAt=    16 MxSgA2=    16.
+ Leave Link  302 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         2.1
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Projected New-EHT guess.
+ Enter ItEHT:  IZDO=4 IZDPar=0 Conv= 1.00D-06 N=   40
+ It=   1                  EEH= -60.8236394838     EQH= 0.000000000000E+00 EH= -60.8236394838
+ JPrj=0 DoOrth=T DoCkMO=T.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 3.0000 <S**2>=12.0000 S= 3.0000
+ Leave Link  401 at Sat Aug 10 08:46:06 2024, MaxMem=  4294967296 cpu:         1.5
+ (Enter /usr/local/g09/l502.exe)
+ UHF open shell SCF:
+ Two-electron integral symmetry not used.
+ Keep R1 and R2 ints in memory in canonical form, NReq=302285489.
+ IVT=       85985 IEndB=       85985 NGot=  4294967296 MDV=  3994927788
+ LenX=  3994927788 LenY=  3994900728
+ Requested convergence on RMS density matrix=1.00D-08 within  64 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  12246 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -665.951315699970
+ Gap=    -0.187 Goal=   None    Shift=    0.000
+ Gap=     0.088 Goal=   None    Shift=    0.000
+ RMSDP=3.47D-02 MaxDP=2.74D+00              OVMax= 9.51D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -666.378570305519     Delta-E=       -0.427254605549 Rises=F Damp=F
+ Gap=    -0.313 Goal=   None    Shift=    0.000
+ Gap=     0.375 Goal=   None    Shift=    0.000
+ RMSDP=7.72D-02 MaxDP=3.43D+00 DE=-4.27D-01 OVMax= 9.93D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -632.379969857807     Delta-E=       33.998600447712 Rises=F Damp=F
+ Gap=     1.363 Goal=   None    Shift=    0.000
+ Gap=    -0.066 Goal=   None    Shift=    0.000
+ RMSDP=1.52D-01 MaxDP=9.38D+00 DE= 3.40D+01 OVMax= 9.98D-01
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -489.238198712169     Delta-E=      143.141771145638 Rises=F Damp=F
+ Gap=    -1.552 Goal=   None    Shift=    0.000
+ Gap=    -0.003 Goal=   None    Shift=    0.000
+ RMSDP=1.64D-01 MaxDP=9.57D+00 DE= 1.43D+02 OVMax= 9.65D-01
+
+ Problem detected with inexpensive integrals.
+ Switching to full accuracy and repeating last cycle.
+ Cycle   5  Pass 1  IDiag  1:
+ E= -489.230721473400     Delta-E=        0.007477238769 Rises=F Damp=F
+ Gap=    -1.552 Goal=   None    Shift=    0.000
+ Gap=    -0.003 Goal=   None    Shift=    0.000
+ RMSDP=1.64D-01 MaxDP=9.57D+00 DE= 7.48D-03 OVMax= 9.65D-01
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -301.862897180012     Delta-E=      187.367824293388 Rises=F Damp=F
+ Gap=     2.883 Goal=   None    Shift=    0.000
+ Gap=    -2.719 Goal=   None    Shift=    0.000
+ RMSDP=1.79D-01 MaxDP=9.23D+00 DE= 1.87D+02 OVMax= 9.95D-01
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -292.817631630017     Delta-E=        9.045265549995 Rises=F Damp=F
+ Gap=    -2.078 Goal=   None    Shift=    0.000
+ Gap=    -0.195 Goal=   None    Shift=    0.000
+ RMSDP=1.88D-01 MaxDP=9.37D+00 DE= 9.05D+00 OVMax= 9.97D-01
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -215.300577486969     Delta-E=       77.517054143048 Rises=F Damp=F
+ Gap=    -0.700 Goal=   None    Shift=    0.000
+ Gap=    -0.883 Goal=   None    Shift=    0.000
+ RMSDP=1.88D-01 MaxDP=1.03D+01 DE= 7.75D+01 OVMax= 9.93D-01
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -297.102500799614     Delta-E=      -81.801923312645 Rises=F Damp=F
+ Gap=    -0.891 Goal=   None    Shift=    0.000
+ Gap=    -0.552 Goal=   None    Shift=    0.000
+ 3-Point extrapolation.
+ RMSDP=1.90D-01 MaxDP=1.03D+01 DE=-8.18D+01 OVMax= 9.95D-01
+
+ Cycle  10  Pass 1  IDiag  1:
+ Spurious integrated density or basis function:
+ NE=   66 NElCor=    0 El error=8.92D+00 rel=1.35D-01 Tolerance=1.00D-03
+ Shell    19     absolute error=1.35D-04              Tolerance=1.20D-02
+ Shell    13       signed error=1.98D-05              Tolerance=1.00D-01
+ Inaccurate quadrature in CalDSu.
+ Error termination via Lnk1e in /usr/local/g09/l502.exe at Sat Aug 10 08:46:11 2024.
+ Job cpu time:       0 days  0 hours  1 minutes 31.2 seconds.
+ File lengths (MBytes):  RWF=      9 Int=      0 D2E=      0 Chk=      4 Scr=      1

--- a/arc/testing/trsh/gaussian/maxsteps.out
+++ b/arc/testing/trsh/gaussian/maxsteps.out
@@ -1,0 +1,11655 @@
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /usr/local/g09/l1.exe "/gtmp/calvin.p/scratch/g09/477574.zeus-master/Gau-997836.inp" -scrdir="/gtmp/calvin.p/scratch/g09/477574.zeus-master/"
+ Entering Link 1 = /usr/local/g09/l1.exe PID=    997837.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                 5-Aug-2024 
+ ******************************************
+ %chk=check.chk
+ %mem=32768mb
+ %NProcShared=16
+ Will use up to   16 processors via shared memory.
+ ----------------------------------------------------------------------
+ #P opt=(calcfc,maxstep=5,tight) guess=read wb97xd/def2tzvp integral=(g
+ rid=ultrafine, Acc2E=14) IOp(2/9=2000) scf=(direct,tight)
+ ----------------------------------------------------------------------
+ 1/7=10,8=5,10=4,14=-1,18=20,19=15,26=4,38=1/1,3;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=44,7=101,11=2,16=1,25=1,30=1,71=2,74=-58,75=-5,116=-2,140=1/1,2,3;
+ 4/5=1/1;
+ 5/5=2,32=2,38=6,87=14/2;
+ 8/6=4,10=90,11=11,87=14/1;
+ 11/6=1,8=1,9=11,15=111,16=1,87=14/1,2,10;
+ 10/6=1,13=1,87=14/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/10=1,18=20,25=1,87=14/1,2,3,16;
+ 1/7=10,8=5,10=4,14=-1,18=20,19=15,26=4/3(2);
+ 2/9=2000/2;
+ 99//99;
+ 2/9=2000/2;
+ 3/5=44,7=101,11=2,16=1,25=1,30=1,71=1,74=-58,75=-5/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,32=2,38=5,87=14/2;
+ 7/87=14/1,2,3,16;
+ 1/7=10,8=5,14=-1,18=20,19=15,26=4/3(-5);
+ 2/9=2000/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ Leave Link    1 at Mon Aug  5 14:29:40 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l101.exe)
+ ----------------------------
+ rxn_3137_p1_[N-]=c1o[nHp]no1
+ ----------------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ N                     2.22627  -0.51614   0.85602 
+ C                     1.17557  -0.65118   0.40733 
+ O                     0.04218  -1.05829  -0.07612 
+ N                    -0.92553  -0.11053  -0.4916 
+ N                    -0.88137   1.19395  -0.47545 
+ O                     0.10426   1.7276   -0.0554 
+ H                    -1.74138  -0.58541  -0.83922 
+ 
+ NAtoms=      7 NQM=        7 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7
+ IAtWgt=          14          12          16          14          14          16           1
+ AtmWgt=  14.0030740  12.0000000  15.9949146  14.0030740  14.0030740  15.9949146   1.0078250
+ NucSpn=           2           0           0           2           2           0           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000   2.0440000   2.0440000   0.0000000   0.0000000
+ NMagM=    0.4037610   0.0000000   0.0000000   0.4037610   0.4037610   0.0000000   2.7928460
+ AtZNuc=   7.0000000   6.0000000   8.0000000   7.0000000   7.0000000   8.0000000   1.0000000
+ Leave Link  101 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         6.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1504         calculate D2E/DX2 analytically  !
+ ! R2    R(2,3)                  1.2977         calculate D2E/DX2 analytically  !
+ ! R3    R(3,4)                  1.4168         calculate D2E/DX2 analytically  !
+ ! R4    R(4,5)                  1.3053         calculate D2E/DX2 analytically  !
+ ! R5    R(4,7)                  1.006          calculate D2E/DX2 analytically  !
+ ! R6    R(5,6)                  1.197          calculate D2E/DX2 analytically  !
+ ! A1    A(2,3,4)              119.7308         calculate D2E/DX2 analytically  !
+ ! A2    A(3,4,5)              129.9247         calculate D2E/DX2 analytically  !
+ ! A3    A(3,4,7)              109.8455         calculate D2E/DX2 analytically  !
+ ! A4    A(5,4,7)              120.2298         calculate D2E/DX2 analytically  !
+ ! A5    A(4,5,6)              118.5387         calculate D2E/DX2 analytically  !
+ ! A6    L(1,2,3,6,-1)         191.5424         calculate D2E/DX2 analytically  !
+ ! A7    L(1,2,3,6,-2)         180.0            calculate D2E/DX2 analytically  !
+ ! D1    D(2,3,4,5)              0.0            calculate D2E/DX2 analytically  !
+ ! D2    D(2,3,4,7)           -180.0            calculate D2E/DX2 analytically  !
+ ! D3    D(3,4,5,6)              0.0            calculate D2E/DX2 analytically  !
+ ! D4    D(7,4,5,6)            180.0            calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=5.00D-02 FncErr=1.00D-07 GrdErr=1.00D-06
+ Number of steps in this run=     27 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226267   -0.516144    0.856015
+      2          6           0        1.175573   -0.651182    0.407334
+      3          8           0        0.042176   -1.058293   -0.076118
+      4          7           0       -0.925528   -0.110525   -0.491595
+      5          7           0       -0.881371    1.193948   -0.475447
+      6          8           0        0.104261    1.727603   -0.055399
+      7          1           0       -1.741377   -0.585406   -0.839217
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150438   0.000000
+     3  O    2.435785   1.297711   0.000000
+     4  N    3.451723   2.348406   1.416805   0.000000
+     5  N    3.788749   2.900832   2.466778   1.305320   0.000000
+     6  O    3.219936   2.649613   2.786665   2.151615   1.196954
+     7  H    4.315183   3.172824   1.996748   1.005964   2.009487
+                    6          7
+     6  O    0.000000
+     7  H    3.061170   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -0.999548   -2.045291    0.000000
+      2          6           0       -0.932456   -0.896811    0.000000
+      3          8           0       -1.117525    0.387636    0.000000
+      4          7           0        0.000000    1.258539    0.000000
+      5          7           0        1.276102    0.983906    0.000000
+      6          8           0        1.613916   -0.164389    0.000000
+      7          1           0       -0.312267    2.214809    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6662905      3.2662265      2.2904004
+ Leave Link  202 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6957709246 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014828032 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6942881214 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   220   220   220   220   220 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:29:41 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.937888    0.044000    0.034118   -0.342442 Ang=  40.60 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A") (A') (A") (A') (A') (A') (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A")
+       Virtual   (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ Leave Link  401 at Mon Aug  5 14:29:42 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -352.236747921028    
+ DIIS: error= 3.54D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -352.236747921028     IErMin= 1 ErrMin= 3.54D-02
+ ErrMax= 3.54D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.31D-01 BMatP= 7.31D-01
+ IDIUse=3 WtCom= 6.46D-01 WtEn= 3.54D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     1.302 Goal=   None    Shift=    0.000
+ GapD=    1.302 DampG=2.000 DampE=0.500 DampFc=1.0000 IDamp=-1.
+ RMSDP=4.35D-03 MaxDP=8.15D-02              OVMax= 2.56D-01
+
+ Cycle   2  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.107774659826     Delta-E=       -0.871026738799 Rises=F Damp=F
+ DIIS: error= 2.07D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.107774659826     IErMin= 2 ErrMin= 2.07D-02
+ ErrMax= 2.07D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.08D-01 BMatP= 7.31D-01
+ IDIUse=3 WtCom= 7.93D-01 WtEn= 2.07D-01
+ Coeff-Com:  0.994D-01 0.901D+00
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:      0.788D-01 0.921D+00
+ Gap=     0.444 Goal=   None    Shift=    0.000
+ RMSDP=1.69D-03 MaxDP=6.63D-02 DE=-8.71D-01 OVMax= 1.19D-01
+
+ Cycle   3  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.138816426650     Delta-E=       -0.031041766824 Rises=F Damp=F
+ DIIS: error= 2.26D-02 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.138816426650     IErMin= 2 ErrMin= 2.07D-02
+ ErrMax= 2.26D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.21D-01 BMatP= 1.08D-01
+ IDIUse=2 WtCom= 0.00D+00 WtEn= 1.00D+00
+ Coeff-En:   0.000D+00 0.387D+00 0.613D+00
+ Coeff:      0.000D+00 0.387D+00 0.613D+00
+ Gap=     0.429 Goal=   None    Shift=    0.000
+ RMSDP=1.18D-03 MaxDP=5.17D-02 DE=-3.10D-02 OVMax= 8.84D-02
+
+ Cycle   4  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.203985107025     Delta-E=       -0.065168680375 Rises=F Damp=F
+ DIIS: error= 1.27D-02 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.203985107025     IErMin= 4 ErrMin= 1.27D-02
+ ErrMax= 1.27D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.76D-02 BMatP= 1.08D-01
+ IDIUse=3 WtCom= 8.73D-01 WtEn= 1.27D-01
+ Coeff-Com: -0.328D-01 0.484D-01 0.349D+00 0.635D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.178D+00 0.822D+00
+ Coeff:     -0.287D-01 0.423D-01 0.327D+00 0.659D+00
+ Gap=     0.361 Goal=   None    Shift=    0.000
+ RMSDP=5.07D-04 MaxDP=1.54D-02 DE=-6.52D-02 OVMax= 3.82D-02
+
+ Cycle   5  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.223537092880     Delta-E=       -0.019551985854 Rises=F Damp=F
+ DIIS: error= 5.57D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223537092880     IErMin= 5 ErrMin= 5.57D-03
+ ErrMax= 5.57D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.39D-03 BMatP= 2.76D-02
+ IDIUse=3 WtCom= 9.44D-01 WtEn= 5.57D-02
+ Coeff-Com: -0.743D-03-0.921D-01 0.732D-01 0.402D+00 0.618D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.701D-03-0.869D-01 0.691D-01 0.379D+00 0.639D+00
+ Gap=     0.358 Goal=   None    Shift=    0.000
+ RMSDP=1.80D-04 MaxDP=5.78D-03 DE=-1.96D-02 OVMax= 1.47D-02
+
+ Cycle   6  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225666301793     Delta-E=       -0.002129208913 Rises=F Damp=F
+ DIIS: error= 1.25D-03 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225666301793     IErMin= 6 ErrMin= 1.25D-03
+ ErrMax= 1.25D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.82D-04 BMatP= 2.39D-03
+ IDIUse=3 WtCom= 9.87D-01 WtEn= 1.25D-02
+ Coeff-Com:  0.264D-02-0.367D-01-0.162D-01 0.574D-01 0.277D+00 0.716D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.261D-02-0.362D-01-0.160D-01 0.567D-01 0.274D+00 0.719D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.55D-05 MaxDP=1.52D-03 DE=-2.13D-03 OVMax= 5.90D-03
+
+ Cycle   7  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225874812536     Delta-E=       -0.000208510743 Rises=F Damp=F
+ DIIS: error= 3.15D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225874812536     IErMin= 7 ErrMin= 3.15D-04
+ ErrMax= 3.15D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.07D-05 BMatP= 1.82D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.15D-03
+ Coeff-Com:  0.150D-02-0.561D-02-0.158D-01-0.240D-01 0.390D-01 0.297D+00
+ Coeff-Com:  0.708D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00
+ Coeff-En:   0.100D+01
+ Coeff:      0.149D-02-0.559D-02-0.158D-01-0.239D-01 0.389D-01 0.296D+00
+ Coeff:      0.709D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.98D-05 MaxDP=5.92D-04 DE=-2.09D-04 OVMax= 3.36D-03
+
+ Cycle   8  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225906696918     Delta-E=       -0.000031884382 Rises=F Damp=F
+ DIIS: error= 1.47D-04 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225906696918     IErMin= 8 ErrMin= 1.47D-04
+ ErrMax= 1.47D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.09D-06 BMatP= 2.07D-05
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.47D-03
+ Coeff-Com: -0.267D-04 0.627D-02-0.307D-02-0.254D-01-0.535D-01-0.397D-01
+ Coeff-Com:  0.366D+00 0.750D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.267D-04 0.626D-02-0.307D-02-0.254D-01-0.535D-01-0.396D-01
+ Coeff:      0.365D+00 0.750D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.01D-05 MaxDP=4.25D-04 DE=-3.19D-05 OVMax= 2.63D-03
+
+ Cycle   9  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225918297083     Delta-E=       -0.000011600166 Rises=F Damp=F
+ DIIS: error= 7.46D-05 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225918297083     IErMin= 9 ErrMin= 7.46D-05
+ ErrMax= 7.46D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.23D-06 BMatP= 6.09D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.261D-03 0.374D-02 0.210D-02-0.550D-02-0.329D-01-0.842D-01
+ Coeff-Com:  0.266D-01 0.358D+00 0.732D+00
+ Coeff:     -0.261D-03 0.374D-02 0.210D-02-0.550D-02-0.329D-01-0.842D-01
+ Coeff:      0.266D-01 0.358D+00 0.732D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.05D-05 MaxDP=2.31D-04 DE=-1.16D-05 OVMax= 1.51D-03
+
+ Cycle  10  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225921249285     Delta-E=       -0.000002952202 Rises=F Damp=F
+ DIIS: error= 3.89D-05 at cycle  10 NSaved=  10.
+ NSaved=10 IEnMin=10 EnMin= -353.225921249285     IErMin=10 ErrMin= 3.89D-05
+ ErrMax= 3.89D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.62D-07 BMatP= 1.23D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.116D-03 0.620D-04 0.177D-02 0.415D-02-0.178D-02-0.304D-01
+ Coeff-Com: -0.784D-01-0.225D-01 0.316D+00 0.811D+00
+ Coeff:     -0.116D-03 0.620D-04 0.177D-02 0.415D-02-0.178D-02-0.304D-01
+ Coeff:     -0.784D-01-0.225D-01 0.316D+00 0.811D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.03D-06 MaxDP=1.41D-04 DE=-2.95D-06 OVMax= 9.22D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ Density matrix breaks symmetry, PCut= 1.00D-04
+ Density matrix has no symmetry -- integrals replicated.
+ E= -353.225922121167     Delta-E=       -0.000000871882 Rises=F Damp=F
+ DIIS: error= 1.68D-05 at cycle  11 NSaved=  11.
+ NSaved=11 IEnMin=11 EnMin= -353.225922121167     IErMin=11 ErrMin= 1.68D-05
+ ErrMax= 1.68D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.14D-08 BMatP= 2.62D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.274D-04-0.987D-03 0.135D-03 0.311D-02 0.849D-02 0.117D-01
+ Coeff-Com: -0.369D-01-0.109D+00-0.103D+00 0.289D+00 0.937D+00
+ Coeff:      0.274D-04-0.987D-03 0.135D-03 0.311D-02 0.849D-02 0.117D-01
+ Coeff:     -0.369D-01-0.109D+00-0.103D+00 0.289D+00 0.937D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.66D-06 MaxDP=9.43D-05 DE=-8.72D-07 OVMax= 5.78D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.225862217947     Delta-E=        0.000059903221 Rises=F Damp=F
+ DIIS: error= 3.63D-06 at cycle  12 NSaved=  12.
+ NSaved=12 IEnMin=11 EnMin= -353.225922121167     IErMin=12 ErrMin= 3.63D-06
+ ErrMax= 3.63D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.08D-09 BMatP= 5.14D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.565D-05-0.906D-04-0.613D-04 0.582D-04 0.768D-03 0.221D-02
+ Coeff-Com:  0.261D-02-0.577D-02-0.331D-01-0.251D-01 0.181D+00 0.878D+00
+ Coeff:      0.565D-05-0.906D-04-0.613D-04 0.582D-04 0.768D-03 0.221D-02
+ Coeff:      0.261D-02-0.577D-02-0.331D-01-0.251D-01 0.181D+00 0.878D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.37D-06 MaxDP=3.66D-05 DE= 5.99D-05 OVMax= 1.99D-04
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.225920701583     Delta-E=       -0.000058483637 Rises=F Damp=F
+ DIIS: error= 1.33D-06 at cycle  13 NSaved=  13.
+ NSaved=13 IEnMin=11 EnMin= -353.225922121167     IErMin=13 ErrMin= 1.33D-06
+ ErrMax= 1.33D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.08D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.184D-05-0.207D-04-0.212D-04-0.436D-05 0.123D-03 0.375D-03
+ Coeff-Com:  0.174D-02 0.518D-03-0.851D-02-0.150D-01 0.488D-01 0.337D+00
+ Coeff-Com:  0.635D+00
+ Coeff:      0.184D-05-0.207D-04-0.212D-04-0.436D-05 0.123D-03 0.375D-03
+ Coeff:      0.174D-02 0.518D-03-0.851D-02-0.150D-01 0.488D-01 0.337D+00
+ Coeff:      0.635D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.03D-07 MaxDP=1.92D-06 DE=-5.85D-05 OVMax= 1.13D-05
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.225922860737     Delta-E=       -0.000002159154 Rises=F Damp=F
+ DIIS: error= 5.42D-07 at cycle  14 NSaved=  14.
+ NSaved=14 IEnMin=14 EnMin= -353.225922860737     IErMin=14 ErrMin= 5.42D-07
+ ErrMax= 5.42D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.39D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.194D-06-0.358D-06-0.190D-05 0.309D-05 0.160D-04 0.376D-04
+ Coeff-Com: -0.893D-04 0.103D-03 0.528D-03 0.224D-03-0.228D-02-0.778D-02
+ Coeff-Com: -0.539D+00 0.155D+01
+ Coeff:      0.194D-06-0.358D-06-0.190D-05 0.309D-05 0.160D-04 0.376D-04
+ Coeff:     -0.893D-04 0.103D-03 0.528D-03 0.224D-03-0.228D-02-0.778D-02
+ Coeff:     -0.539D+00 0.155D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.28D-08 MaxDP=1.79D-06 DE=-2.16D-06 OVMax= 7.89D-06
+
+ Cycle  15  Pass 1  IDiag  1:
+ E= -353.225922124934     Delta-E=        0.000000735803 Rises=F Damp=F
+ DIIS: error= 9.00D-08 at cycle  15 NSaved=  15.
+ NSaved=15 IEnMin=14 EnMin= -353.225922860737     IErMin=15 ErrMin= 9.00D-08
+ ErrMax= 9.00D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.10D-12 BMatP= 4.39D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.262D-06 0.278D-05 0.172D-05-0.212D-05-0.172D-04-0.493D-04
+ Coeff-Com: -0.353D-04 0.241D-03 0.773D-03 0.280D-03-0.371D-02-0.180D-01
+ Coeff-Com: -0.566D-01 0.623D-01 0.101D+01
+ Coeff:     -0.262D-06 0.278D-05 0.172D-05-0.212D-05-0.172D-04-0.493D-04
+ Coeff:     -0.353D-04 0.241D-03 0.773D-03 0.280D-03-0.371D-02-0.180D-01
+ Coeff:     -0.566D-01 0.623D-01 0.101D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.98D-08 MaxDP=4.31D-07 DE= 7.36D-07 OVMax= 1.78D-06
+
+ Cycle  16  Pass 1  IDiag  1:
+ E= -353.225922336444     Delta-E=       -0.000000211510 Rises=F Damp=F
+ DIIS: error= 3.84D-08 at cycle  16 NSaved=  16.
+ NSaved=16 IEnMin=14 EnMin= -353.225922860737     IErMin=16 ErrMin= 3.84D-08
+ ErrMax= 3.84D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-13 BMatP= 1.10D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.267D-07 0.479D-06 0.553D-06 0.432D-06-0.316D-05-0.152D-04
+ Coeff-Com: -0.218D-04 0.240D-04 0.298D-03 0.136D-03-0.113D-02-0.810D-02
+ Coeff-Com:  0.290D-01-0.429D-01-0.126D+00 0.115D+01
+ Coeff:     -0.267D-07 0.479D-06 0.553D-06 0.432D-06-0.316D-05-0.152D-04
+ Coeff:     -0.218D-04 0.240D-04 0.298D-03 0.136D-03-0.113D-02-0.810D-02
+ Coeff:      0.290D-01-0.429D-01-0.126D+00 0.115D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.74D-09 MaxDP=1.45D-07 DE=-2.12D-07 OVMax= 6.28D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922336     A.U. after   16 cycles
+            NFock= 16  Conv=0.67D-08     -V/T= 2.0037
+ KE= 3.519175042159D+02 PE=-1.260205403598D+03 EE= 3.393676889241D+02
+ Leave Link  502 at Mon Aug  5 14:30:03 2024, MaxMem=  4294967296 cpu:       338.3
+ (Enter /usr/local/g09/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   192
+ NBasis=   192 NAE=    22 NBE=    22 NFC=     0 NFV=     0
+ NROrb=    192 NOA=    22 NOB=    22 NVA=   170 NVB=   170
+
+ **** Warning!!: The largest alpha MO coefficient is  0.12180518D+02
+
+ Leave Link  801 at Mon Aug  5 14:30:03 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l1101.exe)
+ Using compressed storage, NAtomX=     7.
+ Will process      8 centers per pass.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+ Leave Link 1101 at Mon Aug  5 14:30:04 2024, MaxMem=  4294967296 cpu:        16.3
+ (Enter /usr/local/g09/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Mon Aug  5 14:30:04 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=     7.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=    4294967136.
+ G2DrvN: will do     8 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 1.00D-14.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    3507 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Mon Aug  5 14:30:24 2024, MaxMem=  4294967296 cpu:       318.6
+ (Enter /usr/local/g09/l1002.exe)
+ Minotr:  Closed shell wavefunction.
+          IDoAtm=1111111
+          Direct CPHF calculation.
+          Differentiating once with respect to nuclear coordinates.
+          Using symmetry in CPHF.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+          MDV=    4294967030 using IRadAn=       1.
+ Generate precomputed XC quadrature information.
+ Keep R1 ints in memory in canonical form, NReq=348853725.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    24 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     0.
+     18 vectors produced by pass  0 Test12= 1.56D-14 4.17D-09 XBig12= 8.81D-02 1.13D-01.
+ AX will form    18 AO Fock derivatives at one time.
+     18 vectors produced by pass  1 Test12= 1.56D-14 4.17D-09 XBig12= 3.30D-02 6.91D-02.
+     18 vectors produced by pass  2 Test12= 1.56D-14 4.17D-09 XBig12= 2.14D-03 1.30D-02.
+     18 vectors produced by pass  3 Test12= 1.56D-14 4.17D-09 XBig12= 4.79D-05 1.65D-03.
+     18 vectors produced by pass  4 Test12= 1.56D-14 4.17D-09 XBig12= 9.55D-07 1.70D-04.
+     18 vectors produced by pass  5 Test12= 1.56D-14 4.17D-09 XBig12= 1.11D-08 2.32D-05.
+     18 vectors produced by pass  6 Test12= 1.56D-14 4.17D-09 XBig12= 7.81D-11 1.69D-06.
+     16 vectors produced by pass  7 Test12= 1.56D-14 4.17D-09 XBig12= 4.87D-13 1.17D-07.
+      3 vectors produced by pass  8 Test12= 1.56D-14 4.17D-09 XBig12= 2.67D-15 1.01D-08.
+ InvSVY:  IOpt=1 It=  1 EMax= 8.88D-16
+ Solved reduced A of dimension   145 with    18 vectors.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Mon Aug  5 14:30:51 2024, MaxMem=  4294967296 cpu:       430.6
+ (Enter /usr/local/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A") (A') (A') (A') (A") (A') (A') (A') (A') (A")
+                 (A') (A') (A") (A') (A') (A') (A') (A") (A') (A')
+                 (A') (A") (A") (A') (A') (A') (A") (A') (A') (A')
+                 (A") (A') (A') (A') (A") (A') (A") (A') (A") (A')
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A") (A")
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A") (A') (A') (A') (A') (A") (A")
+                 (A') (A') (A") (A') (A") (A') (A') (A') (A') (A')
+                 (A") (A') (A') (A") (A") (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A') (A') (A') (A') (A") (A') (A')
+                 (A") (A') (A") (A') (A') (A") (A') (A") (A') (A")
+                 (A') (A') (A") (A') (A") (A') (A") (A') (A") (A')
+                 (A") (A') (A") (A') (A") (A') (A') (A") (A") (A')
+                 (A') (A') (A') (A') (A") (A') (A') (A") (A') (A")
+                 (A') (A") (A') (A') (A') (A") (A") (A") (A') (A")
+                 (A') (A') (A") (A') (A') (A') (A") (A") (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+ The electronic state is 1-A'.
+ Alpha  occ. eigenvalues --  -19.41840 -19.31496 -14.62270 -14.60942 -14.44596
+ Alpha  occ. eigenvalues --  -10.39487  -1.34412  -1.28595  -1.09827  -1.02043
+ Alpha  occ. eigenvalues --   -0.87956  -0.74493  -0.68508  -0.65030  -0.61164
+ Alpha  occ. eigenvalues --   -0.57781  -0.55591  -0.47224  -0.45214  -0.45097
+ Alpha  occ. eigenvalues --   -0.38439  -0.36017
+ Alpha virt. eigenvalues --   -0.00295   0.03616   0.07804   0.10156   0.13543
+ Alpha virt. eigenvalues --    0.19329   0.25026   0.26703   0.28317   0.28517
+ Alpha virt. eigenvalues --    0.32608   0.37413   0.38163   0.38990   0.41104
+ Alpha virt. eigenvalues --    0.43728   0.45327   0.45613   0.48013   0.50818
+ Alpha virt. eigenvalues --    0.52048   0.52621   0.56015   0.57728   0.60036
+ Alpha virt. eigenvalues --    0.63873   0.64489   0.67160   0.70185   0.72775
+ Alpha virt. eigenvalues --    0.73038   0.79032   0.84180   0.86875   0.87525
+ Alpha virt. eigenvalues --    0.97338   0.99620   0.99714   1.06092   1.06823
+ Alpha virt. eigenvalues --    1.21014   1.25086   1.30887   1.30933   1.32032
+ Alpha virt. eigenvalues --    1.32253   1.42695   1.44781   1.45054   1.46864
+ Alpha virt. eigenvalues --    1.50159   1.57948   1.59003   1.63542   1.64971
+ Alpha virt. eigenvalues --    1.70396   1.73557   1.76005   1.84892   1.85269
+ Alpha virt. eigenvalues --    1.87491   1.93324   1.96996   1.98408   2.00130
+ Alpha virt. eigenvalues --    2.11446   2.11932   2.15372   2.16420   2.20376
+ Alpha virt. eigenvalues --    2.20537   2.29004   2.29969   2.35242   2.49172
+ Alpha virt. eigenvalues --    2.51629   2.55008   2.55679   2.61396   2.69198
+ Alpha virt. eigenvalues --    2.71001   2.72099   2.75243   2.76272   2.81077
+ Alpha virt. eigenvalues --    2.91955   2.94342   2.98181   2.98922   2.99821
+ Alpha virt. eigenvalues --    3.09011   3.11497   3.16079   3.20205   3.24403
+ Alpha virt. eigenvalues --    3.34139   3.45383   3.49373   3.50315   3.66521
+ Alpha virt. eigenvalues --    3.68459   3.73856   3.74148   3.81340   3.93045
+ Alpha virt. eigenvalues --    3.98789   4.05413   4.05924   4.12373   4.14803
+ Alpha virt. eigenvalues --    4.32871   4.36259   4.40454   4.47543   4.50901
+ Alpha virt. eigenvalues --    4.52196   4.55218   4.56083   4.65777   4.65963
+ Alpha virt. eigenvalues --    4.69422   4.70470   4.76148   4.77929   4.84287
+ Alpha virt. eigenvalues --    4.88485   4.94288   5.04522   5.16901   5.18677
+ Alpha virt. eigenvalues --    5.20390   5.22841   5.28719   5.31052   5.31614
+ Alpha virt. eigenvalues --    5.37676   5.41411   5.46353   5.47733   5.55984
+ Alpha virt. eigenvalues --    5.62441   5.74797   5.77485   5.85530   5.91140
+ Alpha virt. eigenvalues --    6.02543   6.34125   6.34760   6.40764   6.42121
+ Alpha virt. eigenvalues --    6.46820   6.57460   6.58564   6.68052   6.83860
+ Alpha virt. eigenvalues --    6.85698   6.87309   6.96002   7.01549   7.17701
+ Alpha virt. eigenvalues --    7.22837   7.30314   7.46079   7.67807  23.29875
+ Alpha virt. eigenvalues --   31.86918  31.95663  32.21131  43.87469  44.34859
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.248212   0.846706  -0.028545   0.002347   0.000725  -0.013888
+     2  C    0.846706   4.776258   0.319669  -0.042093  -0.005915   0.025792
+     3  O   -0.028545   0.319669   7.820771   0.062566   0.000513   0.008426
+     4  N    0.002347  -0.042093   0.062566   6.604525   0.148797  -0.128465
+     5  N    0.000725  -0.005915   0.000513   0.148797   6.396318   0.324718
+     6  O   -0.013888   0.025792   0.008426  -0.128465   0.324718   8.081610
+     7  H   -0.000148   0.001933  -0.026160   0.364209  -0.018707   0.005957
+               7
+     1  N   -0.000148
+     2  C    0.001933
+     3  O   -0.026160
+     4  N    0.364209
+     5  N   -0.018707
+     6  O    0.005957
+     7  H    0.375434
+ Mulliken charges:
+               1
+     1  N   -0.055410
+     2  C    0.077652
+     3  O   -0.157239
+     4  N   -0.011885
+     5  N    0.153550
+     6  O   -0.304150
+     7  H    0.297482
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.055410
+     2  C    0.077652
+     3  O   -0.157239
+     4  N    0.285598
+     5  N    0.153550
+     6  O   -0.304150
+ APT charges:
+               1
+     1  N    0.548404
+     2  C   -0.475302
+     3  O   -0.258761
+     4  N   -0.304457
+     5  N    0.040382
+     6  O   -0.279057
+     7  H    0.728791
+ Sum of APT charges =   0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  N    0.548404
+     2  C   -0.475302
+     3  O   -0.258761
+     4  N    0.424334
+     5  N    0.040382
+     6  O   -0.279057
+ Electronic spatial extent (au):  <R**2>=            478.9523
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -1.1651    Y=              5.3389    Z=              0.0000  Tot=              5.4645
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -36.5858   YY=            -33.7581   ZZ=            -31.9105
+   XY=             -3.7648   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -2.5010   YY=              0.3267   ZZ=              2.1743
+   XY=             -3.7648   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -2.7816  YYY=             41.1264  ZZZ=              0.0000  XYY=              3.6204
+  XXY=              4.1957  XXZ=              0.0000  XZZ=              1.6434  YZZ=              2.3951
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -275.9242 YYYY=           -306.4966 ZZZZ=            -27.2024 XXXY=            -60.6278
+ XXXZ=              0.0000 YYYX=            -87.9442 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=           -104.6336 XXZZ=            -47.4787 YYZZ=            -56.3721
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=            -19.0166
+ N-N= 2.156942881214D+02 E-N=-1.260205401943D+03  KE= 3.519175042159D+02
+ Symmetry A'   KE= 3.362837980446D+02
+ Symmetry A"   KE= 1.563370617133D+01
+  Exact polarizability:   0.000   0.000   0.000   0.000   0.000   0.000
+ Approx polarizability:  52.722  -2.703  67.058   0.000   0.000  27.665
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Mon Aug  5 14:30:52 2024, MaxMem=  4294967296 cpu:         3.9
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral second derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 2nd derivatives to the Hessian.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 8 Len=  415
+ Leave Link  701 at Mon Aug  5 14:30:53 2024, MaxMem=  4294967296 cpu:        15.9
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:30:53 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=    100147 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100147 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=  100547 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:31:41 2024, MaxMem=  4294967296 cpu:       767.8
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        =-4.58373213D-01 2.10047291D+00 4.43200353D-17
+ Polarizability= 0.00000000D+00 0.00000000D+00 0.00000000D+00
+                 0.00000000D+00 0.00000000D+00 0.00000000D+00
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000255609   -0.000022594    0.000109269
+      2        6          -0.000216310    0.000249370   -0.000092949
+      3        8           0.000063418   -0.000467104    0.000028072
+      4        7          -0.000086164    0.000395809   -0.000037643
+      5        7          -0.000148329   -0.000160890   -0.000063046
+      6        8           0.000153917    0.000013542    0.000065741
+      7        1          -0.000022142   -0.000008132   -0.000009445
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000467104 RMS     0.000177899
+ Force constants in Cartesian coordinates: 
+                1             2             3             4             5 
+      1  0.103601D+01
+      2  0.136616D+00  0.419150D-01
+      3  0.432224D+00  0.583384D-01  0.208384D+00
+      4 -0.101361D+01 -0.124669D+00 -0.413880D+00  0.142080D+01
+      5 -0.129017D+00 -0.523289D-01 -0.551124D-01  0.212354D+00  0.145894D+00
+      6 -0.413871D+00 -0.532544D-01 -0.221147D+00  0.573652D+00  0.905961D-01
+      7 -0.327696D-01 -0.167343D-01 -0.212343D-01 -0.343616D+00 -0.102848D+00
+      8 -0.440785D-02  0.190275D-01 -0.188769D-02 -0.916352D-01 -0.120913D+00
+      9 -0.212600D-01 -0.715478D-02  0.793672D-02 -0.136896D+00 -0.437422D-01
+     10  0.123126D-01  0.177797D-02  0.428235D-02 -0.657714D-01  0.127294D-01
+     11 -0.420428D-02 -0.213764D-02 -0.178727D-02 -0.152874D-01  0.236028D-01
+     12  0.429483D-02  0.768946D-03  0.411563D-02 -0.239031D-01  0.536972D-02
+     13 -0.843977D-02 -0.463879D-02 -0.287702D-02  0.243515D-01  0.172968D-01
+     14 -0.215745D-02 -0.392418D-02 -0.917208D-03  0.121708D-01  0.726215D-02
+     15 -0.288219D-02 -0.197748D-02 -0.291156D-02  0.854955D-02  0.738474D-02
+     16  0.548323D-02  0.790520D-02  0.132753D-02 -0.195963D-01 -0.128312D-01
+     17  0.264188D-02 -0.342886D-02  0.114090D-02  0.355222D-02  0.209920D-02
+     18  0.133851D-02  0.338992D-02  0.290274D-02 -0.737286D-02 -0.549206D-02
+     19  0.101837D-02 -0.257643D-03  0.156773D-03 -0.255924D-02  0.231470D-02
+     20  0.528402D-03  0.877086D-03  0.225318D-03  0.351361D-02 -0.561571D-02
+     21  0.155135D-03 -0.110559D-03  0.719259D-03 -0.149483D-03  0.996140D-03
+                6             7             8             9            10 
+      6  0.322196D+00
+      7 -0.136873D+00  0.505665D+00
+      8 -0.389512D-01  0.460005D-01  0.245795D+00
+      9 -0.811984D-01  0.214711D+00  0.191496D-01  0.946636D-01
+     10 -0.239615D-01 -0.113261D+00  0.132364D-01 -0.515207D-01  0.642879D+00
+     11 -0.660187D-02  0.296989D-01 -0.136271D+00  0.129896D-01  0.234185D+00
+     12 -0.199820D-01 -0.515550D-01  0.595523D-02 -0.147947D-01  0.279548D+00
+     13  0.853886D-02 -0.372617D-01  0.682564D-01 -0.225890D-01 -0.124842D+00
+     14  0.519439D-02  0.191204D-01 -0.388279D-01  0.828298D-02  0.551076D-02
+     15  0.792165D-02 -0.224865D-01  0.292788D-01  0.560005D-02 -0.457432D-01
+     16 -0.733870D-02  0.343386D-01 -0.229095D-01  0.205868D-01 -0.269470D-01
+     17  0.150857D-02 -0.868738D-02  0.231625D-01 -0.378906D-02 -0.997287D-01
+     18 -0.549812D-02  0.205572D-01 -0.986617D-02 -0.492373D-02 -0.186979D-01
+     19 -0.146982D-03 -0.130954D-01 -0.854082D-02 -0.303193D-02 -0.324370D+00
+     20  0.150844D-02  0.334494D-01  0.802729D-02  0.142638D-01 -0.167711D+00
+     21 -0.229251D-02 -0.311950D-02 -0.367866D-02 -0.728347D-02 -0.143907D+00
+               11            12            13            14            15 
+     11  0.607201D+00
+     12  0.987752D-01  0.106762D+00
+     13  0.212811D-02 -0.457361D-01  0.665194D+00
+     14 -0.214079D+00  0.276405D-02  0.135792D+00  0.411402D+00
+     15  0.131864D-02 -0.373664D-01  0.260024D+00  0.572827D-01  0.166993D+00
+     16 -0.875833D-01 -0.187233D-01 -0.523556D+00 -0.173578D+00 -0.207931D+00
+     17 -0.123717D+00 -0.423201D-01 -0.186138D+00 -0.153257D+00 -0.792925D-01
+     18 -0.371303D-01  0.938580D-02 -0.207904D+00 -0.739258D-01 -0.124778D+00
+     19 -0.158937D+00 -0.143925D+00  0.455368D-02  0.314210D-02  0.104687D-01
+     20 -0.154600D+00 -0.713131D-01 -0.326963D-01 -0.857690D-02 -0.139949D-01
+     21 -0.675640D-01 -0.481203D-01  0.105434D-01  0.131888D-02 -0.154588D-01
+               16            17            18            19            20 
+     16  0.526116D+00
+     17  0.284813D+00  0.261663D+00
+     18  0.215159D+00  0.121199D+00  0.112881D+00
+     19  0.416103D-02  0.354741D-02 -0.307908D-02  0.330292D+00
+     20  0.418444D-02 -0.652201D-02  0.182528D-02  0.158732D+00  0.166410D+00
+     21 -0.308041D-02  0.155308D-02  0.100301D-01  0.139558D+00  0.674852D-01
+               21 
+     21  0.624057D-01
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Force constants in internal coordinates: 
+                1             2             3             4             5 
+      1  0.123896D+01
+      2  0.321334D-01  0.525748D+00
+      3 -0.120270D-01  0.417903D-01  0.255504D+00
+      4 -0.426231D-03  0.175541D-01  0.292280D-01  0.370993D+00
+      5 -0.124237D-02 -0.605586D-03 -0.697940D-02  0.870162D-03  0.483562D+00
+      6  0.738723D-02 -0.130035D-01  0.283690D-01  0.158272D+00 -0.431233D-02
+      7 -0.747366D-02  0.928442D-01  0.708447D-01  0.237762D-01 -0.114008D-02
+      8  0.370327D-02  0.122670D-01  0.527283D-03 -0.148416D-01 -0.243680D-02
+      9 -0.174485D-02 -0.352976D-02  0.265440D-01 -0.966173D-02 -0.129200D-02
+     10 -0.195842D-02 -0.873727D-02 -0.270713D-01  0.245034D-01  0.372880D-02
+     11 -0.210247D-02  0.298091D-01 -0.740435D-01  0.105178D+00  0.401926D-02
+     12 -0.153865D-01 -0.115881D-01  0.181915D-01  0.155727D-01  0.638757D-04
+     13  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     14  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     15  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     16  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     17  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+                6             7             8             9            10 
+      6  0.794032D+00
+      7 -0.812506D-02  0.349585D+00
+      8 -0.985791D-02  0.697525D-01  0.161755D+00
+      9  0.397303D-02 -0.215602D-01 -0.854832D-01  0.110650D+00
+     10  0.588488D-02 -0.481923D-01 -0.762722D-01 -0.251668D-01  0.101439D+00
+     11  0.100372D+00  0.503229D-01 -0.386980D-01  0.218863D-02  0.365093D-01
+     12 -0.116660D-01  0.396883D-01  0.388262D-01 -0.213111D-01 -0.175151D-01
+     13  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     14  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     15  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     16  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+     17  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00  0.000000D+00
+               11            12            13            14            15 
+     11  0.437327D+00
+     12  0.336003D-01  0.111742D+00
+     13  0.000000D+00  0.000000D+00  0.100419D+00
+     14  0.000000D+00  0.000000D+00  0.434318D-02 -0.929534D-02
+     15  0.000000D+00  0.000000D+00  0.285324D-02 -0.436643D-02 -0.572558D-02
+     16  0.000000D+00  0.000000D+00 -0.122737D-02 -0.141735D-02 -0.610132D-03
+     17  0.000000D+00  0.000000D+00  0.394667D-03 -0.678323D-02  0.869511D-03
+               16            17 
+     16  0.235830D-01
+     17  0.227042D-01  0.143730D-01
+ Leave Link  716 at Mon Aug  5 14:31:41 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000403254 RMS     0.000153836
+ Search for a local minimum.
+ Step number   1 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .15384D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Second derivative matrix not updated -- analytic derivatives used.
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.23896
+           R2           0.03213   0.52575
+           R3          -0.01203   0.04179   0.25550
+           R4          -0.00043   0.01755   0.02923   0.37099
+           R5          -0.00124  -0.00061  -0.00698   0.00087   0.48356
+           R6           0.00739  -0.01300   0.02837   0.15827  -0.00431
+           A1          -0.00747   0.09284   0.07084   0.02378  -0.00114
+           A2           0.00370   0.01227   0.00053  -0.01484  -0.00244
+           A3          -0.00174  -0.00353   0.02654  -0.00966  -0.00129
+           A4          -0.00196  -0.00874  -0.02707   0.02450   0.00373
+           A5          -0.00210   0.02981  -0.07404   0.10518   0.00402
+           A6          -0.01539  -0.01159   0.01819   0.01557   0.00006
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.79403
+           A1          -0.00813   0.34958
+           A2          -0.00986   0.06975   0.16176
+           A3           0.00397  -0.02156  -0.08548   0.11065
+           A4           0.00588  -0.04819  -0.07627  -0.02517   0.10144
+           A5           0.10037   0.05032  -0.03870   0.00219   0.03651
+           A6          -0.01167   0.03969   0.03883  -0.02131  -0.01752
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.43733
+           A6           0.03360   0.11174
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08141   0.10068
+     Eigenvalues ---    0.11514   0.15133   0.23626   0.30470   0.37651
+     Eigenvalues ---    0.46313   0.48714   0.59814   0.88665   1.24089
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83977  -0.41785  -0.30926   0.15006   0.04499
+                          R3        A5        A6        A2        A4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74393   0.51897  -0.40714   0.10677   0.00896
+                          A5        A4        A6        A3        A2
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -4.30D-12
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1=  1.97D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -2.40D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -7.34D-06.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.02651488 RMS(Int)=  0.00118585
+ Iteration  2 RMS(Cart)=  0.00154453 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065576
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065576
+ ITry= 1 IFail=0 DXMaxC= 6.17D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17401   0.00028   0.00000   0.00000  -0.00046   2.17355
+    R2        2.45232   0.00012   0.00000   0.00000  -0.00076   2.45156
+    R3        2.67737   0.00024   0.00000   0.00000  -0.00288   2.67449
+    R4        2.46670  -0.00015   0.00000   0.00000  -0.00022   2.46647
+    R5        1.90100   0.00003   0.00000   0.00000  -0.00090   1.90009
+    R6        2.26191   0.00015   0.00000   0.00000  -0.00106   2.26085
+    A1        2.08970  -0.00040   0.00000   0.00000   0.00213   2.09182
+    A2        2.26761  -0.00010   0.00000   0.00000   0.00023   2.26785
+    A3        1.91717   0.00005   0.00000   0.00000   0.00052   1.91768
+    A4        2.09841   0.00005   0.00000   0.00000  -0.00075   2.09765
+    A5        2.06889  -0.00014   0.00000   0.00000  -0.00016   2.06873
+    A6        3.34304   0.00011   0.00000   0.00000   0.00006   3.34311
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11164   0.00000   0.00000
+    D2       -3.14159   0.00000   0.00000  -0.00574   0.00000  -3.14159
+    D3        0.00000   0.00000   0.00000   0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000403     0.000015     NO 
+ RMS     Force            0.000154     0.000010     NO 
+ Maximum Displacement     0.003592     0.000060     NO 
+ RMS     Displacement     0.001544     0.000040     NO 
+ Predicted change in Energy=-4.399825D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:31:41 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226489   -0.518045    0.856114
+      2          6           0        1.175834   -0.651349    0.407446
+      3          8           0        0.042257   -1.056573   -0.076087
+      4          7           0       -0.925014   -0.110561   -0.491375
+      5          7           0       -0.881980    1.193838   -0.475707
+      6          8           0        0.102813    1.728065   -0.056019
+      7          1           0       -1.740397   -0.585376   -0.838799
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150195   0.000000
+     3  O    2.435135   1.297308   0.000000
+     4  N    3.451629   2.348168   1.415279   0.000000
+     5  N    3.790366   2.901598   2.465412   1.305202   0.000000
+     6  O    3.222887   2.650997   2.785368   2.150932   1.196392
+     7  H    4.314331   3.172047   1.995397   1.005486   2.008560
+                    6          7
+     6  O    0.000000
+     7  H    3.059767   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.64D+00
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260639    0.275948    0.000000
+      2          6           0       -1.153360    0.587210    0.000000
+      3          8           0        0.000000    1.181153    0.000000
+      4          7           0        1.188292    0.412402    0.000000
+      5          7           0        1.348210   -0.882966    0.000000
+      6          8           0        0.375023   -1.578854    0.000000
+      7          1           0        1.988932    1.020660    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6792441      3.2634694      2.2901978
+ Leave Link  202 at Mon Aug  5 14:31:41 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7496978468 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014823347 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7482155121 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:31:41 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:31:42 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:31:42 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.814768    0.000000    0.000000    0.579787 Ang=  70.87 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:31:42 2024, MaxMem=  4294967296 cpu:         2.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225916555861    
+ DIIS: error= 1.09D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225916555861     IErMin= 1 ErrMin= 1.09D-04
+ ErrMax= 1.09D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.09D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.28D-06 MaxDP=1.87D-04              OVMax= 5.14D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225921070522     Delta-E=       -0.000004514661 Rises=F Damp=F
+ DIIS: error= 2.12D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225921070522     IErMin= 2 ErrMin= 2.12D-05
+ ErrMax= 2.12D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.56D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.598D-01 0.106D+01
+ Coeff:     -0.598D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.79D-06 MaxDP=8.11D-05 DE=-4.51D-06 OVMax= 1.69D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225921287852     Delta-E=       -0.000000217330 Rises=F Damp=F
+ DIIS: error= 2.33D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225921287852     IErMin= 2 ErrMin= 2.12D-05
+ ErrMax= 2.33D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.80D-08 BMatP= 1.56D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.504D-01 0.432D+00 0.618D+00
+ Coeff:     -0.504D-01 0.432D+00 0.618D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.47D-05 DE=-2.17D-07 OVMax= 9.37D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225921336229     Delta-E=       -0.000000048377 Rises=F Damp=F
+ DIIS: error= 1.23D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225921336229     IErMin= 4 ErrMin= 1.23D-05
+ ErrMax= 1.23D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.80D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.167D-01 0.521D-01 0.360D+00 0.604D+00
+ Coeff:     -0.167D-01 0.521D-01 0.360D+00 0.604D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.05D-07 MaxDP=1.40D-05 DE=-4.84D-08 OVMax= 4.49D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225921356644     Delta-E=       -0.000000020415 Rises=F Damp=F
+ DIIS: error= 3.20D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225921356644     IErMin= 5 ErrMin= 3.20D-06
+ ErrMax= 3.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.01D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.227D-02-0.589D-01 0.451D-01 0.256D+00 0.756D+00
+ Coeff:      0.227D-02-0.589D-01 0.451D-01 0.256D+00 0.756D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=1.01D-05 DE=-2.04D-08 OVMax= 1.64D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225921358757     Delta-E=       -0.000000002114 Rises=F Damp=F
+ DIIS: error= 1.02D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225921358757     IErMin= 6 ErrMin= 1.02D-06
+ ErrMax= 1.02D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.75D-10 BMatP= 2.01D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.334D-01-0.138D-01 0.647D-01 0.357D+00 0.623D+00
+ Coeff:      0.256D-02-0.334D-01-0.138D-01 0.647D-01 0.357D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.92D-06 DE=-2.11D-09 OVMax= 5.11D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225921359025     Delta-E=       -0.000000000268 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225921359025     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.75D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.402D-03 0.179D-03-0.122D-01-0.241D-01-0.345D-01 0.160D+00
+ Coeff-Com:  0.910D+00
+ Coeff:      0.402D-03 0.179D-03-0.122D-01-0.241D-01-0.345D-01 0.160D+00
+ Coeff:      0.910D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.94D-08 MaxDP=1.86D-06 DE=-2.68D-10 OVMax= 4.75D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225921359068     Delta-E=       -0.000000000043 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225921359068     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.19D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.180D-03 0.428D-02-0.210D-02-0.155D-01-0.562D-01-0.344D-01
+ Coeff-Com:  0.347D+00 0.757D+00
+ Coeff:     -0.180D-03 0.428D-02-0.210D-02-0.155D-01-0.562D-01-0.344D-01
+ Coeff:      0.347D+00 0.757D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.60D-07 DE=-4.29D-11 OVMax= 1.30D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225921359079     Delta-E=       -0.000000000011 Rises=F Damp=F
+ DIIS: error= 4.68D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225921359079     IErMin= 9 ErrMin= 4.68D-08
+ ErrMax= 4.68D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-13 BMatP= 4.19D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.947D-04 0.143D-02 0.648D-03-0.322D-02-0.149D-01-0.287D-01
+ Coeff-Com:  0.439D-01 0.256D+00 0.745D+00
+ Coeff:     -0.947D-04 0.143D-02 0.648D-03-0.322D-02-0.149D-01-0.287D-01
+ Coeff:      0.439D-01 0.256D+00 0.745D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.05D-09 MaxDP=1.75D-07 DE=-1.08D-11 OVMax= 5.49D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225921359     A.U. after    9 cycles
+            NFock=  9  Conv=0.70D-08     -V/T= 2.0037
+ KE= 3.519248557153D+02 PE=-1.260314882293D+03 EE= 3.394158897064D+02
+ Leave Link  502 at Mon Aug  5 14:31:54 2024, MaxMem=  4294967296 cpu:       190.3
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:31:55 2024, MaxMem=  4294967296 cpu:        14.0
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:31:55 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:       142.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83263392D+00 1.12146529D+00-4.64652388D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000763355    0.000073340    0.000326029
+      2        6          -0.000515602    0.000508188   -0.000221377
+      3        8           0.000171280   -0.001161899    0.000075611
+      4        7          -0.000211855    0.000685984   -0.000091956
+      5        7          -0.000852395   -0.000235985   -0.000363737
+      6        8           0.000986595    0.000373103    0.000420794
+      7        1          -0.000341378   -0.000242731   -0.000145365
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001161899 RMS     0.000515349
+ Leave Link  716 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001132642 RMS     0.000510176
+ Search for a local minimum.
+ Step number   2 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .51018D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    1    2
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.23410
+           R2           0.02934   0.52414
+           R3          -0.02617   0.03379   0.23292
+           R4          -0.00688   0.01389   0.01773   0.36528
+           R5          -0.00316  -0.00173  -0.01579  -0.00294   0.48337
+           R6           0.00296  -0.01560   0.00765   0.14932  -0.00469
+           A1          -0.02023   0.08575   0.06832   0.02040  -0.01218
+           A2          -0.01206   0.00344  -0.00977  -0.02183  -0.01484
+           A3           0.00760   0.00171   0.03367  -0.00512   0.00588
+           A4           0.00446  -0.00515  -0.02390   0.02694   0.00896
+           A5          -0.01774   0.02104  -0.08680   0.09725  -0.00784
+           A6          -0.01137  -0.00932   0.02292   0.01818   0.00286
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.79333
+           A1          -0.03436   0.38055
+           A2          -0.03925   0.09466   0.17880
+           A3           0.02096  -0.03442  -0.09362   0.11437
+           A4           0.01828  -0.06024  -0.08518  -0.02074   0.10592
+           A5           0.07231   0.07027  -0.02669  -0.00313   0.02981
+           A6          -0.00506   0.03725   0.03851  -0.02151  -0.01700
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.44474
+           A6           0.03424   0.11103
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.07636   0.10068
+     Eigenvalues ---    0.11444   0.14109   0.23746   0.30742   0.40733
+     Eigenvalues ---    0.48175   0.48660   0.60749   0.87135   1.23724
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83984  -0.41778  -0.30919   0.14999   0.04499
+                          A6        A5        A2        A4        R3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74407   0.51884  -0.40701   0.10691   0.00896
+                          R3        A1        R6        R5        R2
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  5.58D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1=  3.53D-10
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -2.97D-10.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -4.35D-05.
+ Quartic linear search produced a step of -0.39711.
+ Iteration  1 RMS(Cart)=  0.02645733 RMS(Int)=  0.00118510
+ Iteration  2 RMS(Cart)=  0.00154210 RMS(Int)=  0.00065572
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065572
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065572
+ ITry= 1 IFail=0 DXMaxC= 6.16D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.70D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17355   0.00083   0.00018   0.00000  -0.00027   2.17328
+    R2        2.45156   0.00043   0.00030   0.00000  -0.00046   2.45110
+    R3        2.67449   0.00073   0.00114   0.00000  -0.00173   2.67276
+    R4        2.46647   0.00015   0.00009   0.00000  -0.00013   2.46634
+    R5        1.90009   0.00044   0.00036   0.00000  -0.00055   1.89955
+    R6        2.26085   0.00113   0.00042   0.00000  -0.00064   2.26022
+    A1        2.09182  -0.00104  -0.00084   0.00000   0.00128   2.09311
+    A2        2.26785  -0.00046  -0.00009   0.00000   0.00014   2.26799
+    A3        1.91768   0.00020  -0.00021   0.00000   0.00032   1.91800
+    A4        2.09765   0.00026   0.00030   0.00000  -0.00045   2.09720
+    A5        2.06873  -0.00034   0.00007   0.00000  -0.00010   2.06863
+    A6        3.34311   0.00007  -0.00003   0.00000   0.00004   3.34315
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001133     0.000015     NO 
+ RMS     Force            0.000510     0.000010     NO 
+ Maximum Displacement     0.002161     0.000060     NO 
+ RMS     Displacement     0.000929     0.000040     NO 
+ Predicted change in Energy=-4.972649D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226623   -0.519188    0.856173
+      2          6           0        1.175991   -0.651448    0.407513
+      3          8           0        0.042306   -1.055537   -0.076068
+      4          7           0       -0.924706   -0.110582   -0.491243
+      5          7           0       -0.882347    1.193771   -0.475864
+      6          8           0        0.101941    1.728342   -0.056392
+      7          1           0       -1.739807   -0.585356   -0.838547
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150050   0.000000
+     3  O    2.434746   1.297066   0.000000
+     4  N    3.451574   2.348026   1.414362   0.000000
+     5  N    3.791338   2.902058   2.464590   1.305131   0.000000
+     6  O    3.224661   2.651828   2.784587   2.150522   1.196055
+     7  H    4.313818   3.171579   1.994585   1.005197   2.008001
+                    6          7
+     6  O    0.000000
+     7  H    3.058922   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 4.67D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261077    0.277073    0.000000
+      2          6           0       -1.153658    0.587297    0.000000
+      3          8           0        0.000000    1.180133    0.000000
+      4          7           0        1.187844    0.412379    0.000000
+      5          7           0        1.348476   -0.882830    0.000000
+      6          8           0        0.375882   -1.578968    0.000000
+      7          1           0        1.988191    1.020544    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6870566      3.2618121      2.2900753
+ Leave Link  202 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7821508768 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014820510 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7806688257 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         3.3
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:32:04 2024, MaxMem=  4294967296 cpu:         0.5
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.814764    0.000000    0.000000    0.579792 Ang=  70.87 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000006 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 6.03D-01
+ Max alpha theta=  0.057 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:32:05 2024, MaxMem=  4294967296 cpu:         3.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225911569180    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225911569180     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=    16.685 Goal=   None    Shift=    0.000
+ RMSDP=9.26D-06 MaxDP=1.87D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225916076627     Delta-E=       -0.000004507447 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225916076627     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.56D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.592D-01 0.106D+01
+ Coeff:     -0.592D-01 0.106D+01
+ Gap=     0.358 Goal=   None    Shift=    0.000
+ RMSDP=2.79D-06 MaxDP=8.18D-05 DE=-4.51D-06 OVMax= 1.68D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225916293871     Delta-E=       -0.000000217245 Rises=F Damp=F
+ DIIS: error= 2.30D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225916293871     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.30D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.75D-08 BMatP= 1.56D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.502D-01 0.430D+00 0.620D+00
+ Coeff:     -0.502D-01 0.430D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.45D-05 DE=-2.17D-07 OVMax= 9.36D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225916341933     Delta-E=       -0.000000048062 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225916341933     IErMin= 4 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.75D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.167D-01 0.531D-01 0.361D+00 0.603D+00
+ Coeff:     -0.167D-01 0.531D-01 0.361D+00 0.603D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.03D-07 MaxDP=1.42D-05 DE=-4.81D-08 OVMax= 4.49D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225916362239     Delta-E=       -0.000000020306 Rises=F Damp=F
+ DIIS: error= 3.20D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225916362239     IErMin= 5 ErrMin= 3.20D-06
+ ErrMax= 3.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.02D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.222D-02-0.585D-01 0.450D-01 0.256D+00 0.756D+00
+ Coeff:      0.222D-02-0.585D-01 0.450D-01 0.256D+00 0.756D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=1.00D-05 DE=-2.03D-08 OVMax= 1.65D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225916364348     Delta-E=       -0.000000002109 Rises=F Damp=F
+ DIIS: error= 1.03D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225916364348     IErMin= 6 ErrMin= 1.03D-06
+ ErrMax= 1.03D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.79D-10 BMatP= 2.02D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.334D-01-0.140D-01 0.649D-01 0.358D+00 0.622D+00
+ Coeff:      0.256D-02-0.334D-01-0.140D-01 0.649D-01 0.358D+00 0.622D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.79D-08 MaxDP=3.92D-06 DE=-2.11D-09 OVMax= 5.14D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225916364627     Delta-E=       -0.000000000279 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225916364627     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.79D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.410D-03 0.661D-04-0.121D-01-0.238D-01-0.336D-01 0.159D+00
+ Coeff-Com:  0.910D+00
+ Coeff:      0.410D-03 0.661D-04-0.121D-01-0.238D-01-0.336D-01 0.159D+00
+ Coeff:      0.910D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.90D-08 MaxDP=1.84D-06 DE=-2.79D-10 OVMax= 4.72D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225916364665     Delta-E=       -0.000000000038 Rises=F Damp=F
+ DIIS: error= 1.69D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225916364665     IErMin= 8 ErrMin= 1.69D-07
+ ErrMax= 1.69D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.07D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.197D-02-0.153D-01-0.558D-01-0.353D-01
+ Coeff-Com:  0.342D+00 0.762D+00
+ Coeff:     -0.178D-03 0.424D-02-0.197D-02-0.153D-01-0.558D-01-0.353D-01
+ Coeff:      0.342D+00 0.762D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.04D-08 MaxDP=9.57D-07 DE=-3.84D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225916364669     Delta-E=       -0.000000000004 Rises=F Damp=F
+ DIIS: error= 3.86D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225916364669     IErMin= 9 ErrMin= 3.86D-08
+ ErrMax= 3.86D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.29D-13 BMatP= 4.07D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.902D-04 0.132D-02 0.712D-03-0.286D-02-0.135D-01-0.279D-01
+ Coeff-Com:  0.346D-01 0.238D+00 0.769D+00
+ Coeff:     -0.902D-04 0.132D-02 0.712D-03-0.286D-02-0.135D-01-0.279D-01
+ Coeff:      0.346D-01 0.238D+00 0.769D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.16D-09 MaxDP=1.78D-07 DE=-4.09D-12 OVMax= 5.64D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225916365     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519293078968D+02 PE=-1.260380814066D+03 EE= 3.394449209788D+02
+ Leave Link  502 at Mon Aug  5 14:32:17 2024, MaxMem=  4294967296 cpu:       190.1
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:32:18 2024, MaxMem=  4294967296 cpu:        13.9
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:32:18 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:       150.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83165782D+00 1.12146673D+00-1.34649838D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.001079122    0.000131764    0.000460835
+      2        6          -0.000691753    0.000617660   -0.000296874
+      3        8           0.000246473   -0.001608094    0.000108672
+      4        7          -0.000306138    0.000908834   -0.000132708
+      5        7          -0.001276258   -0.000286675   -0.000544748
+      6        8           0.001485265    0.000622113    0.000633357
+      7        1          -0.000536712   -0.000385602   -0.000228533
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001608094 RMS     0.000737730
+ Leave Link  716 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001728852 RMS     0.000731180
+ Search for a local minimum.
+ Step number   3 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .73118D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    1
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.23582
+           R2           0.03036   0.52475
+           R3          -0.02092   0.03679   0.24106
+           R4          -0.00489   0.01505   0.02154   0.36694
+           R5          -0.00246  -0.00129  -0.01240  -0.00177   0.48345
+           R6           0.00450  -0.01463   0.01552   0.15203  -0.00457
+           A1          -0.01598   0.08807   0.06812   0.02152  -0.00837
+           A2          -0.00686   0.00633  -0.00722  -0.01964  -0.01062
+           A3           0.00451  -0.00001   0.03175  -0.00654   0.00344
+           A4           0.00235  -0.00632  -0.02453   0.02618   0.00718
+           A5          -0.01258   0.02392  -0.08326   0.09971  -0.00381
+           A6          -0.01283  -0.01015   0.02131   0.01730   0.00182
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.79342
+           A1          -0.02523   0.36900
+           A2          -0.02922   0.08523   0.17200
+           A3           0.01517  -0.02950  -0.09028   0.11277
+           A4           0.01405  -0.05573  -0.08172  -0.02249   0.10422
+           A5           0.08184   0.06261  -0.03172  -0.00077   0.03249
+           A6          -0.00752   0.03841   0.03891  -0.02159  -0.01731
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.44132
+           A6           0.03427   0.11125
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04531874 RMS(Int)=  0.00046437
+ Iteration  2 RMS(Cart)=  0.00144685 RMS(Int)=  0.00000059
+ Iteration  3 RMS(Cart)=  0.00000065 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 1.03D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 2.18D-08 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17328   0.00118   0.00000   0.03405   0.03405   2.20733
+    R2        2.45110   0.00062   0.00000   0.01803   0.01803   2.46913
+    R3        2.67276   0.00109   0.00000   0.03154   0.03154   2.70430
+    R4        2.46634   0.00035   0.00000   0.01004   0.01004   2.47638
+    R5        1.89955   0.00069   0.00000   0.02009   0.02009   1.91964
+    R6        2.26022   0.00173   0.00000   0.05000   0.05000   2.31022
+    A1        2.09311  -0.00136   0.00000  -0.03936  -0.03936   2.05375
+    A2        2.26799  -0.00059   0.00000  -0.01716  -0.01716   2.25083
+    A3        1.91800   0.00024   0.00000   0.00704   0.00704   1.92504
+    A4        2.09720   0.00035   0.00000   0.01012   0.01012   2.10732
+    A5        2.06863  -0.00038   0.00000  -0.01104  -0.01104   2.05759
+    A6        3.34315   0.00003   0.00000   0.00088   0.00088   3.34403
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001729     0.000015     NO 
+ RMS     Force            0.000731     0.000010     NO 
+ Maximum Displacement     0.103299     0.000060     NO 
+ RMS     Displacement     0.046445     0.000040     NO 
+ Predicted change in Energy=-2.300752D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.225053   -0.464525    0.855388
+      2          6           0        1.162343   -0.635270    0.401648
+      3          8           0        0.032983   -1.082248   -0.079996
+      4          7           0       -0.939232   -0.118681   -0.497434
+      5          7           0       -0.867590    1.189506   -0.469549
+      6          8           0        0.155514    1.697052   -0.033435
+      7          1           0       -1.769070   -0.585833   -0.851050
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.168069   0.000000
+     3  O    2.462052   1.306609   0.000000
+     4  N    3.458675   2.343465   1.431054   0.000000
+     5  N    3.749096   2.865208   2.474601   1.310444   0.000000
+     6  O    3.121764   2.577348   2.782389   2.170403   1.222514
+     7  H    4.345074   3.188241   2.021965   1.015828   2.027323
+                    6          7
+     6  O    0.000000
+     7  H    3.095817   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.38D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.246858    0.200824    0.000000
+      2          6           0       -1.136010    0.561937    0.000000
+      3          8           0        0.000000    1.207467    0.000000
+      4          7           0        1.203955    0.433898    0.000000
+      5          7           0        1.346423   -0.868778    0.000000
+      6          8           0        0.334498   -1.554743    0.000000
+      7          1           0        2.015426    1.044981    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.4001439      3.3683508      2.3147414
+ Leave Link  202 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8250531390 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014704525 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8235826865 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6482.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.68D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:32:27 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999988    0.000000    0.000000   -0.004970 Ang=  -0.57 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410099123616    
+ Leave Link  401 at Mon Aug  5 14:32:28 2024, MaxMem=  4294967296 cpu:         7.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220606447070    
+ DIIS: error= 2.91D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220606447070     IErMin= 1 ErrMin= 2.91D-03
+ ErrMax= 2.91D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.47D-03 BMatP= 3.47D-03
+ IDIUse=3 WtCom= 9.71D-01 WtEn= 2.91D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.60D-04 MaxDP=6.33D-03              OVMax= 1.19D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223616445263     Delta-E=       -0.003009998193 Rises=F Damp=F
+ DIIS: error= 5.00D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223616445263     IErMin= 2 ErrMin= 5.00D-04
+ ErrMax= 5.00D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.23D-04 BMatP= 3.47D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.00D-03
+ Coeff-Com: -0.285D-01 0.103D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.284D-01 0.103D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.92D-05 MaxDP=2.26D-03 DE=-3.01D-03 OVMax= 3.75D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223776891880     Delta-E=       -0.000160446618 Rises=F Damp=F
+ DIIS: error= 2.69D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223776891880     IErMin= 3 ErrMin= 2.69D-04
+ ErrMax= 2.69D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.21D-05 BMatP= 1.23D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 2.69D-03
+ Coeff-Com: -0.397D-01 0.250D+00 0.790D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.396D-01 0.249D+00 0.790D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.15D-05 MaxDP=5.26D-04 DE=-1.60D-04 OVMax= 1.30D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223795872755     Delta-E=       -0.000018980875 Rises=F Damp=F
+ DIIS: error= 1.40D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223795872755     IErMin= 4 ErrMin= 1.40D-04
+ ErrMax= 1.40D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.10D-06 BMatP= 2.21D-05
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.40D-03
+ Coeff-Com: -0.114D-01 0.261D-01 0.297D+00 0.688D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.114D-01 0.261D-01 0.297D+00 0.689D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.19D-05 MaxDP=4.01D-04 DE=-1.90D-05 OVMax= 9.05D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223798242238     Delta-E=       -0.000002369483 Rises=F Damp=F
+ DIIS: error= 9.75D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223798242238     IErMin= 5 ErrMin= 9.75D-05
+ ErrMax= 9.75D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.38D-06 BMatP= 4.10D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.230D-02-0.487D-01-0.118D-01 0.473D+00 0.585D+00
+ Coeff:      0.230D-02-0.487D-01-0.118D-01 0.473D+00 0.585D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.52D-06 MaxDP=1.31D-04 DE=-2.37D-06 OVMax= 3.10D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223783297463     Delta-E=        0.000014944775 Rises=F Damp=F
+ DIIS: error= 3.25D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223783297463     IErMin= 1 ErrMin= 3.25D-05
+ ErrMax= 3.25D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.86D-07 BMatP= 3.86D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.52D-06 MaxDP=1.31D-04 DE= 1.49D-05 OVMax= 1.44D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223783629954     Delta-E=       -0.000000332490 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223783629954     IErMin= 2 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.74D-08 BMatP= 3.86D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.878D-01 0.912D+00
+ Coeff:      0.878D-01 0.912D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.83D-06 MaxDP=4.91D-05 DE=-3.32D-07 OVMax= 9.04D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223783624452     Delta-E=        0.000000005501 Rises=F Damp=F
+ DIIS: error= 1.71D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223783629954     IErMin= 2 ErrMin= 1.22D-05
+ ErrMax= 1.71D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.03D-08 BMatP= 4.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.716D-01 0.580D+00 0.491D+00
+ Coeff:     -0.716D-01 0.580D+00 0.491D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.65D-07 MaxDP=2.72D-05 DE= 5.50D-09 OVMax= 5.68D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223783671660     Delta-E=       -0.000000047207 Rises=F Damp=F
+ DIIS: error= 2.26D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223783671660     IErMin= 4 ErrMin= 2.26D-06
+ ErrMax= 2.26D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.36D-09 BMatP= 4.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.322D-01 0.203D+00 0.209D+00 0.620D+00
+ Coeff:     -0.322D-01 0.203D+00 0.209D+00 0.620D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.89D-07 MaxDP=4.94D-06 DE=-4.72D-08 OVMax= 1.23D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223783672698     Delta-E=       -0.000000001038 Rises=F Damp=F
+ DIIS: error= 1.45D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223783672698     IErMin= 5 ErrMin= 1.45D-06
+ ErrMax= 1.45D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.01D-10 BMatP= 1.36D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.299D-02-0.643D-01-0.293D-01 0.354D+00 0.736D+00
+ Coeff:      0.299D-02-0.643D-01-0.293D-01 0.354D+00 0.736D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-07 MaxDP=2.77D-06 DE=-1.04D-09 OVMax= 7.33D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223783673146     Delta-E=       -0.000000000448 Rises=F Damp=F
+ DIIS: error= 2.53D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223783673146     IErMin= 6 ErrMin= 2.53D-07
+ ErrMax= 2.53D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.67D-11 BMatP= 4.01D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.393D-02-0.359D-01-0.273D-01 0.250D-01 0.187D+00 0.847D+00
+ Coeff:      0.393D-02-0.359D-01-0.273D-01 0.250D-01 0.187D+00 0.847D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=3.92D-08 MaxDP=8.07D-07 DE=-4.48D-10 OVMax= 3.07D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223783673175     Delta-E=       -0.000000000029 Rises=F Damp=F
+ DIIS: error= 2.37D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223783673175     IErMin= 7 ErrMin= 2.37D-07
+ ErrMax= 2.37D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.51D-12 BMatP= 1.67D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.108D-02-0.710D-02-0.703D-02-0.284D-01-0.146D-02 0.350D+00
+ Coeff-Com:  0.693D+00
+ Coeff:      0.108D-02-0.710D-02-0.703D-02-0.284D-01-0.146D-02 0.350D+00
+ Coeff:      0.693D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.46D-08 MaxDP=4.43D-07 DE=-2.91D-11 OVMax= 1.25D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223783673183     Delta-E=       -0.000000000008 Rises=F Damp=F
+ DIIS: error= 7.63D-08 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223783673183     IErMin= 8 ErrMin= 7.63D-08
+ ErrMax= 7.63D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.75D-12 BMatP= 4.51D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.305D-03 0.506D-02 0.296D-02-0.275D-01-0.531D-01-0.159D-01
+ Coeff-Com:  0.431D+00 0.657D+00
+ Coeff:     -0.305D-03 0.506D-02 0.296D-02-0.275D-01-0.531D-01-0.159D-01
+ Coeff:      0.431D+00 0.657D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=9.22D-09 MaxDP=2.87D-07 DE=-7.96D-12 OVMax= 8.20D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223783673     A.U. after   13 cycles
+            NFock= 13  Conv=0.92D-08     -V/T= 2.0044
+ KE= 3.516748219445D+02 PE=-1.258340347887D+03 EE= 3.386181595832D+02
+ Leave Link  502 at Mon Aug  5 14:32:41 2024, MaxMem=  4294967296 cpu:       213.6
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6482.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:32:42 2024, MaxMem=  4294967296 cpu:        13.8
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:32:42 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:       147.6
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87425852D+00 1.17663657D+00 2.43798171D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.035564987   -0.007477432   -0.015181346
+      2        6           0.031499407    0.001943104    0.013455663
+      3        8           0.000456371    0.010128764    0.000173885
+      4        7           0.000486005    0.001846687    0.000203819
+      5        7           0.027068062    0.004352614    0.011557122
+      6        8          -0.030863497   -0.014418081   -0.013157922
+      7        1           0.006918639    0.003624345    0.002948780
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.035564987 RMS     0.015619392
+ Leave Link  716 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.039350204 RMS     0.014130367
+ Search for a local minimum.
+ Step number   4 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .14130D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    2    3    4    1
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.22287
+           R2           0.02767   0.52423
+           R3          -0.01557   0.03752   0.24292
+           R4          -0.00268   0.01522   0.02367   0.36883
+           R5          -0.00565  -0.00193  -0.01133  -0.00141   0.48268
+           R6          -0.02340  -0.01963   0.01829   0.15022  -0.01091
+           A1          -0.00961   0.08929   0.06657   0.02126  -0.00685
+           A2           0.00767   0.00873  -0.00653  -0.01712  -0.00743
+           A3          -0.00460  -0.00151   0.03119  -0.00821   0.00145
+           A4          -0.00308  -0.00722  -0.02466   0.02533   0.00598
+           A5           0.00302   0.02641  -0.08148   0.10320  -0.00046
+           A6          -0.02215  -0.01155   0.01934   0.01455  -0.00013
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.75220
+           A1          -0.01386   0.36615
+           A2          -0.01232   0.07987   0.16669
+           A3           0.00486  -0.02618  -0.08716   0.11096
+           A4           0.00747  -0.05369  -0.07953  -0.02379   0.10332
+           A5           0.09772   0.05714  -0.03569   0.00146   0.03423
+           A6          -0.01508   0.04143   0.03981  -0.02198  -0.01783
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.43918
+           A6           0.03374   0.11284
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99048.
+ Iteration  1 RMS(Cart)=  0.04409425 RMS(Int)=  0.00053086
+ Iteration  2 RMS(Cart)=  0.00086858 RMS(Int)=  0.00000017
+ Iteration  3 RMS(Cart)=  0.00000030 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 9.66D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.10D-08 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20733  -0.03935  -0.03300   0.00000  -0.03300   2.17433
+    R2        2.46913  -0.00605  -0.01665   0.00000  -0.01665   2.45248
+    R3        2.70430  -0.00600  -0.02667   0.00000  -0.02667   2.67763
+    R4        2.47638  -0.01029  -0.00959   0.00000  -0.00959   2.46679
+    R5        1.91964  -0.00835  -0.01846   0.00000  -0.01846   1.90117
+    R6        2.31022  -0.03650  -0.04784   0.00000  -0.04784   2.26237
+    A1        2.05375   0.01301   0.03560   0.00000   0.03560   2.08935
+    A2        2.25083   0.00719   0.01662   0.00000   0.01662   2.26745
+    A3        1.92504  -0.00382  -0.00780   0.00000  -0.00780   1.91724
+    A4        2.10732  -0.00337  -0.00883   0.00000  -0.00883   2.09849
+    A5        2.05759   0.00187   0.01119   0.00000   0.01119   2.06878
+    A6        3.34403   0.00387  -0.00098   0.00000  -0.00098   3.34305
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.039350     0.000015     NO 
+ RMS     Force            0.014130     0.000010     NO 
+ Maximum Displacement     0.096648     0.000060     NO 
+ RMS     Displacement     0.043742     0.000040     NO 
+ Predicted change in Energy=-3.064659D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226262   -0.515669    0.856012
+      2          6           0        1.175448   -0.651038    0.407281
+      3          8           0        0.042082   -1.058523   -0.076157
+      4          7           0       -0.925662   -0.110600   -0.491652
+      5          7           0       -0.881238    1.193911   -0.475390
+      6          8           0        0.104755    1.727323   -0.055187
+      7          1           0       -1.741646   -0.585405   -0.839332
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150606   0.000000
+     3  O    2.436036   1.297796   0.000000
+     4  N    3.451796   2.348364   1.416941   0.000000
+     5  N    3.788384   2.900501   2.466854   1.305369   0.000000
+     6  O    3.219020   2.648936   2.786630   2.151795   1.197197
+     7  H    4.315477   3.172978   1.996988   1.006057   2.009657
+                    6          7
+     6  O    0.000000
+     7  H    3.061501   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.36D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259802    0.273376    0.000000
+      2          6           0       -1.152713    0.586821    0.000000
+      3          8           0        0.000000    1.183082    0.000000
+      4          7           0        1.189183    0.412651    0.000000
+      5          7           0        1.347764   -0.883049    0.000000
+      6          8           0        0.373232   -1.578440    0.000000
+      7          1           0        1.990407    1.021086    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6635802      3.2671727      2.2906235
+ Leave Link  202 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6868734351 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014827082 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6853907269 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         3.4
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.814803    0.000000    0.000000    0.579738 Ang=  70.86 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999988    0.000000    0.000000    0.004902 Ang=   0.56 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 9.52D-03
+ Max alpha theta=  1.263 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A") (A')
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A") (A')
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:32:52 2024, MaxMem=  4294967296 cpu:         3.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930760785    
+ DIIS: error= 1.63D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930760785     IErMin= 1 ErrMin= 1.63D-05
+ ErrMax= 1.63D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.23D-08 BMatP= 9.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.418 Goal=   None    Shift=    0.000
+ RMSDP=2.44D-06 MaxDP=6.30D-05              OVMax= 3.50D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925883612     Delta-E=        0.000004877173 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925883612     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.31D-08 BMatP= 8.31D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.44D-06 MaxDP=6.30D-05 DE= 4.88D-06 OVMax= 2.75D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925921448     Delta-E=       -0.000000037837 Rises=F Damp=F
+ DIIS: error= 2.94D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925921448     IErMin= 2 ErrMin= 2.94D-06
+ ErrMax= 2.94D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.23D-09 BMatP= 8.31D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.260D-01 0.103D+01
+ Coeff:     -0.260D-01 0.103D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.63D-07 MaxDP=7.58D-06 DE=-3.78D-08 OVMax= 1.36D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925921489     Delta-E=       -0.000000000041 Rises=F Damp=F
+ DIIS: error= 3.50D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225925921489     IErMin= 2 ErrMin= 2.94D-06
+ ErrMax= 3.50D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.34D-09 BMatP= 1.23D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.285D-01 0.539D+00 0.489D+00
+ Coeff:     -0.285D-01 0.539D+00 0.489D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-07 MaxDP=3.73D-06 DE=-4.07D-11 OVMax= 1.03D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925922429     Delta-E=       -0.000000000939 Rises=F Damp=F
+ DIIS: error= 1.11D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925922429     IErMin= 4 ErrMin= 1.11D-06
+ ErrMax= 1.11D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.07D-11 BMatP= 1.23D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.989D-02 0.133D+00 0.223D+00 0.654D+00
+ Coeff:     -0.989D-02 0.133D+00 0.223D+00 0.654D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.27D-08 MaxDP=1.24D-06 DE=-9.39D-10 OVMax= 2.79D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925922484     Delta-E=       -0.000000000056 Rises=F Damp=F
+ DIIS: error= 3.22D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925922484     IErMin= 5 ErrMin= 3.22D-07
+ ErrMax= 3.22D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.33D-11 BMatP= 8.07D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.119D-02-0.341D-02 0.486D-01 0.333D+00 0.623D+00
+ Coeff:     -0.119D-02-0.341D-02 0.486D-01 0.333D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.16D-08 MaxDP=4.62D-07 DE=-5.58D-11 OVMax= 8.99D-07
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925922491     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 6.66D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925922491     IErMin= 6 ErrMin= 6.66D-08
+ ErrMax= 6.66D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.19D-12 BMatP= 1.33D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.956D-03-0.215D-01-0.137D-01 0.492D-01 0.266D+00 0.720D+00
+ Coeff:      0.956D-03-0.215D-01-0.137D-01 0.492D-01 0.266D+00 0.720D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.05D-09 MaxDP=1.43D-07 DE=-6.59D-12 OVMax= 3.02D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925922     A.U. after    7 cycles
+            NFock=  7  Conv=0.50D-08     -V/T= 2.0037
+ KE= 3.519150395499D+02 PE=-1.260186278660D+03 EE= 3.393599224608D+02
+ Leave Link  502 at Mon Aug  5 14:33:03 2024, MaxMem=  4294967296 cpu:       175.7
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:33:04 2024, MaxMem=  4294967296 cpu:        14.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:33:04 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:       146.8
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83462219D+00 1.12202328D+00 1.38034955D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000127522   -0.000087048   -0.000054309
+      2        6           0.000098617    0.000332677    0.000041445
+      3        8           0.000054940   -0.000321447    0.000024146
+      4        7          -0.000050054    0.000335826   -0.000022088
+      5        7           0.000134109   -0.000089595    0.000057492
+      6        8          -0.000158690   -0.000199389   -0.000067392
+      7        1           0.000048599    0.000028976    0.000020706
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000335826 RMS     0.000150244
+ Leave Link  716 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000391220 RMS     0.000162476
+ Search for a local minimum.
+ Step number   5 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16248D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    5
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.33677
+           R2           0.05942   0.53212
+           R3           0.11365   0.06450   0.31131
+           R4           0.05844   0.02930   0.06974   0.39456
+           R5           0.01687   0.00453   0.01608   0.01070   0.48670
+           R6           0.07466   0.01000   0.13979   0.20538   0.00968
+           A1           0.09356   0.10726   0.08380   0.04880   0.01836
+           A2           0.13565   0.03200   0.03162   0.02106   0.02125
+           A3          -0.07997  -0.01523   0.00793  -0.03081  -0.01523
+           A4          -0.05568  -0.01677  -0.03955   0.00975  -0.00602
+           A5           0.13301   0.05092  -0.03243   0.14471   0.02772
+           A6          -0.06181  -0.01932  -0.00286   0.00003  -0.00748
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.84065
+           A1           0.08521   0.32049
+           A2           0.10784   0.05340   0.16229
+           A3          -0.06592  -0.01246  -0.08612   0.11119
+           A4          -0.04192  -0.04094  -0.07617  -0.02506   0.10123
+           A5           0.21834   0.04629  -0.02430  -0.00652   0.03082
+           A6          -0.04991   0.03167   0.02368  -0.01241  -0.01126
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46489
+           A6           0.01469   0.12078
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.07142   0.10068
+     Eigenvalues ---    0.11548   0.15322   0.23522   0.27371   0.31667
+     Eigenvalues ---    0.46442   0.48842   0.57705   1.00560   1.48177
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                    0.83977   0.41786   0.30926  -0.15006  -0.04499
+                          R3        A5        A1        A3        A2
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          R6        A2        R1        A1        A5
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  6.60D-12
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -6.32D-11
+ I=     2 Stepn=  6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -5.66D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -3.82D-05.
+ Quartic linear search produced a step of  0.00145.
+ Iteration  1 RMS(Cart)=  0.02652931 RMS(Int)=  0.00118640
+ Iteration  2 RMS(Cart)=  0.00154553 RMS(Int)=  0.00065585
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065585
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065585
+ ITry= 1 IFail=0 DXMaxC= 6.17D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17433  -0.00015   0.00000   0.00000  -0.00046   2.17387
+    R2        2.45248   0.00004   0.00000   0.00000  -0.00076   2.45172
+    R3        2.67763   0.00008   0.00000   0.00000  -0.00288   2.67475
+    R4        2.46679  -0.00029   0.00000   0.00000  -0.00022   2.46657
+    R5        1.90117  -0.00006   0.00000   0.00000  -0.00090   1.90027
+    R6        2.26237  -0.00024   0.00000   0.00000  -0.00106   2.26131
+    A1        2.08935  -0.00039   0.00000   0.00000   0.00213   2.09148
+    A2        2.26745  -0.00016   0.00000   0.00000   0.00023   2.26769
+    A3        1.91724   0.00009   0.00000   0.00000   0.00052   1.91776
+    A4        2.09849   0.00007   0.00000   0.00000  -0.00075   2.09774
+    A5        2.06878  -0.00024   0.00000   0.00000  -0.00016   2.06862
+    A6        3.34305   0.00017   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000  -0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.11164   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000  -0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000391     0.000015     NO 
+ RMS     Force            0.000162     0.000010     NO 
+ Maximum Displacement     0.003593     0.000060     NO 
+ RMS     Displacement     0.001544     0.000040     NO 
+ Predicted change in Energy=-3.584195D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226485   -0.517570    0.856111
+      2          6           0        1.175709   -0.651204    0.407392
+      3          8           0        0.042163   -1.056801   -0.076127
+      4          7           0       -0.925148   -0.110636   -0.491432
+      5          7           0       -0.881848    1.193801   -0.475651
+      6          8           0        0.103306    1.727786   -0.055807
+      7          1           0       -1.740666   -0.585375   -0.838914
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150363   0.000000
+     3  O    2.435385   1.297392   0.000000
+     4  N    3.451703   2.348127   1.415414   0.000000
+     5  N    3.790002   2.901267   2.465487   1.305251   0.000000
+     6  O    3.221973   2.650320   2.785333   2.151112   1.196635
+     7  H    4.314625   3.172200   1.995637   1.005580   2.008730
+                    6          7
+     6  O    0.000000
+     7  H    3.060099   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.35D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260532    0.275246    0.000000
+      2          6           0       -1.153208    0.586966    0.000000
+      3          8           0        0.000000    1.181388    0.000000
+      4          7           0        1.188437    0.412613    0.000000
+      5          7           0        1.348206   -0.882823    0.000000
+      6          8           0        0.374662   -1.578631    0.000000
+      7          1           0        1.989173    1.020900    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6765272      3.2644138      2.2904210
+ Leave Link  202 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7408045967 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822405 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7393223563 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:33:14 2024, MaxMem=  4294967296 cpu:         1.9
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:33:15 2024, MaxMem=  4294967296 cpu:         2.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225917999245    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225917999245     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922512428     Delta-E=       -0.000004513183 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922512428     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.589D-01 0.106D+01
+ Coeff:     -0.589D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.51D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922730890     Delta-E=       -0.000000218462 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922730890     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.72D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.428D+00 0.622D+00
+ Coeff:     -0.501D-01 0.428D+00 0.622D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.18D-07 OVMax= 9.33D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922778679     Delta-E=       -0.000000047789 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922778679     IErMin= 4 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.72D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.537D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.537D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.03D-07 MaxDP=1.44D-05 DE=-4.78D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922798977     Delta-E=       -0.000000020298 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922798977     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.451D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.451D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=1.00D-05 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922801112     Delta-E=       -0.000000002135 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922801112     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.85D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.653D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.653D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.13D-09 OVMax= 5.20D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922801387     Delta-E=       -0.000000000275 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922801387     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.85D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.217D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.217D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.85D-06 DE=-2.75D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922801434     Delta-E=       -0.000000000046 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922801434     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.192D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.192D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.65D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922801439     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 3.75D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922801439     IErMin= 9 ErrMin= 3.75D-08
+ ErrMax= 3.75D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.27D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.900D-04 0.131D-02 0.731D-03-0.281D-02-0.133D-01-0.279D-01
+ Coeff-Com:  0.329D-01 0.235D+00 0.774D+00
+ Coeff:     -0.900D-04 0.131D-02 0.731D-03-0.281D-02-0.133D-01-0.279D-01
+ Coeff:      0.329D-01 0.235D+00 0.774D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-5.23D-12 OVMax= 5.73D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922801     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519224306975D+02 PE=-1.260295846801D+03 EE= 3.394081709462D+02
+ Leave Link  502 at Mon Aug  5 14:33:27 2024, MaxMem=  4294967296 cpu:       192.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:33:28 2024, MaxMem=  4294967296 cpu:        13.6
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:33:28 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:       145.7
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83299784D+00 1.12203138D+00 1.77199324D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000399156    0.000012678    0.000170533
+      2        6          -0.000195911    0.000514466   -0.000084786
+      3        8           0.000175353   -0.001061050    0.000077141
+      4        7          -0.000206973    0.000700318   -0.000089900
+      5        7          -0.000567811   -0.000170901   -0.000242270
+      6        8           0.000669025    0.000210501    0.000285436
+      7        1          -0.000272838   -0.000206012   -0.000116154
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001061050 RMS     0.000397418
+ Leave Link  716 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000922873 RMS     0.000394545
+ Search for a local minimum.
+ Step number   6 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .39455D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    2    3    4    1    5
+                                                      6
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.22940
+           R2           0.03157   0.52584
+           R3          -0.00514   0.04131   0.25065
+           R4           0.00247   0.01662   0.02697   0.37042
+           R5          -0.00154  -0.00058  -0.00792  -0.00033   0.48357
+           R6          -0.01522  -0.01255   0.03568   0.15692  -0.00362
+           A1          -0.01073   0.09183   0.07002   0.02364  -0.00267
+           A2           0.01141   0.01062  -0.00425  -0.01502  -0.00476
+           A3          -0.00753  -0.00259   0.02987  -0.00939   0.00005
+           A4          -0.00388  -0.00803  -0.02562   0.02441   0.00471
+           A5           0.00828   0.02796  -0.07948   0.10518   0.00151
+           A6          -0.02528  -0.01095   0.02074   0.01458   0.00083
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.77163
+           A1          -0.01261   0.35328
+           A2          -0.00758   0.07288   0.16277
+           A3           0.00116  -0.02318  -0.08538   0.11011
+           A4           0.00642  -0.04970  -0.07739  -0.02473   0.10213
+           A5           0.10321   0.05292  -0.03788   0.00246   0.03543
+           A6          -0.01581   0.03964   0.03878  -0.02164  -0.01713
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.43825
+           A6           0.03285   0.11309
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.07811   0.10068
+     Eigenvalues ---    0.11522   0.14682   0.23738   0.30381   0.38085
+     Eigenvalues ---    0.46467   0.48629   0.59653   0.86924   1.23222
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83984  -0.41778  -0.30920   0.15000   0.04499
+                          A6        R3        A1        A2        A4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          A6        A2        R3        A5        A3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  1.85D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -1.62D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  3.47D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  6.83D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646461 RMS(Int)=  0.00118466
+ Iteration  2 RMS(Cart)=  0.00154191 RMS(Int)=  0.00065576
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065576
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065576
+ ITry= 1 IFail=0 DXMaxC= 6.16D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17387   0.00043   0.00000   0.00000  -0.00046   2.17342
+    R2        2.45172   0.00036   0.00000   0.00000  -0.00076   2.45096
+    R3        2.67475   0.00067   0.00000   0.00000  -0.00288   2.67187
+    R4        2.46657   0.00005   0.00000   0.00000  -0.00022   2.46634
+    R5        1.90027   0.00036   0.00000   0.00000  -0.00091   1.89937
+    R6        2.26131   0.00075   0.00000   0.00000  -0.00106   2.26025
+    A1        2.09148  -0.00092   0.00000   0.00000   0.00213   2.09361
+    A2        2.26769  -0.00039   0.00000   0.00000   0.00023   2.26792
+    A3        1.91776   0.00016   0.00000   0.00000   0.00052   1.91828
+    A4        2.09774   0.00023   0.00000   0.00000  -0.00075   2.09699
+    A5        2.06862  -0.00032   0.00000   0.00000  -0.00016   2.06845
+    A6        3.34312   0.00010   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00572   0.00000  -3.14159
+    D3        0.00000   0.00000   0.00000   0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000923     0.000015     NO 
+ RMS     Force            0.000395     0.000010     NO 
+ Maximum Displacement     0.003585     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-8.077386D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226705   -0.519467    0.856209
+      2          6           0        1.175969   -0.651370    0.407504
+      3          8           0        0.042244   -1.055083   -0.076096
+      4          7           0       -0.924635   -0.110672   -0.491213
+      5          7           0       -0.882456    1.193690   -0.475910
+      6          8           0        0.101860    1.728246   -0.056426
+      7          1           0       -1.739687   -0.585343   -0.838495
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150122   0.000000
+     3  O    2.434738   1.296991   0.000000
+     4  N    3.451609   2.347889   1.413892   0.000000
+     5  N    3.791614   2.902031   2.464123   1.305133   0.000000
+     6  O    3.224916   2.651700   2.784037   2.150430   1.196075
+     7  H    4.313772   3.171423   1.994289   1.005101   2.007803
+                    6          7
+     6  O    0.000000
+     7  H    3.058696   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.57D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261258    0.277112    0.000000
+      2          6           0       -1.153701    0.587110    0.000000
+      3          8           0        0.000000    1.179697    0.000000
+      4          7           0        1.187692    0.412573    0.000000
+      5          7           0        1.348646   -0.882597    0.000000
+      6          8           0        0.376088   -1.578821    0.000000
+      7          1           0        1.987941    1.020709    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6894905      3.2616648      2.2902187
+ Leave Link  202 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7946899489 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817704 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7932081785 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         3.2
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:33:37 2024, MaxMem=  4294967296 cpu:         2.7
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225909924840    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225909924840     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914426897     Delta-E=       -0.000004502057 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914426897     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.358 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914644305     Delta-E=       -0.000000217408 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914644305     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.74D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.34D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225914692318     Delta-E=       -0.000000048013 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225914692318     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225914712530     Delta-E=       -0.000000020212 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225914712530     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225914714644     Delta-E=       -0.000000002114 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225914714644     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.11D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225914714920     Delta-E=       -0.000000000276 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225914714920     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.289D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.289D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.76D-10 OVMax= 4.69D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225914714972     Delta-E=       -0.000000000052 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225914714972     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-5.18D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225914714971     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 8 EnMin= -353.225914714972     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.11D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.272D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.308D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.272D-02-0.129D-01-0.276D-01
+ Coeff:      0.308D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE= 2.27D-13 OVMax= 5.71D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225914715     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519298213552D+02 PE=-1.260405321738D+03 EE= 3.394563774895D+02
+ Leave Link  502 at Mon Aug  5 14:33:49 2024, MaxMem=  4294967296 cpu:       192.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:33:50 2024, MaxMem=  4294967296 cpu:        13.9
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:33:50 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:34:00 2024, MaxMem=  4294967296 cpu:       155.9
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83137824D+00 1.12203411D+00-7.64910252D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000923363    0.000110126    0.000394324
+      2        6          -0.000488306    0.000695792   -0.000210104
+      3        8           0.000300692   -0.001801834    0.000132243
+      4        7          -0.000364801    0.001069890   -0.000158111
+      5        7          -0.001270870   -0.000254624   -0.000542513
+      6        8           0.001496502    0.000623269    0.000638156
+      7        1          -0.000596579   -0.000442620   -0.000253996
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001801834 RMS     0.000758131
+ Leave Link  716 at Mon Aug  5 14:34:00 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001740254 RMS     0.000755557
+ Search for a local minimum.
+ Step number   7 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .75556D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    5
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.26873
+           R2           0.03535   0.52531
+           R3           0.03885   0.03777   0.22912
+           R4           0.02207   0.01616   0.02798   0.37399
+           R5          -0.00576  -0.00073  -0.01026  -0.00181   0.48402
+           R6          -0.00201  -0.01012   0.06064   0.16641  -0.00518
+           A1           0.06161   0.08862   0.05837   0.03255  -0.00761
+           A2           0.08602   0.00686  -0.01926  -0.00680  -0.00989
+           A3          -0.04915  -0.00023   0.04042  -0.01332   0.00288
+           A4          -0.03687  -0.00663  -0.02116   0.02012   0.00702
+           A5           0.07881   0.02471  -0.09097   0.11374  -0.00340
+           A6          -0.04414  -0.01043   0.02036   0.01129   0.00229
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.77507
+           A1           0.02428   0.36630
+           A2           0.03073   0.08278   0.16900
+           A3          -0.02048  -0.02596  -0.08589   0.10867
+           A4          -0.01025  -0.05682  -0.08311  -0.02278   0.10589
+           A5           0.13911   0.06568  -0.02839  -0.00011   0.02850
+           A6          -0.02487   0.03161   0.03139  -0.01815  -0.01323
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.45053
+           A6           0.02512   0.11617
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04681810 RMS(Int)=  0.00051613
+ Iteration  2 RMS(Cart)=  0.00152630 RMS(Int)=  0.00000063
+ Iteration  3 RMS(Cart)=  0.00000073 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.07D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.20D-08 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17342   0.00101   0.00000   0.02892   0.02892   2.20234
+    R2        2.45096   0.00069   0.00000   0.01983   0.01983   2.47079
+    R3        2.67187   0.00126   0.00000   0.03634   0.03634   2.70821
+    R4        2.46634   0.00038   0.00000   0.01094   0.01094   2.47729
+    R5        1.89937   0.00078   0.00000   0.02238   0.02238   1.92175
+    R6        2.26025   0.00174   0.00000   0.05000   0.05000   2.31025
+    A1        2.09361  -0.00145   0.00000  -0.04166  -0.04166   2.05195
+    A2        2.26792  -0.00062   0.00000  -0.01767  -0.01767   2.25025
+    A3        1.91828   0.00024   0.00000   0.00677   0.00677   1.92505
+    A4        2.09699   0.00038   0.00000   0.01090   0.01090   2.10789
+    A5        2.06845  -0.00039   0.00000  -0.01125  -0.01125   2.05721
+    A6        3.34318   0.00003   0.00000   0.00098   0.00098   3.34416
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001740     0.000015     NO 
+ RMS     Force            0.000756     0.000010     NO 
+ Maximum Displacement     0.106875     0.000060     NO 
+ RMS     Displacement     0.047990     0.000040     NO 
+ Predicted change in Energy=-1.961949D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:34:00 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.223298   -0.462912    0.854635
+      2          6           0        1.163201   -0.634812    0.402014
+      3          8           0        0.033686   -1.083894   -0.079692
+      4          7           0       -0.939638   -0.118582   -0.497607
+      5          7           0       -0.866868    1.190014   -0.469242
+      6          8           0        0.156858    1.696122   -0.032859
+      7          1           0       -1.770536   -0.585935   -0.851676
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.165428   0.000000
+     3  O    2.460282   1.307486   0.000000
+     4  N    3.457064   2.344727   1.433123   0.000000
+     5  N    3.746190   2.865355   2.476571   1.310924   0.000000
+     6  O    3.117571   2.575868   2.783137   2.170586   1.222534
+     7  H    4.344807   3.190759   2.024634   1.016944   2.029006
+                    6          7
+     6  O    0.000000
+     7  H    3.097272   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.244325    0.200983    0.000000
+      2          6           0       -1.136239    0.562048    0.000000
+      3          8           0        0.000000    1.208949    0.000000
+      4          7           0        1.204939    0.433086    0.000000
+      5          7           0        1.345428   -0.870289    0.000000
+      6          8           0        0.332154   -1.554297    0.000000
+      7          1           0        2.017906    1.044036    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.3944083      3.3720130      2.3159080
+ Leave Link  202 at Mon Aug  5 14:34:00 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8244449105 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014710913 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8229738193 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:34:01 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6482.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.65D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:34:01 2024, MaxMem=  4294967296 cpu:         3.8
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:34:01 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000   -0.004615 Ang=  -0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410274555976    
+ Leave Link  401 at Mon Aug  5 14:34:01 2024, MaxMem=  4294967296 cpu:         7.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220507151208    
+ DIIS: error= 3.02D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220507151208     IErMin= 1 ErrMin= 3.02D-03
+ ErrMax= 3.02D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.63D-03 BMatP= 3.63D-03
+ IDIUse=3 WtCom= 9.70D-01 WtEn= 3.02D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.60D-04 MaxDP=5.73D-03              OVMax= 1.21D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223699334704     Delta-E=       -0.003192183496 Rises=F Damp=F
+ DIIS: error= 5.27D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223699334704     IErMin= 2 ErrMin= 5.27D-04
+ ErrMax= 5.27D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.22D-04 BMatP= 3.63D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.27D-03
+ Coeff-Com: -0.388D-01 0.104D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.386D-01 0.104D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.85D-05 MaxDP=2.33D-03 DE=-3.19D-03 OVMax= 3.76D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223866213099     Delta-E=       -0.000166878395 Rises=F Damp=F
+ DIIS: error= 3.29D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223866213099     IErMin= 3 ErrMin= 3.29D-04
+ ErrMax= 3.29D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.08D-05 BMatP= 1.22D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.29D-03
+ Coeff-Com: -0.393D-01 0.246D+00 0.793D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.392D-01 0.246D+00 0.794D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.08D-05 MaxDP=4.35D-04 DE=-1.67D-04 OVMax= 1.23D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223884887871     Delta-E=       -0.000018674772 Rises=F Damp=F
+ DIIS: error= 1.50D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223884887871     IErMin= 4 ErrMin= 1.50D-04
+ ErrMax= 1.50D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.39D-06 BMatP= 2.08D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.50D-03
+ Coeff-Com: -0.934D-02 0.113D-01 0.264D+00 0.734D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.933D-02 0.112D-01 0.264D+00 0.734D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-05 MaxDP=2.43D-04 DE=-1.87D-05 OVMax= 7.23D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223886762218     Delta-E=       -0.000001874347 Rises=F Damp=F
+ DIIS: error= 1.51D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223886762218     IErMin= 4 ErrMin= 1.50D-04
+ ErrMax= 1.51D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.22D-06 BMatP= 3.39D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.51D-03
+ Coeff-Com:  0.246D-02-0.499D-01-0.328D-02 0.496D+00 0.555D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.278D+00 0.722D+00
+ Coeff:      0.246D-02-0.498D-01-0.327D-02 0.495D+00 0.555D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.11D-06 MaxDP=1.53D-04 DE=-1.87D-06 OVMax= 3.58D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223870222835     Delta-E=        0.000016539384 Rises=F Damp=F
+ DIIS: error= 3.46D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223870222835     IErMin= 1 ErrMin= 3.46D-05
+ ErrMax= 3.46D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.19D-07 BMatP= 4.19D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.11D-06 MaxDP=1.53D-04 DE= 1.65D-05 OVMax= 2.16D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223870576147     Delta-E=       -0.000000353313 Rises=F Damp=F
+ DIIS: error= 3.18D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223870576147     IErMin= 2 ErrMin= 3.18D-05
+ ErrMax= 3.18D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.24D-08 BMatP= 4.19D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.131D+00 0.869D+00
+ Coeff:      0.131D+00 0.869D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=5.20D-05 DE=-3.53D-07 OVMax= 1.16D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223870555627     Delta-E=        0.000000020520 Rises=F Damp=F
+ DIIS: error= 3.53D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223870576147     IErMin= 2 ErrMin= 3.18D-05
+ ErrMax= 3.53D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.11D-07 BMatP= 7.24D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.707D-01 0.586D+00 0.484D+00
+ Coeff:     -0.707D-01 0.586D+00 0.484D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=8.94D-07 MaxDP=2.91D-05 DE= 2.05D-08 OVMax= 8.60D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223870640528     Delta-E=       -0.000000084900 Rises=F Damp=F
+ DIIS: error= 3.37D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223870640528     IErMin= 4 ErrMin= 3.37D-06
+ ErrMax= 3.37D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.55D-09 BMatP= 7.24D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.340D-01 0.209D+00 0.195D+00 0.630D+00
+ Coeff:     -0.340D-01 0.209D+00 0.195D+00 0.630D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.67D-07 MaxDP=5.53D-06 DE=-8.49D-08 OVMax= 1.11D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223870641762     Delta-E=       -0.000000001234 Rises=F Damp=F
+ DIIS: error= 1.16D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223870641762     IErMin= 5 ErrMin= 1.16D-06
+ ErrMax= 1.16D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.77D-10 BMatP= 1.55D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.312D-02-0.585D-01-0.390D-01 0.254D+00 0.841D+00
+ Coeff:      0.312D-02-0.585D-01-0.390D-01 0.254D+00 0.841D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.22D-07 MaxDP=3.36D-06 DE=-1.23D-09 OVMax= 7.60D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223870642124     Delta-E=       -0.000000000362 Rises=F Damp=F
+ DIIS: error= 4.58D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223870642124     IErMin= 6 ErrMin= 4.58D-07
+ ErrMax= 4.58D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.62D-11 BMatP= 2.77D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.412D-02-0.384D-01-0.301D-01 0.116D-01 0.279D+00 0.774D+00
+ Coeff:      0.412D-02-0.384D-01-0.301D-01 0.116D-01 0.279D+00 0.774D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=3.99D-08 MaxDP=1.11D-06 DE=-3.62D-10 OVMax= 2.88D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223870642166     Delta-E=       -0.000000000043 Rises=F Damp=F
+ DIIS: error= 1.61D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223870642166     IErMin= 7 ErrMin= 1.61D-07
+ ErrMax= 1.61D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.99D-12 BMatP= 2.62D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.166D-02-0.113D-01-0.930D-02-0.299D-01 0.290D-01 0.411D+00
+ Coeff-Com:  0.609D+00
+ Coeff:      0.166D-02-0.113D-01-0.930D-02-0.299D-01 0.290D-01 0.411D+00
+ Coeff:      0.609D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.92D-08 MaxDP=4.97D-07 DE=-4.27D-11 OVMax= 1.36D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223870642172     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 1.19D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223870642172     IErMin= 8 ErrMin= 1.19D-07
+ ErrMax= 1.19D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.70D-12 BMatP= 8.99D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.371D-03 0.529D-02 0.404D-02-0.232D-01-0.687D-01 0.255D-01
+ Coeff-Com:  0.328D+00 0.729D+00
+ Coeff:     -0.371D-03 0.529D-02 0.404D-02-0.232D-01-0.687D-01 0.255D-01
+ Coeff:      0.328D+00 0.729D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-08 MaxDP=3.49D-07 DE=-5.23D-12 OVMax= 7.40D-07
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.223870642173     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 2.39D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.223870642173     IErMin= 9 ErrMin= 2.39D-08
+ ErrMax= 2.39D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.63D-13 BMatP= 1.70D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.269D-03 0.283D-02 0.221D-02-0.422D-02-0.254D-01-0.431D-01
+ Coeff-Com: -0.277D-02 0.260D+00 0.811D+00
+ Coeff:     -0.269D-03 0.283D-02 0.221D-02-0.422D-02-0.254D-01-0.431D-01
+ Coeff:     -0.277D-02 0.260D+00 0.811D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.26D-09 MaxDP=1.69D-07 DE=-1.59D-12 OVMax= 2.92D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223870642     A.U. after   14 cycles
+            NFock= 14  Conv=0.43D-08     -V/T= 2.0044
+ KE= 3.516797188493D+02 PE=-1.258351704822D+03 EE= 3.386251415113D+02
+ Leave Link  502 at Mon Aug  5 14:34:15 2024, MaxMem=  4294967296 cpu:       208.9
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6482.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:34:16 2024, MaxMem=  4294967296 cpu:        14.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:34:16 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:       142.8
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87485436D+00 1.17344030D+00-1.35754961D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.030517147   -0.006706617   -0.013026009
+      2        6           0.025937093    0.000818846    0.011081228
+      3        8           0.000314366    0.011059094    0.000111265
+      4        7           0.000409458    0.001259808    0.000172334
+      5        7           0.027253560    0.003855521    0.011637422
+      6        8          -0.031097212   -0.014312797   -0.013258008
+      7        1           0.007699882    0.004026144    0.003281768
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.031097212 RMS     0.014463970
+ Leave Link  716 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036692415 RMS     0.013424658
+ Search for a local minimum.
+ Step number   8 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13425D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.34808
+           R2           0.02970   0.52018
+           R3           0.02517   0.02172   0.18988
+           R4           0.03210   0.00945   0.01000   0.36919
+           R5          -0.01368  -0.00564  -0.02851  -0.00930   0.48012
+           R6           0.02601  -0.02297   0.02009   0.15787  -0.01799
+           A1           0.07733   0.08182   0.06168   0.03327  -0.02080
+           A2           0.10178  -0.00304  -0.02808  -0.01006  -0.02554
+           A3          -0.05524   0.00599   0.04774  -0.01016   0.01218
+           A4          -0.04654  -0.00295  -0.01966   0.02021   0.01336
+           A5           0.09832   0.01435  -0.10399   0.11011  -0.01887
+           A6          -0.05706  -0.00757   0.02623   0.01136   0.00616
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.76360
+           A1           0.01281   0.41407
+           A2           0.01430   0.12235   0.19879
+           A3          -0.00872  -0.04635  -0.10030   0.11542
+           A4          -0.00558  -0.07600  -0.09849  -0.01512   0.11361
+           A5           0.12448   0.09952  -0.00389  -0.01144   0.01532
+           A6          -0.02543   0.02556   0.02725  -0.01667  -0.01059
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47070
+           A6           0.02119   0.11793
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99888.
+ Iteration  1 RMS(Cart)=  0.04542768 RMS(Int)=  0.00057216
+ Iteration  2 RMS(Cart)=  0.00092108 RMS(Int)=  0.00000018
+ Iteration  3 RMS(Cart)=  0.00000033 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 9.96D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 8.82D-09 for atom     5.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20234  -0.03381  -0.02798   0.00000  -0.02798   2.17436
+    R2        2.47079  -0.00670  -0.01829   0.00000  -0.01829   2.45250
+    R3        2.70821  -0.00691  -0.03055   0.00000  -0.03055   2.67766
+    R4        2.47729  -0.01068  -0.01049   0.00000  -0.01049   2.46680
+    R5        1.92175  -0.00929  -0.02055   0.00000  -0.02055   1.90120
+    R6        2.31025  -0.03669  -0.04783   0.00000  -0.04783   2.26243
+    A1        2.05195   0.01332   0.03736   0.00000   0.03736   2.08931
+    A2        2.25025   0.00748   0.01719   0.00000   0.01719   2.26743
+    A3        1.92505  -0.00399  -0.00780   0.00000  -0.00780   1.91725
+    A4        2.10789  -0.00349  -0.00939   0.00000  -0.00939   2.09850
+    A5        2.05721   0.00222   0.01156   0.00000   0.01156   2.06877
+    A6        3.34416   0.00385  -0.00111   0.00000  -0.00111   3.34306
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.036692     0.000015     NO 
+ RMS     Force            0.013425     0.000010     NO 
+ Maximum Displacement     0.099608     0.000060     NO 
+ RMS     Displacement     0.045066     0.000040     NO 
+ Predicted change in Energy=-3.093215D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226257   -0.515622    0.856010
+      2          6           0        1.175432   -0.651026    0.407274
+      3          8           0        0.042068   -1.058551   -0.076164
+      4          7           0       -0.925678   -0.110604   -0.491659
+      5          7           0       -0.881217    1.193912   -0.475381
+      6          8           0        0.104821    1.727289   -0.055159
+      7          1           0       -1.741681   -0.585397   -0.839347
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150623   0.000000
+     3  O    2.436063   1.297807   0.000000
+     4  N    3.451803   2.348361   1.416959   0.000000
+     5  N    3.788338   2.900462   2.466865   1.305375   0.000000
+     6  O    3.218908   2.648855   2.786626   2.151816   1.197226
+     7  H    4.315511   3.172998   1.997019   1.006070   2.009679
+                    6          7
+     6  O    0.000000
+     7  H    3.061542   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259787    0.273294    0.000000
+      2          6           0       -1.152695    0.586793    0.000000
+      3          8           0        0.000000    1.183111    0.000000
+      4          7           0        1.189201    0.412675    0.000000
+      5          7           0        1.347762   -0.883034    0.000000
+      6          8           0        0.373187   -1.578413    0.000000
+      7          1           0        1.990438    1.021113    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6632565      3.2672870      2.2906508
+ Leave Link  202 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6858305301 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014826981 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6843478321 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         3.8
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000005 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000    0.004585 Ang=   0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.12D-03
+ Max alpha theta=  1.271 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:34:25 2024, MaxMem=  4294967296 cpu:         4.4
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930772735    
+ DIIS: error= 1.66D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930772735     IErMin= 1 ErrMin= 1.66D-05
+ ErrMax= 1.66D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.21D-08 BMatP= 9.21D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.416 Goal=   None    Shift=    0.000
+ RMSDP=2.17D-06 MaxDP=4.53D-05              OVMax= 3.09D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925888081     Delta-E=        0.000004884654 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925888081     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.29D-08 BMatP= 8.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.17D-06 MaxDP=4.53D-05 DE= 4.88D-06 OVMax= 2.88D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925925604     Delta-E=       -0.000000037524 Rises=F Damp=F
+ DIIS: error= 2.91D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925925604     IErMin= 2 ErrMin= 2.91D-06
+ ErrMax= 2.91D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.43D-09 BMatP= 8.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.198D-01 0.102D+01
+ Coeff:     -0.198D-01 0.102D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.54D-07 MaxDP=7.53D-06 DE=-3.75D-08 OVMax= 1.43D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925925612     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 3.28D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225925925612     IErMin= 2 ErrMin= 2.91D-06
+ ErrMax= 3.28D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-09 BMatP= 1.43D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.280D-01 0.535D+00 0.493D+00
+ Coeff:     -0.280D-01 0.535D+00 0.493D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-07 MaxDP=3.92D-06 DE=-7.16D-12 OVMax= 1.08D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925926677     Delta-E=       -0.000000001066 Rises=F Damp=F
+ DIIS: error= 1.01D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925926677     IErMin= 4 ErrMin= 1.01D-06
+ ErrMax= 1.01D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.67D-11 BMatP= 1.43D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.106D-01 0.146D+00 0.226D+00 0.638D+00
+ Coeff:     -0.106D-01 0.146D+00 0.226D+00 0.638D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.45D-08 MaxDP=1.23D-06 DE=-1.07D-09 OVMax= 2.89D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925926737     Delta-E=       -0.000000000060 Rises=F Damp=F
+ DIIS: error= 4.10D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925926737     IErMin= 5 ErrMin= 4.10D-07
+ ErrMax= 4.10D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.63D-11 BMatP= 8.67D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.179D-02 0.525D-02 0.547D-01 0.344D+00 0.598D+00
+ Coeff:     -0.179D-02 0.525D-02 0.547D-01 0.344D+00 0.598D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.38D-08 MaxDP=4.92D-07 DE=-5.96D-11 OVMax= 1.09D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925926742     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 6.96D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925926742     IErMin= 6 ErrMin= 6.96D-08
+ ErrMax= 6.96D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.42D-12 BMatP= 1.63D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.897D-03-0.212D-01-0.128D-01 0.491D-01 0.262D+00 0.722D+00
+ Coeff:      0.897D-03-0.212D-01-0.128D-01 0.491D-01 0.262D+00 0.722D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.47D-09 MaxDP=1.73D-07 DE=-4.77D-12 OVMax= 3.15D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925927     A.U. after    7 cycles
+            NFock=  7  Conv=0.55D-08     -V/T= 2.0037
+ KE= 3.519147627560D+02 PE=-1.260184061525D+03 EE= 3.393590250099D+02
+ Leave Link  502 at Mon Aug  5 14:34:36 2024, MaxMem=  4294967296 cpu:       170.2
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:34:37 2024, MaxMem=  4294967296 cpu:        14.9
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:34:37 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:34:46 2024, MaxMem=  4294967296 cpu:       144.6
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83466483D+00 1.12208531D+00 3.41575626D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000163699   -0.000093406   -0.000069754
+      2        6           0.000129011    0.000332229    0.000054434
+      3        8           0.000055232   -0.000308575    0.000024244
+      4        7          -0.000049511    0.000336797   -0.000021858
+      5        7           0.000167433   -0.000082654    0.000071717
+      6        8          -0.000195943   -0.000218101   -0.000083272
+      7        1           0.000057476    0.000033711    0.000024489
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000336797 RMS     0.000157893
+ Leave Link  716 at Mon Aug  5 14:34:46 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000376646 RMS     0.000167501
+ Search for a local minimum.
+ Step number   9 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16750D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5    9
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.40803
+           R2           0.03084   0.52102
+           R3           0.03232   0.02199   0.18904
+           R4           0.04169   0.00905   0.00928   0.36918
+           R5          -0.01689  -0.00470  -0.02839  -0.01065   0.48119
+           R6           0.06783  -0.01832   0.02566   0.16416  -0.01455
+           A1           0.11018   0.08027   0.06046   0.03865  -0.02295
+           A2           0.12772  -0.00557  -0.03057  -0.00722  -0.02930
+           A3          -0.06762   0.00740   0.04918  -0.01130   0.01424
+           A4          -0.06010  -0.00183  -0.01861   0.01852   0.01506
+           A5           0.12261   0.01162  -0.10664   0.11211  -0.02322
+           A6          -0.06250  -0.00595   0.02797   0.01190   0.00884
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.80723
+           A1           0.02071   0.41876
+           A2           0.01756   0.13030   0.20755
+           A3          -0.00951  -0.05034  -0.10462   0.11757
+           A4          -0.00806  -0.07996  -0.10293  -0.01294   0.11587
+           A5           0.12774   0.10987   0.00578  -0.01614   0.01035
+           A6          -0.02455   0.01886   0.02249  -0.01442  -0.00807
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.48049
+           A6           0.01733   0.11843
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.04537   0.10068
+     Eigenvalues ---    0.11708   0.13129   0.23900   0.30575   0.42712
+     Eigenvalues ---    0.48267   0.49772   0.60027   0.89865   1.48945
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83977  -0.41786  -0.30926   0.15006   0.04499
+                          R6        A2        R1        R3        A5
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          R3        A1        R6        A6        R5
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  1.48D-12
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -3.05D-13
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  1.79D-12.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  4.69D-05.
+ Quartic linear search produced a step of -0.00214.
+ Iteration  1 RMS(Cart)=  0.02653106 RMS(Int)=  0.00118647
+ Iteration  2 RMS(Cart)=  0.00154565 RMS(Int)=  0.00065586
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065586
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065586
+ ITry= 1 IFail=0 DXMaxC= 6.18D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17436  -0.00019   0.00000   0.00000  -0.00046   2.17390
+    R2        2.45250   0.00003   0.00000   0.00000  -0.00076   2.45174
+    R3        2.67766   0.00007   0.00000   0.00000  -0.00289   2.67478
+    R4        2.46680  -0.00030   0.00000   0.00000  -0.00022   2.46658
+    R5        1.90120  -0.00007   0.00000   0.00000  -0.00090   1.90029
+    R6        2.26243  -0.00028   0.00000   0.00000  -0.00106   2.26137
+    A1        2.08931  -0.00038   0.00000   0.00000   0.00213   2.09144
+    A2        2.26743  -0.00015   0.00000   0.00000   0.00023   2.26767
+    A3        1.91725   0.00008   0.00000   0.00000   0.00052   1.91777
+    A4        2.09850   0.00007   0.00000   0.00000  -0.00075   2.09775
+    A5        2.06877  -0.00024   0.00000   0.00000  -0.00016   2.06861
+    A6        3.34306   0.00018   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11164   0.00000   0.00000
+    D2       -3.14159   0.00000   0.00000  -0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000377     0.000015     NO 
+ RMS     Force            0.000168     0.000010     NO 
+ Maximum Displacement     0.003596     0.000060     NO 
+ RMS     Displacement     0.001545     0.000040     NO 
+ Predicted change in Energy=-2.757789D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:34:46 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226480   -0.517525    0.856109
+      2          6           0        1.175693   -0.651193    0.407386
+      3          8           0        0.042149   -1.056830   -0.076133
+      4          7           0       -0.925164   -0.110640   -0.491439
+      5          7           0       -0.881827    1.193802   -0.475642
+      6          8           0        0.103371    1.727753   -0.055779
+      7          1           0       -1.740701   -0.585367   -0.838929
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150380   0.000000
+     3  O    2.435411   1.297403   0.000000
+     4  N    3.451710   2.348123   1.415432   0.000000
+     5  N    3.789957   2.901229   2.465498   1.305257   0.000000
+     6  O    3.221863   2.650241   2.785329   2.151132   1.196663
+     7  H    4.314659   3.172221   1.995667   1.005592   2.008752
+                    6          7
+     6  O    0.000000
+     7  H    3.060138   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.52D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260517    0.275165    0.000000
+      2          6           0       -1.153191    0.586938    0.000000
+      3          8           0        0.000000    1.181417    0.000000
+      4          7           0        1.188454    0.412636    0.000000
+      5          7           0        1.348205   -0.882808    0.000000
+      6          8           0        0.374618   -1.578605    0.000000
+      7          1           0        1.989203    1.020926    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6762087      3.2645261      2.2904480
+ Leave Link  202 at Mon Aug  5 14:34:46 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7397833288 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822305 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7383010983 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:34:47 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:34:47 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:34:47 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:34:47 2024, MaxMem=  4294967296 cpu:         2.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225918138590    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225918138590     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922655925     Delta-E=       -0.000004517335 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922655925     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.590D-01 0.106D+01
+ Coeff:     -0.590D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.52D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922874708     Delta-E=       -0.000000218782 Rises=F Damp=F
+ DIIS: error= 2.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922874708     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.70D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.428D+00 0.623D+00
+ Coeff:     -0.501D-01 0.428D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.19D-07 OVMax= 9.32D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922922377     Delta-E=       -0.000000047669 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922922377     IErMin= 4 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.70D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.03D-07 MaxDP=1.44D-05 DE=-4.77D-08 OVMax= 4.51D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922942675     Delta-E=       -0.000000020298 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922942675     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=1.00D-05 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922944807     Delta-E=       -0.000000002132 Rises=F Damp=F
+ DIIS: error= 1.05D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922944807     IErMin= 6 ErrMin= 1.05D-06
+ ErrMax= 1.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.05D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.13D-09 OVMax= 5.21D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922945092     Delta-E=       -0.000000000285 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922945092     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.226D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.226D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.85D-06 DE=-2.85D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922945134     Delta-E=       -0.000000000042 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922945134     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.21D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922945141     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 3.73D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922945141     IErMin= 9 ErrMin= 3.73D-08
+ ErrMax= 3.73D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.26D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.898D-04 0.131D-02 0.733D-03-0.279D-02-0.132D-01-0.278D-01
+ Coeff-Com:  0.325D-01 0.235D+00 0.775D+00
+ Coeff:     -0.898D-04 0.131D-02 0.733D-03-0.279D-02-0.132D-01-0.278D-01
+ Coeff:      0.325D-01 0.235D+00 0.775D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-7.39D-12 OVMax= 5.74D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922945     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519221583922D+02 PE=-1.260293675395D+03 EE= 3.394072929591D+02
+ Leave Link  502 at Mon Aug  5 14:34:59 2024, MaxMem=  4294967296 cpu:       187.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:35:00 2024, MaxMem=  4294967296 cpu:        14.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:35:00 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:       143.3
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83304021D+00 1.12209283D+00-6.02198939D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000363664    0.000006522    0.000155380
+      2        6          -0.000166156    0.000513998   -0.000072070
+      3        8           0.000175623   -0.001048420    0.000077230
+      4        7          -0.000206480    0.000701256   -0.000089692
+      5        7          -0.000534937   -0.000163975   -0.000228237
+      6        8           0.000632330    0.000191928    0.000269795
+      7        1          -0.000264044   -0.000201310   -0.000112406
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001048420 RMS     0.000386027
+ Leave Link  716 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000908725 RMS     0.000382594
+ Search for a local minimum.
+ Step number  10 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .38259D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5    9   10
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.37946
+           R2           0.02840   0.52555
+           R3           0.01417   0.03866   0.23897
+           R4           0.03202   0.01488   0.02368   0.37276
+           R5          -0.01457  -0.00035  -0.00979  -0.00304   0.48467
+           R6           0.04182  -0.01438   0.03983   0.16615  -0.00889
+           A1           0.06756   0.08678   0.05888   0.02826  -0.00988
+           A2           0.09127   0.00542  -0.01641  -0.01041  -0.01201
+           A3          -0.04871   0.00021   0.03698  -0.01139   0.00378
+           A4          -0.04256  -0.00563  -0.02057   0.02179   0.00823
+           A5           0.08998   0.02291  -0.09030   0.11077  -0.00588
+           A6          -0.05633  -0.00931   0.02351   0.01155   0.00357
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.79003
+           A1           0.01112   0.36171
+           A2           0.01750   0.08082   0.16987
+           A3          -0.01181  -0.02613  -0.08773   0.11058
+           A4          -0.00568  -0.05469  -0.08214  -0.02285   0.10499
+           A5           0.12933   0.06354  -0.02798  -0.00140   0.02938
+           A6          -0.02650   0.03335   0.03265  -0.01891  -0.01374
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.45088
+           A6           0.02577   0.11664
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.06988   0.10068
+     Eigenvalues ---    0.11612   0.14260   0.23880   0.30898   0.38330
+     Eigenvalues ---    0.46577   0.48696   0.58125   0.89476   1.41768
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83984  -0.41778  -0.30920   0.15000   0.04499
+                          A6        A4        R3        A1        R6
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          R3        A6        A2        A5        A3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -2.46D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -1.80D-13
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -2.45D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  4.81D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646633 RMS(Int)=  0.00118473
+ Iteration  2 RMS(Cart)=  0.00154204 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065577
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065577
+ ITry= 1 IFail=0 DXMaxC= 6.16D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17390   0.00039   0.00000   0.00000  -0.00046   2.17345
+    R2        2.45174   0.00036   0.00000   0.00000  -0.00076   2.45098
+    R3        2.67478   0.00066   0.00000   0.00000  -0.00288   2.67190
+    R4        2.46658   0.00004   0.00000   0.00000  -0.00022   2.46636
+    R5        1.90029   0.00035   0.00000   0.00000  -0.00091   1.89939
+    R6        2.26137   0.00071   0.00000   0.00000  -0.00106   2.26031
+    A1        2.09144  -0.00091   0.00000   0.00000   0.00213   2.09357
+    A2        2.26767  -0.00038   0.00000   0.00000   0.00023   2.26790
+    A3        1.91777   0.00016   0.00000   0.00000   0.00052   1.91829
+    A4        2.09775   0.00022   0.00000   0.00000  -0.00075   2.09700
+    A5        2.06861  -0.00031   0.00000   0.00000  -0.00016   2.06844
+    A6        3.34312   0.00011   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000909     0.000015     NO 
+ RMS     Force            0.000383     0.000010     NO 
+ Maximum Displacement     0.003585     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-7.938906D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226701   -0.519422    0.856207
+      2          6           0        1.175953   -0.651358    0.407497
+      3          8           0        0.042230   -1.055111   -0.076102
+      4          7           0       -0.924651   -0.110676   -0.491220
+      5          7           0       -0.882435    1.193691   -0.475901
+      6          8           0        0.101925    1.728213   -0.056398
+      7          1           0       -1.739722   -0.585335   -0.838510
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150138   0.000000
+     3  O    2.434764   1.297002   0.000000
+     4  N    3.451616   2.347886   1.413910   0.000000
+     5  N    3.791569   2.901993   2.464134   1.305139   0.000000
+     6  O    3.224807   2.651621   2.784034   2.150451   1.196103
+     7  H    4.313806   3.171444   1.994319   1.005113   2.007824
+                    6          7
+     6  O    0.000000
+     7  H    3.058736   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.50D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261243    0.277032    0.000000
+      2          6           0       -1.153684    0.587082    0.000000
+      3          8           0        0.000000    1.179726    0.000000
+      4          7           0        1.187709    0.412597    0.000000
+      5          7           0        1.348645   -0.882582    0.000000
+      6          8           0        0.376045   -1.578795    0.000000
+      7          1           0        1.987972    1.020736    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891717      3.2617767      2.2902456
+ Leave Link  202 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7936708451 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817605 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7921890846 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:35:09 2024, MaxMem=  4294967296 cpu:         3.9
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:35:10 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:35:10 2024, MaxMem=  4294967296 cpu:         2.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225910206273    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225910206273     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914708988     Delta-E=       -0.000004502715 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914708988     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.358 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914926438     Delta-E=       -0.000000217450 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914926438     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.75D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.35D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225914974458     Delta-E=       -0.000000048020 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225914974458     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.75D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225914994662     Delta-E=       -0.000000020205 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225914994662     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225914996790     Delta-E=       -0.000000002128 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225914996790     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.13D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225914997065     Delta-E=       -0.000000000275 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225914997065     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.287D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.287D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.75D-10 OVMax= 4.70D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225914997103     Delta-E=       -0.000000000038 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225914997103     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-3.77D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225914997117     Delta-E=       -0.000000000014 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225914997117     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.12D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.309D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff:      0.309D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE=-1.41D-11 OVMax= 5.71D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225914997     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519295490162D+02 PE=-1.260403154507D+03 EE= 3.394555014092D+02
+ Leave Link  502 at Mon Aug  5 14:35:22 2024, MaxMem=  4294967296 cpu:       195.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:35:23 2024, MaxMem=  4294967296 cpu:        14.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:35:23 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:35:32 2024, MaxMem=  4294967296 cpu:       144.4
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83142044D+00 1.12209587D+00-9.77424283D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000887858    0.000104056    0.000379165
+      2        6          -0.000458545    0.000695340   -0.000197387
+      3        8           0.000300922   -0.001789268    0.000132315
+      4        7          -0.000364361    0.001070807   -0.000157925
+      5        7          -0.001237901   -0.000247575   -0.000528439
+      6        8           0.001459763    0.000604525    0.000622497
+      7        1          -0.000587736   -0.000437885   -0.000250227
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001789268 RMS     0.000744698
+ Leave Link  716 at Mon Aug  5 14:35:32 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001696149 RMS     0.000742079
+ Search for a local minimum.
+ Step number  11 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .74208D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                      9
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.40365
+           R2           0.02998   0.52532
+           R3           0.03284   0.03738   0.23304
+           R4           0.03939   0.01474   0.02482   0.37362
+           R5          -0.01714  -0.00041  -0.01082  -0.00372   0.48496
+           R6           0.05373  -0.01365   0.04771   0.16914  -0.00996
+           A1           0.10200   0.08546   0.05595   0.03206  -0.01250
+           A2           0.12391   0.00398  -0.01951  -0.00704  -0.01464
+           A3          -0.06667   0.00112   0.03934  -0.01313   0.00522
+           A4          -0.05724  -0.00510  -0.01983   0.02017   0.00942
+           A5           0.11975   0.02173  -0.09185   0.11399  -0.00833
+           A6          -0.06250  -0.00919   0.02227   0.01079   0.00423
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.79737
+           A1           0.02630   0.36961
+           A2           0.03102   0.08777   0.17599
+           A3          -0.01910  -0.02908  -0.09028   0.11151
+           A4          -0.01191  -0.05868  -0.08570  -0.02122   0.10693
+           A5           0.14148   0.07134  -0.02096  -0.00459   0.02555
+           A6          -0.02862   0.02972   0.02927  -0.01710  -0.01217
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.45853
+           A6           0.02257   0.11739
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04740960 RMS(Int)=  0.00053262
+ Iteration  2 RMS(Cart)=  0.00156247 RMS(Int)=  0.00000066
+ Iteration  3 RMS(Cart)=  0.00000077 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 1.08D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.53D-08 for atom     4.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17345   0.00097   0.00000   0.02852   0.02852   2.20197
+    R2        2.45098   0.00068   0.00000   0.02011   0.02011   2.47109
+    R3        2.67190   0.00126   0.00000   0.03704   0.03704   2.70894
+    R4        2.46636   0.00037   0.00000   0.01088   0.01088   2.47723
+    R5        1.89939   0.00077   0.00000   0.02265   0.02265   1.92204
+    R6        2.26031   0.00170   0.00000   0.05000   0.05000   2.31031
+    A1        2.09357  -0.00144   0.00000  -0.04233  -0.04233   2.05124
+    A2        2.26790  -0.00061   0.00000  -0.01789  -0.01789   2.25001
+    A3        1.91829   0.00023   0.00000   0.00682   0.00682   1.92511
+    A4        2.09700   0.00038   0.00000   0.01108   0.01108   2.10807
+    A5        2.06844  -0.00039   0.00000  -0.01146  -0.01146   2.05698
+    A6        3.34318   0.00004   0.00000   0.00111   0.00111   3.34429
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001696     0.000015     NO 
+ RMS     Force            0.000742     0.000010     NO 
+ Maximum Displacement     0.108282     0.000060     NO 
+ RMS     Displacement     0.048609     0.000040     NO 
+ Predicted change in Energy=-2.029629D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:35:32 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.222945   -0.462121    0.854483
+      2          6           0        1.163093   -0.634490    0.401967
+      3          8           0        0.033672   -1.084317   -0.079697
+      4          7           0       -0.939779   -0.118584   -0.497667
+      5          7           0       -0.866539    1.189953   -0.469101
+      6          8           0        0.157498    1.695382   -0.032583
+      7          1           0       -1.770891   -0.585821   -0.851828
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.165233   0.000000
+     3  O    2.460231   1.307646   0.000000
+     4  N    3.456755   2.344690   1.433508   0.000000
+     5  N    3.745148   2.864744   2.476755   1.310896   0.000000
+     6  O    3.115731   2.574561   2.782854   2.170436   1.222562
+     7  H    4.344827   3.191024   2.025124   1.017097   2.029213
+                    6          7
+     6  O    0.000000
+     7  H    3.097375   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.243740    0.200188    0.000000
+      2          6           0       -1.136002    0.561692    0.000000
+      3          8           0        0.000000    1.209331    0.000000
+      4          7           0        1.205159    0.433099    0.000000
+      5          7           0        1.345158   -0.870300    0.000000
+      6          8           0        0.331451   -1.553714    0.000000
+      7          1           0        2.018363    1.043989    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.3928260      3.3740228      2.3167004
+ Leave Link  202 at Mon Aug  5 14:35:32 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8347557958 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014708627 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8332849331 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:35:32 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.65D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:35:33 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:35:33 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000   -0.004624 Ang=  -0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410320330472    
+ Leave Link  401 at Mon Aug  5 14:35:33 2024, MaxMem=  4294967296 cpu:         6.6
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220422962005    
+ DIIS: error= 3.05D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220422962005     IErMin= 1 ErrMin= 3.05D-03
+ ErrMax= 3.05D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.70D-03 BMatP= 3.70D-03
+ IDIUse=3 WtCom= 9.69D-01 WtEn= 3.05D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.62D-04 MaxDP=5.69D-03              OVMax= 1.22D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223685366418     Delta-E=       -0.003262404413 Rises=F Damp=F
+ DIIS: error= 5.34D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223685366418     IErMin= 2 ErrMin= 5.34D-04
+ ErrMax= 5.34D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-04 BMatP= 3.70D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.34D-03
+ Coeff-Com: -0.405D-01 0.104D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.403D-01 0.104D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.90D-05 MaxDP=2.34D-03 DE=-3.26D-03 OVMax= 3.79D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223855467092     Delta-E=       -0.000170100674 Rises=F Damp=F
+ DIIS: error= 3.38D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223855467092     IErMin= 3 ErrMin= 3.38D-04
+ ErrMax= 3.38D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-05 BMatP= 1.24D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.38D-03
+ Coeff-Com: -0.392D-01 0.247D+00 0.793D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.391D-01 0.246D+00 0.793D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.10D-05 MaxDP=4.20D-04 DE=-1.70D-04 OVMax= 1.26D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223874258252     Delta-E=       -0.000018791161 Rises=F Damp=F
+ DIIS: error= 1.59D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223874258252     IErMin= 4 ErrMin= 1.59D-04
+ ErrMax= 1.59D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.60D-06 BMatP= 2.10D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.59D-03
+ Coeff-Com: -0.968D-02 0.131D-01 0.272D+00 0.725D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.966D-02 0.131D-01 0.271D+00 0.725D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-05 MaxDP=2.58D-04 DE=-1.88D-05 OVMax= 7.41D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223876266368     Delta-E=       -0.000002008116 Rises=F Damp=F
+ DIIS: error= 1.56D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223876266368     IErMin= 5 ErrMin= 1.56D-04
+ ErrMax= 1.56D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.24D-06 BMatP= 3.60D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.56D-03
+ Coeff-Com:  0.248D-02-0.500D-01-0.142D-02 0.488D+00 0.561D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.274D+00 0.726D+00
+ Coeff:      0.247D-02-0.499D-01-0.142D-02 0.487D+00 0.562D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.27D-06 MaxDP=1.60D-04 DE=-2.01D-06 OVMax= 3.66D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223859073399     Delta-E=        0.000017192969 Rises=F Damp=F
+ DIIS: error= 3.59D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223859073399     IErMin= 1 ErrMin= 3.59D-05
+ ErrMax= 3.59D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.46D-07 BMatP= 4.46D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.27D-06 MaxDP=1.60D-04 DE= 1.72D-05 OVMax= 2.33D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223859444711     Delta-E=       -0.000000371311 Rises=F Damp=F
+ DIIS: error= 3.57D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223859444711     IErMin= 2 ErrMin= 3.57D-05
+ ErrMax= 3.57D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.53D-08 BMatP= 4.46D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.150D+00 0.850D+00
+ Coeff:      0.150D+00 0.850D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.27D-06 MaxDP=5.89D-05 DE=-3.71D-07 OVMax= 1.29D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223859424334     Delta-E=        0.000000020377 Rises=F Damp=F
+ DIIS: error= 3.86D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223859444711     IErMin= 2 ErrMin= 3.57D-05
+ ErrMax= 3.86D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.23D-07 BMatP= 8.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.704D-01 0.577D+00 0.494D+00
+ Coeff:     -0.704D-01 0.577D+00 0.494D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=9.57D-07 MaxDP=3.26D-05 DE= 2.04D-08 OVMax= 9.73D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223859520172     Delta-E=       -0.000000095838 Rises=F Damp=F
+ DIIS: error= 3.88D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223859520172     IErMin= 4 ErrMin= 3.88D-06
+ ErrMax= 3.88D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.88D-09 BMatP= 8.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.359D-01 0.220D+00 0.209D+00 0.607D+00
+ Coeff:     -0.359D-01 0.220D+00 0.209D+00 0.607D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.71D-07 MaxDP=6.14D-06 DE=-9.58D-08 OVMax= 1.21D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223859521616     Delta-E=       -0.000000001445 Rises=F Damp=F
+ DIIS: error= 1.14D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223859521616     IErMin= 5 ErrMin= 1.14D-06
+ ErrMax= 1.14D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.96D-10 BMatP= 1.88D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.299D-02-0.560D-01-0.404D-01 0.237D+00 0.857D+00
+ Coeff:      0.299D-02-0.560D-01-0.404D-01 0.237D+00 0.857D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.32D-07 MaxDP=3.64D-06 DE=-1.44D-09 OVMax= 8.32D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223859522011     Delta-E=       -0.000000000395 Rises=F Damp=F
+ DIIS: error= 4.64D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223859522011     IErMin= 6 ErrMin= 4.64D-07
+ ErrMax= 4.64D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.25D-11 BMatP= 2.96D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.425D-02-0.399D-01-0.327D-01 0.173D-01 0.307D+00 0.744D+00
+ Coeff:      0.425D-02-0.399D-01-0.327D-01 0.173D-01 0.307D+00 0.744D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.15D-08 MaxDP=1.14D-06 DE=-3.95D-10 OVMax= 3.20D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223859522057     Delta-E=       -0.000000000045 Rises=F Damp=F
+ DIIS: error= 1.87D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223859522057     IErMin= 7 ErrMin= 1.87D-07
+ ErrMax= 1.87D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.28D-11 BMatP= 3.25D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.185D-02-0.128D-01-0.109D-01-0.289D-01 0.362D-01 0.428D+00
+ Coeff-Com:  0.586D+00
+ Coeff:      0.185D-02-0.128D-01-0.109D-01-0.289D-01 0.362D-01 0.428D+00
+ Coeff:      0.586D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.09D-08 MaxDP=5.55D-07 DE=-4.54D-11 OVMax= 1.46D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223859522065     Delta-E=       -0.000000000008 Rises=F Damp=F
+ DIIS: error= 1.10D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223859522065     IErMin= 8 ErrMin= 1.10D-07
+ ErrMax= 1.10D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.56D-12 BMatP= 1.28D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.360D-03 0.509D-02 0.414D-02-0.214D-01-0.702D-01 0.273D-01
+ Coeff-Com:  0.272D+00 0.784D+00
+ Coeff:     -0.360D-03 0.509D-02 0.414D-02-0.214D-01-0.702D-01 0.273D-01
+ Coeff:      0.272D+00 0.784D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.25D-08 MaxDP=3.73D-07 DE=-8.07D-12 OVMax= 8.47D-07
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.223859522071     Delta-E=       -0.000000000006 Rises=F Damp=F
+ DIIS: error= 3.03D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.223859522071     IErMin= 9 ErrMin= 3.03D-08
+ ErrMax= 3.03D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.83D-13 BMatP= 1.56D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.288D-03 0.302D-02 0.243D-02-0.455D-02-0.288D-01-0.402D-01
+ Coeff-Com: -0.303D-02 0.286D+00 0.785D+00
+ Coeff:     -0.288D-03 0.302D-02 0.243D-02-0.455D-02-0.288D-01-0.402D-01
+ Coeff:     -0.303D-02 0.286D+00 0.785D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.45D-09 MaxDP=1.85D-07 DE=-6.37D-12 OVMax= 2.96D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223859522     A.U. after   14 cycles
+            NFock= 14  Conv=0.44D-08     -V/T= 2.0044
+ KE= 3.516797744297D+02 PE=-1.258373719084D+03 EE= 3.386368001988D+02
+ Leave Link  502 at Mon Aug  5 14:35:47 2024, MaxMem=  4294967296 cpu:       222.4
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:35:48 2024, MaxMem=  4294967296 cpu:        14.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:35:48 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:35:57 2024, MaxMem=  4294967296 cpu:       145.3
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87546249D+00 1.17320019D+00-2.62334919D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.030137538   -0.006676742   -0.012863864
+      2        6           0.025517181    0.000678060    0.010902093
+      3        8           0.000280495    0.011283524    0.000096324
+      4        7           0.000379020    0.001074486    0.000159715
+      5        7           0.027312021    0.003801002    0.011662516
+      6        8          -0.031157553   -0.014237993   -0.013283948
+      7        1           0.007806374    0.004077664    0.003327164
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.031157553 RMS     0.014396631
+ Leave Link  716 at Mon Aug  5 14:35:57 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036721702 RMS     0.013402253
+ Search for a local minimum.
+ Step number  12 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13402D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                     12    9
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.41282
+           R2           0.02073   0.52192
+           R3           0.00820   0.02729   0.21191
+           R4           0.03009   0.00934   0.01095   0.36593
+           R5          -0.02647  -0.00339  -0.02216  -0.00914   0.48310
+           R6           0.03244  -0.02699   0.00778   0.14969  -0.02188
+           A1           0.09158   0.07841   0.05550   0.02579  -0.02475
+           A2           0.11189  -0.00416  -0.02556  -0.01533  -0.02711
+           A3          -0.05933   0.00575   0.04320  -0.00832   0.01218
+           A4          -0.05257  -0.00159  -0.01764   0.02365   0.01493
+           A5           0.10816   0.01336  -0.10108   0.10492  -0.02030
+           A6          -0.06082  -0.00676   0.02724   0.01380   0.00706
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.75233
+           A1          -0.00050   0.40370
+           A2           0.00053   0.11354   0.19417
+           A3          -0.00158  -0.04271  -0.09974   0.11640
+           A4           0.00105  -0.07083  -0.09443  -0.01666   0.11109
+           A5           0.11070   0.09062  -0.00842  -0.01096   0.01939
+           A6          -0.02051   0.02977   0.03038  -0.01782  -0.01257
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46625
+           A6           0.02428   0.11648
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99989.
+ Iteration  1 RMS(Cart)=  0.04609917 RMS(Int)=  0.00059090
+ Iteration  2 RMS(Cart)=  0.00094560 RMS(Int)=  0.00000019
+ Iteration  3 RMS(Cart)=  0.00000035 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.01D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.54D-08 for atom     4.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20197  -0.03340  -0.02761   0.00000  -0.02761   2.17436
+    R2        2.47109  -0.00679  -0.01859   0.00000  -0.01859   2.45250
+    R3        2.70894  -0.00705  -0.03127   0.00000  -0.03127   2.67767
+    R4        2.47723  -0.01066  -0.01043   0.00000  -0.01043   2.46680
+    R5        1.92204  -0.00941  -0.02084   0.00000  -0.02084   1.90120
+    R6        2.31031  -0.03672  -0.04787   0.00000  -0.04787   2.26243
+    A1        2.05124   0.01357   0.03807   0.00000   0.03807   2.08931
+    A2        2.25001   0.00760   0.01743   0.00000   0.01743   2.26743
+    A3        1.92511  -0.00406  -0.00786   0.00000  -0.00786   1.91725
+    A4        2.10807  -0.00354  -0.00957   0.00000  -0.00957   2.09850
+    A5        2.05698   0.00239   0.01179   0.00000   0.01179   2.06877
+    A6        3.34429   0.00389  -0.00124   0.00000  -0.00124   3.34306
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.036722     0.000015     NO 
+ RMS     Force            0.013402     0.000010     NO 
+ Maximum Displacement     0.101113     0.000060     NO 
+ RMS     Displacement     0.045729     0.000040     NO 
+ Predicted change in Energy=-3.044964D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:35:57 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226255   -0.515628    0.856008
+      2          6           0        1.175427   -0.651030    0.407272
+      3          8           0        0.042062   -1.058555   -0.076166
+      4          7           0       -0.925680   -0.110600   -0.491660
+      5          7           0       -0.881210    1.193916   -0.475378
+      6          8           0        0.104835    1.727285   -0.055153
+      7          1           0       -1.741687   -0.585388   -0.839350
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150624   0.000000
+     3  O    2.436066   1.297808   0.000000
+     4  N    3.451804   2.348360   1.416961   0.000000
+     5  N    3.788334   2.900458   2.466866   1.305376   0.000000
+     6  O    3.218897   2.648847   2.786626   2.151818   1.197229
+     7  H    4.315515   3.173000   1.997022   1.006071   2.009681
+                    6          7
+     6  O    0.000000
+     7  H    3.061546   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259785    0.273286    0.000000
+      2          6           0       -1.152694    0.586790    0.000000
+      3          8           0        0.000000    1.183114    0.000000
+      4          7           0        1.189203    0.412677    0.000000
+      5          7           0        1.347762   -0.883033    0.000000
+      6          8           0        0.373182   -1.578411    0.000000
+      7          1           0        1.990441    1.021116    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6632240      3.2672987      2.2906536
+ Leave Link  202 at Mon Aug  5 14:35:57 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6857275116 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014826971 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6842448145 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:35:57 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:35:58 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:35:58 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000001 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000    0.004599 Ang=   0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.12D-04
+ Max alpha theta=  1.286 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:35:58 2024, MaxMem=  4294967296 cpu:         4.3
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930772692    
+ DIIS: error= 1.66D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930772692     IErMin= 1 ErrMin= 1.66D-05
+ ErrMax= 1.66D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.21D-08 BMatP= 9.21D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.412 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.52D-05              OVMax= 3.10D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925888250     Delta-E=        0.000004884441 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925888250     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.29D-08 BMatP= 8.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.52D-05 DE= 4.88D-06 OVMax= 2.89D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925925773     Delta-E=       -0.000000037522 Rises=F Damp=F
+ DIIS: error= 2.90D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925925773     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 2.90D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.47D-09 BMatP= 8.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.188D-01 0.102D+01
+ Coeff:     -0.188D-01 0.102D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.55D-07 MaxDP=7.52D-06 DE=-3.75D-08 OVMax= 1.44D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925925754     Delta-E=        0.000000000019 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.225925925773     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.65D-09 BMatP= 1.47D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.280D-01 0.537D+00 0.491D+00
+ Coeff:     -0.280D-01 0.537D+00 0.491D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.12D-07 MaxDP=3.90D-06 DE= 1.91D-11 OVMax= 1.08D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925926865     Delta-E=       -0.000000001111 Rises=F Damp=F
+ DIIS: error= 9.67D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925926865     IErMin= 4 ErrMin= 9.67D-07
+ ErrMax= 9.67D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.93D-11 BMatP= 1.47D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.108D-01 0.149D+00 0.226D+00 0.636D+00
+ Coeff:     -0.108D-01 0.149D+00 0.226D+00 0.636D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.50D-08 MaxDP=1.18D-06 DE=-1.11D-09 OVMax= 2.90D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925926929     Delta-E=       -0.000000000064 Rises=F Damp=F
+ DIIS: error= 4.08D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925926929     IErMin= 5 ErrMin= 4.08D-07
+ ErrMax= 4.08D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-11 BMatP= 8.93D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.185D-02 0.613D-02 0.546D-01 0.342D+00 0.599D+00
+ Coeff:     -0.185D-02 0.613D-02 0.546D-01 0.342D+00 0.599D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.41D-08 MaxDP=4.93D-07 DE=-6.42D-11 OVMax= 1.12D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925926938     Delta-E=       -0.000000000009 Rises=F Damp=F
+ DIIS: error= 6.95D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925926938     IErMin= 6 ErrMin= 6.95D-08
+ ErrMax= 6.95D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.43D-12 BMatP= 1.66D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.895D-03-0.212D-01-0.127D-01 0.475D-01 0.261D+00 0.725D+00
+ Coeff:      0.895D-03-0.212D-01-0.127D-01 0.475D-01 0.261D+00 0.725D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.52D-09 MaxDP=1.78D-07 DE=-9.09D-12 OVMax= 3.15D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925927     A.U. after    7 cycles
+            NFock=  7  Conv=0.55D-08     -V/T= 2.0037
+ KE= 3.519147351015D+02 PE=-1.260183842481D+03 EE= 3.393589366380D+02
+ Leave Link  502 at Mon Aug  5 14:36:10 2024, MaxMem=  4294967296 cpu:       184.1
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:36:11 2024, MaxMem=  4294967296 cpu:        14.6
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:36:11 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:       145.2
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83466912D+00 1.12209143D+00-1.84711683D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000167262   -0.000094035   -0.000071275
+      2        6           0.000131989    0.000332167    0.000055706
+      3        8           0.000055259   -0.000307266    0.000024253
+      4        7          -0.000049458    0.000336866   -0.000021836
+      5        7           0.000170767   -0.000081959    0.000073140
+      6        8          -0.000199668   -0.000219961   -0.000084859
+      7        1           0.000058372    0.000034188    0.000024871
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000336866 RMS     0.000158728
+ Leave Link  716 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000375169 RMS     0.000168067
+ Search for a local minimum.
+ Step number  13 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16807D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                     12   13
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.43170
+           R2           0.01988   0.52198
+           R3           0.01157   0.02745   0.21444
+           R4           0.03169   0.00906   0.01099   0.36508
+           R5          -0.02882  -0.00327  -0.02235  -0.00951   0.48340
+           R6           0.03388  -0.02778   0.00636   0.14738  -0.02261
+           A1           0.09960   0.07760   0.05643   0.02436  -0.02609
+           A2           0.12090  -0.00480  -0.02376  -0.01617  -0.02842
+           A3          -0.06455   0.00600   0.04181  -0.00813   0.01285
+           A4          -0.05635  -0.00120  -0.01806   0.02431   0.01557
+           A5           0.11708   0.01274  -0.09926   0.10414  -0.02158
+           A6          -0.06330  -0.00646   0.02717   0.01427   0.00751
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.74693
+           A1          -0.00519   0.40252
+           A2          -0.00312   0.11389   0.19599
+           A3          -0.00008  -0.04358  -0.10137   0.11763
+           A4           0.00320  -0.07031  -0.09462  -0.01625   0.11087
+           A5           0.10725   0.09112  -0.00651  -0.01263   0.01914
+           A6          -0.01912   0.03018   0.03039  -0.01764  -0.01275
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46824
+           A6           0.02424   0.11635
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.06512   0.10068
+     Eigenvalues ---    0.11560   0.13710   0.23855   0.30973   0.41677
+     Eigenvalues ---    0.47663   0.49190   0.59291   0.84197   1.48884
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                    0.83977   0.41786   0.30926  -0.15006  -0.04499
+                          R3        A6        A2        A5        A3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          A6        A2        A4        A5        R4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  1.59D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -3.37D-11
+ I=     2 Stepn=  6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -1.78D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  4.16D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02653124 RMS(Int)=  0.00118648
+ Iteration  2 RMS(Cart)=  0.00154575 RMS(Int)=  0.00065586
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065586
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065586
+ ITry= 1 IFail=0 DXMaxC= 6.17D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17436  -0.00019   0.00000   0.00000  -0.00046   2.17391
+    R2        2.45250   0.00003   0.00000   0.00000  -0.00076   2.45174
+    R3        2.67767   0.00007   0.00000   0.00000  -0.00289   2.67478
+    R4        2.46680  -0.00030   0.00000   0.00000  -0.00022   2.46658
+    R5        1.90120  -0.00007   0.00000   0.00000  -0.00090   1.90030
+    R6        2.26243  -0.00029   0.00000   0.00000  -0.00106   2.26137
+    A1        2.08931  -0.00038   0.00000   0.00000   0.00213   2.09144
+    A2        2.26743  -0.00015   0.00000   0.00000   0.00023   2.26767
+    A3        1.91725   0.00008   0.00000   0.00000   0.00052   1.91777
+    A4        2.09850   0.00007   0.00000   0.00000  -0.00075   2.09775
+    A5        2.06877  -0.00023   0.00000   0.00000  -0.00016   2.06860
+    A6        3.34306   0.00018   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000  -0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.11164   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000  -0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000375     0.000015     NO 
+ RMS     Force            0.000168     0.000010     NO 
+ Maximum Displacement     0.003595     0.000060     NO 
+ RMS     Displacement     0.001545     0.000040     NO 
+ Predicted change in Energy=-2.801591D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226477   -0.517530    0.856108
+      2          6           0        1.175689   -0.651197    0.407384
+      3          8           0        0.042143   -1.056833   -0.076135
+      4          7           0       -0.925166   -0.110636   -0.491440
+      5          7           0       -0.881820    1.193806   -0.475639
+      6          8           0        0.103385    1.727748   -0.055773
+      7          1           0       -1.740707   -0.585358   -0.838931
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150381   0.000000
+     3  O    2.435414   1.297404   0.000000
+     4  N    3.451710   2.348123   1.415434   0.000000
+     5  N    3.789952   2.901225   2.465499   1.305258   0.000000
+     6  O    3.221851   2.650232   2.785329   2.151135   1.196666
+     7  H    4.314662   3.172223   1.995670   1.005593   2.008754
+                    6          7
+     6  O    0.000000
+     7  H    3.060143   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.46D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260515    0.275156    0.000000
+      2          6           0       -1.153189    0.586935    0.000000
+      3          8           0        0.000000    1.181420    0.000000
+      4          7           0        1.188456    0.412639    0.000000
+      5          7           0        1.348204   -0.882807    0.000000
+      6          8           0        0.374614   -1.578602    0.000000
+      7          1           0        1.989206    1.020929    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6761743      3.2645383      2.2904509
+ Leave Link  202 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7396748045 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822295 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7381925750 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:36:20 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:36:21 2024, MaxMem=  4294967296 cpu:         2.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225918154839    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225918154839     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922671069     Delta-E=       -0.000004516230 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922671069     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.590D-01 0.106D+01
+ Coeff:     -0.590D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.52D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922889818     Delta-E=       -0.000000218750 Rises=F Damp=F
+ DIIS: error= 2.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922889818     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.70D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.428D+00 0.623D+00
+ Coeff:     -0.501D-01 0.428D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.19D-07 OVMax= 9.32D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922937470     Delta-E=       -0.000000047652 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922937470     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.70D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.77D-08 OVMax= 4.51D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922957762     Delta-E=       -0.000000020291 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922957762     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=9.99D-06 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922959893     Delta-E=       -0.000000002131 Rises=F Damp=F
+ DIIS: error= 1.05D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922959893     IErMin= 6 ErrMin= 1.05D-06
+ ErrMax= 1.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.05D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.13D-09 OVMax= 5.21D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922960167     Delta-E=       -0.000000000274 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922960167     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.223D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.223D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.85D-06 DE=-2.74D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922960214     Delta-E=       -0.000000000047 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922960214     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.71D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922960217     Delta-E=       -0.000000000003 Rises=F Damp=F
+ DIIS: error= 3.73D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922960217     IErMin= 9 ErrMin= 3.73D-08
+ ErrMax= 3.73D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.26D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff-Com:  0.326D-01 0.235D+00 0.774D+00
+ Coeff:     -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff:      0.326D-01 0.235D+00 0.774D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-3.18D-12 OVMax= 5.74D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922960     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519221295596D+02 PE=-1.260293444919D+03 EE= 3.394071998240D+02
+ Leave Link  502 at Mon Aug  5 14:36:33 2024, MaxMem=  4294967296 cpu:       201.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:36:34 2024, MaxMem=  4294967296 cpu:        14.3
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:36:34 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:36:43 2024, MaxMem=  4294967296 cpu:       140.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83304469D+00 1.12209930D+00-6.06537505D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000359967    0.000005872    0.000153802
+      2        6          -0.000163073    0.000513935   -0.000070753
+      3        8           0.000175645   -0.001047052    0.000077237
+      4        7          -0.000206429    0.000701333   -0.000089670
+      5        7          -0.000531457   -0.000163251   -0.000226752
+      6        8           0.000628445    0.000189965    0.000268139
+      7        1          -0.000263097   -0.000200802   -0.000112003
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001047052 RMS     0.000384842
+ Leave Link  716 at Mon Aug  5 14:36:43 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000907196 RMS     0.000381339
+ Search for a local minimum.
+ Step number  14 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .38134D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   11   12
+                                                      9   13   14
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.39520
+           R2           0.02524   0.52559
+           R3           0.01271   0.03912   0.25037
+           R4           0.02527   0.01407   0.02335   0.36790
+           R5          -0.01848  -0.00024  -0.01092  -0.00359   0.48513
+           R6           0.02264  -0.01705   0.02905   0.15263  -0.00931
+           A1           0.05741   0.08553   0.06835   0.01958  -0.01219
+           A2           0.08615   0.00446  -0.00498  -0.01698  -0.01456
+           A3          -0.04800   0.00052   0.02934  -0.00897   0.00524
+           A4          -0.03815  -0.00498  -0.02436   0.02596   0.00932
+           A5           0.08520   0.02183  -0.08030   0.10400  -0.00837
+           A6          -0.05371  -0.00864   0.02306   0.01483   0.00427
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.76060
+           A1          -0.02205   0.35526
+           A2          -0.01135   0.08005   0.17429
+           A3           0.00178  -0.02907  -0.09323   0.11514
+           A4           0.00957  -0.05098  -0.08106  -0.02191   0.10297
+           A5           0.10126   0.06128  -0.02518  -0.00590   0.03108
+           A6          -0.01672   0.03841   0.03600  -0.01983  -0.01617
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.45222
+           A6           0.02929   0.11463
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.07943   0.10068
+     Eigenvalues ---    0.11536   0.14830   0.23813   0.30682   0.38950
+     Eigenvalues ---    0.47041   0.48752   0.58725   0.85350   1.42309
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83984  -0.41778  -0.30920   0.15000   0.04499
+                          A6        A2        A4        A1        R6
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          A6        A2        A5        R3        A4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -3.23D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -2.80D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -4.22D-12.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  6.04D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646651 RMS(Int)=  0.00118473
+ Iteration  2 RMS(Cart)=  0.00154204 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065577
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065577
+ ITry= 1 IFail=0 DXMaxC= 6.16D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17391   0.00039   0.00000   0.00000  -0.00046   2.17345
+    R2        2.45174   0.00036   0.00000   0.00000  -0.00076   2.45098
+    R3        2.67478   0.00066   0.00000   0.00000  -0.00288   2.67191
+    R4        2.46658   0.00003   0.00000   0.00000  -0.00022   2.46636
+    R5        1.90030   0.00035   0.00000   0.00000  -0.00091   1.89939
+    R6        2.26137   0.00070   0.00000   0.00000  -0.00106   2.26031
+    A1        2.09144  -0.00091   0.00000   0.00000   0.00213   2.09356
+    A2        2.26767  -0.00038   0.00000   0.00000   0.00023   2.26790
+    A3        1.91777   0.00016   0.00000   0.00000   0.00052   1.91829
+    A4        2.09775   0.00022   0.00000   0.00000  -0.00075   2.09700
+    A5        2.06860  -0.00031   0.00000   0.00000  -0.00016   2.06844
+    A6        3.34312   0.00011   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000907     0.000015     NO 
+ RMS     Force            0.000381     0.000010     NO 
+ Maximum Displacement     0.003586     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-7.924074D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:36:43 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226698   -0.519428    0.856206
+      2          6           0        1.175949   -0.651363    0.407495
+      3          8           0        0.042224   -1.055115   -0.076104
+      4          7           0       -0.924653   -0.110672   -0.491221
+      5          7           0       -0.882428    1.193695   -0.475898
+      6          8           0        0.101939    1.728209   -0.056392
+      7          1           0       -1.739728   -0.585326   -0.838513
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150140   0.000000
+     3  O    2.434767   1.297003   0.000000
+     4  N    3.451617   2.347886   1.413912   0.000000
+     5  N    3.791564   2.901989   2.464135   1.305140   0.000000
+     6  O    3.224795   2.651612   2.784034   2.150453   1.196106
+     7  H    4.313810   3.171446   1.994322   1.005114   2.007826
+                    6          7
+     6  O    0.000000
+     7  H    3.058740   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.52D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261242    0.277023    0.000000
+      2          6           0       -1.153682    0.587079    0.000000
+      3          8           0        0.000000    1.179729    0.000000
+      4          7           0        1.187711    0.412599    0.000000
+      5          7           0        1.348645   -0.882581    0.000000
+      6          8           0        0.376040   -1.578792    0.000000
+      7          1           0        1.987975    1.020738    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891373      3.2617887      2.2902484
+ Leave Link  202 at Mon Aug  5 14:36:43 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7935611626 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817595 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7920794031 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:36:43 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:36:44 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:36:44 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:36:44 2024, MaxMem=  4294967296 cpu:         3.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225910236111    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225910236111     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914738889     Delta-E=       -0.000004502778 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914738889     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.358 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914956343     Delta-E=       -0.000000217454 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914956343     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.75D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.35D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225915004357     Delta-E=       -0.000000048014 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225915004357     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.75D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225915024576     Delta-E=       -0.000000020219 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225915024576     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225915026684     Delta-E=       -0.000000002108 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225915026684     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.11D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225915026973     Delta-E=       -0.000000000289 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225915026973     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.286D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.286D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.89D-10 OVMax= 4.70D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225915027009     Delta-E=       -0.000000000036 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225915027009     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-3.62D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225915027019     Delta-E=       -0.000000000009 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225915027019     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.12D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.309D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff:      0.309D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE=-9.21D-12 OVMax= 5.71D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225915027     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519295202260D+02 PE=-1.260402921774D+03 EE= 3.394554071182D+02
+ Leave Link  502 at Mon Aug  5 14:36:56 2024, MaxMem=  4294967296 cpu:       192.3
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:36:57 2024, MaxMem=  4294967296 cpu:        14.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:36:57 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:       141.6
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83142492D+00 1.12210229D+00-1.38557236D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000884185    0.000103417    0.000377597
+      2        6          -0.000455489    0.000695274   -0.000196081
+      3        8           0.000300929   -0.001787895    0.000132316
+      4        7          -0.000364307    0.001070865   -0.000157902
+      5        7          -0.001234421   -0.000246837   -0.000526954
+      6        8           0.001455887    0.000602545    0.000620845
+      7        1          -0.000586784   -0.000437368   -0.000249821
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001787895 RMS     0.000743286
+ Leave Link  716 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001691494 RMS     0.000740656
+ Search for a local minimum.
+ Step number  15 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .74066D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                     12   14   15   13
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.42388
+           R2           0.02562   0.52542
+           R3           0.02642   0.03817   0.24624
+           R4           0.03231   0.01370   0.02361   0.36832
+           R5          -0.02140  -0.00025  -0.01175  -0.00431   0.48544
+           R6           0.03258  -0.01709   0.03391   0.15419  -0.01040
+           A1           0.08491   0.08408   0.06552   0.02142  -0.01461
+           A2           0.11346   0.00291  -0.00793  -0.01516  -0.01705
+           A3          -0.06295   0.00140   0.03130  -0.00994   0.00659
+           A4          -0.05051  -0.00432  -0.02337   0.02510   0.01045
+           A5           0.11120   0.02046  -0.08218   0.10593  -0.01076
+           A6          -0.06055  -0.00830   0.02273   0.01425   0.00500
+           A7          -0.00001   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.76267
+           A1          -0.01390   0.35863
+           A2          -0.00327   0.08360   0.17786
+           A3          -0.00278  -0.03070  -0.09481   0.11576
+           A4           0.00605  -0.05290  -0.08305  -0.02096   0.10400
+           A5           0.10890   0.06577  -0.02068  -0.00804   0.02872
+           A6          -0.01836   0.03614   0.03372  -0.01862  -0.01510
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.45750
+           A6           0.02696   0.11537
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04747303 RMS(Int)=  0.00053440
+ Iteration  2 RMS(Cart)=  0.00156637 RMS(Int)=  0.00000066
+ Iteration  3 RMS(Cart)=  0.00000077 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.08D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 7.02D-09 for atom     5.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17345   0.00096   0.00000   0.02848   0.02848   2.20193
+    R2        2.45098   0.00068   0.00000   0.02014   0.02014   2.47112
+    R3        2.67191   0.00126   0.00000   0.03711   0.03711   2.70902
+    R4        2.46636   0.00037   0.00000   0.01087   0.01087   2.47723
+    R5        1.89939   0.00077   0.00000   0.02268   0.02268   1.92207
+    R6        2.26031   0.00169   0.00000   0.05000   0.05000   2.31031
+    A1        2.09356  -0.00143   0.00000  -0.04240  -0.04240   2.05116
+    A2        2.26790  -0.00061   0.00000  -0.01792  -0.01792   2.24998
+    A3        1.91829   0.00023   0.00000   0.00682   0.00682   1.92511
+    A4        2.09700   0.00038   0.00000   0.01110   0.01110   2.10809
+    A5        2.06844  -0.00039   0.00000  -0.01149  -0.01149   2.05695
+    A6        3.34318   0.00004   0.00000   0.00112   0.00112   3.34431
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001691     0.000015     NO 
+ RMS     Force            0.000741     0.000010     NO 
+ Maximum Displacement     0.108433     0.000060     NO 
+ RMS     Displacement     0.048676     0.000040     NO 
+ Predicted change in Energy=-2.069655D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.222906   -0.462047    0.854466
+      2          6           0        1.163079   -0.634461    0.401961
+      3          8           0        0.033666   -1.084362   -0.079700
+      4          7           0       -0.939794   -0.118580   -0.497674
+      5          7           0       -0.866499    1.189950   -0.469084
+      6          8           0        0.157574    1.695302   -0.032551
+      7          1           0       -1.770931   -0.585800   -0.851845
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.165213   0.000000
+     3  O    2.460227   1.307663   0.000000
+     4  N    3.456722   2.344686   1.433549   0.000000
+     5  N    3.745037   2.864678   2.476775   1.310893   0.000000
+     6  O    3.115534   2.574420   2.782824   2.170420   1.222565
+     7  H    4.344830   3.191052   2.025177   1.017114   2.029235
+                    6          7
+     6  O    0.000000
+     7  H    3.097386   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.243678    0.200103    0.000000
+      2          6           0       -1.135977    0.561654    0.000000
+      3          8           0        0.000000    1.209372    0.000000
+      4          7           0        1.205183    0.433101    0.000000
+      5          7           0        1.345130   -0.870301    0.000000
+      6          8           0        0.331376   -1.553651    0.000000
+      7          1           0        2.018412    1.043984    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.3926566      3.3742376      2.3167851
+ Leave Link  202 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8358509020 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014708379 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8343800641 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.65D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:37:06 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:37:07 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000   -0.004625 Ang=  -0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410325256512    
+ Leave Link  401 at Mon Aug  5 14:37:07 2024, MaxMem=  4294967296 cpu:         7.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220413785535    
+ DIIS: error= 3.06D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220413785535     IErMin= 1 ErrMin= 3.06D-03
+ ErrMax= 3.06D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.71D-03 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.69D-01 WtEn= 3.06D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.63D-04 MaxDP=5.69D-03              OVMax= 1.22D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223683786119     Delta-E=       -0.003270000584 Rises=F Damp=F
+ DIIS: error= 5.35D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223683786119     IErMin= 2 ErrMin= 5.35D-04
+ ErrMax= 5.35D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-04 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.35D-03
+ Coeff-Com: -0.407D-01 0.104D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.405D-01 0.104D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.90D-05 MaxDP=2.34D-03 DE=-3.27D-03 OVMax= 3.79D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223854234699     Delta-E=       -0.000170448580 Rises=F Damp=F
+ DIIS: error= 3.39D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223854234699     IErMin= 3 ErrMin= 3.39D-04
+ ErrMax= 3.39D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-05 BMatP= 1.24D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.39D-03
+ Coeff-Com: -0.392D-01 0.247D+00 0.792D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.391D-01 0.246D+00 0.793D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.10D-05 MaxDP=4.18D-04 DE=-1.70D-04 OVMax= 1.26D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223873038290     Delta-E=       -0.000018803592 Rises=F Damp=F
+ DIIS: error= 1.60D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223873038290     IErMin= 4 ErrMin= 1.60D-04
+ ErrMax= 1.60D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.63D-06 BMatP= 2.10D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.60D-03
+ Coeff-Com: -0.972D-02 0.134D-01 0.273D+00 0.724D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.971D-02 0.134D-01 0.272D+00 0.724D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-05 MaxDP=2.59D-04 DE=-1.88D-05 OVMax= 7.42D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223875064359     Delta-E=       -0.000002026069 Rises=F Damp=F
+ DIIS: error= 1.57D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223875064359     IErMin= 5 ErrMin= 1.57D-04
+ ErrMax= 1.57D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.25D-06 BMatP= 3.63D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.57D-03
+ Coeff-Com:  0.248D-02-0.500D-01-0.122D-02 0.487D+00 0.562D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.273D+00 0.727D+00
+ Coeff:      0.248D-02-0.499D-01-0.121D-02 0.486D+00 0.562D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE=-2.03D-06 OVMax= 3.67D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223857800607     Delta-E=        0.000017263752 Rises=F Damp=F
+ DIIS: error= 3.60D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223857800607     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.60D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.49D-07 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE= 1.73D-05 OVMax= 2.35D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223858173714     Delta-E=       -0.000000373108 Rises=F Damp=F
+ DIIS: error= 3.61D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223858173714     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.61D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.67D-08 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.152D+00 0.848D+00
+ Coeff:      0.152D+00 0.848D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.28D-06 MaxDP=5.96D-05 DE=-3.73D-07 OVMax= 1.30D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223858153476     Delta-E=        0.000000020239 Rises=F Damp=F
+ DIIS: error= 3.89D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223858173714     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.89D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-07 BMatP= 8.67D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.704D-01 0.576D+00 0.495D+00
+ Coeff:     -0.704D-01 0.576D+00 0.495D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=9.64D-07 MaxDP=3.29D-05 DE= 2.02D-08 OVMax= 9.83D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223858250403     Delta-E=       -0.000000096928 Rises=F Damp=F
+ DIIS: error= 3.93D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223858250403     IErMin= 4 ErrMin= 3.93D-06
+ ErrMax= 3.93D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.92D-09 BMatP= 8.67D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.361D-01 0.221D+00 0.211D+00 0.605D+00
+ Coeff:     -0.361D-01 0.221D+00 0.211D+00 0.605D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.72D-07 MaxDP=6.21D-06 DE=-9.69D-08 OVMax= 1.22D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223858251872     Delta-E=       -0.000000001469 Rises=F Damp=F
+ DIIS: error= 1.14D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223858251872     IErMin= 5 ErrMin= 1.14D-06
+ ErrMax= 1.14D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.98D-10 BMatP= 1.92D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.858D+00
+ Coeff:      0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.858D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.33D-07 MaxDP=3.67D-06 DE=-1.47D-09 OVMax= 8.41D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223858252273     Delta-E=       -0.000000000401 Rises=F Damp=F
+ DIIS: error= 4.62D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223858252273     IErMin= 6 ErrMin= 4.62D-07
+ ErrMax= 4.62D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.31D-11 BMatP= 2.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.742D+00
+ Coeff:      0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.742D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.17D-08 MaxDP=1.14D-06 DE=-4.01D-10 OVMax= 3.22D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223858252322     Delta-E=       -0.000000000049 Rises=F Damp=F
+ DIIS: error= 1.89D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223858252322     IErMin= 7 ErrMin= 1.89D-07
+ ErrMax= 1.89D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.31D-11 BMatP= 3.31D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.186D-02-0.129D-01-0.110D-01-0.289D-01 0.363D-01 0.429D+00
+ Coeff-Com:  0.586D+00
+ Coeff:      0.186D-02-0.129D-01-0.110D-01-0.289D-01 0.363D-01 0.429D+00
+ Coeff:      0.586D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.11D-08 MaxDP=5.62D-07 DE=-4.90D-11 OVMax= 1.47D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223858252332     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 1.09D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223858252332     IErMin= 8 ErrMin= 1.09D-07
+ ErrMax= 1.09D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.55D-12 BMatP= 1.31D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff-Com:  0.268D+00 0.787D+00
+ Coeff:     -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff:      0.268D+00 0.787D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.26D-08 MaxDP=3.75D-07 DE=-1.05D-11 OVMax= 8.56D-07
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.223858252330     Delta-E=        0.000000000002 Rises=F Damp=F
+ DIIS: error= 3.09D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 8 EnMin= -353.223858252332     IErMin= 9 ErrMin= 3.09D-08
+ ErrMax= 3.09D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.87D-13 BMatP= 1.55D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.290D-03 0.304D-02 0.245D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff-Com: -0.262D-02 0.290D+00 0.781D+00
+ Coeff:     -0.290D-03 0.304D-02 0.245D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff:     -0.262D-02 0.290D+00 0.781D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.46D-09 MaxDP=1.86D-07 DE= 1.82D-12 OVMax= 2.97D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223858252     A.U. after   14 cycles
+            NFock= 14  Conv=0.45D-08     -V/T= 2.0044
+ KE= 3.516797774756D+02 PE=-1.258376054644D+03 EE= 3.386380388523D+02
+ Leave Link  502 at Mon Aug  5 14:37:20 2024, MaxMem=  4294967296 cpu:       201.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:37:21 2024, MaxMem=  4294967296 cpu:        14.2
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:37:21 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:37:29 2024, MaxMem=  4294967296 cpu:       138.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87552842D+00 1.17317447D+00-2.47091169D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.030098580   -0.006673645   -0.012847223
+      2        6           0.025473953    0.000663097    0.010883652
+      3        8           0.000276936    0.011307542    0.000094753
+      4        7           0.000375830    0.001054624    0.000158393
+      5        7           0.027318219    0.003795097    0.011665177
+      6        8          -0.031164004   -0.014229788   -0.013286722
+      7        1           0.007817646    0.004083072    0.003331970
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.031164004 RMS     0.014389854
+ Leave Link  716 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036724756 RMS     0.013400182
+ Search for a local minimum.
+ Step number  16 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13400D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                     12   14   15   16   13
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.43613
+           R2           0.01820   0.52313
+           R3           0.01147   0.03192   0.23462
+           R4           0.02634   0.00982   0.01474   0.36276
+           R5          -0.02975  -0.00232  -0.01906  -0.00835   0.48408
+           R6           0.01380  -0.02734   0.00736   0.13894  -0.02009
+           A1           0.08320   0.07955   0.06627   0.01737  -0.02266
+           A2           0.11132  -0.00226  -0.01039  -0.02023  -0.02527
+           A3          -0.06149   0.00425   0.03274  -0.00716   0.01110
+           A4          -0.04982  -0.00199  -0.02235   0.02739   0.01417
+           A5           0.10920   0.01500  -0.08680   0.10030  -0.01882
+           A6          -0.06097  -0.00650   0.02598   0.01633   0.00715
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.72207
+           A1          -0.03146   0.37991
+           A2          -0.02270   0.10041   0.19059
+           A3           0.00792  -0.03990  -0.10174   0.11952
+           A4           0.01478  -0.06051  -0.08885  -0.01778   0.10663
+           A5           0.08884   0.07869  -0.01132  -0.01312   0.02444
+           A6          -0.01232   0.03614   0.03420  -0.01888  -0.01532
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46397
+           A6           0.02776   0.11487
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.99999.
+ Iteration  1 RMS(Cart)=  0.04617118 RMS(Int)=  0.00059293
+ Iteration  2 RMS(Cart)=  0.00094825 RMS(Int)=  0.00000019
+ Iteration  3 RMS(Cart)=  0.00000035 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.01D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 2.08D-08 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20193  -0.03336  -0.02757   0.00000  -0.02757   2.17437
+    R2        2.47112  -0.00679  -0.01862   0.00000  -0.01862   2.45250
+    R3        2.70902  -0.00706  -0.03135   0.00000  -0.03135   2.67767
+    R4        2.47723  -0.01066  -0.01043   0.00000  -0.01043   2.46680
+    R5        1.92207  -0.00943  -0.02087   0.00000  -0.02087   1.90120
+    R6        2.31031  -0.03672  -0.04788   0.00000  -0.04788   2.26243
+    A1        2.05116   0.01359   0.03815   0.00000   0.03815   2.08931
+    A2        2.24998   0.00761   0.01745   0.00000   0.01745   2.26743
+    A3        1.92511  -0.00406  -0.00786   0.00000  -0.00786   1.91725
+    A4        2.10809  -0.00355  -0.00959   0.00000  -0.00959   2.09850
+    A5        2.05695   0.00241   0.01182   0.00000   0.01182   2.06877
+    A6        3.34431   0.00389  -0.00125   0.00000  -0.00125   3.34306
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.036725     0.000015     NO 
+ RMS     Force            0.013400     0.000010     NO 
+ Maximum Displacement     0.101274     0.000060     NO 
+ RMS     Displacement     0.045800     0.000040     NO 
+ Predicted change in Energy=-3.039991D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226252   -0.515639    0.856007
+      2          6           0        1.175424   -0.651037    0.407270
+      3          8           0        0.042057   -1.058555   -0.076168
+      4          7           0       -0.925681   -0.110595   -0.491660
+      5          7           0       -0.881205    1.193921   -0.475376
+      6          8           0        0.104843    1.727284   -0.055150
+      7          1           0       -1.741690   -0.585378   -0.839351
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150624   0.000000
+     3  O    2.436066   1.297808   0.000000
+     4  N    3.451804   2.348360   1.416961   0.000000
+     5  N    3.788333   2.900458   2.466866   1.305376   0.000000
+     6  O    3.218896   2.648846   2.786626   2.151818   1.197229
+     7  H    4.315515   3.173001   1.997023   1.006071   2.009681
+                    6          7
+     6  O    0.000000
+     7  H    3.061546   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259785    0.273285    0.000000
+      2          6           0       -1.152693    0.586790    0.000000
+      3          8           0        0.000000    1.183115    0.000000
+      4          7           0        1.189203    0.412678    0.000000
+      5          7           0        1.347762   -0.883033    0.000000
+      6          8           0        0.373182   -1.578410    0.000000
+      7          1           0        1.990441    1.021116    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6632205      3.2672999      2.2906539
+ Leave Link  202 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6857165244 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014826970 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6842338275 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000    0.004601 Ang=   0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.20D-05
+ Max alpha theta=  1.288 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:37:30 2024, MaxMem=  4294967296 cpu:         4.1
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930772685    
+ DIIS: error= 1.66D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930772685     IErMin= 1 ErrMin= 1.66D-05
+ ErrMax= 1.66D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.21D-08 BMatP= 9.21D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.411 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05              OVMax= 3.10D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925888266     Delta-E=        0.000004884419 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925888266     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.30D-08 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05 DE= 4.88D-06 OVMax= 2.89D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925925787     Delta-E=       -0.000000037521 Rises=F Damp=F
+ DIIS: error= 2.90D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925925787     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 2.90D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.47D-09 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.187D-01 0.102D+01
+ Coeff:     -0.187D-01 0.102D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.55D-07 MaxDP=7.52D-06 DE=-3.75D-08 OVMax= 1.44D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925925769     Delta-E=        0.000000000017 Rises=F Damp=F
+ DIIS: error= 3.20D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.225925925787     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 3.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-09 BMatP= 1.47D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.280D-01 0.537D+00 0.491D+00
+ Coeff:     -0.280D-01 0.537D+00 0.491D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-07 MaxDP=3.89D-06 DE= 1.73D-11 OVMax= 1.08D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925926887     Delta-E=       -0.000000001118 Rises=F Damp=F
+ DIIS: error= 9.59D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925926887     IErMin= 4 ErrMin= 9.59D-07
+ ErrMax= 9.59D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.97D-11 BMatP= 1.47D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.109D-01 0.149D+00 0.226D+00 0.635D+00
+ Coeff:     -0.109D-01 0.149D+00 0.226D+00 0.635D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.51D-08 MaxDP=1.18D-06 DE=-1.12D-09 OVMax= 2.90D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925926955     Delta-E=       -0.000000000068 Rises=F Damp=F
+ DIIS: error= 4.07D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925926955     IErMin= 5 ErrMin= 4.07D-07
+ ErrMax= 4.07D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-11 BMatP= 8.97D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.186D-02 0.623D-02 0.546D-01 0.342D+00 0.599D+00
+ Coeff:     -0.186D-02 0.623D-02 0.546D-01 0.342D+00 0.599D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.41D-08 MaxDP=4.93D-07 DE=-6.84D-11 OVMax= 1.12D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925926966     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 6.94D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925926966     IErMin= 6 ErrMin= 6.94D-08
+ ErrMax= 6.94D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.43D-12 BMatP= 1.66D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Coeff:      0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.53D-09 MaxDP=1.79D-07 DE=-1.02D-11 OVMax= 3.15D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925927     A.U. after    7 cycles
+            NFock=  7  Conv=0.55D-08     -V/T= 2.0037
+ KE= 3.519147321467D+02 PE=-1.260183819115D+03 EE= 3.393589272136D+02
+ Leave Link  502 at Mon Aug  5 14:37:41 2024, MaxMem=  4294967296 cpu:       177.7
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:37:43 2024, MaxMem=  4294967296 cpu:        16.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:37:43 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:37:52 2024, MaxMem=  4294967296 cpu:       152.7
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83466958D+00 1.12209208D+00-3.03068803D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000167642   -0.000094101   -0.000071437
+      2        6           0.000132307    0.000332159    0.000055842
+      3        8           0.000055261   -0.000307126    0.000024253
+      4        7          -0.000049451    0.000336874   -0.000021833
+      5        7           0.000171123   -0.000081885    0.000073292
+      6        8          -0.000200067   -0.000220159   -0.000085029
+      7        1           0.000058468    0.000034239    0.000024912
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000336874 RMS     0.000158818
+ Leave Link  716 at Mon Aug  5 14:37:52 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000375011 RMS     0.000168128
+ Search for a local minimum.
+ Step number  17 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16813D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   10   11
+                                                     12   14   15   16   17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.45883
+           R2           0.01744   0.52315
+           R3           0.01646   0.03190   0.23670
+           R4           0.02904   0.00947   0.01487   0.36204
+           R5          -0.03232  -0.00225  -0.01958  -0.00887   0.48434
+           R6           0.01665  -0.02809   0.00680   0.13685  -0.02089
+           A1           0.09417   0.07873   0.06823   0.01648  -0.02426
+           A2           0.12336  -0.00298  -0.00796  -0.02057  -0.02692
+           A3          -0.06838   0.00457   0.03111  -0.00724   0.01198
+           A4          -0.05499  -0.00159  -0.02315   0.02781   0.01495
+           A5           0.12123   0.01428  -0.08444   0.10004  -0.02047
+           A6          -0.06435  -0.00616   0.02579   0.01667   0.00771
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.71637
+           A1          -0.03563   0.38048
+           A2          -0.02551   0.10262   0.19420
+           A3           0.00885  -0.04184  -0.10435   0.12125
+           A4           0.01667  -0.06078  -0.08986  -0.01691   0.10676
+           A5           0.08632   0.08111  -0.00760  -0.01574   0.02335
+           A6          -0.01112   0.03608   0.03373  -0.01845  -0.01528
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46778
+           A6           0.02723   0.11488
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.07825   0.10068
+     Eigenvalues ---    0.11492   0.14436   0.23837   0.30894   0.40395
+     Eigenvalues ---    0.47721   0.49162   0.59063   0.80756   1.51098
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                    0.83977   0.41786   0.30926  -0.15006  -0.04499
+                          A6        A2        R3        A5        A3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          A6        R3        A2        A5        A4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  3.19D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -3.94D-11
+ I=     2 Stepn=  6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -7.49D-12.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  3.81D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02653126 RMS(Int)=  0.00118648
+ Iteration  2 RMS(Cart)=  0.00154566 RMS(Int)=  0.00065586
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065586
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065586
+ ITry= 1 IFail=0 DXMaxC= 6.17D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17437  -0.00020   0.00000   0.00000  -0.00046   2.17391
+    R2        2.45250   0.00003   0.00000   0.00000  -0.00076   2.45174
+    R3        2.67767   0.00007   0.00000   0.00000  -0.00289   2.67478
+    R4        2.46680  -0.00030   0.00000   0.00000  -0.00022   2.46658
+    R5        1.90120  -0.00007   0.00000   0.00000  -0.00090   1.90030
+    R6        2.26243  -0.00029   0.00000   0.00000  -0.00106   2.26137
+    A1        2.08931  -0.00038   0.00000   0.00000   0.00213   2.09144
+    A2        2.26743  -0.00015   0.00000   0.00000   0.00023   2.26767
+    A3        1.91725   0.00008   0.00000   0.00000   0.00052   1.91777
+    A4        2.09850   0.00007   0.00000   0.00000  -0.00075   2.09775
+    A5        2.06877  -0.00023   0.00000   0.00000  -0.00016   2.06860
+    A6        3.34306   0.00018   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000  -0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.11164   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000  -0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000375     0.000015     NO 
+ RMS     Force            0.000168     0.000010     NO 
+ Maximum Displacement     0.003595     0.000060     NO 
+ RMS     Displacement     0.001545     0.000040     NO 
+ Predicted change in Energy=-2.840604D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:37:52 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226475   -0.517542    0.856107
+      2          6           0        1.175686   -0.651203    0.407382
+      3          8           0        0.042138   -1.056834   -0.076137
+      4          7           0       -0.925167   -0.110631   -0.491440
+      5          7           0       -0.881814    1.193811   -0.475636
+      6          8           0        0.103394    1.727748   -0.055770
+      7          1           0       -1.740710   -0.585348   -0.838933
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150381   0.000000
+     3  O    2.435415   1.297404   0.000000
+     4  N    3.451710   2.348123   1.415434   0.000000
+     5  N    3.789951   2.901225   2.465499   1.305258   0.000000
+     6  O    3.221850   2.650231   2.785329   2.151135   1.196667
+     7  H    4.314663   3.172223   1.995671   1.005594   2.008754
+                    6          7
+     6  O    0.000000
+     7  H    3.060143   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.48D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260515    0.275156    0.000000
+      2          6           0       -1.153189    0.586934    0.000000
+      3          8           0        0.000000    1.181420    0.000000
+      4          7           0        1.188456    0.412639    0.000000
+      5          7           0        1.348204   -0.882806    0.000000
+      6          8           0        0.374613   -1.578602    0.000000
+      7          1           0        1.989207    1.020929    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6761706      3.2645394      2.2904511
+ Leave Link  202 at Mon Aug  5 14:37:52 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7396620670 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822294 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7381798376 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:37:52 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:37:53 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:37:53 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:37:53 2024, MaxMem=  4294967296 cpu:         2.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225918156567    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225918156567     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922672681     Delta-E=       -0.000004516113 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922672681     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.590D-01 0.106D+01
+ Coeff:     -0.590D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.52D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922891429     Delta-E=       -0.000000218748 Rises=F Damp=F
+ DIIS: error= 2.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922891429     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.70D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.427D+00 0.623D+00
+ Coeff:     -0.501D-01 0.427D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.19D-07 OVMax= 9.32D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922939065     Delta-E=       -0.000000047636 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922939065     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.70D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.76D-08 OVMax= 4.51D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922959353     Delta-E=       -0.000000020288 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922959353     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=9.99D-06 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922961495     Delta-E=       -0.000000002142 Rises=F Damp=F
+ DIIS: error= 1.05D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922961495     IErMin= 6 ErrMin= 1.05D-06
+ ErrMax= 1.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.05D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.14D-09 OVMax= 5.21D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922961768     Delta-E=       -0.000000000273 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922961768     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.223D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.223D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.85D-06 DE=-2.73D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922961816     Delta-E=       -0.000000000048 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922961816     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.79D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922961819     Delta-E=       -0.000000000004 Rises=F Damp=F
+ DIIS: error= 3.74D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922961819     IErMin= 9 ErrMin= 3.74D-08
+ ErrMax= 3.74D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.26D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff-Com:  0.327D-01 0.235D+00 0.774D+00
+ Coeff:     -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff:      0.327D-01 0.235D+00 0.774D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-3.75D-12 OVMax= 5.74D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922962     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519221265947D+02 PE=-1.260293418137D+03 EE= 3.394071887425D+02
+ Leave Link  502 at Mon Aug  5 14:38:05 2024, MaxMem=  4294967296 cpu:       193.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:38:06 2024, MaxMem=  4294967296 cpu:        15.4
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:38:06 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:38:15 2024, MaxMem=  4294967296 cpu:       143.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83304516D+00 1.12209989D+00-1.99118851D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000359610    0.000005807    0.000153649
+      2        6          -0.000162782    0.000513922   -0.000070629
+      3        8           0.000175637   -0.001046896    0.000077233
+      4        7          -0.000206415    0.000701326   -0.000089664
+      5        7          -0.000531105   -0.000163177   -0.000226601
+      6        8           0.000628051    0.000189762    0.000267971
+      7        1          -0.000262996   -0.000200744   -0.000111960
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001046896 RMS     0.000384719
+ Leave Link  716 at Mon Aug  5 14:38:15 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000907038 RMS     0.000381210
+ Search for a local minimum.
+ Step number  18 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .38121D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    2    3    4    1    6
+                                                      7    8    5   11   12
+                                                      9   15   16   13   17
+                                                     18
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.43497
+           R2           0.02241   0.52553
+           R3           0.02084   0.03908   0.25901
+           R4           0.02663   0.01297   0.02343   0.36445
+           R5          -0.02428  -0.00019  -0.01278  -0.00485   0.48571
+           R6           0.01378  -0.01989   0.02386   0.14200  -0.01100
+           A1           0.06942   0.08354   0.07830   0.01416  -0.01645
+           A2           0.10348   0.00272   0.00582  -0.02029  -0.01894
+           A3          -0.05918   0.00123   0.02244  -0.00821   0.00763
+           A4          -0.04430  -0.00396  -0.02826   0.02849   0.01131
+           A5           0.10305   0.02002  -0.07064   0.10080  -0.01267
+           A6          -0.05848  -0.00773   0.02250   0.01673   0.00554
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.73039
+           A1          -0.04643   0.35728
+           A2          -0.02989   0.08707   0.18548
+           A3           0.00939  -0.03583  -0.10183   0.12103
+           A4           0.02050  -0.05123  -0.08365  -0.01920   0.10285
+           A5           0.08378   0.06740  -0.01498  -0.01381   0.02879
+           A6          -0.01016   0.04051   0.03651  -0.01940  -0.01711
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46160
+           A6           0.02972   0.11392
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08427   0.10068
+     Eigenvalues ---    0.11498   0.15206   0.23759   0.30482   0.39836
+     Eigenvalues ---    0.47598   0.48953   0.59236   0.82085   1.47139
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                    0.83984   0.41778   0.30920  -0.15000  -0.04499
+                          A6        R3        A4        R6        A1
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          A6        A2        A4        A5        R4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  3.84D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -5.40D-11
+ I=     2 Stepn=  6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -1.56D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -6.94D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646653 RMS(Int)=  0.00118473
+ Iteration  2 RMS(Cart)=  0.00154204 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065577
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065577
+ ITry= 1 IFail=0 DXMaxC= 6.15D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17391   0.00039   0.00000   0.00000  -0.00046   2.17345
+    R2        2.45174   0.00036   0.00000   0.00000  -0.00076   2.45098
+    R3        2.67478   0.00066   0.00000   0.00000  -0.00288   2.67191
+    R4        2.46658   0.00003   0.00000   0.00000  -0.00022   2.46636
+    R5        1.90030   0.00035   0.00000   0.00000  -0.00091   1.89939
+    R6        2.26137   0.00070   0.00000   0.00000  -0.00106   2.26031
+    A1        2.09144  -0.00091   0.00000   0.00000   0.00213   2.09356
+    A2        2.26767  -0.00038   0.00000   0.00000   0.00023   2.26790
+    A3        1.91777   0.00016   0.00000   0.00000   0.00052   1.91829
+    A4        2.09775   0.00022   0.00000   0.00000  -0.00075   2.09700
+    A5        2.06860  -0.00031   0.00000   0.00000  -0.00016   2.06844
+    A6        3.34312   0.00011   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000  -0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.11166   0.00000   0.00000
+    D2       -3.14159   0.00000   0.00000   0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000  -0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000907     0.000015     NO 
+ RMS     Force            0.000381     0.000010     NO 
+ Maximum Displacement     0.003585     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-7.922522D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:38:15 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226696   -0.519439    0.856205
+      2          6           0        1.175946   -0.651369    0.407494
+      3          8           0        0.042219   -1.055115   -0.076106
+      4          7           0       -0.924654   -0.110667   -0.491221
+      5          7           0       -0.882423    1.193700   -0.475896
+      6          8           0        0.101948    1.728208   -0.056389
+      7          1           0       -1.739731   -0.585316   -0.838514
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150140   0.000000
+     3  O    2.434767   1.297003   0.000000
+     4  N    3.451617   2.347886   1.413912   0.000000
+     5  N    3.791564   2.901989   2.464136   1.305140   0.000000
+     6  O    3.224794   2.651612   2.784034   2.150454   1.196106
+     7  H    4.313810   3.171446   1.994323   1.005114   2.007827
+                    6          7
+     6  O    0.000000
+     7  H    3.058741   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.55D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261241    0.277022    0.000000
+      2          6           0       -1.153682    0.587079    0.000000
+      3          8           0        0.000000    1.179729    0.000000
+      4          7           0        1.187711    0.412599    0.000000
+      5          7           0        1.348645   -0.882581    0.000000
+      6          8           0        0.376039   -1.578792    0.000000
+      7          1           0        1.987975    1.020739    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891332      3.2617898      2.2902486
+ Leave Link  202 at Mon Aug  5 14:38:15 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7935465588 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817596 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7920647992 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:38:15 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:38:16 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:38:16 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:38:16 2024, MaxMem=  4294967296 cpu:         2.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225910239465    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225910239465     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914742057     Delta-E=       -0.000004502592 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914742057     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914959497     Delta-E=       -0.000000217440 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914959497     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.74D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.35D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225915007512     Delta-E=       -0.000000048015 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225915007512     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225915027721     Delta-E=       -0.000000020209 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225915027721     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225915029844     Delta-E=       -0.000000002123 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225915029844     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.12D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225915030117     Delta-E=       -0.000000000273 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225915030117     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.286D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.286D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.73D-10 OVMax= 4.69D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225915030158     Delta-E=       -0.000000000040 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225915030158     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-4.05D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225915030168     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225915030168     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.12D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.309D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff:      0.309D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE=-1.03D-11 OVMax= 5.70D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225915030     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519295173828D+02 PE=-1.260402891455D+03 EE= 3.394553942427D+02
+ Leave Link  502 at Mon Aug  5 14:38:28 2024, MaxMem=  4294967296 cpu:       193.7
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:38:29 2024, MaxMem=  4294967296 cpu:        13.5
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:38:29 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:       140.0
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83142530D+00 1.12210279D+00 2.54130073D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000883891    0.000103355    0.000377472
+      2        6          -0.000455265    0.000695259   -0.000195985
+      3        8           0.000300915   -0.001787729    0.000132310
+      4        7          -0.000364290    0.001070848   -0.000157895
+      5        7          -0.001234089   -0.000246772   -0.000526812
+      6        8           0.001455515    0.000602344    0.000620686
+      7        1          -0.000586678   -0.000437304   -0.000249776
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001787729 RMS     0.000743149
+ Leave Link  716 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001691044 RMS     0.000740517
+ Search for a local minimum.
+ Step number  19 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .74052D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    3    4    1    6    7
+                                                      8    5   10   11   12
+                                                     14   15   16   18   19
+                                                     17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.47105
+           R2           0.02220   0.52539
+           R3           0.03224   0.03830   0.25596
+           R4           0.03426   0.01250   0.02342   0.36477
+           R5          -0.02774  -0.00018  -0.01352  -0.00566   0.48605
+           R6           0.02688  -0.02040   0.02703   0.14332  -0.01242
+           A1           0.09647   0.08198   0.07571   0.01559  -0.01899
+           A2           0.13012   0.00114   0.00333  -0.01880  -0.02151
+           A3          -0.07345   0.00209   0.02397  -0.00901   0.00900
+           A4          -0.05667  -0.00324  -0.02730   0.02781   0.01251
+           A5           0.12897   0.01858  -0.07225   0.10248  -0.01517
+           A6          -0.06598  -0.00731   0.02242   0.01618   0.00635
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.73260
+           A1          -0.04004   0.35999
+           A2          -0.02342   0.09030   0.18901
+           A3           0.00577  -0.03746  -0.10355   0.12183
+           A4           0.01765  -0.05284  -0.08546  -0.01828   0.10374
+           A5           0.09022   0.07161  -0.01053  -0.01605   0.02658
+           A6          -0.01178   0.03849   0.03444  -0.01830  -0.01614
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.46685
+           A6           0.02751   0.11467
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04747911 RMS(Int)=  0.00053457
+ Iteration  2 RMS(Cart)=  0.00156675 RMS(Int)=  0.00000066
+ Iteration  3 RMS(Cart)=  0.00000077 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.08D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.27D-08 for atom     6.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17345   0.00096   0.00000   0.02848   0.02848   2.20193
+    R2        2.45098   0.00068   0.00000   0.02015   0.02015   2.47113
+    R3        2.67191   0.00126   0.00000   0.03712   0.03712   2.70902
+    R4        2.46636   0.00037   0.00000   0.01087   0.01087   2.47723
+    R5        1.89939   0.00077   0.00000   0.02268   0.02268   1.92207
+    R6        2.26031   0.00169   0.00000   0.05000   0.05000   2.31031
+    A1        2.09356  -0.00143   0.00000  -0.04241  -0.04241   2.05115
+    A2        2.26790  -0.00061   0.00000  -0.01792  -0.01792   2.24998
+    A3        1.91829   0.00023   0.00000   0.00682   0.00682   1.92511
+    A4        2.09700   0.00038   0.00000   0.01110   0.01110   2.10809
+    A5        2.06844  -0.00039   0.00000  -0.01149  -0.01149   2.05695
+    A6        3.34318   0.00004   0.00000   0.00112   0.00112   3.34431
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001691     0.000015     NO 
+ RMS     Force            0.000741     0.000010     NO 
+ Maximum Displacement     0.108447     0.000060     NO 
+ RMS     Displacement     0.048682     0.000040     NO 
+ Predicted change in Energy=-2.088227D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.222901   -0.462051    0.854464
+      2          6           0        1.163075   -0.634464    0.401959
+      3          8           0        0.033661   -1.084366   -0.079702
+      4          7           0       -0.939796   -0.118575   -0.497675
+      5          7           0       -0.866490    1.189954   -0.469080
+      6          8           0        0.157588    1.695293   -0.032545
+      7          1           0       -1.770937   -0.585790   -0.851848
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.165212   0.000000
+     3  O    2.460227   1.307664   0.000000
+     4  N    3.456720   2.344685   1.433553   0.000000
+     5  N    3.745027   2.864672   2.476776   1.310893   0.000000
+     6  O    3.115516   2.574406   2.782820   2.170418   1.222565
+     7  H    4.344831   3.191054   2.025181   1.017115   2.029237
+                    6          7
+     6  O    0.000000
+     7  H    3.097387   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.243673    0.200094    0.000000
+      2          6           0       -1.135974    0.561650    0.000000
+      3          8           0        0.000000    1.209376    0.000000
+      4          7           0        1.205185    0.433101    0.000000
+      5          7           0        1.345127   -0.870300    0.000000
+      6          8           0        0.331369   -1.553645    0.000000
+      7          1           0        2.018416    1.043984    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.3926420      3.3742582      2.3167933
+ Leave Link  202 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8359617666 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014708350 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8344909317 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.65D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         3.3
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:38:38 2024, MaxMem=  4294967296 cpu:         0.5
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000   -0.004626 Ang=  -0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410325726633    
+ Leave Link  401 at Mon Aug  5 14:38:39 2024, MaxMem=  4294967296 cpu:         6.5
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220412862353    
+ DIIS: error= 3.06D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220412862353     IErMin= 1 ErrMin= 3.06D-03
+ ErrMax= 3.06D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.71D-03 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.69D-01 WtEn= 3.06D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.63D-04 MaxDP=5.69D-03              OVMax= 1.23D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223683591019     Delta-E=       -0.003270728666 Rises=F Damp=F
+ DIIS: error= 5.35D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223683591019     IErMin= 2 ErrMin= 5.35D-04
+ ErrMax= 5.35D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-04 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.35D-03
+ Coeff-Com: -0.407D-01 0.104D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.405D-01 0.104D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.90D-05 MaxDP=2.34D-03 DE=-3.27D-03 OVMax= 3.79D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223854074228     Delta-E=       -0.000170483210 Rises=F Damp=F
+ DIIS: error= 3.39D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223854074228     IErMin= 3 ErrMin= 3.39D-04
+ ErrMax= 3.39D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-05 BMatP= 1.24D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.39D-03
+ Coeff-Com: -0.392D-01 0.247D+00 0.792D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.391D-01 0.246D+00 0.793D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.10D-05 MaxDP=4.18D-04 DE=-1.70D-04 OVMax= 1.26D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223872879368     Delta-E=       -0.000018805139 Rises=F Damp=F
+ DIIS: error= 1.60D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223872879368     IErMin= 4 ErrMin= 1.60D-04
+ ErrMax= 1.60D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.63D-06 BMatP= 2.10D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.60D-03
+ Coeff-Com: -0.973D-02 0.134D-01 0.273D+00 0.724D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.971D-02 0.134D-01 0.272D+00 0.724D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-05 MaxDP=2.59D-04 DE=-1.88D-05 OVMax= 7.43D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223874906687     Delta-E=       -0.000002027319 Rises=F Damp=F
+ DIIS: error= 1.57D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223874906687     IErMin= 5 ErrMin= 1.57D-04
+ ErrMax= 1.57D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.25D-06 BMatP= 3.63D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.57D-03
+ Coeff-Com:  0.248D-02-0.500D-01-0.120D-02 0.486D+00 0.562D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.273D+00 0.727D+00
+ Coeff:      0.248D-02-0.499D-01-0.120D-02 0.486D+00 0.563D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE=-2.03D-06 OVMax= 3.67D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223857636033     Delta-E=        0.000017270654 Rises=F Damp=F
+ DIIS: error= 3.60D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223857636033     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.60D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.49D-07 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE= 1.73D-05 OVMax= 2.35D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223858009333     Delta-E=       -0.000000373300 Rises=F Damp=F
+ DIIS: error= 3.61D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223858009333     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.61D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.69D-08 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.152D+00 0.848D+00
+ Coeff:      0.152D+00 0.848D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.28D-06 MaxDP=5.96D-05 DE=-3.73D-07 OVMax= 1.30D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223857989098     Delta-E=        0.000000020235 Rises=F Damp=F
+ DIIS: error= 3.89D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223858009333     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.89D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-07 BMatP= 8.69D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.704D-01 0.576D+00 0.495D+00
+ Coeff:     -0.704D-01 0.576D+00 0.495D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=9.64D-07 MaxDP=3.29D-05 DE= 2.02D-08 OVMax= 9.84D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223858086124     Delta-E=       -0.000000097027 Rises=F Damp=F
+ DIIS: error= 3.94D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223858086124     IErMin= 4 ErrMin= 3.94D-06
+ ErrMax= 3.94D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.92D-09 BMatP= 8.69D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.361D-01 0.221D+00 0.211D+00 0.604D+00
+ Coeff:     -0.361D-01 0.221D+00 0.211D+00 0.604D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.72D-07 MaxDP=6.21D-06 DE=-9.70D-08 OVMax= 1.22D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223858087606     Delta-E=       -0.000000001481 Rises=F Damp=F
+ DIIS: error= 1.14D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223858087606     IErMin= 5 ErrMin= 1.14D-06
+ ErrMax= 1.14D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.98D-10 BMatP= 1.92D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.859D+00
+ Coeff:      0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.859D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.33D-07 MaxDP=3.67D-06 DE=-1.48D-09 OVMax= 8.41D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223858088002     Delta-E=       -0.000000000396 Rises=F Damp=F
+ DIIS: error= 4.62D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223858088002     IErMin= 6 ErrMin= 4.62D-07
+ ErrMax= 4.62D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.32D-11 BMatP= 2.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.741D+00
+ Coeff:      0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.741D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.17D-08 MaxDP=1.14D-06 DE=-3.96D-10 OVMax= 3.22D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223858088042     Delta-E=       -0.000000000040 Rises=F Damp=F
+ DIIS: error= 1.89D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223858088042     IErMin= 7 ErrMin= 1.89D-07
+ ErrMax= 1.89D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.32D-11 BMatP= 3.32D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.186D-02-0.129D-01-0.110D-01-0.289D-01 0.363D-01 0.429D+00
+ Coeff-Com:  0.586D+00
+ Coeff:      0.186D-02-0.129D-01-0.110D-01-0.289D-01 0.363D-01 0.429D+00
+ Coeff:      0.586D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.11D-08 MaxDP=5.62D-07 DE=-4.00D-11 OVMax= 1.47D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223858088056     Delta-E=       -0.000000000015 Rises=F Damp=F
+ DIIS: error= 1.09D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223858088056     IErMin= 8 ErrMin= 1.09D-07
+ ErrMax= 1.09D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.55D-12 BMatP= 1.32D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff-Com:  0.268D+00 0.787D+00
+ Coeff:     -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff:      0.268D+00 0.787D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.26D-08 MaxDP=3.75D-07 DE=-1.46D-11 OVMax= 8.57D-07
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.223858088058     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 3.10D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.223858088058     IErMin= 9 ErrMin= 3.10D-08
+ ErrMax= 3.10D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.87D-13 BMatP= 1.55D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.291D-03 0.305D-02 0.246D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff-Com: -0.257D-02 0.290D+00 0.781D+00
+ Coeff:     -0.291D-03 0.305D-02 0.246D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff:     -0.257D-02 0.290D+00 0.781D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.47D-09 MaxDP=1.86D-07 DE=-2.27D-12 OVMax= 2.97D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223858088     A.U. after   14 cycles
+            NFock= 14  Conv=0.45D-08     -V/T= 2.0044
+ KE= 3.516797752634D+02 PE=-1.258376286085D+03 EE= 3.386381618022D+02
+ Leave Link  502 at Mon Aug  5 14:38:52 2024, MaxMem=  4294967296 cpu:       217.8
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:38:53 2024, MaxMem=  4294967296 cpu:        14.0
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:38:53 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:39:02 2024, MaxMem=  4294967296 cpu:       144.0
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87553538D+00 1.17317283D+00-4.29619451D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.030096774   -0.006673518   -0.012846452
+      2        6           0.025471861    0.000661904    0.010882761
+      3        8           0.000276649    0.011309688    0.000094626
+      4        7           0.000375523    0.001052738    0.000158266
+      5        7           0.027318805    0.003794521    0.011665428
+      6        8          -0.031164616   -0.014228780   -0.013286985
+      7        1           0.007818552    0.004083447    0.003332356
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.031164616 RMS     0.014389616
+ Leave Link  716 at Mon Aug  5 14:39:02 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036724955 RMS     0.013400250
+ Search for a local minimum.
+ Step number  20 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13400D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    4    1    6    7    8
+                                                      5   10   11   12   14
+                                                     15   16   18   19   20
+                                                     17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.48571
+           R2           0.01644   0.52368
+           R3           0.02397   0.03405   0.24923
+           R4           0.03054   0.00957   0.01760   0.36055
+           R5          -0.03523  -0.00180  -0.01873  -0.00889   0.48489
+           R6           0.01338  -0.02853   0.00859   0.13121  -0.02072
+           A1           0.10230   0.07907   0.07753   0.01344  -0.02452
+           A2           0.13490  -0.00223   0.00324  -0.02162  -0.02726
+           A3          -0.07591   0.00390   0.02395  -0.00757   0.01212
+           A4          -0.05900  -0.00168  -0.02719   0.02919   0.01514
+           A5           0.13319   0.01492  -0.07386   0.09912  -0.02095
+           A6          -0.06707  -0.00597   0.02435   0.01774   0.00805
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.69900
+           A1          -0.05026   0.37472
+           A2          -0.03530   0.10274   0.19932
+           A3           0.01210  -0.04448  -0.10937   0.12509
+           A4           0.02320  -0.05826  -0.08995  -0.01572   0.10567
+           A5           0.07735   0.08176  -0.00229  -0.02073   0.02302
+           A6          -0.00702   0.03810   0.03430  -0.01815  -0.01615
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47325
+           A6           0.02764   0.11431
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -1.00000.
+ Iteration  1 RMS(Cart)=  0.04617812 RMS(Int)=  0.00059313
+ Iteration  2 RMS(Cart)=  0.00094850 RMS(Int)=  0.00000019
+ Iteration  3 RMS(Cart)=  0.00000035 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 1.01D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 7.33D-09 for atom     4.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20193  -0.03335  -0.02757   0.00000  -0.02757   2.17437
+    R2        2.47113  -0.00679  -0.01863   0.00000  -0.01863   2.45250
+    R3        2.70902  -0.00706  -0.03135   0.00000  -0.03135   2.67767
+    R4        2.47723  -0.01066  -0.01043   0.00000  -0.01043   2.46680
+    R5        1.92207  -0.00943  -0.02087   0.00000  -0.02087   1.90120
+    R6        2.31031  -0.03672  -0.04788   0.00000  -0.04788   2.26243
+    A1        2.05115   0.01360   0.03815   0.00000   0.03815   2.08931
+    A2        2.24998   0.00761   0.01745   0.00000   0.01745   2.26743
+    A3        1.92511  -0.00406  -0.00786   0.00000  -0.00786   1.91725
+    A4        2.10809  -0.00355  -0.00959   0.00000  -0.00959   2.09850
+    A5        2.05695   0.00241   0.01182   0.00000   0.01182   2.06877
+    A6        3.34431   0.00389  -0.00125   0.00000  -0.00125   3.34306
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.036725     0.000015     NO 
+ RMS     Force            0.013400     0.000010     NO 
+ Maximum Displacement     0.101290     0.000060     NO 
+ RMS     Displacement     0.045807     0.000040     NO 
+ Predicted change in Energy=-3.039609D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:39:02 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226250   -0.515651    0.856006
+      2          6           0        1.175421   -0.651043    0.407269
+      3          8           0        0.042052   -1.058555   -0.076170
+      4          7           0       -0.925681   -0.110590   -0.491660
+      5          7           0       -0.881199    1.193926   -0.475374
+      6          8           0        0.104851    1.727284   -0.055146
+      7          1           0       -1.741693   -0.585369   -0.839352
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150625   0.000000
+     3  O    2.436066   1.297808   0.000000
+     4  N    3.451804   2.348360   1.416961   0.000000
+     5  N    3.788333   2.900458   2.466866   1.305376   0.000000
+     6  O    3.218896   2.648846   2.786626   2.151818   1.197229
+     7  H    4.315515   3.173001   1.997023   1.006071   2.009681
+                    6          7
+     6  O    0.000000
+     7  H    3.061546   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259785    0.273285    0.000000
+      2          6           0       -1.152693    0.586790    0.000000
+      3          8           0        0.000000    1.183115    0.000000
+      4          7           0        1.189204    0.412678    0.000000
+      5          7           0        1.347762   -0.883033    0.000000
+      6          8           0        0.373182   -1.578410    0.000000
+      7          1           0        1.990441    1.021116    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6632202      3.2673000      2.2906540
+ Leave Link  202 at Mon Aug  5 14:39:02 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6857155306 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014826969 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6842328336 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:39:02 2024, MaxMem=  4294967296 cpu:         1.0
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:39:03 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:39:03 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000    0.004601 Ang=   0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.08D-06
+ Max alpha theta=  1.288 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:39:03 2024, MaxMem=  4294967296 cpu:         3.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930772682    
+ DIIS: error= 1.66D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930772682     IErMin= 1 ErrMin= 1.66D-05
+ ErrMax= 1.66D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.21D-08 BMatP= 9.21D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.411 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05              OVMax= 3.10D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925888268     Delta-E=        0.000004884413 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925888268     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.30D-08 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05 DE= 4.88D-06 OVMax= 2.89D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925925785     Delta-E=       -0.000000037516 Rises=F Damp=F
+ DIIS: error= 2.90D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925925785     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 2.90D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.48D-09 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.187D-01 0.102D+01
+ Coeff:     -0.187D-01 0.102D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.55D-07 MaxDP=7.52D-06 DE=-3.75D-08 OVMax= 1.44D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925925762     Delta-E=        0.000000000022 Rises=F Damp=F
+ DIIS: error= 3.20D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.225925925785     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 3.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-09 BMatP= 1.48D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.280D-01 0.537D+00 0.491D+00
+ Coeff:     -0.280D-01 0.537D+00 0.491D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-07 MaxDP=3.89D-06 DE= 2.24D-11 OVMax= 1.08D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925926889     Delta-E=       -0.000000001127 Rises=F Damp=F
+ DIIS: error= 9.58D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925926889     IErMin= 4 ErrMin= 9.58D-07
+ ErrMax= 9.58D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.98D-11 BMatP= 1.48D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.109D-01 0.150D+00 0.226D+00 0.635D+00
+ Coeff:     -0.109D-01 0.150D+00 0.226D+00 0.635D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.51D-08 MaxDP=1.17D-06 DE=-1.13D-09 OVMax= 2.90D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925926955     Delta-E=       -0.000000000066 Rises=F Damp=F
+ DIIS: error= 4.07D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925926955     IErMin= 5 ErrMin= 4.07D-07
+ ErrMax= 4.07D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-11 BMatP= 8.98D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.186D-02 0.625D-02 0.546D-01 0.342D+00 0.599D+00
+ Coeff:     -0.186D-02 0.625D-02 0.546D-01 0.342D+00 0.599D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.41D-08 MaxDP=4.93D-07 DE=-6.59D-11 OVMax= 1.12D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925926964     Delta-E=       -0.000000000009 Rises=F Damp=F
+ DIIS: error= 6.94D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925926964     IErMin= 6 ErrMin= 6.94D-08
+ ErrMax= 6.94D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.43D-12 BMatP= 1.66D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Coeff:      0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.53D-09 MaxDP=1.79D-07 DE=-8.98D-12 OVMax= 3.15D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925927     A.U. after    7 cycles
+            NFock=  7  Conv=0.55D-08     -V/T= 2.0037
+ KE= 3.519147318792D+02 PE=-1.260183817001D+03 EE= 3.393589263609D+02
+ Leave Link  502 at Mon Aug  5 14:39:14 2024, MaxMem=  4294967296 cpu:       176.1
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:39:15 2024, MaxMem=  4294967296 cpu:        13.7
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:39:15 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:       139.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83466962D+00 1.12209214D+00 1.10842734D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000167677   -0.000094106   -0.000071452
+      2        6           0.000132337    0.000332158    0.000055855
+      3        8           0.000055259   -0.000307114    0.000024253
+      4        7          -0.000049448    0.000336874   -0.000021832
+      5        7           0.000171155   -0.000081879    0.000073305
+      6        8          -0.000200104   -0.000220176   -0.000085045
+      7        1           0.000058477    0.000034243    0.000024916
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000336874 RMS     0.000158826
+ Leave Link  716 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000374996 RMS     0.000168134
+ Search for a local minimum.
+ Step number  21 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16813D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    6    7    8    5
+                                                     10   11   12   14   15
+                                                     16   18   19   20   17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.51434
+           R2           0.01608   0.52349
+           R3           0.03162   0.03338   0.24958
+           R4           0.03513   0.00900   0.01741   0.35990
+           R5          -0.03825  -0.00191  -0.01995  -0.00975   0.48511
+           R6           0.02159  -0.02980   0.00748   0.12942  -0.02245
+           A1           0.12082   0.07761   0.07900   0.01321  -0.02738
+           A2           0.15323  -0.00351   0.00514  -0.02142  -0.02996
+           A3          -0.08595   0.00453   0.02269  -0.00790   0.01354
+           A4          -0.06728  -0.00102  -0.02783   0.02932   0.01642
+           A5           0.15092   0.01373  -0.07186   0.09942  -0.02353
+           A6          -0.07161  -0.00559   0.02401   0.01788   0.00876
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.69442
+           A1          -0.05214   0.37921
+           A2          -0.03626   0.10813   0.20549
+           A3           0.01214  -0.04793  -0.11318   0.12737
+           A4           0.02412  -0.06020  -0.09231  -0.01419   0.10651
+           A5           0.07667   0.08724   0.00392  -0.02453   0.02061
+           A6          -0.00634   0.03719   0.03311  -0.01736  -0.01575
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47946
+           A6           0.02643   0.11449
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08398   0.10068
+     Eigenvalues ---    0.11461   0.14922   0.23794   0.30754   0.40140
+     Eigenvalues ---    0.47939   0.49530   0.59202   0.78713   1.59085
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83977  -0.41786  -0.30926   0.15006   0.04499
+                          A6        A2        A4        A5        R3
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          A6        A2        A4        R3        A5
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -3.09D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -5.94D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  2.86D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -3.42D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02653126 RMS(Int)=  0.00118648
+ Iteration  2 RMS(Cart)=  0.00154570 RMS(Int)=  0.00065586
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065586
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065586
+ ITry= 1 IFail=0 DXMaxC= 6.18D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17437  -0.00020   0.00000   0.00000  -0.00046   2.17391
+    R2        2.45250   0.00003   0.00000   0.00000  -0.00076   2.45174
+    R3        2.67767   0.00007   0.00000   0.00000  -0.00289   2.67478
+    R4        2.46680  -0.00030   0.00000   0.00000  -0.00022   2.46658
+    R5        1.90120  -0.00007   0.00000   0.00000  -0.00090   1.90030
+    R6        2.26243  -0.00029   0.00000   0.00000  -0.00106   2.26137
+    A1        2.08931  -0.00037   0.00000   0.00000   0.00213   2.09144
+    A2        2.26743  -0.00015   0.00000   0.00000   0.00023   2.26767
+    A3        1.91725   0.00008   0.00000   0.00000   0.00052   1.91777
+    A4        2.09850   0.00007   0.00000   0.00000  -0.00075   2.09775
+    A5        2.06877  -0.00023   0.00000   0.00000  -0.00016   2.06860
+    A6        3.34306   0.00018   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11164   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000375     0.000015     NO 
+ RMS     Force            0.000168     0.000010     NO 
+ Maximum Displacement     0.003595     0.000060     NO 
+ RMS     Displacement     0.001545     0.000040     NO 
+ Predicted change in Energy=-2.858748D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226473   -0.517554    0.856106
+      2          6           0        1.175683   -0.651209    0.407381
+      3          8           0        0.042133   -1.056834   -0.076139
+      4          7           0       -0.925167   -0.110626   -0.491441
+      5          7           0       -0.881809    1.193816   -0.475634
+      6          8           0        0.103402    1.727747   -0.055766
+      7          1           0       -1.740713   -0.585339   -0.838934
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150381   0.000000
+     3  O    2.435415   1.297404   0.000000
+     4  N    3.451710   2.348123   1.415434   0.000000
+     5  N    3.789951   2.901225   2.465499   1.305258   0.000000
+     6  O    3.221850   2.650231   2.785329   2.151135   1.196667
+     7  H    4.314663   3.172223   1.995671   1.005594   2.008754
+                    6          7
+     6  O    0.000000
+     7  H    3.060143   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.47D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260515    0.275155    0.000000
+      2          6           0       -1.153189    0.586934    0.000000
+      3          8           0        0.000000    1.181420    0.000000
+      4          7           0        1.188456    0.412639    0.000000
+      5          7           0        1.348204   -0.882806    0.000000
+      6          8           0        0.374613   -1.578602    0.000000
+      7          1           0        1.989207    1.020929    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6761708      3.2645395      2.2904512
+ Leave Link  202 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7396632692 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822293 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7381810399 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         0.8
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         3.3
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:39:24 2024, MaxMem=  4294967296 cpu:         2.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225918156453    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225918156453     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922672804     Delta-E=       -0.000004516350 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922672804     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.590D-01 0.106D+01
+ Coeff:     -0.590D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.52D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922891558     Delta-E=       -0.000000218754 Rises=F Damp=F
+ DIIS: error= 2.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922891558     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.70D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.427D+00 0.623D+00
+ Coeff:     -0.501D-01 0.427D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.19D-07 OVMax= 9.32D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922939204     Delta-E=       -0.000000047646 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922939204     IErMin= 4 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.70D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.76D-08 OVMax= 4.51D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922959495     Delta-E=       -0.000000020291 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922959495     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=9.99D-06 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922961626     Delta-E=       -0.000000002131 Rises=F Damp=F
+ DIIS: error= 1.05D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922961626     IErMin= 6 ErrMin= 1.05D-06
+ ErrMax= 1.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.05D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.13D-09 OVMax= 5.21D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922961907     Delta-E=       -0.000000000281 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922961907     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.221D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.221D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.85D-06 DE=-2.81D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922961949     Delta-E=       -0.000000000042 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922961949     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.16D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922961958     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 3.74D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922961958     IErMin= 9 ErrMin= 3.74D-08
+ ErrMax= 3.74D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.26D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff-Com:  0.327D-01 0.235D+00 0.774D+00
+ Coeff:     -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff:      0.327D-01 0.235D+00 0.774D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-9.78D-12 OVMax= 5.74D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922962     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519221263524D+02 PE=-1.260293420323D+03 EE= 3.394071899687D+02
+ Leave Link  502 at Mon Aug  5 14:39:35 2024, MaxMem=  4294967296 cpu:       175.1
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:39:36 2024, MaxMem=  4294967296 cpu:        13.3
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:39:36 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:       154.2
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83304531D+00 1.12209995D+00-9.10086941D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000359531    0.000005798    0.000153616
+      2        6          -0.000162699    0.000513922   -0.000070593
+      3        8           0.000175630   -0.001046891    0.000077230
+      4        7          -0.000206407    0.000701324   -0.000089660
+      5        7          -0.000531081   -0.000163160   -0.000226591
+      6        8           0.000628024    0.000189749    0.000267959
+      7        1          -0.000262999   -0.000200743   -0.000111961
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001046891 RMS     0.000384707
+ Leave Link  716 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000907026 RMS     0.000381198
+ Search for a local minimum.
+ Step number  22 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .38120D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    6    7    8    5   11
+                                                     12    9   15   16   13
+                                                     19   20   17   21   22
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.50409
+           R2           0.01946   0.52541
+           R3           0.03359   0.03874   0.26689
+           R4           0.03311   0.01172   0.02390   0.36161
+           R5          -0.03270  -0.00016  -0.01510  -0.00663   0.48650
+           R6           0.01918  -0.02312   0.02011   0.13306  -0.01417
+           A1           0.09932   0.08093   0.08864   0.01087  -0.02246
+           A2           0.13704   0.00045   0.01696  -0.02160  -0.02489
+           A3          -0.07868   0.00222   0.01546  -0.00847   0.01082
+           A4          -0.05836  -0.00268  -0.03242   0.03008   0.01408
+           A5           0.13655   0.01775  -0.06035   0.09962  -0.01848
+           A6          -0.06762  -0.00672   0.02150   0.01805   0.00725
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.70493
+           A1          -0.06437   0.36572
+           A2          -0.04243   0.09998   0.20206
+           A3           0.01383  -0.04554  -0.11310   0.12821
+           A4           0.02860  -0.05444  -0.08896  -0.01511   0.10408
+           A5           0.07228   0.07972   0.00089  -0.02456   0.02367
+           A6          -0.00519   0.04057   0.03512  -0.01798  -0.01715
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47683
+           A6           0.02824   0.11375
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08695   0.10068
+     Eigenvalues ---    0.11482   0.15467   0.23713   0.30392   0.40543
+     Eigenvalues ---    0.48032   0.49588   0.59808   0.79778   1.56510
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                    0.83984   0.41778   0.30920  -0.15000  -0.04499
+                          A6        A4        A2        R6        A1
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          A6        A2        A4        A5        R1
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1=  3.88D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -6.54D-11
+ I=     2 Stepn=  6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad= -2.66D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  7.94D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646653 RMS(Int)=  0.00118473
+ Iteration  2 RMS(Cart)=  0.00154192 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065577
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065577
+ ITry= 1 IFail=0 DXMaxC= 6.15D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17391   0.00039   0.00000   0.00000  -0.00046   2.17345
+    R2        2.45174   0.00036   0.00000   0.00000  -0.00076   2.45098
+    R3        2.67478   0.00066   0.00000   0.00000  -0.00288   2.67191
+    R4        2.46658   0.00003   0.00000   0.00000  -0.00022   2.46636
+    R5        1.90030   0.00035   0.00000   0.00000  -0.00091   1.89939
+    R6        2.26137   0.00070   0.00000   0.00000  -0.00106   2.26031
+    A1        2.09144  -0.00091   0.00000   0.00000   0.00213   2.09356
+    A2        2.26767  -0.00038   0.00000   0.00000   0.00023   2.26790
+    A3        1.91777   0.00016   0.00000   0.00000   0.00052   1.91829
+    A4        2.09775   0.00022   0.00000   0.00000  -0.00075   2.09700
+    A5        2.06860  -0.00031   0.00000   0.00000  -0.00016   2.06844
+    A6        3.34312   0.00011   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000  -0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000  -0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000907     0.000015     NO 
+ RMS     Force            0.000381     0.000010     NO 
+ Maximum Displacement     0.003585     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-7.922436D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226694   -0.519451    0.856204
+      2          6           0        1.175943   -0.651375    0.407493
+      3          8           0        0.042214   -1.055115   -0.076108
+      4          7           0       -0.924654   -0.110662   -0.491221
+      5          7           0       -0.882417    1.193705   -0.475894
+      6          8           0        0.101956    1.728207   -0.056385
+      7          1           0       -1.739734   -0.585307   -0.838515
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150140   0.000000
+     3  O    2.434767   1.297003   0.000000
+     4  N    3.451617   2.347886   1.413912   0.000000
+     5  N    3.791564   2.901989   2.464135   1.305140   0.000000
+     6  O    3.224794   2.651612   2.784034   2.150454   1.196106
+     7  H    4.313810   3.171446   1.994323   1.005114   2.007827
+                    6          7
+     6  O    0.000000
+     7  H    3.058741   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.55D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261241    0.277022    0.000000
+      2          6           0       -1.153682    0.587079    0.000000
+      3          8           0        0.000000    1.179729    0.000000
+      4          7           0        1.187712    0.412599    0.000000
+      5          7           0        1.348645   -0.882581    0.000000
+      6          8           0        0.376039   -1.578792    0.000000
+      7          1           0        1.987975    1.020739    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891334      3.2617899      2.2902487
+ Leave Link  202 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7935476745 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817595 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7920659150 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         3.6
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:39:46 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:39:47 2024, MaxMem=  4294967296 cpu:         2.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225910239642    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225910239642     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914742273     Delta-E=       -0.000004502631 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914742273     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914959721     Delta-E=       -0.000000217447 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914959721     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.74D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.35D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225915007735     Delta-E=       -0.000000048014 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225915007735     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225915027946     Delta-E=       -0.000000020211 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225915027946     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225915030064     Delta-E=       -0.000000002118 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225915030064     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.12D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225915030341     Delta-E=       -0.000000000278 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225915030341     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.285D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.285D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.78D-10 OVMax= 4.69D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225915030385     Delta-E=       -0.000000000044 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225915030385     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-4.40D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225915030395     Delta-E=       -0.000000000010 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225915030395     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.12D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.309D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff:      0.309D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE=-1.00D-11 OVMax= 5.71D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225915030     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519295171086D+02 PE=-1.260402893439D+03 EE= 3.394553953852D+02
+ Leave Link  502 at Mon Aug  5 14:39:58 2024, MaxMem=  4294967296 cpu:       183.0
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:39:59 2024, MaxMem=  4294967296 cpu:        14.3
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:39:59 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:40:08 2024, MaxMem=  4294967296 cpu:       143.8
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83142544D+00 1.12210289D+00-6.85630812D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000883815    0.000103344    0.000377439
+      2        6          -0.000455184    0.000695261   -0.000195951
+      3        8           0.000300906   -0.001787728    0.000132306
+      4        7          -0.000364283    0.001070852   -0.000157892
+      5        7          -0.001234053   -0.000246748   -0.000526797
+      6        8           0.001455479    0.000602320    0.000620671
+      7        1          -0.000586680   -0.000437301   -0.000249777
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001787728 RMS     0.000743133
+ Leave Link  716 at Mon Aug  5 14:40:08 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001690999 RMS     0.000740503
+ Search for a local minimum.
+ Step number  23 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .74050D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    7    8    5   10   11
+                                                     12   14   15   16   18
+                                                     19   20   22   23   17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.49499
+           R2           0.01912   0.52549
+           R3           0.03312   0.03940   0.26980
+           R4           0.02979   0.01184   0.02492   0.36098
+           R5          -0.03237  -0.00012  -0.01464  -0.00644   0.48653
+           R6           0.01150  -0.02320   0.02109   0.13076  -0.01380
+           A1           0.09273   0.08155   0.09135   0.01025  -0.02189
+           A2           0.13076   0.00103   0.01982  -0.02209  -0.02443
+           A3          -0.07571   0.00189   0.01382  -0.00839   0.01059
+           A4          -0.05505  -0.00292  -0.03363   0.03048   0.01383
+           A5           0.13022   0.01828  -0.05767   0.09898  -0.01801
+           A6          -0.06488  -0.00678   0.02093   0.01861   0.00714
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.69867
+           A1          -0.06838   0.36542
+           A2          -0.04616   0.10046   0.20312
+           A3           0.01545  -0.04629  -0.11410   0.12895
+           A4           0.03071  -0.05417  -0.08902  -0.01486   0.10388
+           A5           0.06846   0.07980   0.00149  -0.02530   0.02380
+           A6          -0.00323   0.04123   0.03564  -0.01811  -0.01752
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47701
+           A6           0.02889   0.11330
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04747978 RMS(Int)=  0.00053459
+ Iteration  2 RMS(Cart)=  0.00156679 RMS(Int)=  0.00000066
+ Iteration  3 RMS(Cart)=  0.00000077 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.08D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.47D-08 for atom     6.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17345   0.00096   0.00000   0.02848   0.02848   2.20193
+    R2        2.45098   0.00068   0.00000   0.02015   0.02015   2.47113
+    R3        2.67191   0.00126   0.00000   0.03712   0.03712   2.70902
+    R4        2.46636   0.00037   0.00000   0.01087   0.01087   2.47723
+    R5        1.89939   0.00077   0.00000   0.02268   0.02268   1.92207
+    R6        2.26031   0.00169   0.00000   0.05000   0.05000   2.31031
+    A1        2.09356  -0.00143   0.00000  -0.04241  -0.04241   2.05115
+    A2        2.26790  -0.00061   0.00000  -0.01792  -0.01792   2.24998
+    A3        1.91829   0.00023   0.00000   0.00682   0.00682   1.92511
+    A4        2.09700   0.00038   0.00000   0.01110   0.01110   2.10809
+    A5        2.06844  -0.00039   0.00000  -0.01149  -0.01149   2.05695
+    A6        3.34318   0.00004   0.00000   0.00112   0.00112   3.34431
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001691     0.000015     NO 
+ RMS     Force            0.000741     0.000010     NO 
+ Maximum Displacement     0.108449     0.000060     NO 
+ RMS     Displacement     0.048683     0.000040     NO 
+ Predicted change in Energy=-2.114960D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:40:08 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.222898   -0.462062    0.854463
+      2          6           0        1.163072   -0.634470    0.401958
+      3          8           0        0.033656   -1.084367   -0.079704
+      4          7           0       -0.939797   -0.118570   -0.497675
+      5          7           0       -0.866484    1.189959   -0.469078
+      6          8           0        0.157596    1.695292   -0.032541
+      7          1           0       -1.770940   -0.585780   -0.851849
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.165211   0.000000
+     3  O    2.460226   1.307664   0.000000
+     4  N    3.456719   2.344685   1.433553   0.000000
+     5  N    3.745025   2.864671   2.476777   1.310893   0.000000
+     6  O    3.115513   2.574405   2.782821   2.170418   1.222565
+     7  H    4.344830   3.191054   2.025182   1.017115   2.029237
+                    6          7
+     6  O    0.000000
+     7  H    3.097387   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.243671    0.200093    0.000000
+      2          6           0       -1.135974    0.561650    0.000000
+      3          8           0        0.000000    1.209377    0.000000
+      4          7           0        1.205185    0.433101    0.000000
+      5          7           0        1.345127   -0.870300    0.000000
+      6          8           0        0.331368   -1.553645    0.000000
+      7          1           0        2.018417    1.043984    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.3926386      3.3742608      2.3167943
+ Leave Link  202 at Mon Aug  5 14:40:08 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       214.8359733205 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014708351 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      214.8345024854 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:40:08 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.65D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:40:09 2024, MaxMem=  4294967296 cpu:         3.4
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:40:09 2024, MaxMem=  4294967296 cpu:         0.5
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000   -0.004625 Ang=  -0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -340.410325757256    
+ Leave Link  401 at Mon Aug  5 14:40:09 2024, MaxMem=  4294967296 cpu:         6.8
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.220412802666    
+ DIIS: error= 3.06D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.220412802666     IErMin= 1 ErrMin= 3.06D-03
+ ErrMax= 3.06D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.71D-03 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.69D-01 WtEn= 3.06D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ GapD=    0.938 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.63D-04 MaxDP=5.69D-03              OVMax= 1.23D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -353.223683606295     Delta-E=       -0.003270803630 Rises=F Damp=F
+ DIIS: error= 5.35D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223683606295     IErMin= 2 ErrMin= 5.35D-04
+ ErrMax= 5.35D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-04 BMatP= 3.71D-03
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.35D-03
+ Coeff-Com: -0.407D-01 0.104D+01
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:     -0.405D-01 0.104D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=7.90D-05 MaxDP=2.34D-03 DE=-3.27D-03 OVMax= 3.79D-03
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -353.223854092119     Delta-E=       -0.000170485823 Rises=F Damp=F
+ DIIS: error= 3.39D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.223854092119     IErMin= 3 ErrMin= 3.39D-04
+ ErrMax= 3.39D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-05 BMatP= 1.24D-04
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 3.39D-03
+ Coeff-Com: -0.392D-01 0.247D+00 0.792D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.391D-01 0.246D+00 0.793D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.10D-05 MaxDP=4.18D-04 DE=-1.70D-04 OVMax= 1.26D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -353.223872897165     Delta-E=       -0.000018805047 Rises=F Damp=F
+ DIIS: error= 1.60D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223872897165     IErMin= 4 ErrMin= 1.60D-04
+ ErrMax= 1.60D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.63D-06 BMatP= 2.10D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.60D-03
+ Coeff-Com: -0.973D-02 0.134D-01 0.273D+00 0.724D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.971D-02 0.134D-01 0.272D+00 0.724D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-05 MaxDP=2.59D-04 DE=-1.88D-05 OVMax= 7.43D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -353.223874924860     Delta-E=       -0.000002027695 Rises=F Damp=F
+ DIIS: error= 1.57D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223874924860     IErMin= 5 ErrMin= 1.57D-04
+ ErrMax= 1.57D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.25D-06 BMatP= 3.63D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.57D-03
+ Coeff-Com:  0.248D-02-0.500D-01-0.119D-02 0.486D+00 0.562D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.273D+00 0.727D+00
+ Coeff:      0.248D-02-0.499D-01-0.119D-02 0.486D+00 0.563D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE=-2.03D-06 OVMax= 3.67D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.223857653585     Delta-E=        0.000017271274 Rises=F Damp=F
+ DIIS: error= 3.60D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.223857653585     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.60D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.49D-07 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=5.29D-06 MaxDP=1.61D-04 DE= 1.73D-05 OVMax= 2.35D-04
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.223858026889     Delta-E=       -0.000000373303 Rises=F Damp=F
+ DIIS: error= 3.61D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.223858026889     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.61D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.69D-08 BMatP= 4.49D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.152D+00 0.848D+00
+ Coeff:      0.152D+00 0.848D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.28D-06 MaxDP=5.96D-05 DE=-3.73D-07 OVMax= 1.30D-04
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.223858006659     Delta-E=        0.000000020229 Rises=F Damp=F
+ DIIS: error= 3.89D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.223858026889     IErMin= 1 ErrMin= 3.60D-05
+ ErrMax= 3.89D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.24D-07 BMatP= 8.69D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.704D-01 0.576D+00 0.495D+00
+ Coeff:     -0.704D-01 0.576D+00 0.495D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=9.64D-07 MaxDP=3.29D-05 DE= 2.02D-08 OVMax= 9.84D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.223858103707     Delta-E=       -0.000000097048 Rises=F Damp=F
+ DIIS: error= 3.94D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.223858103707     IErMin= 4 ErrMin= 3.94D-06
+ ErrMax= 3.94D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.92D-09 BMatP= 8.69D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.361D-01 0.221D+00 0.211D+00 0.604D+00
+ Coeff:     -0.361D-01 0.221D+00 0.211D+00 0.604D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.72D-07 MaxDP=6.21D-06 DE=-9.70D-08 OVMax= 1.22D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -353.223858105182     Delta-E=       -0.000000001475 Rises=F Damp=F
+ DIIS: error= 1.14D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.223858105182     IErMin= 5 ErrMin= 1.14D-06
+ ErrMax= 1.14D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.98D-10 BMatP= 1.92D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.859D+00
+ Coeff:      0.297D-02-0.557D-01-0.405D-01 0.235D+00 0.859D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.33D-07 MaxDP=3.67D-06 DE=-1.47D-09 OVMax= 8.41D-06
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -353.223858105571     Delta-E=       -0.000000000389 Rises=F Damp=F
+ DIIS: error= 4.62D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.223858105571     IErMin= 6 ErrMin= 4.62D-07
+ ErrMax= 4.62D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.32D-11 BMatP= 2.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.741D+00
+ Coeff:      0.426D-02-0.400D-01-0.330D-01 0.176D-01 0.310D+00 0.741D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.17D-08 MaxDP=1.14D-06 DE=-3.89D-10 OVMax= 3.22D-06
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -353.223858105623     Delta-E=       -0.000000000051 Rises=F Damp=F
+ DIIS: error= 1.89D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.223858105623     IErMin= 7 ErrMin= 1.89D-07
+ ErrMax= 1.89D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.32D-11 BMatP= 3.32D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.187D-02-0.129D-01-0.110D-01-0.289D-01 0.364D-01 0.429D+00
+ Coeff-Com:  0.586D+00
+ Coeff:      0.187D-02-0.129D-01-0.110D-01-0.289D-01 0.364D-01 0.429D+00
+ Coeff:      0.586D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=2.11D-08 MaxDP=5.62D-07 DE=-5.14D-11 OVMax= 1.47D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -353.223858105632     Delta-E=       -0.000000000009 Rises=F Damp=F
+ DIIS: error= 1.09D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.223858105632     IErMin= 8 ErrMin= 1.09D-07
+ ErrMax= 1.09D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.55D-12 BMatP= 1.32D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff-Com:  0.268D+00 0.787D+00
+ Coeff:     -0.358D-03 0.506D-02 0.415D-02-0.212D-01-0.703D-01 0.275D-01
+ Coeff:      0.268D+00 0.787D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=1.26D-08 MaxDP=3.75D-07 DE=-9.44D-12 OVMax= 8.57D-07
+
+ Cycle  14  Pass 1  IDiag  1:
+ E= -353.223858105637     Delta-E=       -0.000000000005 Rises=F Damp=F
+ DIIS: error= 3.10D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.223858105637     IErMin= 9 ErrMin= 3.10D-08
+ ErrMax= 3.10D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.87D-13 BMatP= 1.55D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.291D-03 0.305D-02 0.246D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff-Com: -0.258D-02 0.290D+00 0.781D+00
+ Coeff:     -0.291D-03 0.305D-02 0.246D-02-0.458D-02-0.292D-01-0.400D-01
+ Coeff:     -0.258D-02 0.290D+00 0.781D+00
+ Gap=     0.350 Goal=   None    Shift=    0.000
+ RMSDP=4.47D-09 MaxDP=1.86D-07 DE=-4.89D-12 OVMax= 2.97D-07
+
+ SCF Done:  E(RwB97XD) =  -353.223858106     A.U. after   14 cycles
+            NFock= 14  Conv=0.45D-08     -V/T= 2.0044
+ KE= 3.516797772392D+02 PE=-1.258376313503D+03 EE= 3.386381756729D+02
+ Leave Link  502 at Mon Aug  5 14:40:23 2024, MaxMem=  4294967296 cpu:       221.4
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2444 LenP2D=    6483.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:40:24 2024, MaxMem=  4294967296 cpu:        14.9
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:40:24 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:       147.9
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.87553535D+00 1.17317229D+00-6.25536724D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.030095120   -0.006673119   -0.012845746
+      2        6           0.025470081    0.000661387    0.010882001
+      3        8           0.000276670    0.011309981    0.000094635
+      4        7           0.000375497    0.001052594    0.000158255
+      5        7           0.027318875    0.003794240    0.011665459
+      6        8          -0.031164796   -0.014228610   -0.013287063
+      7        1           0.007818794    0.004083527    0.003332459
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.031164796 RMS     0.014389271
+ Leave Link  716 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036725069 RMS     0.013400051
+ Search for a local minimum.
+ Step number  24 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13400D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    8    5   10   11   12
+                                                     14   15   16   18   19
+                                                     20   22   23   24   17
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.48558
+           R2           0.01660   0.52475
+           R3           0.02895   0.03841   0.26894
+           R4           0.02621   0.01100   0.02381   0.35984
+           R5          -0.03502  -0.00104  -0.01602  -0.00740   0.48541
+           R6          -0.00153  -0.02674   0.01592   0.12613  -0.01787
+           A1           0.09204   0.08254   0.09382   0.01071  -0.02088
+           A2           0.12947   0.00166   0.02163  -0.02188  -0.02382
+           A3          -0.07506   0.00157   0.01284  -0.00853   0.01031
+           A4          -0.05441  -0.00323  -0.03447   0.03040   0.01351
+           A5           0.12824   0.01858  -0.05649   0.09885  -0.01774
+           A6          -0.06390  -0.00668   0.02102   0.01885   0.00719
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.68074
+           A1          -0.06655   0.36540
+           A2          -0.04564   0.10069   0.20353
+           A3           0.01515  -0.04661  -0.11448   0.12924
+           A4           0.03049  -0.05408  -0.08905  -0.01476   0.10381
+           A5           0.06769   0.07997   0.00178  -0.02559   0.02381
+           A6          -0.00218   0.04160   0.03588  -0.01821  -0.01767
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47713
+           A6           0.02915   0.11323
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -1.00000.
+ Iteration  1 RMS(Cart)=  0.04617886 RMS(Int)=  0.00059315
+ Iteration  2 RMS(Cart)=  0.00094853 RMS(Int)=  0.00000019
+ Iteration  3 RMS(Cart)=  0.00000035 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 1.01D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 1.53D-08 for atom     5.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.20193  -0.03335  -0.02756   0.00000  -0.02756   2.17437
+    R2        2.47113  -0.00680  -0.01863   0.00000  -0.01863   2.45250
+    R3        2.70902  -0.00706  -0.03135   0.00000  -0.03135   2.67767
+    R4        2.47723  -0.01066  -0.01043   0.00000  -0.01043   2.46680
+    R5        1.92207  -0.00943  -0.02087   0.00000  -0.02087   1.90120
+    R6        2.31031  -0.03673  -0.04788   0.00000  -0.04788   2.26243
+    A1        2.05115   0.01360   0.03816   0.00000   0.03816   2.08931
+    A2        2.24998   0.00761   0.01745   0.00000   0.01745   2.26743
+    A3        1.92511  -0.00406  -0.00786   0.00000  -0.00786   1.91725
+    A4        2.10809  -0.00355  -0.00959   0.00000  -0.00959   2.09850
+    A5        2.05695   0.00241   0.01182   0.00000   0.01182   2.06877
+    A6        3.34431   0.00389  -0.00125   0.00000  -0.00125   3.34306
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.036725     0.000015     NO 
+ RMS     Force            0.013400     0.000010     NO 
+ Maximum Displacement     0.101291     0.000060     NO 
+ RMS     Displacement     0.045808     0.000040     NO 
+ Predicted change in Energy=-3.039483D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226248   -0.515663    0.856005
+      2          6           0        1.175418   -0.651049    0.407268
+      3          8           0        0.042047   -1.058556   -0.076172
+      4          7           0       -0.925682   -0.110585   -0.491661
+      5          7           0       -0.881194    1.193931   -0.475371
+      6          8           0        0.104859    1.727283   -0.055143
+      7          1           0       -1.741696   -0.585359   -0.839354
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150625   0.000000
+     3  O    2.436066   1.297808   0.000000
+     4  N    3.451804   2.348360   1.416961   0.000000
+     5  N    3.788333   2.900458   2.466866   1.305376   0.000000
+     6  O    3.218896   2.648846   2.786626   2.151818   1.197229
+     7  H    4.315515   3.173001   1.997023   1.006071   2.009681
+                    6          7
+     6  O    0.000000
+     7  H    3.061546   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 1.27D-02
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.259785    0.273285    0.000000
+      2          6           0       -1.152693    0.586790    0.000000
+      3          8           0        0.000000    1.183115    0.000000
+      4          7           0        1.189204    0.412678    0.000000
+      5          7           0        1.347762   -0.883033    0.000000
+      6          8           0        0.373182   -1.578410    0.000000
+      7          1           0        1.990441    1.021116    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6632201      3.2673000      2.2906540
+ Leave Link  202 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.6857153954 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014826969 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.6842326985 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         0.9
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999989    0.000000    0.000000    0.004601 Ang=   0.53 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.23D-06
+ Max alpha theta=  1.288 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A") (A') (A') (A")
+                 (A") (A') (A") (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:40:34 2024, MaxMem=  4294967296 cpu:         4.0
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -353.225930772681    
+ DIIS: error= 1.66D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225930772681     IErMin= 1 ErrMin= 1.66D-05
+ ErrMax= 1.66D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.21D-08 BMatP= 9.21D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    15.411 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05              OVMax= 3.10D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225925888267     Delta-E=        0.000004884414 Rises=F Damp=F
+ DIIS: error= 1.58D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225925888267     IErMin= 1 ErrMin= 1.58D-05
+ ErrMax= 1.58D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.30D-08 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-06 MaxDP=4.51D-05 DE= 4.88D-06 OVMax= 2.89D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225925925792     Delta-E=       -0.000000037526 Rises=F Damp=F
+ DIIS: error= 2.90D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225925925792     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 2.90D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.48D-09 BMatP= 8.30D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.187D-01 0.102D+01
+ Coeff:     -0.187D-01 0.102D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.55D-07 MaxDP=7.52D-06 DE=-3.75D-08 OVMax= 1.44D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225925925766     Delta-E=        0.000000000026 Rises=F Damp=F
+ DIIS: error= 3.20D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -353.225925925792     IErMin= 2 ErrMin= 2.90D-06
+ ErrMax= 3.20D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-09 BMatP= 1.48D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.280D-01 0.537D+00 0.491D+00
+ Coeff:     -0.280D-01 0.537D+00 0.491D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-07 MaxDP=3.89D-06 DE= 2.61D-11 OVMax= 1.08D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225925926889     Delta-E=       -0.000000001123 Rises=F Damp=F
+ DIIS: error= 9.58D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225925926889     IErMin= 4 ErrMin= 9.58D-07
+ ErrMax= 9.58D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.98D-11 BMatP= 1.48D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.109D-01 0.150D+00 0.226D+00 0.635D+00
+ Coeff:     -0.109D-01 0.150D+00 0.226D+00 0.635D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=3.51D-08 MaxDP=1.17D-06 DE=-1.12D-09 OVMax= 2.90D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225925926955     Delta-E=       -0.000000000067 Rises=F Damp=F
+ DIIS: error= 4.07D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225925926955     IErMin= 5 ErrMin= 4.07D-07
+ ErrMax= 4.07D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-11 BMatP= 8.98D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.186D-02 0.625D-02 0.546D-01 0.342D+00 0.599D+00
+ Coeff:     -0.186D-02 0.625D-02 0.546D-01 0.342D+00 0.599D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.41D-08 MaxDP=4.93D-07 DE=-6.65D-11 OVMax= 1.12D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225925926966     Delta-E=       -0.000000000011 Rises=F Damp=F
+ DIIS: error= 6.94D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225925926966     IErMin= 6 ErrMin= 6.94D-08
+ ErrMax= 6.94D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.43D-12 BMatP= 1.66D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Coeff:      0.895D-03-0.212D-01-0.127D-01 0.472D-01 0.261D+00 0.725D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.53D-09 MaxDP=1.79D-07 DE=-1.09D-11 OVMax= 3.15D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225925927     A.U. after    7 cycles
+            NFock=  7  Conv=0.55D-08     -V/T= 2.0037
+ KE= 3.519147318429D+02 PE=-1.260183816713D+03 EE= 3.393589262450D+02
+ Leave Link  502 at Mon Aug  5 14:40:45 2024, MaxMem=  4294967296 cpu:       174.6
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6476.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:40:46 2024, MaxMem=  4294967296 cpu:        14.5
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:40:46 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:40:55 2024, MaxMem=  4294967296 cpu:       142.7
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83466962D+00 1.12209215D+00-5.49977534D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7          -0.000167682   -0.000094106   -0.000071454
+      2        6           0.000132343    0.000332157    0.000055857
+      3        8           0.000055258   -0.000307112    0.000024252
+      4        7          -0.000049447    0.000336875   -0.000021831
+      5        7           0.000171159   -0.000081879    0.000073307
+      6        8          -0.000200109   -0.000220177   -0.000085048
+      7        1           0.000058478    0.000034243    0.000024916
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000336875 RMS     0.000158827
+ Leave Link  716 at Mon Aug  5 14:40:55 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000374994 RMS     0.000168134
+ Search for a local minimum.
+ Step number  25 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16813D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    5   10   11   12   14
+                                                     15   16   18   19   20
+                                                     22   23   24   25
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.48463
+           R2           0.01670   0.52476
+           R3           0.02917   0.03848   0.26921
+           R4           0.02597   0.01106   0.02398   0.35984
+           R5          -0.03488  -0.00104  -0.01598  -0.00734   0.48541
+           R6          -0.00186  -0.02668   0.01618   0.12609  -0.01779
+           A1           0.09162   0.08264   0.09421   0.01068  -0.02077
+           A2           0.12904   0.00178   0.02204  -0.02187  -0.02370
+           A3          -0.07487   0.00150   0.01261  -0.00855   0.01024
+           A4          -0.05417  -0.00328  -0.03465   0.03042   0.01345
+           A5           0.12774   0.01870  -0.05609   0.09885  -0.01761
+           A6          -0.06361  -0.00672   0.02092   0.01887   0.00713
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.68046
+           A1          -0.06676   0.36529
+           A2          -0.04575   0.10066   0.20358
+           A3           0.01515  -0.04666  -0.11456   0.12930
+           A4           0.03060  -0.05400  -0.08902  -0.01475   0.10377
+           A5           0.06761   0.07995   0.00182  -0.02566   0.02384
+           A6          -0.00210   0.04171   0.03595  -0.01824  -0.01772
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47713
+           A6           0.02923   0.11320
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08766   0.10068
+     Eigenvalues ---    0.11474   0.15517   0.23659   0.30284   0.40887
+     Eigenvalues ---    0.47894   0.49161   0.60476   0.77639   1.53901
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83977  -0.41786  -0.30926   0.15006   0.04499
+                          A6        A2        R3        A5        A4
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74392   0.51898  -0.40714   0.10676   0.00896
+                          A6        A2        A4        A5        R1
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ RFO step:  Lambda=-1.39454725D-02 EMin=-1.39454696D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -2.71D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -6.73D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  4.02D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad= -3.32D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02653126 RMS(Int)=  0.00118648
+ Iteration  2 RMS(Cart)=  0.00154566 RMS(Int)=  0.00065586
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065586
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065586
+ ITry= 1 IFail=0 DXMaxC= 6.18D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.71D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17437  -0.00020   0.00000   0.00000  -0.00046   2.17391
+    R2        2.45250   0.00003   0.00000   0.00000  -0.00076   2.45174
+    R3        2.67767   0.00007   0.00000   0.00000  -0.00289   2.67478
+    R4        2.46680  -0.00030   0.00000   0.00000  -0.00022   2.46658
+    R5        1.90120  -0.00007   0.00000   0.00000  -0.00090   1.90030
+    R6        2.26243  -0.00029   0.00000   0.00000  -0.00106   2.26137
+    A1        2.08931  -0.00037   0.00000   0.00000   0.00213   2.09144
+    A2        2.26743  -0.00015   0.00000   0.00000   0.00023   2.26767
+    A3        1.91725   0.00008   0.00000   0.00000   0.00052   1.91777
+    A4        2.09850   0.00007   0.00000   0.00000  -0.00075   2.09775
+    A5        2.06877  -0.00023   0.00000   0.00000  -0.00016   2.06860
+    A6        3.34306   0.00018   0.00000   0.00000   0.00006   3.34312
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11164   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00574   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04420   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07109   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000375     0.000015     NO 
+ RMS     Force            0.000168     0.000010     NO 
+ Maximum Displacement     0.003595     0.000060     NO 
+ RMS     Displacement     0.001545     0.000040     NO 
+ Predicted change in Energy=-2.885792D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:40:55 2024, MaxMem=  4294967296 cpu:         0.2
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226470   -0.517566    0.856105
+      2          6           0        1.175680   -0.651216    0.407380
+      3          8           0        0.042128   -1.056834   -0.076141
+      4          7           0       -0.925168   -0.110621   -0.491441
+      5          7           0       -0.881803    1.193821   -0.475632
+      6          8           0        0.103410    1.727746   -0.055763
+      7          1           0       -1.740715   -0.585329   -0.838935
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150381   0.000000
+     3  O    2.435415   1.297404   0.000000
+     4  N    3.451710   2.348123   1.415434   0.000000
+     5  N    3.789951   2.901225   2.465499   1.305258   0.000000
+     6  O    3.221850   2.650231   2.785329   2.151135   1.196667
+     7  H    4.314663   3.172223   1.995671   1.005594   2.008754
+                    6          7
+     6  O    0.000000
+     7  H    3.060143   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 6.48D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.260515    0.275155    0.000000
+      2          6           0       -1.153189    0.586934    0.000000
+      3          8           0        0.000000    1.181420    0.000000
+      4          7           0        1.188456    0.412639    0.000000
+      5          7           0        1.348204   -0.882806    0.000000
+      6          8           0        0.374613   -1.578602    0.000000
+      7          1           0        1.989207    1.020929    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6761706      3.2645396      2.2904512
+ Leave Link  202 at Mon Aug  5 14:40:55 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7396625457 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014822294 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7381803164 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:40:55 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.32D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:40:56 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:40:56 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000010 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:40:56 2024, MaxMem=  4294967296 cpu:         2.7
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225918156604    
+ DIIS: error= 1.11D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225918156604     IErMin= 1 ErrMin= 1.11D-04
+ ErrMax= 1.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-06 BMatP= 4.78D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.11D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.38D-06 MaxDP=1.87D-04              OVMax= 5.17D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225922672864     Delta-E=       -0.000004516260 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225922672864     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.78D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.590D-01 0.106D+01
+ Coeff:     -0.590D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.24D-05 DE=-4.52D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225922891624     Delta-E=       -0.000000218760 Rises=F Damp=F
+ DIIS: error= 2.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225922891624     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.70D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.427D+00 0.623D+00
+ Coeff:     -0.501D-01 0.427D+00 0.623D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.19D-07 OVMax= 9.32D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225922939267     Delta-E=       -0.000000047643 Rises=F Damp=F
+ DIIS: error= 1.22D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225922939267     IErMin= 4 ErrMin= 1.22D-05
+ ErrMax= 1.22D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.46D-08 BMatP= 7.70D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Coeff:     -0.168D-01 0.536D-01 0.362D+00 0.601D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.76D-08 OVMax= 4.51D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225922959550     Delta-E=       -0.000000020283 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225922959550     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.05D-09 BMatP= 2.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Coeff:      0.218D-02-0.583D-01 0.452D-01 0.256D+00 0.755D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.62D-07 MaxDP=9.99D-06 DE=-2.03D-08 OVMax= 1.67D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225922961688     Delta-E=       -0.000000002137 Rises=F Damp=F
+ DIIS: error= 1.05D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225922961688     IErMin= 6 ErrMin= 1.05D-06
+ ErrMax= 1.05D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.86D-10 BMatP= 2.05D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Coeff:      0.257D-02-0.335D-01-0.142D-01 0.654D-01 0.359D+00 0.620D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.82D-08 MaxDP=3.93D-06 DE=-2.14D-09 OVMax= 5.21D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225922961966     Delta-E=       -0.000000000279 Rises=F Damp=F
+ DIIS: error= 3.39D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225922961966     IErMin= 7 ErrMin= 3.39D-07
+ ErrMax= 3.39D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-11 BMatP= 2.86D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.414D-03 0.221D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff-Com:  0.912D+00
+ Coeff:      0.414D-03 0.221D-04-0.121D-01-0.237D-01-0.334D-01 0.157D+00
+ Coeff:      0.912D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.91D-08 MaxDP=1.84D-06 DE=-2.79D-10 OVMax= 4.74D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225922962011     Delta-E=       -0.000000000045 Rises=F Damp=F
+ DIIS: error= 1.70D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225922962011     IErMin= 8 ErrMin= 1.70D-07
+ ErrMax= 1.70D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.09D-12 BMatP= 2.10D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff-Com:  0.342D+00 0.763D+00
+ Coeff:     -0.178D-03 0.424D-02-0.193D-02-0.153D-01-0.559D-01-0.361D-01
+ Coeff:      0.342D+00 0.763D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.05D-08 MaxDP=9.59D-07 DE=-4.49D-11 OVMax= 1.28D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225922962017     Delta-E=       -0.000000000006 Rises=F Damp=F
+ DIIS: error= 3.74D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225922962017     IErMin= 9 ErrMin= 3.74D-08
+ ErrMax= 3.74D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.26D-13 BMatP= 4.09D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff-Com:  0.327D-01 0.235D+00 0.774D+00
+ Coeff:     -0.898D-04 0.131D-02 0.733D-03-0.280D-02-0.132D-01-0.279D-01
+ Coeff:      0.327D-01 0.235D+00 0.774D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.23D-09 MaxDP=1.79D-07 DE=-5.80D-12 OVMax= 5.74D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225922962     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519221263176D+02 PE=-1.260293418905D+03 EE= 3.394071893087D+02
+ Leave Link  502 at Mon Aug  5 14:41:09 2024, MaxMem=  4294967296 cpu:       201.1
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:41:10 2024, MaxMem=  4294967296 cpu:        14.5
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:41:10 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:       143.5
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83304532D+00 1.12209992D+00-1.74377136D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000359537    0.000005797    0.000153618
+      2        6          -0.000162705    0.000513918   -0.000070596
+      3        8           0.000175622   -0.001046881    0.000077227
+      4        7          -0.000206400    0.000701316   -0.000089657
+      5        7          -0.000531082   -0.000163159   -0.000226591
+      6        8           0.000628024    0.000189746    0.000267959
+      7        1          -0.000262997   -0.000200738   -0.000111960
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001046881 RMS     0.000384704
+ Leave Link  716 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         0.4
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000907020 RMS     0.000381196
+ Search for a local minimum.
+ Step number  26 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .38120D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points   11   12    9   15   16
+                                                     13   19   20   21   23
+                                                     24   17   25   26
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.49022
+           R2           0.01857   0.52557
+           R3           0.03042   0.03962   0.27142
+           R4           0.02851   0.01180   0.02461   0.36072
+           R5          -0.03219  -0.00012  -0.01485  -0.00641   0.48648
+           R6           0.00398  -0.02339   0.02065   0.12939  -0.01359
+           A1           0.08510   0.08185   0.09455   0.00924  -0.02176
+           A2           0.12604   0.00131   0.02204  -0.02266  -0.02432
+           A3          -0.07367   0.00170   0.01256  -0.00818   0.01054
+           A4          -0.05238  -0.00301  -0.03460   0.03084   0.01378
+           A5           0.12632   0.01844  -0.05622   0.09844  -0.01795
+           A6          -0.06495  -0.00669   0.02150   0.01866   0.00712
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.69015
+           A1          -0.07353   0.36684
+           A2          -0.04883   0.10188   0.20433
+           A3           0.01621  -0.04747  -0.11498   0.12951
+           A4           0.03261  -0.05441  -0.08935  -0.01454   0.10388
+           A5           0.06611   0.08056   0.00217  -0.02585   0.02368
+           A6          -0.00291   0.04215   0.03626  -0.01845  -0.01781
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47729
+           A6           0.02938   0.11340
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+     Eigenvalues ---   -0.01395  -0.00607   0.04269   0.08762   0.10068
+     Eigenvalues ---    0.11469   0.15487   0.23679   0.30233   0.41008
+     Eigenvalues ---    0.48088   0.49684   0.60656   0.78709   1.54206
+ Eigenvalue     1 is  -1.39D-02 should be greater than     0.000000 Eigenvector:
+                          D1        D2        D4        D3        A7
+   1                   -0.83984  -0.41778  -0.30920   0.15000   0.04499
+                          A6        A2        A4        A1        R6
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Eigenvalue     2 is  -6.07D-03 should be greater than     0.000000 Eigenvector:
+                          D2        D4        D3        D1        A7
+   1                   -0.74406   0.51885  -0.40701   0.10691   0.00896
+                          A6        A2        A4        A5        A1
+   1                    0.00000   0.00000   0.00000   0.00000   0.00000
+ Use linear search instead of GDIIS.
+ RFO step:  Lambda=-1.39454723D-02 EMin=-1.39454693D-02
+ I=     1 Eig=   -1.39D-02 Dot1= -3.86D-11
+ I=     1 Stepn=  1.25D-01 RXN=   1.25D-01 EDone=F
+ I=     2 Eig=   -6.07D-03 Dot1= -7.68D-11
+ I=     2 Stepn= -6.25D-02 RXN=   1.40D-01 EDone=F
+ Mixed    2 eigenvectors in step.  Raw Step.Grad=  3.82D-11.
+ RFO eigenvector is Hessian eigenvector with negative curvature.
+ Taking step of  1.40D-01 in eigenvector direction(s).  Step.Grad=  8.10D-05.
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.02646653 RMS(Int)=  0.00118474
+ Iteration  2 RMS(Cart)=  0.00154213 RMS(Int)=  0.00065577
+ Iteration  3 RMS(Cart)=  0.00000165 RMS(Int)=  0.00065577
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00065577
+ ITry= 1 IFail=0 DXMaxC= 6.16D-02 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 6.69D-02 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17391   0.00039   0.00000   0.00000  -0.00046   2.17345
+    R2        2.45174   0.00036   0.00000   0.00000  -0.00076   2.45098
+    R3        2.67478   0.00066   0.00000   0.00000  -0.00288   2.67191
+    R4        2.46658   0.00003   0.00000   0.00000  -0.00022   2.46636
+    R5        1.90030   0.00035   0.00000   0.00000  -0.00091   1.89939
+    R6        2.26137   0.00070   0.00000   0.00000  -0.00106   2.26031
+    A1        2.09144  -0.00091   0.00000   0.00000   0.00213   2.09356
+    A2        2.26767  -0.00038   0.00000   0.00000   0.00023   2.26790
+    A3        1.91777   0.00016   0.00000   0.00000   0.00052   1.91829
+    A4        2.09775   0.00022   0.00000   0.00000  -0.00075   2.09700
+    A5        2.06860  -0.00031   0.00000   0.00000  -0.00016   2.06844
+    A6        3.34312   0.00011   0.00000   0.00000   0.00006   3.34318
+    A7        3.14159   0.00000   0.00000   0.00506   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000  -0.11166   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000  -0.00572   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.04419   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000  -0.07108   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000907     0.000015     NO 
+ RMS     Force            0.000381     0.000010     NO 
+ Maximum Displacement     0.003586     0.000060     NO 
+ RMS     Displacement     0.001541     0.000040     NO 
+ Predicted change in Energy=-7.922318D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226691   -0.519463    0.856203
+      2          6           0        1.175940   -0.651382    0.407491
+      3          8           0        0.042209   -1.055116   -0.076110
+      4          7           0       -0.924655   -0.110657   -0.491222
+      5          7           0       -0.882412    1.193709   -0.475891
+      6          8           0        0.101964    1.728206   -0.056382
+      7          1           0       -1.739736   -0.585297   -0.838517
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150140   0.000000
+     3  O    2.434767   1.297003   0.000000
+     4  N    3.451617   2.347886   1.413912   0.000000
+     5  N    3.791564   2.901989   2.464135   1.305140   0.000000
+     6  O    3.224794   2.651611   2.784033   2.150454   1.196106
+     7  H    4.313810   3.171446   1.994323   1.005114   2.007827
+                    6          7
+     6  O    0.000000
+     7  H    3.058741   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 7.52D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261241    0.277022    0.000000
+      2          6           0       -1.153682    0.587079    0.000000
+      3          8           0        0.000000    1.179729    0.000000
+      4          7           0        1.187712    0.412600    0.000000
+      5          7           0        1.348645   -0.882581    0.000000
+      6          8           0        0.376039   -1.578792    0.000000
+      7          1           0        1.987975    1.020739    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891337      3.2617901      2.2902488
+ Leave Link  202 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         0.0
+ (Enter /usr/local/g09/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   155 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are    67 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are   131 symmetry adapted basis functions of A'  symmetry.
+ There are    61 symmetry adapted basis functions of A"  symmetry.
+   192 basis functions,   314 primitive gaussians,   222 cartesian basis functions
+    22 alpha electrons       22 beta electrons
+       nuclear repulsion energy       215.7935501549 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+  HFx wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+  DFx wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=    7 NActive=    7 NUniq=    7 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0014817594 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      215.7920683955 Hartrees.
+ Leave Link  301 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         1.1
+ (Enter /usr/local/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   192 RedAO= T EigKep=  4.31D-04  NBF=   131    61
+ NBsUse=   192 1.00D-06 EigRej= -1.00D+00 NBFU=   131    61
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   219   219   219   219   219 MxSgAt=     7 MxSgA2=     7.
+ Leave Link  302 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         3.7
+ (Enter /usr/local/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         0.6
+ (Enter /usr/local/g09/l401.exe)
+ Initial guess from the checkpoint file:  "check.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000011 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+                 (A") (A") (A") (A") (A") (A") (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Mon Aug  5 14:41:19 2024, MaxMem=  4294967296 cpu:         2.9
+ (Enter /usr/local/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=518419670.
+ IVT=      171636 IEndB=      171636 NGot=  4294967296 MDV=  4207304620
+ LenX=  4207304620 LenY=  4207254895
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=  18528 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -353.225910239729    
+ DIIS: error= 1.10D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -353.225910239729     IErMin= 1 ErrMin= 1.10D-04
+ ErrMax= 1.10D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.77D-06 BMatP= 4.77D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.10D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.938 Goal=   None    Shift=    0.000
+ RMSDP=9.37D-06 MaxDP=1.88D-04              OVMax= 5.16D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -353.225914742447     Delta-E=       -0.000004502719 Rises=F Damp=F
+ DIIS: error= 2.13D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -353.225914742447     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.13D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-07 BMatP= 4.77D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.588D-01 0.106D+01
+ Coeff:     -0.588D-01 0.106D+01
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.80D-06 MaxDP=8.23D-05 DE=-4.50D-06 OVMax= 1.67D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -353.225914959897     Delta-E=       -0.000000217450 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -353.225914959897     IErMin= 2 ErrMin= 2.13D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.74D-08 BMatP= 1.57D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.501D-01 0.429D+00 0.621D+00
+ Coeff:     -0.501D-01 0.429D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=1.10D-06 MaxDP=3.46D-05 DE=-2.17D-07 OVMax= 9.34D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -353.225915007910     Delta-E=       -0.000000048013 Rises=F Damp=F
+ DIIS: error= 1.21D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -353.225915007910     IErMin= 4 ErrMin= 1.21D-05
+ ErrMax= 1.21D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.45D-08 BMatP= 7.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Coeff:     -0.168D-01 0.538D-01 0.361D+00 0.602D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=6.02D-07 MaxDP=1.44D-05 DE=-4.80D-08 OVMax= 4.50D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -353.225915028121     Delta-E=       -0.000000020211 Rises=F Damp=F
+ DIIS: error= 3.21D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -353.225915028121     IErMin= 5 ErrMin= 3.21D-06
+ ErrMax= 3.21D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.04D-09 BMatP= 2.45D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Coeff:      0.216D-02-0.582D-01 0.451D-01 0.257D+00 0.754D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.61D-07 MaxDP=9.95D-06 DE=-2.02D-08 OVMax= 1.66D-05
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -353.225915030242     Delta-E=       -0.000000002120 Rises=F Damp=F
+ DIIS: error= 1.04D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -353.225915030242     IErMin= 6 ErrMin= 1.04D-06
+ ErrMax= 1.04D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.84D-10 BMatP= 2.04D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Coeff:      0.256D-02-0.335D-01-0.141D-01 0.654D-01 0.359D+00 0.621D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=8.80D-08 MaxDP=3.93D-06 DE=-2.12D-09 OVMax= 5.19D-06
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -353.225915030522     Delta-E=       -0.000000000280 Rises=F Damp=F
+ DIIS: error= 3.38D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -353.225915030522     IErMin= 7 ErrMin= 3.38D-07
+ ErrMax= 3.38D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.09D-11 BMatP= 2.84D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.416D-03-0.288D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff-Com:  0.911D+00
+ Coeff:      0.416D-03-0.288D-04-0.121D-01-0.236D-01-0.328D-01 0.157D+00
+ Coeff:      0.911D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=5.88D-08 MaxDP=1.83D-06 DE=-2.80D-10 OVMax= 4.69D-06
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -353.225915030563     Delta-E=       -0.000000000041 Rises=F Damp=F
+ DIIS: error= 1.68D-07 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -353.225915030563     IErMin= 8 ErrMin= 1.68D-07
+ ErrMax= 1.68D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.02D-12 BMatP= 2.09D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff-Com:  0.340D+00 0.764D+00
+ Coeff:     -0.177D-03 0.421D-02-0.190D-02-0.152D-01-0.555D-01-0.360D-01
+ Coeff:      0.340D+00 0.764D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-08 MaxDP=9.55D-07 DE=-4.12D-11 OVMax= 1.27D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -353.225915030570     Delta-E=       -0.000000000007 Rises=F Damp=F
+ DIIS: error= 3.61D-08 at cycle   9 NSaved=   9.
+ NSaved= 9 IEnMin= 9 EnMin= -353.225915030570     IErMin= 9 ErrMin= 3.61D-08
+ ErrMax= 3.61D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.12D-13 BMatP= 4.02D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff-Com:  0.309D-01 0.231D+00 0.779D+00
+ Coeff:     -0.886D-04 0.128D-02 0.736D-03-0.273D-02-0.129D-01-0.276D-01
+ Coeff:      0.309D-01 0.231D+00 0.779D+00
+ Gap=     0.357 Goal=   None    Shift=    0.000
+ RMSDP=7.20D-09 MaxDP=1.79D-07 DE=-6.82D-12 OVMax= 5.70D-07
+
+ SCF Done:  E(RwB97XD) =  -353.225915031     A.U. after    9 cycles
+            NFock=  9  Conv=0.72D-08     -V/T= 2.0037
+ KE= 3.519295170656D+02 PE=-1.260402898335D+03 EE= 3.394553978436D+02
+ Leave Link  502 at Mon Aug  5 14:41:32 2024, MaxMem=  4294967296 cpu:       198.7
+ (Enter /usr/local/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ R6Disp: Adding Grimme-D2 dispersion energy 1st derivatives to the gradient.
+   2 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=    2485 NPrTT=    8136 LenC2=    2443 LenP2D=    6477.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Leave Link  701 at Mon Aug  5 14:41:33 2024, MaxMem=  4294967296 cpu:        14.3
+ (Enter /usr/local/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Mon Aug  5 14:41:33 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=T KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         1 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2527 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Mon Aug  5 14:41:42 2024, MaxMem=  4294967296 cpu:       149.7
+ (Enter /usr/local/g09/l716.exe)
+ Dipole        = 1.83142559D+00 1.12210286D+00-4.87726790D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        7           0.000883760    0.000103336    0.000377416
+      2        6          -0.000455119    0.000695255   -0.000195923
+      3        8           0.000300891   -0.001787718    0.000132299
+      4        7          -0.000364268    0.001070839   -0.000157885
+      5        7          -0.001234068   -0.000246739   -0.000526803
+      6        8           0.001455492    0.000602324    0.000620677
+      7        1          -0.000586688   -0.000437297   -0.000249780
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001787718 RMS     0.000743127
+ Leave Link  716 at Mon Aug  5 14:41:42 2024, MaxMem=  4294967296 cpu:         0.3
+ (Enter /usr/local/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001691014 RMS     0.000740497
+ Search for a local minimum.
+ Step number  27 out of a maximum of   27
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .74050D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points   11   12   14   15   16
+                                                     18   19   20   22   23
+                                                     24   26   27   25
+ The second derivative matrix:
+                          R1        R2        R3        R4        R5
+           R1           1.49082
+           R2           0.01835   0.52561
+           R3           0.03105   0.03994   0.27208
+           R4           0.02873   0.01179   0.02487   0.36079
+           R5          -0.03223  -0.00008  -0.01450  -0.00639   0.48652
+           R6           0.00347  -0.02341   0.02199   0.12950  -0.01348
+           A1           0.08534   0.08205   0.09452   0.00939  -0.02152
+           A2           0.12628   0.00143   0.02199  -0.02257  -0.02419
+           A3          -0.07371   0.00163   0.01257  -0.00820   0.01048
+           A4          -0.05257  -0.00306  -0.03457   0.03077   0.01371
+           A5           0.12684   0.01854  -0.05623   0.09858  -0.01782
+           A6          -0.06532  -0.00664   0.02158   0.01861   0.00715
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          R6        A1        A2        A3        A4
+           R6           0.68940
+           A1          -0.07302   0.36620
+           A2          -0.04839   0.10157   0.20415
+           A3           0.01599  -0.04737  -0.11491   0.12949
+           A4           0.03239  -0.05420  -0.08924  -0.01458   0.10382
+           A5           0.06669   0.08031   0.00203  -0.02577   0.02375
+           A6          -0.00304   0.04212   0.03626  -0.01848  -0.01778
+           A7           0.00000   0.00000   0.00000   0.00000   0.00000
+           D1           0.00000   0.00000   0.00000   0.00000   0.00000
+           D2           0.00000   0.00000   0.00000   0.00000   0.00000
+           D3           0.00000   0.00000   0.00000   0.00000   0.00000
+           D4           0.00000   0.00000   0.00000   0.00000   0.00000
+                          A5        A6        A7        D1        D2
+           A5           0.47721
+           A6           0.02934   0.11347
+           A7           0.00000   0.00000   0.10042
+           D1           0.00000   0.00000   0.00434  -0.00930
+           D2           0.00000   0.00000   0.00285  -0.00437  -0.00573
+           D3           0.00000   0.00000  -0.00123  -0.00142  -0.00061
+           D4           0.00000   0.00000   0.00039  -0.00678   0.00087
+                          D3        D4
+           D3           0.02358
+           D4           0.02270   0.01437
+ ITU=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ Use linear search instead of GDIIS.
+ Skip linear search -- no minimum in search direction.
+ Steepest descent instead of Quadratic search.
+ Steepest descent step scaled to max of 0.05000.
+ Iteration  1 RMS(Cart)=  0.04747861 RMS(Int)=  0.00053456
+ Iteration  2 RMS(Cart)=  0.00156670 RMS(Int)=  0.00000066
+ Iteration  3 RMS(Cart)=  0.00000077 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.08D-01 DCOld= 1.00D+10 DXMaxT= 5.00D-02 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 2.18D-08 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.17345   0.00096   0.00000   0.02848   0.02848   2.20193
+    R2        2.45098   0.00068   0.00000   0.02015   0.02015   2.47113
+    R3        2.67191   0.00126   0.00000   0.03712   0.03712   2.70902
+    R4        2.46636   0.00037   0.00000   0.01087   0.01087   2.47723
+    R5        1.89939   0.00077   0.00000   0.02268   0.02268   1.92207
+    R6        2.26031   0.00169   0.00000   0.05000   0.05000   2.31031
+    A1        2.09356  -0.00143   0.00000  -0.04241  -0.04241   2.05115
+    A2        2.26790  -0.00061   0.00000  -0.01792  -0.01792   2.24998
+    A3        1.91829   0.00023   0.00000   0.00682   0.00682   1.92511
+    A4        2.09700   0.00038   0.00000   0.01110   0.01110   2.10809
+    A5        2.06844  -0.00039   0.00000  -0.01149  -0.01149   2.05695
+    A6        3.34318   0.00004   0.00000   0.00112   0.00112   3.34431
+    A7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D4        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001691     0.000015     NO 
+ RMS     Force            0.000740     0.000010     NO 
+ Maximum Displacement     0.108447     0.000060     NO 
+ RMS     Displacement     0.048681     0.000040     NO 
+ Predicted change in Energy=-2.112158D-03
+ Optimization stopped.
+    -- Number of steps exceeded,  NStep=  27
+    -- Flag reset to prevent archiving.
+                           ----------------------------
+                           ! Non-Optimized Parameters !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.1652         -DE/DX =    0.001               !
+ ! R2    R(2,3)                  1.3077         -DE/DX =    0.0007              !
+ ! R3    R(3,4)                  1.4336         -DE/DX =    0.0013              !
+ ! R4    R(4,5)                  1.3109         -DE/DX =    0.0004              !
+ ! R5    R(4,7)                  1.0171         -DE/DX =    0.0008              !
+ ! R6    R(5,6)                  1.2226         -DE/DX =    0.0017              !
+ ! A1    A(2,3,4)              117.5224         -DE/DX =   -0.0014              !
+ ! A2    A(3,4,5)              128.9143         -DE/DX =   -0.0006              !
+ ! A3    A(3,4,7)              110.3008         -DE/DX =    0.0002              !
+ ! A4    A(5,4,7)              120.7849         -DE/DX =    0.0004              !
+ ! A5    A(4,5,6)              117.8546         -DE/DX =   -0.0004              !
+ ! A6    L(1,2,3,6,-1)         191.6147         -DE/DX =    0.0                 !
+ ! A7    L(1,2,3,6,-2)         180.0            -DE/DX =    0.0                 !
+ ! D1    D(2,3,4,5)              0.0            -DE/DX =    0.0                 !
+ ! D2    D(2,3,4,7)            180.0            -DE/DX =    0.0                 !
+ ! D3    D(3,4,5,6)              0.0            -DE/DX =    0.0                 !
+ ! D4    D(7,4,5,6)            180.0            -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Largest change from initial coordinates is atom    1       2.592 Angstoms.
+ Leave Link  103 at Mon Aug  5 14:41:43 2024, MaxMem=  4294967296 cpu:         0.1
+ (Enter /usr/local/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0        2.226691   -0.519463    0.856203
+      2          6           0        1.175940   -0.651382    0.407491
+      3          8           0        0.042209   -1.055116   -0.076110
+      4          7           0       -0.924655   -0.110657   -0.491222
+      5          7           0       -0.882412    1.193709   -0.475891
+      6          8           0        0.101964    1.728206   -0.056382
+      7          1           0       -1.739736   -0.585297   -0.838517
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  N    0.000000
+     2  C    1.150140   0.000000
+     3  O    2.434767   1.297003   0.000000
+     4  N    3.451617   2.347886   1.413912   0.000000
+     5  N    3.791564   2.901989   2.464135   1.305140   0.000000
+     6  O    3.224794   2.651611   2.784033   2.150454   1.196106
+     7  H    4.313810   3.171446   1.994323   1.005114   2.007827
+                    6          7
+     6  O    0.000000
+     7  H    3.058741   0.000000
+ Stoichiometry    CHN3O2
+ Framework group  CS[SG(CHN3O2)]
+ Deg. of freedom    11
+ Full point group                 CS      NOp   2
+ RotChk:  IX=2 Diff= 8.48D-16
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          7           0       -2.261241    0.277022    0.000000
+      2          6           0       -1.153682    0.587079    0.000000
+      3          8           0        0.000000    1.179729    0.000000
+      4          7           0        1.187712    0.412600    0.000000
+      5          7           0        1.348645   -0.882581    0.000000
+      6          8           0        0.376039   -1.578792    0.000000
+      7          1           0        1.987975    1.020739    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6891337      3.2617901      2.2902488
+ Leave Link  202 at Mon Aug  5 14:41:43 2024, MaxMem=  4294967296 cpu:         0.7
+ (Enter /usr/local/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A") (A')
+       Virtual   (A") (A') (A') (A') (A") (A') (A') (A') (A') (A")
+                 (A') (A') (A") (A') (A') (A') (A') (A") (A') (A')
+                 (A') (A") (A") (A') (A') (A') (A") (A') (A') (A')
+                 (A") (A') (A') (A') (A") (A') (A") (A') (A") (A')
+                 (A") (A') (A') (A") (A') (A') (A') (A') (A") (A")
+                 (A') (A') (A') (A") (A') (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A") (A') (A') (A') (A') (A") (A")
+                 (A') (A') (A") (A') (A") (A') (A') (A') (A') (A')
+                 (A") (A') (A') (A") (A") (A") (A') (A') (A") (A')
+                 (A') (A") (A') (A') (A') (A') (A') (A") (A') (A')
+                 (A") (A') (A") (A') (A') (A") (A') (A") (A') (A")
+                 (A') (A') (A") (A') (A") (A') (A") (A') (A") (A')
+                 (A") (A') (A") (A') (A") (A') (A') (A") (A") (A')
+                 (A') (A') (A') (A') (A") (A') (A') (A") (A') (A")
+                 (A') (A") (A') (A') (A') (A") (A") (A") (A') (A")
+                 (A') (A') (A") (A') (A') (A') (A") (A") (A') (A')
+                 (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+ The electronic state is 1-A'.
+ Alpha  occ. eigenvalues --  -19.41853 -19.31479 -14.62238 -14.60929 -14.44594
+ Alpha  occ. eigenvalues --  -10.39495  -1.34498  -1.28678  -1.09846  -1.02063
+ Alpha  occ. eigenvalues --   -0.88037  -0.74568  -0.68510  -0.65090  -0.61152
+ Alpha  occ. eigenvalues --   -0.57813  -0.55609  -0.47228  -0.45234  -0.45096
+ Alpha  occ. eigenvalues --   -0.38423  -0.36008
+ Alpha virt. eigenvalues --   -0.00259   0.03743   0.07824   0.10159   0.13554
+ Alpha virt. eigenvalues --    0.19381   0.25072   0.26704   0.28323   0.28502
+ Alpha virt. eigenvalues --    0.32633   0.37421   0.38160   0.38991   0.41143
+ Alpha virt. eigenvalues --    0.43738   0.45345   0.45612   0.48059   0.50831
+ Alpha virt. eigenvalues --    0.52087   0.52621   0.56020   0.57750   0.60046
+ Alpha virt. eigenvalues --    0.63859   0.64502   0.67206   0.70192   0.72752
+ Alpha virt. eigenvalues --    0.73034   0.79075   0.84228   0.86837   0.87506
+ Alpha virt. eigenvalues --    0.97343   0.99630   0.99755   1.06162   1.06876
+ Alpha virt. eigenvalues --    1.21059   1.25117   1.30919   1.30960   1.32072
+ Alpha virt. eigenvalues --    1.32237   1.42720   1.44822   1.45038   1.46893
+ Alpha virt. eigenvalues --    1.50171   1.57978   1.59049   1.63545   1.64987
+ Alpha virt. eigenvalues --    1.70458   1.73573   1.76029   1.84888   1.85290
+ Alpha virt. eigenvalues --    1.87416   1.93380   1.97008   1.98471   2.00153
+ Alpha virt. eigenvalues --    2.11413   2.12038   2.15313   2.16554   2.20408
+ Alpha virt. eigenvalues --    2.20815   2.29109   2.29994   2.35263   2.49191
+ Alpha virt. eigenvalues --    2.51746   2.55065   2.55726   2.61495   2.69270
+ Alpha virt. eigenvalues --    2.70983   2.72201   2.75300   2.76309   2.81167
+ Alpha virt. eigenvalues --    2.91985   2.94386   2.98215   2.98904   2.99912
+ Alpha virt. eigenvalues --    3.09133   3.11585   3.16155   3.20302   3.24409
+ Alpha virt. eigenvalues --    3.34206   3.45443   3.49367   3.50411   3.66566
+ Alpha virt. eigenvalues --    3.68564   3.74198   3.74247   3.81504   3.93110
+ Alpha virt. eigenvalues --    3.98930   4.05415   4.05945   4.12506   4.14884
+ Alpha virt. eigenvalues --    4.32971   4.36426   4.40402   4.47604   4.50915
+ Alpha virt. eigenvalues --    4.52214   4.55299   4.56024   4.65798   4.66019
+ Alpha virt. eigenvalues --    4.69477   4.70525   4.76174   4.78266   4.84407
+ Alpha virt. eigenvalues --    4.88619   4.94407   5.04539   5.16894   5.18638
+ Alpha virt. eigenvalues --    5.20426   5.22899   5.28714   5.31176   5.31633
+ Alpha virt. eigenvalues --    5.37698   5.41521   5.46425   5.48217   5.56151
+ Alpha virt. eigenvalues --    5.62480   5.75052   5.77615   5.85692   5.91204
+ Alpha virt. eigenvalues --    6.03089   6.34161   6.34881   6.40746   6.42365
+ Alpha virt. eigenvalues --    6.47092   6.58032   6.58636   6.68193   6.84232
+ Alpha virt. eigenvalues --    6.86031   6.87414   6.96156   7.01722   7.17764
+ Alpha virt. eigenvalues --    7.23274   7.30419   7.46173   7.68096  23.30422
+ Alpha virt. eigenvalues --   31.87030  31.96008  32.21170  43.87602  44.35409
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  N    6.247600   0.846749  -0.028576   0.002350   0.000727  -0.013713
+     2  C    0.846749   4.776205   0.320035  -0.042302  -0.005828   0.025887
+     3  O   -0.028576   0.320035   7.820660   0.062390   0.000462   0.008461
+     4  N    0.002350  -0.042302   0.062390   6.604224   0.148404  -0.128726
+     5  N    0.000727  -0.005828   0.000462   0.148404   6.397170   0.324490
+     6  O   -0.013713   0.025887   0.008461  -0.128726   0.324490   8.082304
+     7  H   -0.000149   0.001924  -0.026390   0.364674  -0.018765   0.005988
+               7
+     1  N   -0.000149
+     2  C    0.001924
+     3  O   -0.026390
+     4  N    0.364674
+     5  N   -0.018765
+     6  O    0.005988
+     7  H    0.375652
+ Mulliken charges:
+               1
+     1  N   -0.054989
+     2  C    0.077331
+     3  O   -0.157042
+     4  N   -0.011015
+     5  N    0.153340
+     6  O   -0.304691
+     7  H    0.297066
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  N   -0.054989
+     2  C    0.077331
+     3  O   -0.157042
+     4  N    0.286051
+     5  N    0.153340
+     6  O   -0.304691
+ Electronic spatial extent (au):  <R**2>=            478.9822
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              4.6550    Y=              2.8521    Z=              0.0000  Tot=              5.4593
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -36.4316   YY=            -33.9481   ZZ=            -31.9016
+   XY=              3.8465   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -2.3379   YY=              0.1457   ZZ=              2.1922
+   XY=              3.8465   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             39.0239  YYY=              6.3838  ZZZ=              0.0000  XYY=              4.0539
+  XXY=              7.6404  XXZ=              0.0000  XZZ=              2.8061  YZZ=             -0.7671
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=           -413.4810 YYYY=           -204.6219 ZZZZ=            -27.1881 XXXY=             62.5544
+ XXXZ=              0.0000 YYYX=             45.1055 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=            -87.0565 XXZZ=            -67.2328 YYZZ=            -36.6151
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=             12.2467
+ N-N= 2.157920683955D+02 E-N=-1.260402895391D+03  KE= 3.519295170656D+02
+ Symmetry A'   KE= 3.362936310344D+02
+ Symmetry A"   KE= 1.563588603124D+01
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Mon Aug  5 14:41:43 2024, MaxMem=  4294967296 cpu:         3.5
+ (Enter /usr/local/g09/l9999.exe)
+
+
+ THE LENGTH OF A MEETING IS PROPORTIONAL TO THE
+ SQUARE OF THE PARTICIPANTS.
+ Error termination request processed by link 9999.
+ Error termination via Lnk1e in /usr/local/g09/l9999.exe at Mon Aug  5 14:41:43 2024.
+ Job cpu time:       0 days  3 hours  9 minutes 52.1 seconds.
+ File lengths (MBytes):  RWF=     30 Int=      0 D2E=      0 Chk=      4 Scr=      1


### PR DESCRIPTION
There are times when we do not get convergence of the optimisation of a molecule and we only receive an output of `l9999.exe`. Currently, we do not make any drastic changes then to the input file for Gaussian for troubleshooting and may end up determining we cannot converge the molecule and therefore give up.

However, further up the file we may find the number of steps is a limit (the example output file shows 27 steps is the max for opt). Therefore, this aims to troubleshoot it by increasing the cycles for opt. Removed increase of scf maxcycle as DM/QC (512) have their own default values compared to default algorithm (128). If non-convergence is still not occuring, then checking if the scf is shaking manually should be done. https://wongzit.github.io/method-to-solve-the-scf-not-converged/

Edit: I have now included more methods for dealing with other errors, such as L502 - `Inaccurate quadrature in CalDSu`

I have attempted to provide comments against each trsh_keyword to explain what they do