### PR TITLE
Increasing opt maxcycles for fine opt

### DIFF
--- a/arc/job/adapters/gaussian.py
+++ b/arc/job/adapters/gaussian.py
@@ -274,6 +274,9 @@ class GaussianAdapter(JobAdapter):
                 # There are no analytical 2nd derivatives (FC) for this method.
                 keywords = ['ts', 'noeigentest', 'maxcycles=100'] if self.is_ts else []
             if self.fine:
+                # Check if maxcycles is already in the keywords
+                if 'maxcycles' not in keywords:
+                    keywords.append(f'maxcycles={max_c}')
                 if self.level.method_type in ['dft', 'composite']:
                     # Note that the Acc2E argument is not available in Gaussian03
                     input_dict['fine'] = f'integral=(grid=ultrafine, {integral_algorithm})'


### PR DESCRIPTION
Commonly, our fine opt fails due to number of steps exceeded. Whilst we may troubleshoot this after an initial failure, I believe it is best to set the maxcycles at 100 to begin with so that we increase the chance of convergence prior to troubleshooting. This can reduce our creation of opt jobs.