### PR TITLE
Run CCS/VTZ for [H] instead of more complex WF methods

### DIFF
--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -578,8 +578,7 @@ def check_job_status_in_stdout(job_id: int,
             return 'errored'
     elif servers[server]['cluster_soft'].lower() == 'htcondor':
         return 'running'
-    else:
-        raise ValueError(f'Unknown cluster software {servers[server]["cluster_soft"]}')
+    raise ValueError(f'Unknown cluster software {servers[server]["cluster_soft"]}')
 
 
 def delete_all_arc_jobs(server_list: list,

--- a/arc/main.py
+++ b/arc/main.py
@@ -384,7 +384,7 @@ class ARC(object):
                 indices_to_pop.append(i)
                 converted_reactions.append(ARCReaction(reaction_dict=rxn, species_list=self.species))
             elif not isinstance(rxn, ARCReaction):
-                raise ValueError(f'A reaction should either be an `ARCReaction` object.\nGot {type(rxn)} for {rxn}')
+                raise ValueError(f'An input reaction should be an `ARCReaction` object. Got:\n{type(rxn)} for {rxn}')
         for i in reversed(range(len(self.reactions))):  # pop from the end, so other indices won't change
             if i in indices_to_pop:
                 self.reactions.pop(i)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -1274,10 +1274,10 @@ class Scheduler(object):
 
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
-                        xyz=self.species_dict[label].conformers[conformer],
-                        level_of_theory=self.conformer_sp_level,
-                        job_type='conf_sp',
-                        conformer=conformer)
+                         xyz=self.species_dict[label].conformers[conformer],
+                         level_of_theory=self.conformer_sp_level,
+                         job_type='conf_sp',
+                         conformer=conformer)
             return
         # determine_occ(xyz=self.xyz, charge=self.charge)
         if level == self.opt_level and not self.composite_method \
@@ -1348,6 +1348,10 @@ class Scheduler(object):
                              xyz=self.species_dict[label].get_xyz(generate=False),
                              level_of_theory='ccsd/vdz',
                              job_type='sp')
+        mol = self.species_dict[label].mol
+        if mol is not None and len(mol.atoms) == 1 and mol.atoms[0].element.symbol == 'H' and 'DLPNO' in level.method:
+            # Run only CCSD for an H atom instead of DLPNO-CCSD(T) / etc.
+            level = Level(repr='ccsd/vtz', software=level.software, args=level.args)
         if self.job_types['sp']:
             if self.species_dict[label].multi_species:
                 if self.output_multi_spc[self.species_dict[label].multi_species].get('sp', False):

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -989,6 +989,12 @@ class Scheduler(object):
                         self.running_jobs[label].pop(self.running_jobs[label].index(job_name))
                     return False
 
+        RETRY_COUNT, RETRY_SLEEP_SECONDS = 5, 10
+        i = RETRY_COUNT
+        while i and not os.path.isfile(job.local_path_to_output_file):
+            i -= 1
+            time.sleep(RETRY_SLEEP_SECONDS)
+
         if not os.path.isfile(job.local_path_to_output_file) and not job.execution_type == 'incore':
             job.rename_output_file()
         if not os.path.isfile(job.local_path_to_output_file) and not job.execution_type == 'incore':

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -1076,6 +1076,8 @@ class ARCSpecies(object):
         other_aromatic = generate_aromatic_resonance_structure(mol=other, copy=False) if other.is_cyclic() else []
         other = other_aromatic[0] if len(other_aromatic) else other
         if isinstance(other, Molecule):
+            if len(self.mol.atoms) != len(other.atoms):
+                return False
             if self.mol_list is not None and len(self.mol_list):
                 for mol_ in [self.mol] + self.mol_list:
                     if mol_.copy(deep=True).is_isomorphic(other):
@@ -1083,7 +1085,7 @@ class ARCSpecies(object):
                 return False
             else:
                 return self.mol.copy(deep=True).is_isomorphic(other)
-        raise SpeciesError(f'Can only compare isomorphism to other ARCSpecies, RMG Species, or Molecule '
+        raise SpeciesError(f'Can only compare isomorphism to other ARCSpecies or Molecule '
                            f'object instances, got {other} which is of type {type(other)}.')
 
     def generate_conformers(self,


### PR DESCRIPTION
Methods such as `DLPNO-CCSD(T)` which is frequenctly used for kinetics due to it's efficiency and relatively good accuracy cannot be applied for `[H]`. This method relies on electron pairs for defining correlation spaces, and the H radical has only one electron.
Therefore, reactions such as `RH + H <=> R + H2` cannot be computed using this method. However, since the energy of H is relatively simple, it is "known" percisely or can be computed using another Coupled-Cluster method without the DLPNO (Domain-based Local Pair Natural Orbital) assumption. This PR runs a simple and quick CC job for H if a DLPNO method was requested for it.