### PR TITLE
Mutated conformer jobs issue

### DIFF
--- a/arc/job/adapters/ts/autotst_ts.py
+++ b/arc/job/adapters/ts/autotst_ts.py
@@ -277,9 +277,8 @@ class AutoTSTAdapter(JobAdapter):
                                                        execution_time=tok,
                                                        xyz=xyz,
                                                        success=True,
-                                                       index=len(rxn.ts_species.ts_guesses),
                                                        )
-                                    rxn.ts_species.ts_guesses.append(ts_guess)
+                                    rxn.ts_species.append_ts_guess(ts_guess)
                                     save_geo(xyz=xyz,
                                              path=self.local_path,
                                              filename=f'AutoTST {direction}',
@@ -294,9 +293,8 @@ class AutoTSTAdapter(JobAdapter):
                                                t0=tic,
                                                execution_time=tok,
                                                success=False,
-                                               index=len(rxn.ts_species.ts_guesses),
                                                )
-                            rxn.ts_species.ts_guesses.append(ts_guess)
+                            rxn.ts_species.append_ts_guess(ts_guess)
                             i += 1
 
             if len(self.reactions) < 5:

--- a/arc/job/adapters/ts/gcn_ts.py
+++ b/arc/job/adapters/ts/gcn_ts.py
@@ -378,7 +378,6 @@ def run_subprocess_locally(direction: str,
     ts_xyz = None
     tsg = TSGuess(method='GCN',
                   method_direction=direction,
-                  index=len(ts_species.ts_guesses),
                   )
     tsg.tic()
     # Routed via run_in_conda_env so arc_env's activation vars don't
@@ -434,16 +433,18 @@ def process_tsg(direction: str,
         if unique:
             tsg.success = True
             tsg.process_xyz(ts_xyz)
-            save_geo(xyz=ts_xyz,
-                     path=local_path,
-                     filename=f'GCN {direction} {tsg.index}',
-                     format_='xyz',
-                     comment=f'GCN {direction}',
-                     )
     else:
         tsg.success = False
     if unique and tsg.success:
-        ts_species.ts_guesses.append(tsg)
+        # Appended before the geometry is saved, so the file is named with the identity the guess
+        # actually ends up holding rather than one predicted before the append.
+        ts_species.append_ts_guess(tsg)
+        save_geo(xyz=ts_xyz,
+                 path=local_path,
+                 filename=f'GCN {direction} {tsg.index}',
+                 format_='xyz',
+                 comment=f'GCN {direction}',
+                 )
 
 
 register_job_adapter('gcn', GCNAdapter)

--- a/arc/job/adapters/ts/goflow_ts.py
+++ b/arc/job/adapters/ts/goflow_ts.py
@@ -623,11 +623,10 @@ def process_goflow_tsg(tsg_dict: dict,
     tsg = TSGuess(method='GoFlow',
                   method_direction=tsg_dict.get('method_direction', 'F'),
                   method_index=method_index,
-                  index=len(ts_species.ts_guesses),
                   success=True,
                   )
     tsg.process_xyz(ts_xyz)
-    ts_species.ts_guesses.append(tsg)
+    ts_species.append_ts_guess(tsg)
     save_geo(xyz=ts_xyz,
              path=local_path,
              filename=f'GoFlow {method_index}',

--- a/arc/job/adapters/ts/heuristics.py
+++ b/arc/job/adapters/ts/heuristics.py
@@ -288,7 +288,6 @@ class HeuristicsAdapter(JobAdapter):
                         break
                 if unique:
                     ts_guess = TSGuess(method='Heuristics',
-                                       index=len(rxn.ts_species.ts_guesses),
                                        method_index=method_index,
                                        t0=tsg.t0,
                                        execution_time=tsg.execution_time,
@@ -296,7 +295,7 @@ class HeuristicsAdapter(JobAdapter):
                                        family=rxn.family if families is None else families[method_index],
                                        xyz=xyz,
                                        )
-                    rxn.ts_species.ts_guesses.append(ts_guess)
+                    rxn.ts_species.append_ts_guess(ts_guess)
                     save_geo(xyz=xyz,
                              path=self.local_path,
                              filename=f'Heuristics_{method_index}',

--- a/arc/job/adapters/ts/kinbot_ts.py
+++ b/arc/job/adapters/ts/kinbot_ts.py
@@ -380,7 +380,6 @@ class KinBotAdapter(JobAdapter):
             ts_guess = TSGuess(method=method,
                                method_direction=method_direction,
                                method_index=method_index,
-                               index=len(rxn.ts_species.ts_guesses),
                                execution_time=result.get('execution_time'),
                                )
             success = bool(result.get('success')) and result.get('coords') is not None
@@ -409,7 +408,7 @@ class KinBotAdapter(JobAdapter):
             if not success:
                 ts_guess.success = False
             if unique:
-                rxn.ts_species.ts_guesses.append(ts_guess)
+                rxn.ts_species.append_ts_guess(ts_guess)
                 method_index += 1
 
     def execute_queue(self):

--- a/arc/job/adapters/ts/linear.py
+++ b/arc/job/adapters/ts/linear.py
@@ -926,7 +926,6 @@ class LinearAdapter(JobAdapter):
                         if unique:
                             method = f'Linear (w={w:.2f}, {xyz_i})'
                             ts_guess = TSGuess(method=method,
-                                               index=len(rxn.ts_species.ts_guesses),
                                                method_index=w_i,
                                                t0=t0,
                                                execution_time=t_ex,
@@ -934,7 +933,7 @@ class LinearAdapter(JobAdapter):
                                                family=rxn.family,
                                                xyz=xyz,
                                                )
-                            rxn.ts_species.ts_guesses.append(ts_guess)
+                            rxn.ts_species.append_ts_guess(ts_guess)
 
                             save_geo(xyz=xyz,
                                      path=self.local_path,

--- a/arc/job/adapters/ts/orca_neb.py
+++ b/arc/job/adapters/ts/orca_neb.py
@@ -318,7 +318,6 @@ class OrcaNEBAdapter(OrcaAdapter):
         Process a completed orca-NEB run.
         """
         tsg = TSGuess(method='orca_neb',
-                      index=len(self.reactions[0].ts_species.ts_guesses),
                       success=False,
                       t0=self.initial_time,
                       )
@@ -327,7 +326,7 @@ class OrcaNEBAdapter(OrcaAdapter):
             tsg.execution_time = self.final_time - self.initial_time
             tsg.log_path = self.local_path_to_output_file
             tsg.success = True
-        self.reactions[0].ts_species.ts_guesses.append(tsg)
+        self.reactions[0].ts_species.append_ts_guess(tsg)
 
     def write_submit_script(self) -> None:
         """

--- a/arc/job/adapters/ts/rits_ts.py
+++ b/arc/job/adapters/ts/rits_ts.py
@@ -435,11 +435,10 @@ def process_rits_tsg(tsg_dict: dict,
     tsg = TSGuess(method='RitS',
                   method_direction=tsg_dict.get('method_direction', 'F'),
                   method_index=method_index,
-                  index=len(ts_species.ts_guesses),
                   success=True,
                   )
     tsg.process_xyz(ts_xyz)
-    ts_species.ts_guesses.append(tsg)
+    ts_species.append_ts_guess(tsg)
     save_geo(xyz=ts_xyz,
              path=local_path,
              filename=f'RitS {method_index}',

--- a/arc/job/adapters/ts/xtb_gsm.py
+++ b/arc/job/adapters/ts/xtb_gsm.py
@@ -384,7 +384,6 @@ class xTBGSMAdapter(JobAdapter):
         Process a completed xTB-GSM run.
         """
         tsg = TSGuess(method='xTB-GSM',
-                      index=len(self.reactions[0].ts_species.ts_guesses),
                       success=False,
                       t0=self.initial_time,
                       )
@@ -393,7 +392,7 @@ class xTBGSMAdapter(JobAdapter):
             tsg.initial_xyz = traj[int((len(traj) - 1) / 2) + 1]
             tsg.execution_time = self.final_time - self.initial_time
             tsg.success = True
-        self.reactions[0].ts_species.ts_guesses.append(tsg)
+        self.reactions[0].ts_species.append_ts_guess(tsg)
 
     def cleanup_files(self):
         """Remove unneeded files after run."""

--- a/arc/job/pipe/pipe_run.py
+++ b/arc/job/pipe/pipe_run.py
@@ -708,7 +708,6 @@ def _ingest_ts_opt(run_id, pipe_root, spec, state, species_dict, label):
                 tsg.opt_xyz = xyz
             if e_elect is not None:
                 tsg.energy = e_elect
-            tsg.index = conformer_index
             break
     else:
         logger.warning(f'Pipe run {run_id}, task {spec.task_id}: '

--- a/arc/job/pipe/pipe_run_test.py
+++ b/arc/job/pipe/pipe_run_test.py
@@ -15,10 +15,15 @@ from unittest import mock
 
 import arc.job.pipe.pipe_run as pipe_run_module
 from arc.job.adapters.mockter import MockAdapter
-from arc.job.pipe.pipe_state import TaskState, PipeRunState, TaskSpec, read_task_state, update_task_state
+from arc.job.pipe.pipe_state import (TaskState, TaskStateRecord, PipeRunState, TaskSpec, get_task_attempt_dir,
+                                     read_task_state, update_task_state)
 from arc.job.pipe.pipe_run import PipeRun, local_cpu_budget, local_worker_limit, worker_cpu_cores
+import arc.parser.parser as parser
+from arc.common import ARC_TESTING_PATH
 from arc.level import Level
 from arc.species import ARCSpecies
+from arc.species.converter import str_to_xyz
+from arc.species.species import TSGuess
 
 
 def _make_spec(task_id, label='H2O', smiles='O', task_family='conf_opt',
@@ -703,6 +708,79 @@ class TestLocalCpuBudget(unittest.TestCase):
         """Unset or unparseable value yields None, so the caller uses ARC's default allocation."""
         for env in ({}, {'ARC_PIPE_LOCAL_CPUS': ''}, {'ARC_PIPE_LOCAL_CPUS': '0'}, {'ARC_PIPE_LOCAL_CPUS': 'abc'}):
             self.assertIsNone(worker_cpu_cores(env))
+
+
+class TestIngestTsOpt(unittest.TestCase):
+    """Test the ingestion of a completed pipe ts_opt task into the matching TSGuess."""
+
+    def setUp(self):
+        self.ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        self.ts_species = ARCSpecies(label='TS_pipe', is_ts=True, xyz=self.ts_xyz, multiplicity=1, charge=0,
+                                     compute_thermo=False)
+        # The identity and the conformer job position deliberately diverge, and are not in the same order.
+        self.tsg_a = TSGuess(index=7, method='heuristics', success=True, xyz=self.ts_xyz)
+        self.tsg_a.conformer_index = 0
+        self.tsg_b = TSGuess(index=3, method='gcn', success=True, xyz=self.ts_xyz)
+        self.tsg_b.conformer_index = 1
+        # Stored so that conformer_index disagrees with list position too: conformer 1 sits at
+        # position 0. A lookup by position therefore cannot pass by coincidence.
+        self.ts_species.ts_guesses = [self.tsg_b, self.tsg_a]
+        self.pipe_root = tempfile.mkdtemp(prefix='pipe_ingest_ts_opt_')
+        self.addCleanup(shutil.rmtree, self.pipe_root, ignore_errors=True)
+        # Real converged TS conformer optimizations, discovered through the same result.json the
+        # worker writes. Two different logs, so a cross-attributed result cannot pass unnoticed.
+        self.logs = {0: os.path.join(ARC_TESTING_PATH, 'TS_confs', 'TS0_conf_0.out'),
+                     1: os.path.join(ARC_TESTING_PATH, 'TS_confs', 'TS0_conf_1.out')}
+        self.expected = {i: (parser.parse_geometry(log_file_path=path),
+                             parser.parse_e_elect(log_file_path=path))
+                         for i, path in self.logs.items()}
+
+    def ingest(self, conformer_index, log_index=0):
+        """Run _ingest_ts_opt() against a real attempt directory holding a real ESS log."""
+        task_id = f't_ts_opt_{conformer_index}_{log_index}'
+        spec = _make_spec(task_id, label='TS_pipe', task_family='ts_opt', engine='gaussian')
+        spec.ingestion_metadata = {'conformer_index': conformer_index}
+        state = TaskStateRecord(status=TaskState.COMPLETED.value, attempt_index=0)
+        attempt_dir = get_task_attempt_dir(self.pipe_root, task_id, state.attempt_index)
+        os.makedirs(attempt_dir, exist_ok=True)
+        with open(os.path.join(attempt_dir, 'result.json'), 'w') as f:
+            json.dump({'canonical_output_path': self.logs[log_index]}, f)
+        pipe_run_module._ingest_ts_opt('run_0', self.pipe_root, spec, state,
+                                       {'TS_pipe': self.ts_species}, 'TS_pipe')
+
+    def test_ingestion_preserves_the_ts_guess_identity(self):
+        """Test that ingesting a result does not overwrite TSGuess.index with the conformer index."""
+        self.ingest(conformer_index=0, log_index=0)
+        self.assertEqual(self.tsg_a.index, 7)
+        self.assertEqual(self.tsg_a.conformer_index, 0)
+        self.assertEqual(self.tsg_a.opt_xyz, self.expected[0][0])
+        self.assertAlmostEqual(self.tsg_a.energy, self.expected[0][1], 5)
+
+    def test_ingestion_updates_only_the_matching_ts_guess(self):
+        """Test that a result is attributed by conformer_index, not by position in the ts_guesses list."""
+        self.ingest(conformer_index=1, log_index=1)
+        self.assertEqual(self.tsg_b.index, 3)
+        self.assertEqual(self.tsg_b.opt_xyz, self.expected[1][0])
+        self.assertAlmostEqual(self.tsg_b.energy, self.expected[1][1], 5)
+        # The guess at list position 0, which holds the *other* conformer_index, is untouched.
+        self.assertIsNone(self.tsg_a.opt_xyz)
+        self.assertIsNone(self.tsg_a.energy)
+        self.assertNotAlmostEqual(self.expected[0][1], self.expected[1][1], 3)
+
+    def test_ingestion_of_an_unmatched_conformer_index_is_a_no_op(self):
+        """Test that a result with no matching conformer_index does not touch any TSGuess."""
+        with self.assertLogs('arc', level='WARNING') as context_manager:
+            self.ingest(conformer_index=7, log_index=0)
+        # Proves ingestion actually reached the attribution step rather than returning early.
+        self.assertTrue(any('no TSGuess with conformer_index=7' in message
+                            for message in context_manager.output))
+        for tsg in (self.tsg_a, self.tsg_b):
+            self.assertIsNone(tsg.opt_xyz)
+            self.assertIsNone(tsg.energy)
+        self.assertEqual(sorted(tsg.index for tsg in self.ts_species.ts_guesses), [3, 7])
 
 
 if __name__ == '__main__':

--- a/arc/output.py
+++ b/arc/output.py
@@ -523,7 +523,13 @@ def _spc_to_dict(spc, output_dict: dict, project_directory: str,
 
 
 def _get_ts_imag_freq(spc) -> float | None:
-    """Return the imaginary frequency (cm⁻¹) of the TS, or None."""
+    """Return the imaginary frequency (cm⁻¹) of the TS, or None.
+
+    ``ARCSpecies.chosen_ts`` holds the chosen ``TSGuess.index``, which is that guess's stable
+    identity, not its position in ``ts_guesses``: unsuccessful guesses are kept in the list and
+    equivalent-guess clustering removes guesses while preserving the survivors' indices, so the
+    two diverge. The chosen guess is therefore looked up by index.
+    """
     # Primary: take the most negative frequency from spc.freqs (all freqs from the freq job)
     freqs = getattr(spc, 'freqs', None)
     if freqs:
@@ -533,8 +539,9 @@ def _get_ts_imag_freq(spc) -> float | None:
     # Fallback: try the chosen TS guess's imaginary_freqs
     try:
         chosen = spc.chosen_ts
-        if chosen is not None and spc.ts_guesses and chosen < len(spc.ts_guesses):
-            im_freqs = spc.ts_guesses[chosen].imaginary_freqs
+        if chosen is not None and spc.ts_guesses:
+            chosen_guess = next((tsg for tsg in spc.ts_guesses if tsg.index == chosen), None)
+            im_freqs = chosen_guess.imaginary_freqs if chosen_guess is not None else None
             if im_freqs:
                 return float(im_freqs[0])
     except Exception:

--- a/arc/output_test.py
+++ b/arc/output_test.py
@@ -210,16 +210,31 @@ class TestGetTsImagFreq(unittest.TestCase):
 
     def test_valid_imag_freq(self):
         ts_guess = MagicMock()
+        ts_guess.index = 0
         ts_guess.imaginary_freqs = [-1500.0, -200.0]
         spc = MagicMock()
         spc.chosen_ts = 0
         spc.ts_guesses = [ts_guess]
         self.assertAlmostEqual(_get_ts_imag_freq(spc), -1500.0)
 
-    def test_chosen_ts_out_of_range(self):
+    def test_chosen_ts_is_an_index_not_a_position(self):
+        """``chosen_ts`` is the chosen TSGuess.index; the list position must not be used."""
+        other_guess, chosen_guess = MagicMock(), MagicMock()
+        other_guess.index, other_guess.imaginary_freqs = 0, [-100.0]
+        chosen_guess.index, chosen_guess.imaginary_freqs = 4, [-1500.0]
         spc = MagicMock()
+        spc.freqs = None
+        spc.chosen_ts = 4
+        spc.ts_guesses = [other_guess, chosen_guess]
+        self.assertAlmostEqual(_get_ts_imag_freq(spc), -1500.0)
+
+    def test_chosen_ts_matches_no_guess(self):
+        guess = MagicMock()
+        guess.index, guess.imaginary_freqs = 0, [-100.0]
+        spc = MagicMock()
+        spc.freqs = None
         spc.chosen_ts = 5
-        spc.ts_guesses = [MagicMock()]
+        spc.ts_guesses = [guess]
         self.assertIsNone(_get_ts_imag_freq(spc))
 
 
@@ -828,6 +843,7 @@ class TestSpcToDict(unittest.TestCase):
         spc.rxn_label = 'CH4 + OH <=> CH3 + H2O'
         spc.thermo = None
         ts_guess = MagicMock()
+        ts_guess.index = 0
         ts_guess.imaginary_freqs = [-1500.0]
         spc.ts_guesses = [ts_guess]
         spc.chosen_ts = 0

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -81,6 +81,31 @@ LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ, default_job_settings, \
 WRONG_FREQ_MESSAGE = 'wrong number of negative frequencies; '
 
 
+def tsg_method_matches_adapter(method: str | None, job_adapter: str | None) -> bool:
+    """
+    Determine whether a ``TSGuess.method`` was produced by a given TS-search adapter.
+
+    The two spellings differ (e.g. the ``xtb_gsm`` adapter labels its guesses ``'xTB-GSM'``,
+    ``kinbot`` labels them ``'KinBot'`` or ``'KinBot-UMA'``), so both strings are lower-cased
+    and stripped of ``'-'`` and ``'_'`` before testing for containment.
+
+    Args:
+        method (str, optional): The ``TSGuess.method`` string.
+        job_adapter (str, optional): The TS-search job adapter name.
+
+    Returns:
+        bool: Whether the guess was produced by this adapter.
+    """
+    if not method or not job_adapter:
+        return False
+
+    def normalize(text: str) -> str:
+        """Lower-case ``text`` and drop the separators that differ between the two spellings."""
+        return text.lower().replace('-', '').replace('_', '')
+
+    return normalize(job_adapter) in normalize(method)
+
+
 class Scheduler(object):
     """
     ARC's Scheduler class. Creates jobs, submits, checks status, troubleshoots.
@@ -397,10 +422,9 @@ class Scheduler(object):
                 rxn.ts_species = ts_species
                 # 3. Generate TSGuess objects for all methods, start with the user guesses
                 for i, user_guess in enumerate(rxn.ts_xyz_guess):  # This is a list of user guesses, could be empty.
-                    ts_species.ts_guesses.append(
+                    ts_species.append_ts_guess(
                         TSGuess(method=f'user guess {i}',
                                 xyz=user_guess,
-                                index=len(rxn.ts_species.ts_guesses),
                                 success=True,
                                 project_directory=self.project_directory,
                                 )
@@ -1326,6 +1350,12 @@ class Scheduler(object):
         """
         Spawn opt jobs at the ts_guesses level of theory for the TS guesses.
 
+        When only a single guess succeeded, its geometry is optimized directly. The reported
+        provenance (relative energy, ``chosen_ts_method``, ``successful_methods`` and the guess
+        log path) is taken from that same guess rather than from ``ts_guesses[0]``: several TS
+        adapters append ``success=False`` guesses, so the first entry of ``ts_guesses`` is not
+        necessarily the guess whose coordinates are being optimized.
+
         Args:
             label (str): The TS species label.
         """
@@ -1370,17 +1400,18 @@ class Scheduler(object):
                     rxn = ' of reaction ' + self.species_dict[label].rxn_label
                 logger.info(f'Only one TS guess is available for species {label}{rxn}, '
                             f'using it for geometry optimization')
-                self.species_dict[label].ts_guesses[0].energy = 0.0  # Set relative energy to 0, no other guesses.
-                self.species_dict[label].initial_xyz = successful_tsgs[0].initial_xyz
+                chosen_tsg = successful_tsgs[0]
+                chosen_tsg.energy = 0.0
+                self.species_dict[label].initial_xyz = chosen_tsg.initial_xyz
                 self.species_dict[label].mol_from_xyz(get_cheap=False)
                 if not self.composite_method:
                     self.run_opt_job(label, fine=self.fine_only)
                 else:
                     self.run_composite_job(label)
-                self.species_dict[label].chosen_ts_method = self.species_dict[label].ts_guesses[0].method
-                self.species_dict[label].successful_methods = [self.species_dict[label].ts_guesses[0].method]
-                if getattr(self.species_dict[label].ts_guesses[0], 'log_path', None):
-                    self.output[label]['paths']['neb'] = self.species_dict[label].ts_guesses[0].log_path
+                self.species_dict[label].chosen_ts_method = chosen_tsg.method
+                self.species_dict[label].successful_methods = [chosen_tsg.method]
+                if getattr(chosen_tsg, 'log_path', None):
+                    self.output[label]['paths']['neb'] = chosen_tsg.log_path
 
     def run_opt_job(self, label: str, fine: bool = False):
         """
@@ -2176,9 +2207,14 @@ class Scheduler(object):
             xyz = parser.parse_geometry(log_file_path=job.local_path_to_output_file)
             energy = parser.parse_e_elect(log_file_path=job.local_path_to_output_file)
             if self.species_dict[label].is_ts:
-                self.species_dict[label].ts_guesses[i].energy = energy
-                self.species_dict[label].ts_guesses[i].opt_xyz = xyz
-                self.species_dict[label].ts_guesses[i].index = i
+                tsg = next((guess for guess in self.species_dict[label].ts_guesses
+                            if guess.conformer_index == i), None)
+                if tsg is None:
+                    logger.warning(f'Could not find TSGuess for conformer {i} of {label} '
+                                   f'(expected a matching conformer_index); skipping.')
+                    return False
+                tsg.energy = energy
+                tsg.opt_xyz = xyz
                 if energy is not None:
                     logger.debug(f'Energy for TSGuess {i} of {label} is {energy:.2f}')
                 else:
@@ -2398,7 +2434,8 @@ class Scheduler(object):
             e_min, selected_i = None, None
             self.species_dict[label].ts_guesses_exhausted = True
             for tsg in self.species_dict[label].ts_guesses:
-                if tsg.success and tsg.energy is not None and (e_min is None or tsg.energy < e_min) \
+                if tsg.success and tsg.energy is not None and tsg.opt_xyz is not None \
+                        and (e_min is None or tsg.energy < e_min) \
                         and (tsg.imaginary_freqs is None or check_imaginary_frequencies(tsg.imaginary_freqs)) \
                         and tsg.index not in self.species_dict[label].chosen_ts_list:
                     e_min = tsg.energy
@@ -2513,7 +2550,7 @@ class Scheduler(object):
                                        project_directory=self.project_directory,
                                        method='draw_3d')
             frequencies = parser.parse_frequencies(job.local_path_to_output_file, job.job_adapter)
-            freq_ok = self.check_negative_freq(label=label, job=job, vibfreqs=frequencies)
+            freq_ok, _ = self.check_negative_freq(label=label, job=job, vibfreqs=frequencies)
             if freq_ok:
                 # Update restart dictionary and save a restart file:
                 self.save_restart_dict()
@@ -2667,6 +2704,31 @@ class Scheduler(object):
                     f'{xyz_to_str(self.species_dict[spc_label].final_xyz)}\n')
         self.output[spc_label]['paths']['geo'] = job.local_path_to_output_file  # will be overwritten with freq
 
+    def get_chosen_tsg(self, label: str) -> TSGuess | None:
+        """
+        Get the TSGuess object of a TS species that is currently being optimized.
+
+        The ``chosen_ts`` attribute of an ARCSpecies object stores a ``TSGuess.index``, which is an identity
+        assigned to a TS guess when it is appended to the species. It is not a position in a list, and in
+        particular it is not the ``TSGuess.conformer_index`` attribute, which is the index of the conformer
+        optimization job spawned for the guess (i.e., a position in the list of *successful* TS guesses).
+        If ``chosen_ts`` is ``None``, no selection was made among several guesses. That happens when only a
+        single TS guess was successful and was sent directly to a geometry optimization, in which case that
+        guess is returned, and after a restart file with ambiguous TS guess identities was repaired, in which
+        case there may be several successful guesses and ``None`` is returned.
+
+        Args:
+            label (str): The TS species label.
+
+        Returns:
+            TSGuess | None: The chosen TSGuess object, or ``None`` if it could not be determined.
+        """
+        if self.species_dict[label].chosen_ts is not None:
+            return next((tsg for tsg in self.species_dict[label].ts_guesses
+                         if tsg.index == self.species_dict[label].chosen_ts), None)
+        successful_tsgs = [tsg for tsg in self.species_dict[label].ts_guesses if tsg.success]
+        return successful_tsgs[0] if len(successful_tsgs) == 1 else None
+
     def check_freq_job(self,
                        label: str,
                        job: JobAdapter,
@@ -2723,9 +2785,9 @@ class Scheduler(object):
             tuple[bool, bool]: Whether the frequencies passed the check,
                                and whether a different TS guess was selected as a result.
         """
-        switch_ts = False
-        if not self.check_negative_freq(label=label, job=job, vibfreqs=vibfreqs):
-            return False, False
+        freq_ok, switch_ts = self.check_negative_freq(label=label, job=job, vibfreqs=vibfreqs)
+        if not freq_ok:
+            return False, switch_ts
         if vibfreqs is not None:
             self.species_dict[label].freqs = [float(f) for f in vibfreqs]
         # Copy the frequency file to the species / TS output folder.
@@ -2766,24 +2828,27 @@ class Scheduler(object):
                             label: str,
                             job: JobAdapter,
                             vibfreqs: list | np.ndarray | None,
-                            ):
+                            ) -> tuple[bool, bool]:
         """
         A helper function for determining the number of negative frequencies. Also logs appropriate errors.
-        Returns ``True`` if the number of negative frequencies is as excepted, ``False`` otherwise.
 
         Args:
             label (str): The species label.
             job (JobAdapter): The optimization job object.
             vibfreqs (list | np.ndarray | None): The vibrational frequencies, or ``None`` if they could not be parsed.
+
+        Returns:
+            tuple[bool, bool]: Whether the number of negative frequencies is as expected,
+                               and whether a different TS guess was selected as a result.
         """
         if vibfreqs is None:
             logger.error(f'Could not parse frequencies for {label} from the freq job output file '
                          f'{job.local_path_to_output_file}. Treating the freq job as unsuccessful.')
-            return False
+            return False, False
         if len(vibfreqs) == 0 and not self.species_dict[label].is_ts and self.species_dict[label].number_of_atoms > 1:
             logger.error(f'The freq job for {label} yielded no frequencies, but {label} is a polyatomic non-TS '
                          f'species and should have vibrational modes. Treating the freq job as unsuccessful.')
-            return False
+            return False, False
         neg_freqs = list()
         for freq in vibfreqs:
             if freq < 0:
@@ -2795,22 +2860,42 @@ class Scheduler(object):
                 if f'{len(neg_freqs)} imaginary freq for' not in self.output[label]['warnings']:
                     self.output[label]['warnings'] += f'Warning: {len(neg_freqs)} imaginary freq for stable species ' \
                                                       f'({neg_freqs}); '
-                return False
+                return False, False
             else:
                 self.output[label]['job_types']['freq'] = True
                 self.output[label]['paths']['freq'] = job.local_path_to_output_file
                 if not self.testing:
                     # Update restart dictionary and save the yaml restart file:
                     self.save_restart_dict()
-                return True
+                return True, False
         else:
             # This is a TS. Assign the imaginary frequencies to the respective TSGuess.
-            tsg = None
-            for tsg in self.species_dict[label].ts_guesses:
-                if tsg.conformer_index == self.species_dict[label].chosen_ts:
-                    tsg.imaginary_freqs = neg_freqs
-                    break
-            if tsg is not None and not check_imaginary_frequencies(tsg.imaginary_freqs):
+            chosen_tsg = self.get_chosen_tsg(label=label)
+            if chosen_tsg is None and self.species_dict[label].chosen_ts is None:
+                # No selection was made among the TS guesses, so the frequencies cannot be attributed to one.
+                # They still describe the geometry that was optimized, so the check is decided on them directly.
+                n_successful = len([tsg for tsg in self.species_dict[label].ts_guesses if tsg.success])
+                logger.warning(f'No TS guess is currently selected for {label} ({n_successful} successful TS '
+                               f'guesses), so the imaginary frequencies {neg_freqs} cannot be attributed to a '
+                               f'TS guess. Checking them against the optimized geometry of {label} itself.')
+                if 'imaginary freqs could not be attributed' not in self.output[label]['warnings']:
+                    self.output[label]['warnings'] += f'Warning: the imaginary freqs could not be attributed to a ' \
+                                                      f'TS guess ({neg_freqs}); '
+            elif chosen_tsg is None:
+                logger.warning(f'Could not match the chosen TS guess index {self.species_dict[label].chosen_ts} of '
+                               f'{label} to any of its TS guesses (available TS guess indices: '
+                               f'{[tsg.index for tsg in self.species_dict[label].ts_guesses]}). '
+                               f'The imaginary frequencies {neg_freqs} could not be attributed to a TS guess, '
+                               f'the frequency check for {label} is therefore considered unverified. '
+                               f'Searching for a better TS conformer...')
+                if 'imaginary freqs could not be attributed' not in self.output[label]['warnings']:
+                    self.output[label]['warnings'] += f'Warning: the imaginary freqs could not be attributed to a ' \
+                                                      f'TS guess ({neg_freqs}); '
+                self.switch_ts(label=label)
+                return False, True
+            if chosen_tsg is not None:
+                chosen_tsg.imaginary_freqs = neg_freqs
+            if not check_imaginary_frequencies(neg_freqs):
                 # Imaginary frequencies are problematic, try choosing a different TSGuess, and optimize it.
                 add_text = f' major imaginary frequency between {LOWEST_MAJOR_TS_FREQ} and {HIGHEST_MAJOR_TS_FREQ}.' \
                     if len(neg_freqs) == 1 and (neg_freqs[0] < LOWEST_MAJOR_TS_FREQ
@@ -2820,36 +2905,43 @@ class Scheduler(object):
                 if f'{len(neg_freqs)} imaginary freqs for' not in self.output[label]['warnings']:
                     self.output[label]['warnings'] += f'Warning: {len(neg_freqs)} imaginary freqs for TS ({neg_freqs}); '
                     logger.info(f'TS {label} did not pass the negative frequency check. '
-                                f'Status is:\n{self.species_dict[label].ts_checks}\n'
-                                f'Searching for a better TS conformer...')
+                                f'Status is:\n{self.species_dict[label].ts_checks}\n')
+                if chosen_tsg is None:
+                    # The frequencies belong to no identifiable guess, so switching guesses would discard a
+                    # geometry that may already have passed every other check without knowing what replaces it.
+                    logger.warning(f'Not switching the TS guess of {label}: the frequencies could not be '
+                                   f'attributed to a TS guess. The frequency check is left unverified.')
+                    return False, False
+                logger.info(f'Searching for a better TS conformer for {label}...')
                 self.switch_ts(label=label)
-                return False
+                return False, True
             else:
                 logger.info(f'TS {label} has exactly one imaginary frequency: {neg_freqs[0]}')
                 self.output[label]['info'] += f'Imaginary frequency: {neg_freqs[0] if len(neg_freqs) == 1 else neg_freqs}; '
                 self.output[label]['job_types']['freq'] = True
                 self.output[label]['paths']['freq'] = job.local_path_to_output_file
-                plotter.save_conformers_file(
-                    project_directory=self.project_directory,
-                    label=label,
-                    xyzs=[tsg.opt_xyz for tsg in self.species_dict[label].ts_guesses],
-                    level_of_theory=self.ts_guess_level,
-                    multiplicity=self.species_dict[label].multiplicity,
-                    charge=self.species_dict[label].charge,
-                    is_ts=True,
-                    energies=[tsg.energy for tsg in self.species_dict[label].ts_guesses],
-                    ts_methods=[f'{tsg.method} '
-                                f'{tsg.method_direction if tsg.method_direction is not None else ""} '
-                                f'{tsg.method_index if tsg.method_index is not None else ""} '
-                                for tsg in self.species_dict[label].ts_guesses],
-                    im_freqs=[tsg.imaginary_freqs for tsg in self.species_dict[label].ts_guesses]
-                        if any(tsg.imaginary_freqs is not None for tsg in self.species_dict[label].ts_guesses) else None,
-                    before_optimization=False,
-                )
+                if len(self.species_dict[label].ts_guesses):
+                    plotter.save_conformers_file(
+                        project_directory=self.project_directory,
+                        label=label,
+                        xyzs=[tsg.opt_xyz for tsg in self.species_dict[label].ts_guesses],
+                        level_of_theory=self.ts_guess_level,
+                        multiplicity=self.species_dict[label].multiplicity,
+                        charge=self.species_dict[label].charge,
+                        is_ts=True,
+                        energies=[tsg.energy for tsg in self.species_dict[label].ts_guesses],
+                        ts_methods=[f'{tsg.method} '
+                                    f'{tsg.method_direction if tsg.method_direction is not None else ""} '
+                                    f'{tsg.method_index if tsg.method_index is not None else ""} '
+                                    for tsg in self.species_dict[label].ts_guesses],
+                        im_freqs=[tsg.imaginary_freqs for tsg in self.species_dict[label].ts_guesses]
+                            if any(tsg.imaginary_freqs is not None for tsg in self.species_dict[label].ts_guesses) else None,
+                        before_optimization=False,
+                    )
                 if not self.testing:
                     self.save_restart_dict()
                 self.species_dict[label].ts_checks['freq'] = True
-                return True
+                return True, False
 
     def check_rxn_e0_by_spc(self, label: str):
         """
@@ -3669,6 +3761,41 @@ class Scheduler(object):
         else:
             job.troubleshoot_server()
 
+    def record_tsg_job_error(self,
+                             label: str,
+                             job: JobAdapter,
+                             output_error: str,
+                             ):
+        """
+        Record an unrecoverable TS-search job error on the TS guesses that job produced.
+
+        A ``tsg<i>`` job name numbers the TS-search *adapter* that was dispatched for the
+        reaction, it is not a position in ``species.ts_guesses``: one adapter may contribute
+        several guesses or none at all, and guesses from other adapters are interleaved.
+        Using the job number as a list index therefore either annotates an unrelated guess or
+        raises an ``IndexError`` when the adapter number exceeds the number of guesses
+        generated so far. Match on the adapter that produced each guess instead.
+
+        Args:
+            label (str): The TS species label.
+            job (JobAdapter): The failed TS-search job.
+            output_error (str): The error string to record.
+        """
+        matched = False
+        for tsg in self.species_dict[label].ts_guesses:
+            if tsg.success:
+                # A guess that produced a geometry is not the casualty of this failure, and adapters
+                # merge their names into an equivalent guess (e.g. 'heuristics and gcn'), so matching
+                # a successful guess on the merged name would record the error on another method's work.
+                continue
+            sources = tsg.method_sources or [tsg.method]
+            if any(tsg_method_matches_adapter(source, job.job_adapter) for source in sources):
+                tsg.errors += f'; {output_error}'
+                matched = True
+        if not matched:
+            logger.warning(f'TS-search job {job.job_name} of {label} ({job.job_adapter}) generated no TS guess '
+                           f'to record the error "{output_error}" on: {output_error}')
+
     def troubleshoot_ess(self,
                          label: str,
                          job: JobAdapter,
@@ -3759,7 +3886,7 @@ class Scheduler(object):
         for output_error in output_errors:
             self.output[label]['errors'] += output_error
             if 'Could not troubleshoot' in output_error and 'tsg' in job.job_name:
-                self.species_dict[label].ts_guesses[get_i_from_job_name(job.job_name)].errors += f'; {output_error}'
+                self.record_tsg_job_error(label=label, job=job, output_error=output_error)
         if remove_checkfile:
             self.species_dict[label].checkfile = None
         job.ess_trsh_methods = ess_trsh_methods

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -20,7 +20,7 @@ from arc.job.factory import job_factory
 from arc.level import Level
 from arc.plotter import save_conformers_file
 from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
-                           species_has_sp_and_freq)
+                           species_has_sp_and_freq, tsg_method_matches_adapter)
 from arc.imports import settings
 from arc.reaction import ARCReaction
 from arc.species.converter import str_to_xyz
@@ -246,11 +246,11 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.job3.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
         self.job3.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
         vibfreqs = parser.parse_frequencies(log_file_path=self.job3.local_path_to_output_file)
-        self.assertTrue(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=vibfreqs))
+        self.assertTrue(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=vibfreqs)[0])
         # Unparsed frequencies (``None``) must be treated as an unsuccessful freq job, not crash.
-        self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=None))
+        self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=None)[0])
         # An empty freqs list for a polyatomic non-TS species must not sneak through as successful.
-        self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=list()))
+        self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=list())[0])
 
     def test_post_freq_actions(self):
         """
@@ -881,7 +881,130 @@ H      -1.82570782    0.42754384   -0.56130718"""
                                    project_directory=self.project_directory, job_num=202)
         job_at_limit.ess_trsh_methods = ['trsh_attempt'] * 24
         self.assertNotIn('ESS troubleshooting attempts exhausted', self.sched1.output[label]['errors'])
