### PR TITLE
Improves RMG-Py cloning in CI & fixes website build

### DIFF
--- a/.github/workflows/cont_int.yml
+++ b/.github/workflows/cont_int.yml
@@ -57,10 +57,15 @@ jobs:
     - name: Clone & checkout RMG-Py at specific SHA
       if: steps.cache-rmg-py.outputs.cache-hit != 'true'
       run: |
-        git clone --filter=blob:none --no-checkout https://github.com/ReactionMechanismGenerator/RMG-Py.git RMG-Py
-        cd RMG-Py
-        git fetch --no-tags --prune origin ${RMG_PY_COMMIT}
-        git checkout --detach ${RMG_PY_COMMIT}
+        if [ -d RMG-Py/.git ]; then
+          echo "Updating cached RMG-Py…"
+          git -C RMG-Py fetch --depth=1 origin ${RMG_PY_COMMIT}
+          git -C RMG-Py checkout --force ${RMG_PY_COMMIT}
+        else
+          echo "Cloning RMG-Py…"
+          git clone --filter=blob:none --no-checkout https://github.com/ReactionMechanismGenerator/RMG-Py.git RMG-Py
+          git -C RMG-Py checkout --detach ${RMG_PY_COMMIT}
+        fi
 
     - name: Cache RMG-database
       id: cache-rmg-db

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -81,4 +81,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build/html/
+          publish_dir: ./ARC/docs/_build/html/


### PR DESCRIPTION
Addresses an issue where the RMG-Py repository was being cloned repeatedly during CI runs.

- Optimizes the CI workflow by checking for the existence of the RMG-Py directory before attempting to clone it.
- If the directory exists, the workflow now fetches and checks out the specified commit instead of re-cloning the entire repository.

Website deployment is now pointed to the ./ARC/ folder


