### PR TITLE
Don't gen xyz when checking if a species is monoatomic

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1020,7 +1020,9 @@ class ARCSpecies(object):
         """
         if self.mol is not None and len(self.mol.atoms):
             return len(self.mol.atoms) == 1
-        xyz = self.get_xyz()
+        if self.mol_list is not None and len(self.mol_list):
+            return len(self.mol_list[0].atoms) == 1
+        xyz = self.get_xyz(generate=False)
         if xyz is not None:
             return len(xyz['symbols']) == 1
         return None


### PR DESCRIPTION
To avoid inf. recursions (is_monoatomic → get_xyz → get_cheap_conformer → is_monoatomic), don't generate a cheap xyz when checking if a species is monoatomic