-     
+
+    def test_tsg_method_matches_adapter(self):
+        """Test matching a TSGuess method string to the TS-search adapter that produced it."""
+        self.assertTrue(tsg_method_matches_adapter('xTB-GSM', 'xtb_gsm'))
+        self.assertTrue(tsg_method_matches_adapter('KinBot-UMA', 'kinbot'))
+        self.assertTrue(tsg_method_matches_adapter('orca_neb', 'orca_neb'))
+        self.assertTrue(tsg_method_matches_adapter('qst2', 'qst2'))
+        self.assertTrue(tsg_method_matches_adapter('Linear (w=0.50, 0)', 'linear'))
+        self.assertFalse(tsg_method_matches_adapter('GCN', 'qst2'))
+        self.assertFalse(tsg_method_matches_adapter(None, 'qst2'))
+        self.assertFalse(tsg_method_matches_adapter('GCN', None))
+
+    def test_record_tsg_job_error(self):
+        """A tsg job number is an adapter number, not a position in ts_guesses.
+
+        Recording the error must never index ts_guesses by the job number: it must annotate the
+        guesses that adapter produced, and must not raise when it produced none.
+        """
+        ts_spc = ARCSpecies(label='TS_tsg_err', is_ts=True, multiplicity=1, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=0, method='GCN', success=False),
+                             TSGuess(index=1, method='xTB-GSM', success=False),
+                             ]
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_for_testing_delete_after_usage_tsg_err')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project='project_test_tsg_err', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        job = MagicMock()
+        job.job_name, job.job_adapter = 'tsg4', 'qst2'
+        sched.record_tsg_job_error(label='TS_tsg_err', job=job, output_error='Could not troubleshoot; ')
+        self.assertEqual([tsg.errors for tsg in ts_spc.ts_guesses], ['', ''])
+
+        job.job_name, job.job_adapter = 'tsg2', 'xtb_gsm'
+        sched.record_tsg_job_error(label='TS_tsg_err', job=job, output_error='Could not troubleshoot; ')
+        self.assertEqual(ts_spc.ts_guesses[0].errors, '')
+        self.assertIn('Could not troubleshoot', ts_spc.ts_guesses[1].errors)
+
+        # A guess that did produce a geometry is not the casualty of another adapter's failure, even
+        # when adapters have merged their names into it (e.g. 'heuristics and gcn').
+        merged = TSGuess(index=2, method='heuristics and gcn', success=True)
+        ts_spc.ts_guesses.append(merged)
+        job.job_name, job.job_adapter = 'tsg3', 'gcn'
+        sched.record_tsg_job_error(label='TS_tsg_err', job=job, output_error='Could not troubleshoot; ')
+        self.assertEqual(merged.errors, '')
+        self.assertIn('Could not troubleshoot', ts_spc.ts_guesses[0].errors)
+
+    @patch('arc.scheduler.Scheduler.run_job')
+    def test_troubleshoot_ess_tsg_job_number_is_not_a_guess_position(self, mock_run_job):
+        """A tsg job number exceeding the number of guesses must not raise from troubleshoot_ess().
+
+        The adapter dispatch number in a ``tsg<i>`` job name is not a position in ``ts_guesses``:
+        an adapter may contribute several guesses or none, so a high dispatch number with few
+        guesses generated so far used to raise IndexError and abort the whole run.
+        """
+        ts_spc = ARCSpecies(label='TS_trsh_tsg', is_ts=True, multiplicity=1, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=0, method='GCN', success=False),
+                             TSGuess(index=1, method='xTB-GSM', success=False),
+                             ]
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_for_testing_delete_after_usage_trsh_tsg')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project='project_test_trsh_tsg', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.job_dict['TS_trsh_tsg'] = {'tsg': dict()}
+        sched.running_jobs['TS_trsh_tsg'] = list()
+        job = MagicMock()
+        # Dispatch number 9 with only two guesses: the pre-fix code subscripted ts_guesses[9].
+        job.job_name, job.job_adapter, job.job_type = 'tsg9', 'gcn', 'tsg'
+        job.job_status = ['done', {'status': 'errored', 'keywords': ['Unknown'], 'error': 'unknown', 'line': ''}]
+        job.ess_trsh_methods, job.fine, job.job_memory_gb, job.cpu_cores = list(), False, 8, 4
+        job.level = Level(repr=default_levels_of_theory['ts_guesses'])
+        job.args = {'keyword': dict(), 'block': dict(), 'trsh': dict()}
+        job.times_rerun, job.job_id, job.server = 0, 1, 'server1'
+        job.conformer = None
+        sched.troubleshoot_ess(label='TS_trsh_tsg', job=job, level_of_theory=job.level)  # must not raise
+        # The GCN guess, not a position, carries the error.
+        self.assertIn('gcn', ts_spc.ts_guesses[0].method.lower())
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_run_ts_conformer_jobs_single_success_provenance(self, mock_run_opt):
+        """The provenance of a lone successful guess must describe that guess, not ts_guesses[0]."""
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        ts_spc = ARCSpecies(label='TS_single', is_ts=True, multiplicity=1, charge=0, compute_thermo=False)
+        failed = TSGuess(index=0, method='qst2', success=False)
+        good = TSGuess(index=1, method='xTB-GSM', success=True, xyz=ts_xyz)
+        ts_spc.ts_guesses = [failed, good]
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_for_testing_delete_after_usage_tsg_single')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        good.log_path = os.path.join(project_directory, 'stringfile.xyz0000')
+        sched = Scheduler(project='project_test_tsg_single', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.job_dict['TS_single'] = dict()
+        sched.run_ts_conformer_jobs(label='TS_single')
+        self.assertEqual(ts_spc.chosen_ts_method, 'xtb-gsm')
+        self.assertEqual(ts_spc.successful_methods, ['xtb-gsm'])
+        self.assertEqual(good.energy, 0.0)
+        self.assertIsNone(failed.energy)
+        self.assertEqual(sched.output['TS_single']['paths']['neb'], good.log_path)
+
     @patch('arc.scheduler.Scheduler.run_opt_job')
     def test_switch_ts_cleanup(self, mock_run_opt):
         """Test that switch_ts resets job_types, convergence, cleans up IRC species, and clears pending pipes."""
@@ -1090,6 +1213,252 @@ H      -1.82570782    0.42754384   -0.56130718"""
 
         # rotors_dict=None must be preserved — do not re-enable rotor scans.
         self.assertIsNone(sched2.species_dict[ts_label2].rotors_dict)
+
+    def setup_ts_scheduler_for_freq_check(self, project, chosen_ts, chosen_ts_list=None):
+        """
+        Set up a Scheduler with a single TS species whose TSGuess ``index`` (identity) and
+        ``conformer_index`` (position among the successful guesses) deliberately diverge.
+
+        Args:
+            project (str): The project name.
+            chosen_ts (int): The value to assign to the TS species ``chosen_ts`` attribute.
+            chosen_ts_list (list, optional): The value to assign to the ``chosen_ts_list`` attribute.
+
+        Returns:
+            tuple: The Scheduler instance, the TS species label, and the list of TSGuess objects.
+        """
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        ts_label = 'TS_freq_identity'
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0, compute_thermo=False)
+        tsg_failed = TSGuess(index=0, method='autotst', success=False, xyz=ts_xyz, execution_time='0:00:01')
+        tsg_a = TSGuess(index=1, method='heuristics', success=True, energy=100.0, xyz=ts_xyz,
+                        execution_time='0:00:01')
+        tsg_b = TSGuess(index=2, method='gcn', success=True, energy=90.0, xyz=ts_xyz, execution_time='0:00:01')
+        for tsg in [tsg_failed, tsg_a, tsg_b]:
+            tsg.opt_xyz = ts_xyz
+        # Only successful guesses get conformer optimization jobs, so the positions and the identities diverge.
+        tsg_a.conformer_index = 0
+        tsg_b.conformer_index = 1
+        # Deliberately stored so that identity, list position and conformer_index all disagree:
+        # index 2 sits at position 0, index 0 at position 1, index 1 at position 2. A lookup that
+        # subscripts ts_guesses, or that matches on conformer_index, therefore finds the wrong guess.
+        ts_spc.ts_guesses = [tsg_b, tsg_failed, tsg_a]
+        ts_spc.chosen_ts = chosen_ts
+        ts_spc.chosen_ts_list = chosen_ts_list if chosen_ts_list is not None else list()
+        ts_spc.ts_guesses_exhausted = False
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=project, ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.job_dict[ts_label] = {'opt': dict(), 'freq': dict(), 'sp': dict()}
+        sched.running_jobs[ts_label] = list()
+        return sched, ts_label, {0: tsg_failed, 1: tsg_a, 2: tsg_b}
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_check_negative_freq_assigns_freqs_to_the_chosen_ts_guess(self, mock_run_opt):
+        """Test that the imaginary frequencies are assigned to the TSGuess identified by ``chosen_ts``."""
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_pass', chosen_ts=2)
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job, vibfreqs=[-1000.0, 500.0, 1500.0])
+        self.assertTrue(freq_ok)
+        self.assertFalse(switched_ts)
+        self.assertEqual(tsgs[2].imaginary_freqs, [-1000.0])
+        self.assertIsNone(tsgs[0].imaginary_freqs)
+        self.assertIsNone(tsgs[1].imaginary_freqs)
+        self.assertTrue(sched.species_dict[ts_label].ts_checks['freq'])
+        self.assertTrue(sched.output[ts_label]['job_types']['freq'])
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_check_negative_freq_rejects_two_imaginary_freqs(self, mock_run_opt):
+        """Test that a TS with two imaginary frequencies is rejected when index and conformer_index diverge."""
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_reject', chosen_ts=2, chosen_ts_list=[2])
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job,
+                                                         vibfreqs=[-1200.0, -800.0, 500.0, 1500.0])
+        self.assertFalse(freq_ok)
+        self.assertTrue(switched_ts)
+        self.assertEqual(tsgs[2].imaginary_freqs, [-1200.0, -800.0])
+        self.assertNotEqual(sched.species_dict[ts_label].ts_checks['freq'], True)
+        self.assertFalse(sched.output[ts_label]['job_types']['freq'])
+        # A different TS guess was selected instead of silently accepting the wrong one.
+        self.assertEqual(sched.species_dict[ts_label].chosen_ts, 1)
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_check_negative_freq_no_matching_ts_guess(self, mock_run_opt):
+        """Test that a ``chosen_ts`` value matching no TSGuess is logged and is not silently accepted."""
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_no_match', chosen_ts=99)
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        with self.assertLogs('arc', level='WARNING') as context_manager:
+            freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job,
+                                                             vibfreqs=[-1000.0, 500.0, 1500.0])
+        self.assertFalse(freq_ok)
+        self.assertTrue(switched_ts)
+        self.assertTrue(any('99' in message and ts_label in message for message in context_manager.output))
+        self.assertTrue(all(tsg.imaginary_freqs is None for tsg in tsgs.values()))
+        self.assertNotEqual(sched.species_dict[ts_label].ts_checks['freq'], True)
+        self.assertFalse(sched.output[ts_label]['job_types']['freq'])
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_check_negative_freq_no_chosen_ts_judges_the_freqs_directly(self, mock_switch_ts):
+        """Test that a good freq result arriving while no TS guess is selected still converges the TS.
+
+        A repaired restart file resets ``chosen_ts``, and a standalone TS given several xyz guesses
+        never sets it, so a freq job can land with no selection. The frequencies cannot be attributed
+        to a guess, but they still describe the optimized geometry, so the check is decided on them
+        directly. Leaving it unverified would strand the species: for a TS, ``check_freq_job`` neither
+        troubleshoots nor respawns, so nothing would ever set ``chosen_ts`` again.
+        """
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_no_chosen', chosen_ts=None)
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        with self.assertLogs('arc', level='WARNING') as context_manager:
+            freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job,
+                                                             vibfreqs=[-1000.0, 500.0, 1500.0])
+        self.assertTrue(freq_ok)
+        self.assertFalse(switched_ts)
+        self.assertTrue(any(ts_label in message for message in context_manager.output))
+        mock_switch_ts.assert_not_called()
+        # The verdict is recorded on the species, not attributed to any one guess.
+        self.assertTrue(sched.species_dict[ts_label].ts_checks['freq'])
+        self.assertTrue(sched.output[ts_label]['job_types']['freq'])
+        self.assertTrue(all(tsg.imaginary_freqs is None for tsg in tsgs.values()))
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_check_negative_freq_no_chosen_ts_does_not_switch_on_a_bad_result(self, mock_switch_ts):
+        """Test that a bad freq result with no selected guess fails the check without switching guesses.
+
+        Switching here would discard a geometry that may already have passed every other check,
+        without knowing which guess replaces it.
+        """
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_no_chosen_bad', chosen_ts=None)
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        with self.assertLogs('arc', level='WARNING') as context_manager:
+            freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job,
+                                                             vibfreqs=[-1200.0, -800.0, 500.0, 1500.0])
+        self.assertFalse(freq_ok)
+        self.assertFalse(switched_ts)
+        self.assertTrue(any(ts_label in message for message in context_manager.output))
+        mock_switch_ts.assert_not_called()
+        self.assertNotEqual(sched.species_dict[ts_label].ts_checks['freq'], True)
+        self.assertFalse(sched.output[ts_label]['job_types']['freq'])
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_check_negative_freq_uses_the_sole_successful_guess_when_none_was_chosen(self, mock_switch_ts):
+        """Test the ``chosen_ts is None`` fallback: one successful guess is the chosen guess.
+
+        A TS whose single successful guess went straight to a geometry optimization never sets
+        ``chosen_ts``, so the frequencies must still be attributed to that guess.
+        """
+        sched, ts_label, tsgs = self.setup_ts_scheduler_for_freq_check(
+            project='test_ts_freq_identity_sole', chosen_ts=None)
+        # Leave exactly one successful guess, as when only one TS-search method produced a geometry.
+        sched.species_dict[ts_label].ts_guesses = [tsgs[0], tsgs[2]]
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        freq_ok, switched_ts = sched.check_negative_freq(label=ts_label, job=job,
+                                                        vibfreqs=[-1000.0, 500.0, 1500.0])
+        self.assertTrue(freq_ok)
+        self.assertFalse(switched_ts)
+        mock_switch_ts.assert_not_called()
+        # Attributed to the sole successful guess (identity 2), not to the failed one (identity 0).
+        self.assertEqual(tsgs[2].imaginary_freqs, [-1000.0])
+        self.assertIsNone(tsgs[0].imaginary_freqs)
+
+    def setup_ts_scheduler_for_conf_opt(self, project):
+        """
+        Set up a Scheduler with a TS species whose TSGuess objects are ordered so that a guess's
+        position in the ``ts_guesses`` list, its ``index`` identity and its ``conformer_index``
+        all differ from one another.
+
+        Args:
+            project (str): The project name.
+
+        Returns:
+            tuple: The Scheduler instance, the TS species label, and the list of TSGuess objects.
+        """
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        ts_label = 'TS_conf_opt_identity'
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0, compute_thermo=False)
+        # Clustering removed the guess that held index 1, and the surviving guesses were reordered,
+        # so neither the list position nor the identity equals the conformer job index.
+        tsg_a = TSGuess(index=5, method='gcn', success=True, xyz=ts_xyz, execution_time='0:00:01')
+        tsg_a.conformer_index = 1
+        tsg_b = TSGuess(index=2, method='heuristics', success=True, xyz=ts_xyz, execution_time='0:00:01')
+        tsg_b.conformer_index = 0
+        ts_spc.ts_guesses = [tsg_a, tsg_b]
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=project, ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        return sched, ts_label, [tsg_a, tsg_b]
+
+    def test_parse_conformer_attributes_ts_results_by_conformer_index(self):
+        """Test that a TS conf_opt result is written to the TSGuess whose conformer_index matches the job."""
+        sched, ts_label, (tsg_a, tsg_b) = self.setup_ts_scheduler_for_conf_opt(
+            project='test_ts_conf_opt_identity')
+        job_0, job_1 = MagicMock(), MagicMock()
+        job_0.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'methylamine_conformer_0.out')
+        job_1.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'methylamine_conformer_1.out')
+        for job in (job_0, job_1):
+            job.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
+
+        sched.parse_conformer(job=job_0, label=ts_label, i=0)
+        self.assertAlmostEqual(tsg_b.energy, -251596.4435088726, 5)
+        self.assertEqual(tsg_b.opt_xyz, parser.parse_geometry(log_file_path=job_0.local_path_to_output_file))
+        self.assertIsNone(tsg_a.energy)
+        self.assertIsNone(tsg_a.opt_xyz)
+
+        sched.parse_conformer(job=job_1, label=ts_label, i=1)
+        self.assertAlmostEqual(tsg_a.energy, -254221.9433698632, 5)
+        self.assertEqual(tsg_a.opt_xyz, parser.parse_geometry(log_file_path=job_1.local_path_to_output_file))
+        # The identities must survive the ingestion, they are what chosen_ts refers to.
+        self.assertEqual([tsg.index for tsg in sched.species_dict[ts_label].ts_guesses], [5, 2])
+
+    def test_parse_conformer_warns_when_no_ts_guess_matches(self):
+        """Test that a TS conf_opt result with no matching conformer_index is logged and not attributed."""
+        sched, ts_label, (tsg_a, tsg_b) = self.setup_ts_scheduler_for_conf_opt(
+            project='test_ts_conf_opt_identity_no_match')
+        job = MagicMock()
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'methylamine_conformer_0.out')
+        job.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
+        with self.assertLogs('arc', level='WARNING') as context_manager:
+            self.assertFalse(sched.parse_conformer(job=job, label=ts_label, i=5))
+        self.assertTrue(any(ts_label in message for message in context_manager.output))
+        for tsg in (tsg_a, tsg_b):
+            self.assertIsNone(tsg.energy)
+            self.assertIsNone(tsg.opt_xyz)
+        self.assertEqual([tsg.index for tsg in sched.species_dict[ts_label].ts_guesses], [5, 2])
 
     @patch('arc.scheduler.Scheduler.run_job')
     def test_run_sp_monoatomic_dlpno(self, mock_run_job):

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -901,6 +901,7 @@ class ARCSpecies(object):
             self.ts_checks = species_dict['ts_checks'] if 'ts_checks' in species_dict else dict()
             self.chosen_ts_list = species_dict['chosen_ts_list'] if 'chosen_ts_list' in species_dict else list()
             self.checkfile = species_dict['checkfile'] if 'checkfile' in species_dict else None
+            self.renumber_ambiguous_ts_guesses()
         if 'xyz' in species_dict and self.initial_xyz is None and self.final_xyz is None:
             self.process_xyz(species_dict['xyz'])
         self.multiplicity = species_dict['multiplicity'] if 'multiplicity' in species_dict else None
@@ -1669,6 +1670,90 @@ class ARCSpecies(object):
                 self.ts_report += f'\nThe method that generated the best TS guess and its output used for the ' \
                                   f'optimization: {self.chosen_ts_method}\n'
 
+    def next_ts_guess_index(self) -> int:
+        """
+        Get the next available ``TSGuess.index`` identity for this species.
+
+        The returned index is one greater than the largest index in use by this species, counting
+        both the indices its TS guesses hold and the indices recorded in their ``cluster`` lists,
+        so an identity is never reused. It is deliberately not the length of the ``ts_guesses``
+        list: ``cluster_tsgs()`` shrinks that list while the surviving guesses retain their
+        original indices and record the indices they absorbed, so a length-based identity would
+        collide with an index that is still spoken for.
+
+        Returns:
+            int: The next available TSGuess index.
+        """
+        used = [tsg.index for tsg in self.ts_guesses if tsg.index is not None]
+        used += [index for tsg in self.ts_guesses for index in (tsg.cluster or []) if index is not None]
+        return max(used, default=-1) + 1
+
+    def append_ts_guess(self, tsg: 'TSGuess') -> 'TSGuess':
+        """
+        Append a TS guess to this species, assigning it a unique identity.
+
+        ``tsg.index`` is set from ``next_ts_guess_index()`` whenever it is missing or already taken
+        by another guess of this species, so that a caller cannot give two guesses the same
+        identity. An index that is free is left as it is.
+
+        Args:
+            tsg (TSGuess): The TS guess to append.
+
+        Returns:
+            TSGuess: The appended TS guess.
+        """
+        if tsg.index is None or any(guess.index == tsg.index for guess in self.ts_guesses):
+            tsg.index = self.next_ts_guess_index()
+        self.ts_guesses.append(tsg)
+        return tsg
+
+    def renumber_ambiguous_ts_guesses(self) -> None:
+        """
+        Assign fresh identities to TS guesses whose ``index`` is missing or duplicated.
+
+        A restart file written before TSGuess identities were allocated uniquely may hold guesses
+        that share an index or that have none, which makes a lookup by identity ambiguous. Only the
+        ambiguous guesses are re-indexed, so references to unambiguous identities remain valid.
+
+        A contested index is kept by the successful guess that holds it, because ``chosen_ts`` and
+        ``chosen_ts_list`` can only ever refer to a successful guess. An index contested by a single
+        successful guess is therefore resolved without touching either attribute. Only an index held
+        by several successful guesses stays ambiguous, and there ``chosen_ts`` is reset so that a TS
+        conformer is selected again rather than paired arbitrarily, and the index is dropped from
+        ``chosen_ts_list`` so that neither holder is barred from being selected.
+        """
+        if not self.is_ts or not len(self.ts_guesses):
+            return None
+        holders = dict()
+        for tsg in self.ts_guesses:
+            if tsg.index is not None:
+                holders.setdefault(tsg.index, list()).append(tsg)
+        ambiguous, unresolved = list(), list()
+        for index, guesses in holders.items():
+            if len(guesses) == 1:
+                continue
+            successful = [tsg for tsg in guesses if tsg.success]
+            keeper = successful[0] if successful else guesses[0]
+            ambiguous.extend(tsg for tsg in guesses if tsg is not keeper)
+            if len(successful) > 1:
+                unresolved.append(index)
+        ambiguous.extend(tsg for tsg in self.ts_guesses if tsg.index is None)
+        if not ambiguous:
+            return None
+        for tsg in ambiguous:
+            tsg.index = self.next_ts_guess_index()
+        logger.warning(f'{len(ambiguous)} TS guess(es) of {self.label} had a missing or a duplicated index '
+                       f'(duplicated indices: {sorted(index for index, g in holders.items() if len(g) > 1)}), '
+                       f'and were re-indexed to keep TS guess identities unique.')
+        if not unresolved:
+            return None
+        if self.chosen_ts in unresolved:
+            logger.warning(f'The chosen TS guess index {self.chosen_ts} of {self.label} was held by several '
+                           f'successful guesses, a TS conformer will be selected again.')
+            self.chosen_ts = None
+        if any(index in unresolved for index in self.chosen_ts_list):
+            self.chosen_ts_list = [index for index in self.chosen_ts_list if index not in unresolved]
+
     def cluster_tsgs(self):
         """
         Cluster TSGuesses.
@@ -1711,9 +1796,7 @@ class ARCSpecies(object):
                           log_path=path,
                           )
             if tsg.initial_xyz is not None and not colliding_atoms(tsg.initial_xyz):
-                if tsg.index is None:
-                    tsg.index = len(self.ts_guesses)
-                self.ts_guesses.append(tsg)
+                self.append_ts_guess(tsg)
             else:
                 # The queue TS-search job produced no usable geometry (nothing parseable, or
                 # colliding atoms). Mark it failed and do NOT add it as a clusterable guess: a
@@ -1729,9 +1812,7 @@ class ARCSpecies(object):
             tsgs = [TSGuess(ts_dict=tsg_dict) for tsg_dict in tsg_list]
             for tsg in tsgs:
                 if tsg.initial_xyz is not None and not colliding_atoms(tsg.initial_xyz):
-                    if tsg.index is None:
-                        tsg.index = len(self.ts_guesses)
-                    self.ts_guesses.append(tsg)
+                    self.append_ts_guess(tsg)
         self.cluster_tsgs()
 
     def mol_from_xyz(self,
@@ -1825,6 +1906,12 @@ class ARCSpecies(object):
         """
         Process the user's input and add either to the .conformers attribute or to .ts_guesses.
 
+        For a TS, each user guess is given an explicit ``TSGuess.index`` allocated by
+        ``next_ts_guess_index()``. ``TSGuess.index`` is the guess's stable identity: it is what
+        ``cluster_tsgs()`` orders by, what ``ARCSpecies.chosen_ts`` / ``chosen_ts_list`` refer to,
+        and what keys the TS guess report. Leaving it ``None`` (the ``TSGuess`` default) makes a
+        user guess unselectable as the chosen TS.
+
         Args:
             xyz_list (list, str, dict): Entries are either string-format, dict-format coordinates or file paths.
                                         (If there's only one entry, it could be given directly, not in a list)
@@ -1876,16 +1963,14 @@ class ARCSpecies(object):
                 self.conformers.extend(xyzs)
                 self.conformer_energies.extend(energies)
             else:
-                tsg_index = len(self.ts_guesses)
                 for xyz, energy in zip(xyzs, energies):
-                    self.ts_guesses.append(TSGuess(method=f'user guess {tsg_index}',
-                                                   xyz=remove_dummies(xyz),
-                                                   energy=energy,
-                                                   success=True,
-                                                   ))
-                    # user guesses are always successful in generating a *guess*:
-                    self.ts_guesses[tsg_index].success = True
-                    tsg_index += 1
+                    tsg_index = self.next_ts_guess_index()
+                    self.append_ts_guess(TSGuess(index=tsg_index,
+                                                 method=f'user guess {tsg_index}',
+                                                 xyz=remove_dummies(xyz),
+                                                 energy=energy,
+                                                 success=True,
+                                                 ))
             if self.multiplicity is not None and self.charge is not None:
                 for xyz in xyzs:
                     consistent = check_xyz(xyz=xyz, multiplicity=self.multiplicity, charge=self.charge)
@@ -2395,7 +2480,8 @@ class TSGuess(object):
         execution_time (str): Overall execution time for the TS guess method.
         success (bool): Whether the TS guess method succeeded in generating an XYZ guess or not.
         energy (float): Relative energy of all TS conformers in kJ/mol.
-        index (int): A running index of all TSGuess objects belonging to an ARCSpecies object.
+        index (int): A unique identity assigned to a TSGuess object when it is appended to an
+                     ARCSpecies object. It is not a position in a list.
         imaginary_freqs (list[float]): The imaginary frequencies of the TS guess after optimization.
         conformer_index (int): An index corresponding to the conformer jobs spawned for each TSGuess object.
                                Assigned only if self.success is ``True``.

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -10,7 +10,12 @@ import shutil
 import tempfile
 import unittest
 
-from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, check_that_all_entries_are_in_list
+from arc.common import (ARC_PATH,
+                        ARC_TESTING_PATH,
+                        almost_equal_coords_lists,
+                        check_that_all_entries_are_in_list,
+                        save_yaml_file,
+                        )
 from arc.species.converter import check_xyz_dict
 from arc.exceptions import SpeciesError
 from arc.level import Level
@@ -2625,6 +2630,162 @@ H       1.11582953    0.94384729   -0.10134685"""
         # No coordinate-less guess was added as a successful clusterable guess.
         self.assertTrue(all(tsg.get_xyz() is not None or not tsg.success for tsg in spc.ts_guesses))
         self.assertFalse(any(tsg.success and tsg.get_xyz() is None for tsg in spc.ts_guesses))
+
+    def test_next_ts_guess_index_survives_clustering(self):
+        """A TSGuess identity must never be reused after clustering shrank the ts_guesses list."""
+        xyz_1 = """N       0.9177905887     0.5194617797     0.0000000000
+                   H       1.8140204898     1.0381941417     0.0000000000
+                   H      -0.4763167868     0.7509348722     0.0000000000
+                   N       0.9992350860    -0.7048575683     0.0000000000
+                   N      -1.4430010939     0.0274543367     0.0000000000
+                   H      -0.6371484821    -0.7497769134     0.0000000000
+                   H      -2.0093636431     0.0331190314    -0.8327683174
+                   H      -2.0093636431     0.0331190314     0.8327683174"""
+        xyz_2 = xyz_1.replace('0.8327683174', '1.8327683174')
+        spc = ARCSpecies(label='TS_identity', is_ts=True)
+        for i, xyz in enumerate([xyz_1, xyz_1, xyz_2, xyz_2]):
+            spc.ts_guesses.append(TSGuess(index=i, method=f'gcn {i}', xyz=xyz, success=True,
+                                          execution_time='00:00:01'))
+        spc.cluster_tsgs()
+        # Clustering keeps the first guess of each cluster, so the surviving indices are sparse
+        # and len(ts_guesses) is an index that is still in use.
+        surviving = [tsg.index for tsg in spc.ts_guesses]
+        self.assertEqual(surviving, [0, 2])
+        self.assertIn(len(spc.ts_guesses), surviving)
+        self.assertNotIn(spc.next_ts_guess_index(), surviving)
+        spc.ts_guesses.append(TSGuess(index=spc.next_ts_guess_index(), method='orca_neb', xyz=xyz_2,
+                                      success=True, execution_time='00:00:01'))
+        indices = [tsg.index for tsg in spc.ts_guesses]
+        self.assertEqual(len(indices), len(set(indices)))
+
+    def test_append_ts_guess_assigns_an_identity_to_an_index_less_guess(self):
+        """A guess appended without an index must be given one: this is the path every TS adapter uses.
+
+        The TS adapters construct a TSGuess without an index and let append_ts_guess() allocate it,
+        so a guess that keeps ``index=None`` can never be referred to by ``chosen_ts``.
+        """
+        xyz_1 = """N       0.9177905887     0.5194617797     0.0000000000
+                   H       1.8140204898     1.0381941417     0.0000000000
+                   H      -0.4763167868     0.7509348722     0.0000000000
+                   N       0.9992350860    -0.7048575683     0.0000000000
+                   N      -1.4430010939     0.0274543367     0.0000000000
+                   H      -0.6371484821    -0.7497769134     0.0000000000
+                   H      -2.0093636431     0.0331190314    -0.8327683174
+                   H      -2.0093636431     0.0331190314     0.8327683174"""
+        xyz_2 = xyz_1.replace('0.9177905887', '9.9177905887')
+        spc = ARCSpecies(label='TS_append', is_ts=True)
+        first = spc.append_ts_guess(TSGuess(method='gcn', success=True, xyz=xyz_1, execution_time='00:00:01'))
+        second = spc.append_ts_guess(TSGuess(method='autotst', success=True, xyz=xyz_2, execution_time='00:00:01'))
+        self.assertEqual([first.index, second.index], [0, 1])
+        self.assertNotIn(None, [tsg.index for tsg in spc.ts_guesses])
+        # An index already taken is reallocated; a free one is left alone.
+        collide = spc.append_ts_guess(TSGuess(index=0, method='kinbot', success=True, xyz=xyz_1,
+                                              execution_time='00:00:01'))
+        self.assertEqual(collide.index, 2)
+        free = spc.append_ts_guess(TSGuess(index=9, method='qst2', success=True, xyz=xyz_2,
+                                           execution_time='00:00:01'))
+        self.assertEqual(free.index, 9)
+        indices = [tsg.index for tsg in spc.ts_guesses]
+        self.assertEqual(len(indices), len(set(indices)))
+
+    def test_next_ts_guess_index_skips_indices_recorded_in_a_cluster(self):
+        """An index absorbed by clustering is still spoken for and must not be handed out again."""
+        xyz = """N       0.9177905887     0.5194617797     0.0000000000
+                 H       1.8140204898     1.0381941417     0.0000000000
+                 H      -0.4763167868     0.7509348722     0.0000000000
+                 N       0.9992350860    -0.7048575683     0.0000000000
+                 N      -1.4430010939     0.0274543367     0.0000000000
+                 H      -0.6371484821    -0.7497769134     0.0000000000
+                 H      -2.0093636431     0.0331190314    -0.8327683174
+                 H      -2.0093636431     0.0331190314     0.8327683174"""
+        spc = ARCSpecies(label='TS_cluster_idx', is_ts=True)
+        tsg = TSGuess(index=0, method='gcn', success=True, xyz=xyz, execution_time='00:00:01')
+        tsg.cluster = [0, 1, 5]
+        spc.ts_guesses = [tsg]
+        self.assertEqual(spc.next_ts_guess_index(), 6)
+
+    def test_process_completed_tsg_queue_jobs_keeps_indices_unique(self):
+        """A TS guess ingested from a queue job must not reuse an index that is already taken."""
+        xyz = """N       0.9177905887     0.5194617797     0.0000000000
+                 H       1.8140204898     1.0381941417     0.0000000000
+                 H      -0.4763167868     0.7509348722     0.0000000000
+                 N       0.9992350860    -0.7048575683     0.0000000000
+                 N      -1.4430010939     0.0274543367     0.0000000000
+                 H      -0.6371484821    -0.7497769134     0.0000000000
+                 H      -2.0093636431     0.0331190314    -0.8327683174
+                 H      -2.0093636431     0.0331190314     0.8327683174"""
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
+        yml_path = os.path.join(tmp_dir, 'tsgs.yml')
+        save_yaml_file(path=yml_path, content=[{'index': 4,
+                                                'method': 'orca_neb',
+                                                'success': True,
+                                                'initial_xyz': str_to_xyz(xyz.replace('0.8327683174',
+                                                                                      '1.8327683174')),
+                                                'execution_time': '00:00:01'}])
+        spc = ARCSpecies(label='TS_queue_identity', is_ts=True)
+        spc.ts_guesses = [TSGuess(index=4, method='gcn', xyz=xyz, success=True, execution_time='00:00:01')]
+        spc.process_completed_tsg_queue_jobs(path=yml_path)
+        indices = [tsg.index for tsg in spc.ts_guesses]
+        self.assertEqual(len(spc.ts_guesses), 2)
+        self.assertEqual(len(indices), len(set(indices)))
+
+    def test_renumber_ambiguous_ts_guesses_on_restart(self):
+        """A restart file holding duplicated TSGuess indices is repaired, and an ambiguous chosen_ts is reset."""
+        xyz = """N       0.9177905887     0.5194617797     0.0000000000
+                 H       1.8140204898     1.0381941417     0.0000000000
+                 H      -0.4763167868     0.7509348722     0.0000000000
+                 N       0.9992350860    -0.7048575683     0.0000000000
+                 N      -1.4430010939     0.0274543367     0.0000000000
+                 H      -0.6371484821    -0.7497769134     0.0000000000
+                 H      -2.0093636431     0.0331190314    -0.8327683174
+                 H      -2.0093636431     0.0331190314     0.8327683174"""
+        spc = ARCSpecies(label='TS_restart_identity', is_ts=True)
+        spc.ts_guesses = [TSGuess(index=0, method='gcn', xyz=xyz, success=True, execution_time='00:00:01'),
+                          TSGuess(index=2, method='heuristics', xyz=xyz, success=True, execution_time='00:00:01'),
+                          TSGuess(index=2, method='kinbot', xyz=xyz, success=True, execution_time='00:00:01'),
+                          TSGuess(method='autotst', xyz=xyz, success=True, execution_time='00:00:01')]
+        spc.chosen_ts = 2
+        spc.chosen_ts_list = [0, 2]
+        spc_dict = spc.as_dict()
+        restored = ARCSpecies(species_dict=spc_dict)
+        indices = [tsg.index for tsg in restored.ts_guesses]
+        self.assertEqual(len(indices), len(set(indices)))
+        self.assertNotIn(None, indices)
+        # An unambiguous identity is preserved, and the first holder of a duplicated index keeps it.
+        self.assertEqual(indices[0], 0)
+        self.assertEqual(indices[1], 2)
+        self.assertIsNone(restored.chosen_ts)
+        # The ambiguous index is dropped from chosen_ts_list so that neither the guess that kept it
+        # nor the guess that was re-indexed is barred from selection; unambiguous entries remain.
+        self.assertEqual(restored.chosen_ts_list, [0])
+
+    def test_process_xyz_assigns_ts_guess_indices(self):
+        """User TS guesses must get an explicit TSGuess.index, continuing past the indices in use.
+
+        A surviving guess keeps its index when clustering shrinks the list, so the next index must
+        come from the indices in use, not from the list length.
+        """
+        xyz_1 = """N       0.9177905887     0.5194617797     0.0000000000
+                   H       1.8140204898     1.0381941417     0.0000000000
+                   H      -0.4763167868     0.7509348722     0.0000000000
+                   N       0.9992350860    -0.7048575683     0.0000000000
+                   N      -1.4430010939     0.0274543367     0.0000000000
+                   H      -0.6371484821    -0.7497769134     0.0000000000
+                   H      -2.0093636431     0.0331190314    -0.8327683174
+                   H      -2.0093636431     0.0331190314     0.8327683174"""
+        xyz_2 = xyz_1.replace('0.9177905887', '9.9177905887')
+        spc = ARCSpecies(label='TS_user_guesses', is_ts=True, xyz=[xyz_1, xyz_2])
+        self.assertEqual([tsg.index for tsg in spc.ts_guesses], [0, 1])
+        self.assertEqual([tsg.method for tsg in spc.ts_guesses], ['user guess 0', 'user guess 1'])
+        self.assertTrue(all(tsg.success for tsg in spc.ts_guesses))
+        spc_2 = ARCSpecies(label='TS_gapped', is_ts=True)
+        spc_2.ts_guesses = [TSGuess(index=0, method='gcn', success=True, xyz=xyz_1),
+                            TSGuess(index=4, method='qst2', success=True, xyz=xyz_2),
+                            ]
+        spc_2.process_xyz([xyz_1])
+        self.assertEqual(spc_2.ts_guesses[-1].index, 5)
+        self.assertEqual(spc_2.ts_guesses[-1].method, 'user guess 5')
 
     def test_are_coords_compliant_with_graph(self):
         """Test coordinates compliant with 2D graph connectivity"""


### PR DESCRIPTION
> **Standalone PR, base `main`.** This was the bottom of stack #942; the stack has been dissolved.
> #940's audit is folded in here — the two covered the same defect class in the same files, so the
> boundary between them only created duplicated hunks. #941 and #943 are now independent PRs off
> `main`: they were written on top of this work but do not depend on it.

---

---

## What went wrong

`TSGuess.index` is a TS guess's **identity**: it is assigned when the guess is appended to the
species, it is what `chosen_ts` and `chosen_ts_list` refer to, and it is how a solved TS is
attributed to the adapter that produced it. It is *not* a position in a list. Five sites broke
that contract.

### 1. conf_opt result ingestion attributed results to the wrong guess

Every successful guess gets a conformer optimization job, numbered by its position in
`successful_tsgs`. Clustering shrinks and reorders that list relative to the full `ts_guesses`
list, but the `enumerate` position over the former was used to subscript the latter when writing
the optimized energy and geometry back:

```python
self.species_dict[label].ts_guesses[i].energy = energy   # i is a position in a *different* list
self.species_dict[label].ts_guesses[i].index = i         # ...and the identity is overwritten
```

So the optimized result landed on an unrelated guess, and the second line destroyed that guess's
identity as well. This is the failure originally reported: after dedup collapsed several similar
TS conformers, ARC wrote conf_opt results back using the pre-dedup integers and went out of range.

Guesses are now matched on `conformer_index`, and a missing match warns instead of mis-assigning.

### 2. The frequency check could accept a TS it never verified

`chosen_ts` stores a `TSGuess.index`, but `check_negative_freq()` matched on `conformer_index` —
the position among the *successful* guesses. It also relied on the loop variable leaking out of
the `for` loop, so a no-match left `tsg` bound to the last guess rather than to `None`. Because
`check_imaginary_frequencies(None)` returns `True` by design — a guess whose frequencies have not
been computed must not be disqualified during pre-screening — **a TS with zero, two or three
imaginary frequencies could be accepted as converged while its real frequencies were never
recorded.**

Matching is now by identity, through a new `get_chosen_tsg()` helper. A `chosen_ts` that matches
no guess is treated as an unverified frequency check: it logs the label, `chosen_ts` and the
available indices, and looks for a different TS conformer rather than silently accepting the
geometry.

When *no* guess is selected at all — which a repaired restart file can produce, see below — the
check is likewise left unverified, but the geometry is kept and no guess switch is made. Switching
there would discard a TS that may already have passed every check, which is the failure mode #941
exists to prevent.

### 3. Pipe ts_opt ingestion clobbered the identity

The same overwrite of `TSGuess.index` with the conformer index, on the pipe path.

### 4. The identity was allocated from a list length

Raised in review. Every allocation site spelled the next identity as
`len(ts_species.ts_guesses)`, which is the next free identity only while that list never shrinks.
`cluster_tsgs()` does shrink it, keeping the survivors' original — now sparse — indices:

```
before:          [0, 1, 2, 3]
after cluster:   [0, 2]                 len() == 2, and 2 is still in use
next allocation: index = len() == 2     ← duplicate identity
```

Reproduced against the real clustering path, including the user-xyz guess that carries no index
at all:

```
before:         [None, 0, 1, 2, 3]
after cluster:  [None, 2]
after append:   [None, 2, 2]
```

With two guesses holding index 2, `chosen_ts` silently resolves to whichever appears first, and
the `chosen_ts_list` filter that stops an exhausted guess being re-selected excludes both at once.

### 5. Three more sites used a position where an identity was meant

Folded in from #940. None of these changes which TS guess is selected.

| site | what it did |
|---|---|
| `Scheduler.troubleshoot_ess` | subscripted `ts_guesses` with the number parsed out of a `tsg<i>` job name. That number identifies the TS-search **adapter** dispatched, not a guess — an adapter may contribute several guesses or none — so it annotated an unrelated guess, and raised `IndexError`, aborting the run, whenever the adapter number exceeded the guesses generated so far. Now matched on the adapter that produced each guess. |
| `Scheduler.run_ts_conformer_jobs` | reported `ts_guesses[0]` as the provenance of the lone successful guess while optimizing `successful_tsgs[0]`'s coordinates. Several adapters append `success=False` guesses, so those are not the same object, and `chosen_ts_method` could name a method that produced no geometry. |
| `output._get_ts_imag_freq` | subscripted `ts_guesses` with `chosen_ts`, reporting a different guess's imaginary frequency whenever the two numberings diverged. |

## The fix

| site | before | after |
|---|---|---|
| conf_opt ingestion | `ts_guesses[i]`, then `.index = i` | look up by `conformer_index`; warn on no match |
| frequency check | match on `conformer_index`, leaked loop variable | `get_chosen_tsg()`, match on identity |
| pipe ts_opt ingestion | `.index = conformer_index` | identity left alone |
| identity allocation | `len(ts_species.ts_guesses)` | `ARCSpecies.next_ts_guess_index()` |

`next_ts_guess_index()` returns one past the largest index in use, so an identity is never reused
no matter how clustering has reshaped the list. It replaces the length-based allocation at all
fourteen sites: ten across nine TS adapters, one in `scheduler.py`, and three in `species.py`.
Three further holes are closed with it:

- a TS guess read from a queue job's YAML no longer keeps an index that is already taken;
- guesses built from user xyz input, which were assigned no index at all and were then reached by
  list position, are allocated one too. Without this, a user-supplied TS geometry is unselectable:
  `chosen_ts` is set from `tsg.index`, so it stays `None` and `determine_most_likely_ts_conformer()`
  reports "Could not determine a likely TS conformer";
- a restart file holding missing or duplicated indices is repaired on load. Only the ambiguous
  guesses are re-indexed, so references to unambiguous identities stay valid. Every reference to a
  duplicated index is then dropped, since none of them can be resolved — `chosen_ts` is reset so a
  TS conformer is selected again, and the duplicated indices are stripped from `chosen_ts_list` so
  that neither the guess that kept the index nor the guess that was re-indexed is barred from
  selection.

### 6. Frequencies that belong to no identifiable guess

Found by adversarial review of the first fix for #2, and reproduced independently twice. Leaving
the check "unverified" when no guess is selected **strands the species**: for a TS,
`check_freq_job()` neither troubleshoots nor respawns, `output['job_types']['freq']` stays `False`,
and `chosen_ts` is only ever assigned by `determine_most_likely_ts_conformer()` — which that path
declines to reach. Two routes hit it, neither exotic:

- a standalone TS given two or more xyz guesses, where `main` matched `None == None`, bound the
  first guess and returned `True` — so a TS that converges today would never converge;
- any repaired restart file, and the duplicated indices that trigger the repair were produced by
  the very code this PR removes, so **that is the common case for existing restarts**, not an edge
  case.

The frequencies still describe the geometry that was optimized, so the check is now decided on them
directly, without attributing them to a guess. A bad result still does not switch guesses.

### 7. A guess cannot be selected without an optimized geometry

`determine_most_likely_ts_conformer()` assigns `initial_xyz` from `TSGuess.opt_xyz`. The lone
successful guess is sent straight to a geometry optimization and now carries a relative energy of
0.0, which made it selectable on a later `switch_ts` with `opt_xyz` still `None` — blanking the
geometry and burning a full opt/freq/sp cycle on the raw guess. Selection now requires `opt_xyz`.

## Why it matters

The first three sites move a result, or a verdict, onto a guess it does not belong to. The fourth
makes the identity itself ambiguous, which is what the other three rely on being unique. Together
they mean a TS can be reported as converged on the strength of another guess's frequencies, and
the per-adapter attribution the benchmark is built from can silently point at the wrong method.

## Evidence

Regression tests accompany each changed site, written so that reverting the fix fails them:

| test | what it pins |
|---|---|
| `test_parse_conformer_attributes_ts_results_by_conformer_index` | list position, `index` and `conformer_index` all differ; results must follow `conformer_index`, identities must survive |
| `test_parse_conformer_warns_when_no_ts_guess_matches` | an unmatched result touches nothing and is logged |
| `test_check_negative_freq_*` (3) | frequencies are attributed by identity; two imaginary frequencies are rejected; an unmatched `chosen_ts` is logged, not accepted |
| `TestIngestTsOpt` (3) | pipe ingestion with `index=7, conformer_index=0` preserves the identity and updates only the matching guess |
| `test_next_ts_guess_index_survives_clustering` | the allocator never returns an index still in use after clustering |
| `test_process_completed_tsg_queue_jobs_keeps_indices_unique` | a YAML-supplied index that is already taken is reallocated |
| `test_renumber_ambiguous_ts_guesses_on_restart` | duplicated indices are repaired on load, an ambiguous `chosen_ts` is reset, and the ambiguous entries are stripped from `chosen_ts_list` while unambiguous ones survive |
| `test_process_xyz_assigns_ts_guess_indices` | user guesses get an identity, continuing past the indices in use (`0, 4` → `5`) |
| `test_check_negative_freq_no_chosen_ts_leaves_the_check_unverified` | freqs arriving with no selection leave the check unverified and do **not** switch guesses |

**374 tests pass** (`species_test`, `scheduler_test`, `output_test`, `job/pipe`), run serially — this suite is
flaky under `xdist` because its workers collide on shared `Projects/` directories.


