### PR TITLE
Fix atom-map crash for constitutional-isomer cuts (H-abs with identical donors)

### DIFF
--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -304,6 +304,12 @@ def map_rxn(rxn: 'ARCReaction',
         return None
 
     fragment_maps = map_pairs(pairs)
+    if any(m is None for m in fragment_maps):
+        logger.error(f'Could not map all scissored pairs for reaction {rxn} ({rxn.family}); '
+                     f'{sum(1 for m in fragment_maps if m is None)}/{len(fragment_maps)} pair(s) failed.')
+        if rxn.product_dicts is not None and len(rxn.product_dicts) - 1 > pdi < MAX_PDI:
+            return map_rxn(rxn, backend=backend, product_dict_index_to_try=pdi + 1)
+        return None
     total_atoms = sum(len(sp.mol.atoms) for sp in reactants)
     atom_map = glue_maps(maps=fragment_maps,
                          pairs=pairs,

--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -303,6 +303,12 @@ def map_rxn(rxn: ARCReaction,
         return None
 
     fragment_maps = map_pairs(pairs)
+    if any(m is None for m in fragment_maps):
+        logger.error(f'Could not map all scissored pairs for reaction {rxn} ({rxn.family}); '
+                     f'{sum(1 for m in fragment_maps if m is None)}/{len(fragment_maps)} pair(s) failed.')
+        if rxn.product_dicts is not None and len(rxn.product_dicts) - 1 > pdi < MAX_PDI:
+            return map_rxn(rxn, backend=backend, product_dict_index_to_try=pdi + 1)
+        return None
     total_atoms = sum(len(sp.mol.atoms) for sp in reactants)
     atom_map = glue_maps(maps=fragment_maps,
                          pairs=pairs,

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -1165,21 +1165,31 @@ def update_xyz(species: List[ARCSpecies]) -> List[ARCSpecies]:
     return new
 
 
-def r_cut_p_cut_isomorphic(reactant: ARCSpecies, product_: ARCSpecies) -> bool:
+def r_cut_p_cut_isomorphic(reactant: ARCSpecies, product_: ARCSpecies, strict: bool = False) -> bool:
     """
     A function for checking if the reactant and product are the same molecule.
 
     Args:
         reactant (ARCSpecies): An ARCSpecies. might be as a result of scissors()
         product_ (ARCSpecies): an ARCSpecies. might be as a result of scissors()
+        strict (bool, optional): When ``True``, require full graph isomorphism. When ``False`` (default),
+            accept either fingerprint (formula) match or graph isomorphism — the looser criterion lets
+            downstream ``map_two_species`` recover atom correspondence in rearrangements whose cut
+            fragments are not strictly isomorphic. Strict mode is used as a first pass in
+            ``pairing_reactants_and_products_for_mapping`` to avoid pairing constitutional isomers
+            that share a molecular formula but differ in graph structure.
 
     Returns:
         bool: ``True`` if they are isomorphic, ``False`` otherwise.
     """
     res1 = generate_resonance_structures_safely(reactant.mol, save_order=True)
     for res in res1:
-        if res.fingerprint == product_.mol.fingerprint or product_.mol.is_isomorphic(res, save_order=True):
-            return True
+        if strict:
+            if product_.mol.is_isomorphic(res, save_order=True):
+                return True
+        else:
+            if res.fingerprint == product_.mol.fingerprint or product_.mol.is_isomorphic(res, save_order=True):
+                return True
     return False
 
 
@@ -1189,6 +1199,12 @@ def pairing_reactants_and_products_for_mapping(r_cuts: List[ARCSpecies],
     """
     A function for matching reactants and products in scissored products.
 
+    Greedy two-pass pairing:
+        1) Strict graph isomorphism — avoids pairing constitutional isomers that merely share a
+           molecular formula (e.g. α- vs β-radical positional isomers in H-abstraction).
+        2) Loose fingerprint-or-isomorphic fallback — for rearrangements whose cut fragments are
+           not strictly isomorphic but can still be aligned by ``map_two_species``.
+
     Args:
         r_cuts (List[ARCSpecies]): A list of the scissored species in the reactants
         p_cuts (List[ARCSpecies]): A list of the scissored species in the reactants
@@ -1197,7 +1213,16 @@ def pairing_reactants_and_products_for_mapping(r_cuts: List[ARCSpecies],
         List[Tuple[ARCSpecies,ARCSpecies]]: A list of paired reactant and products, to be sent to map_two_species.
     """
     pairs: List[Tuple[ARCSpecies, ARCSpecies]] = list()
+    unmatched_r: List[ARCSpecies] = list()
     for react in r_cuts:
+        for idx, prod in enumerate(p_cuts):
+            if r_cut_p_cut_isomorphic(react, prod, strict=True):
+                pairs.append((react, prod))
+                p_cuts.pop(idx)
+                break
+        else:
+            unmatched_r.append(react)
+    for react in unmatched_r:
         for idx, prod in enumerate(p_cuts):
             if r_cut_p_cut_isomorphic(react, prod):
                 pairs.append((react, prod))
@@ -1236,28 +1261,34 @@ def label_species_atoms(species: List['ARCSpecies']) -> None:
             index += 1
 
 
-def glue_maps(maps: List[List[int]],
+def glue_maps(maps: List[Optional[List[int]]],
               pairs: List[Tuple[ARCSpecies, ARCSpecies]],
               r_label_map: Dict[str, int],
               p_label_map: Dict[str, int],
               total_atoms: int,
-              ) -> List[int]:
+              ) -> Optional[List[int]]:
     """
     Join the maps from the parts of a bimolecular reaction.
 
     Args:
-        maps (List[List[int]]): The list of all maps of the isomorphic cuts.
+        maps (List[Optional[List[int]]]): The per-pair maps of the isomorphic cuts. An entry may
+            be ``None`` when ``map_two_species`` could not produce a map for that pair; in that
+            case ``glue_maps`` aborts and returns ``None`` so the caller can fall back.
         pairs (List[Tuple[ARCSpecies, ARCSpecies]]): The pairs of the reactants and products.
         r_label_map (Dict[str, int]): A dictionary mapping the reactant labels to their indices.
         p_label_map (Dict[str, int]): A dictionary mapping the product labels to their indices.
         total_atoms (int): The total number of atoms across all reactants.
 
     Returns:
-        List[int]: An Atom Map of the complete reaction.
+        Optional[List[int]]: The complete atom map, or ``None`` if any per-pair map is ``None``.
     """
     # 1) Build base map
     am_dict: Dict[int,int] = {}
     for map_list, (r_cut, p_cut) in zip(maps, pairs):
+        if map_list is None:
+            logger.warning(f'glue_maps: received a None per-pair map for '
+                           f'{r_cut.mol.smiles} -> {p_cut.mol.smiles}; cannot build atom map.')
+            return None
         for local_i, r_atom in enumerate(r_cut.mol.atoms):
             r_glob = int(r_atom.label)
             p_glob = int(p_cut.mol.atoms[map_list[local_i]].label)

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -1163,21 +1163,31 @@ def update_xyz(species: list[ARCSpecies]) -> list[ARCSpecies]:
     return new
 
 
-def r_cut_p_cut_isomorphic(reactant: ARCSpecies, product_: ARCSpecies) -> bool:
+def r_cut_p_cut_isomorphic(reactant: ARCSpecies, product_: ARCSpecies, strict: bool = False) -> bool:
     """
     A function for checking if the reactant and product are the same molecule.
 
     Args:
         reactant (ARCSpecies): An ARCSpecies. might be as a result of scissors()
         product_ (ARCSpecies): an ARCSpecies. might be as a result of scissors()
+        strict (bool, optional): When ``True``, require full graph isomorphism. When ``False`` (default),
+            accept either fingerprint (formula) match or graph isomorphism — the looser criterion lets
+            downstream ``map_two_species`` recover atom correspondence in rearrangements whose cut
+            fragments are not strictly isomorphic. Strict mode is used as a first pass in
+            ``pairing_reactants_and_products_for_mapping`` to avoid pairing constitutional isomers
+            that share a molecular formula but differ in graph structure.
 
     Returns:
         bool: ``True`` if they are isomorphic, ``False`` otherwise.
     """
     res1 = generate_resonance_structures_safely(reactant.mol, save_order=True)
     for res in res1:
-        if res.fingerprint == product_.mol.fingerprint or product_.mol.is_isomorphic(res, save_order=True):
-            return True
+        if strict:
+            if product_.mol.is_isomorphic(res, save_order=True):
+                return True
+        else:
+            if res.fingerprint == product_.mol.fingerprint or product_.mol.is_isomorphic(res, save_order=True):
+                return True
     return False
 
 
@@ -1187,6 +1197,12 @@ def pairing_reactants_and_products_for_mapping(r_cuts: list[ARCSpecies],
     """
     A function for matching reactants and products in scissored products.
 
+    Greedy two-pass pairing:
+        1) Strict graph isomorphism — avoids pairing constitutional isomers that merely share a
+           molecular formula (e.g. α- vs β-radical positional isomers in H-abstraction).
+        2) Loose fingerprint-or-isomorphic fallback — for rearrangements whose cut fragments are
+           not strictly isomorphic but can still be aligned by ``map_two_species``.
+
     Args:
         r_cuts (list[ARCSpecies]): A list of the scissored species in the reactants
         p_cuts (list[ARCSpecies]): A list of the scissored species in the reactants
@@ -1195,7 +1211,16 @@ def pairing_reactants_and_products_for_mapping(r_cuts: list[ARCSpecies],
         list[tuple[ARCSpecies,ARCSpecies]]: A list of paired reactant and products, to be sent to map_two_species.
     """
     pairs: list[tuple[ARCSpecies, ARCSpecies]] = list()
+    unmatched_r: list[ARCSpecies] = list()
     for react in r_cuts:
+        for idx, prod in enumerate(p_cuts):
+            if r_cut_p_cut_isomorphic(react, prod, strict=True):
+                pairs.append((react, prod))
+                p_cuts.pop(idx)
+                break
+        else:
+            unmatched_r.append(react)
+    for react in unmatched_r:
         for idx, prod in enumerate(p_cuts):
             if r_cut_p_cut_isomorphic(react, prod):
                 pairs.append((react, prod))
@@ -1234,28 +1259,34 @@ def label_species_atoms(species: list[ARCSpecies]) -> None:
             index += 1
 
 
-def glue_maps(maps: list[list[int]],
+def glue_maps(maps: list[list[int] | None],
               pairs: list[tuple[ARCSpecies, ARCSpecies]],
               r_label_map: dict[str, int],
               p_label_map: dict[str, int],
               total_atoms: int,
-              ) -> list[int]:
+              ) -> list[int] | None:
     """
     Join the maps from the parts of a bimolecular reaction.
 
     Args:
-        maps (list[list[int]]): The list of all maps of the isomorphic cuts.
+        maps (list[list[int] | None]): The per-pair maps of the isomorphic cuts. An entry may
+            be ``None`` when ``map_two_species`` could not produce a map for that pair; in that
+            case ``glue_maps`` aborts and returns ``None`` so the caller can fall back.
         pairs (list[tuple[ARCSpecies, ARCSpecies]]): The pairs of the reactants and products.
         r_label_map (dict[str, int]): A dictionary mapping the reactant labels to their indices.
         p_label_map (dict[str, int]): A dictionary mapping the product labels to their indices.
         total_atoms (int): The total number of atoms across all reactants.
 
     Returns:
-        list[int]: An Atom Map of the complete reaction.
+        list[int] | None: The complete atom map, or ``None`` if any per-pair map is ``None``.
     """
     # 1) Build base map
     am_dict: dict[int,int] = {}
     for map_list, (r_cut, p_cut) in zip(maps, pairs):
+        if map_list is None:
+            logger.warning(f'glue_maps: received a None per-pair map for '
+                           f'{r_cut.mol.smiles} -> {p_cut.mol.smiles}; cannot build atom map.')
+            return None
         for local_i, r_atom in enumerate(r_cut.mol.atoms):
             r_glob = int(r_atom.label)
             p_glob = int(p_cut.mol.atoms[map_list[local_i]].label)

--- a/arc/mapping/engine_test.py
+++ b/arc/mapping/engine_test.py
@@ -1576,6 +1576,33 @@ class TestMappingEngine(unittest.TestCase):
         self.assertTrue(engine.r_cut_p_cut_isomorphic(ARCSpecies(label="r1", smiles="F[C]F", multiplicity=1),
                                                ARCSpecies(label="r1", smiles="F[C]F", multiplicity=3)))
 
+    def test_r_cut_p_cut_isomorphic_strict(self):
+        """Strict mode rejects constitutional isomers that share a molecular formula."""
+        alpha = ARCSpecies(label='alpha', smiles='C[CH]OCCC')  # α-radical
+        beta = ARCSpecies(label='beta', smiles='CC[CH]OCC')    # β-radical
+        self.assertTrue(engine.r_cut_p_cut_isomorphic(alpha, beta, strict=False))
+        self.assertFalse(engine.r_cut_p_cut_isomorphic(alpha, beta, strict=True))
+        same_a = ARCSpecies(label='a', smiles='CC[CH]OCC')
+        same_b = ARCSpecies(label='b', smiles='CC[CH]OCC')
+        self.assertTrue(engine.r_cut_p_cut_isomorphic(same_a, same_b, strict=True))
+
+    def test_pairing_prefers_strict_match_for_formula_isomers(self):
+        """
+        H-abstraction where abstractor = same species on both sides and the two
+        radicals on the radical side are α/β positional isomers of the same
+        skeleton. Strict-first pairing must match intact radicals with their
+        isomorphic cut-fragment counterparts, not with the wrong intact radical.
+        """
+        r_1 = ARCSpecies(label='r1', smiles='CC[CH]OCC')
+        r_2 = ARCSpecies(label='r2', smiles='CCCOCC')
+        p_1 = ARCSpecies(label='p1', smiles='C[CH]OCCC')
+        p_2 = ARCSpecies(label='p2', smiles='CCCOCC')
+        rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_1, p_2])
+        self.assertEqual(rxn.family, 'H_Abstraction')
+        atom_map = rxn.atom_map
+        self.assertIsNotNone(atom_map)
+        self.assertEqual(len(atom_map), sum(s.number_of_atoms for s in rxn.r_species))
+
     def test_pairing_reactants_and_products_for_mapping(self):
         """Test the pairing_reactants_and_products_for_mapping() function"""
         smiles = ['CC(=O)O[CH]CN', '[H]', '[CH3]']

--- a/arc/reaction/reaction.py
+++ b/arc/reaction/reaction.py
@@ -941,8 +941,6 @@ class ARCReaction(object):
                 A length-2 tuple is which entries represent reactants and product information, respectively.
                 Each entry is a list of tuples, each represents a bond and contains sorted atom indices.
         """
-        if self.atom_map is None:
-            raise ReactionError('Cannot get bonds without an atom map.')
         reactants, products = self.get_reactants_and_products()
         r_bonds, p_bonds = list(), list()
         len_atoms = 0
@@ -956,6 +954,8 @@ class ARCReaction(object):
         len_atoms = 0
         if r_bonds_only:
             return r_bonds, p_bonds
+        if self.atom_map is None:
+            raise ReactionError('Cannot get product bonds without an atom map.')
         for spc in products:
             for i, atom_1 in enumerate(spc.mol.atoms):
                 for atom2, bond12 in atom_1.edges.items():
@@ -964,10 +964,66 @@ class ARCReaction(object):
                     if bond not in p_bonds:
                         p_bonds.append(bond)
             len_atoms += spc.number_of_atoms
-        mapped_p_bonds = list()
-        for p_bond in p_bonds:
-            mapped_p_bonds.append(tuple([self.atom_map.index(p_bond[0]), self.atom_map.index(p_bond[1])]))
         return r_bonds, p_bonds
+
+    def _get_reactive_bonds_from_family(
+        self,
+    ) -> Optional[Tuple[List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]]]]:
+        """
+        Derive formed, broken, and order-changed bonds directly from the RMG family's
+        recipe actions and ``r_label_map``, bypassing ``atom_map``.
+
+        All tuples are in reactant global index space. This is the canonical source
+        used elsewhere in ARC (see ``arc.mapping.engine.find_all_breaking_bonds``),
+        and is sufficient for NMD validation which only needs reactive-atom roles.
+
+        Returns:
+            Optional[Tuple[formed, broken, changed]]: ``None`` when the family or
+            ``r_label_map`` is unavailable and the label-based path cannot be taken.
+        """
+        if self.family is None or not self.product_dicts:
+            return None
+        r_label_map = self.product_dicts[0].get('r_label_map')
+        if not r_label_map:
+            return None
+        actions = ReactionFamily(label=self.family).actions
+        formed, broken, changed = list(), list(), list()
+        for action in actions:
+            kind = action[0].upper()
+            if kind not in ('BREAK_BOND', 'FORM_BOND', 'CHANGE_BOND'):
+                continue
+            label_1, label_2 = action[1], action[3]
+            idx_1 = self._resolve_label_index(r_label_map, label_1, preferred_occurrence=0)
+            idx_2 = self._resolve_label_index(
+                r_label_map, label_2,
+                preferred_occurrence=1 if label_1 == label_2 else 0,
+            )
+            if idx_1 is None or idx_2 is None or idx_1 == idx_2:
+                return None
+            bond = tuple(sorted((idx_1, idx_2)))
+            if kind == 'FORM_BOND':
+                formed.append(bond)
+            elif kind == 'BREAK_BOND':
+                broken.append(bond)
+            else:
+                changed.append(bond)
+        return formed, broken, changed
+
+    @staticmethod
+    def _resolve_label_index(
+        label_map: Dict[str, int],
+        label: str,
+        preferred_occurrence: int = 0,
+    ) -> Optional[int]:
+        """Resolve an RMG label (e.g. ``'*1'``) to a global atom index in ``label_map``.
+
+        When the same label appears twice in a recipe (e.g. ``R_Recombination``),
+        the label map disambiguates duplicates via suffixed keys (``'*'``, ``'*_2'``).
+        """
+        keys = sorted(k for k in label_map if k == label or k.startswith(f'{label}_'))
+        if not keys:
+            return None
+        return label_map[keys[min(preferred_occurrence, len(keys) - 1)]]
 
     def get_formed_and_broken_bonds(self) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
         """
@@ -975,6 +1031,15 @@ class ARCReaction(object):
         Returns:
             Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]: The formed and broken bonds.
         """
+        if self.atom_map is None and self.family and self.product_dicts:
+            family_bonds = self._get_reactive_bonds_from_family()
+            if family_bonds is not None:
+                formed, broken, _changed = family_bonds
+                logger.warning(
+                    f'Using RMG-family-derived formed/broken bonds for reaction {self} '
+                    f'because no atom map is available.'
+                )
+                return formed, broken
         r_bonds, p_bonds = self.get_bonds()
         r_bonds, p_bonds = set(r_bonds), set(p_bonds)
         formed_bonds, broken_bonds = p_bonds - r_bonds, r_bonds - p_bonds
@@ -986,6 +1051,11 @@ class ARCReaction(object):
         Returns:
             List[Tuple[int, int]]: The bonds that change their bond order.
         """
+        if self.atom_map is None and self.family and self.product_dicts:
+            family_bonds = self._get_reactive_bonds_from_family()
+            if family_bonds is not None:
+                _formed, _broken, changed = family_bonds
+                return changed
         r_bonds, p_bonds = self.get_bonds()
         r_bonds, p_bonds = set(r_bonds), set(p_bonds)
         shared_bonds = p_bonds.intersection(r_bonds)

--- a/arc/reaction/reaction.py
+++ b/arc/reaction/reaction.py
@@ -939,8 +939,6 @@ class ARCReaction(object):
                 A length-2 tuple is which entries represent reactants and product information, respectively.
                 Each entry is a list of tuples, each represents a bond and contains sorted atom indices.
         """
-        if self.atom_map is None:
-            raise ReactionError('Cannot get bonds without an atom map.')
         reactants, products = self.get_reactants_and_products()
         r_bonds, p_bonds = list(), list()
         len_atoms = 0
@@ -954,6 +952,8 @@ class ARCReaction(object):
         len_atoms = 0
         if r_bonds_only:
             return r_bonds, p_bonds
+        if self.atom_map is None:
+            raise ReactionError('Cannot get product bonds without an atom map.')
         for spc in products:
             for i, atom_1 in enumerate(spc.mol.atoms):
                 for atom2, bond12 in atom_1.edges.items():
@@ -962,10 +962,66 @@ class ARCReaction(object):
                     if bond not in p_bonds:
                         p_bonds.append(bond)
             len_atoms += spc.number_of_atoms
-        mapped_p_bonds = list()
-        for p_bond in p_bonds:
-            mapped_p_bonds.append(tuple([self.atom_map.index(p_bond[0]), self.atom_map.index(p_bond[1])]))
         return r_bonds, p_bonds
+
+    def _get_reactive_bonds_from_family(
+        self,
+    ) -> tuple[list[tuple[int, int]], list[tuple[int, int]], list[tuple[int, int]]] | None:
+        """
+        Derive formed, broken, and order-changed bonds directly from the RMG family's
+        recipe actions and ``r_label_map``, bypassing ``atom_map``.
+
+        All tuples are in reactant global index space. This is the canonical source
+        used elsewhere in ARC (see ``arc.mapping.engine.find_all_breaking_bonds``),
+        and is sufficient for NMD validation which only needs reactive-atom roles.
+
+        Returns:
+            tuple[formed, broken, changed] | None: ``None`` when the family or
+            ``r_label_map`` is unavailable and the label-based path cannot be taken.
+        """
+        if self.family is None or not self.product_dicts:
+            return None
+        r_label_map = self.product_dicts[0].get('r_label_map')
+        if not r_label_map:
+            return None
+        actions = ReactionFamily(label=self.family).actions
+        formed, broken, changed = list(), list(), list()
+        for action in actions:
+            kind = action[0].upper()
+            if kind not in ('BREAK_BOND', 'FORM_BOND', 'CHANGE_BOND'):
+                continue
+            label_1, label_2 = action[1], action[3]
+            idx_1 = self._resolve_label_index(r_label_map, label_1, preferred_occurrence=0)
+            idx_2 = self._resolve_label_index(
+                r_label_map, label_2,
+                preferred_occurrence=1 if label_1 == label_2 else 0,
+            )
+            if idx_1 is None or idx_2 is None or idx_1 == idx_2:
+                return None
+            bond = tuple(sorted((idx_1, idx_2)))
+            if kind == 'FORM_BOND':
+                formed.append(bond)
+            elif kind == 'BREAK_BOND':
+                broken.append(bond)
+            else:
+                changed.append(bond)
+        return formed, broken, changed
+
+    @staticmethod
+    def _resolve_label_index(
+        label_map: dict[str, int],
+        label: str,
+        preferred_occurrence: int = 0,
+    ) -> int | None:
+        """Resolve an RMG label (e.g. ``'*1'``) to a global atom index in ``label_map``.
+
+        When the same label appears twice in a recipe (e.g. ``R_Recombination``),
+        the label map disambiguates duplicates via suffixed keys (``'*'``, ``'*_2'``).
+        """
+        keys = sorted(k for k in label_map if k == label or k.startswith(f'{label}_'))
+        if not keys:
+            return None
+        return label_map[keys[min(preferred_occurrence, len(keys) - 1)]]
 
     def get_formed_and_broken_bonds(self) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
         """
@@ -973,6 +1029,15 @@ class ARCReaction(object):
         Returns:
             tuple[list[tuple[int, int]], list[tuple[int, int]]]: The formed and broken bonds.
         """
+        if self.atom_map is None and self.family and self.product_dicts:
+            family_bonds = self._get_reactive_bonds_from_family()
+            if family_bonds is not None:
+                formed, broken, _changed = family_bonds
+                logger.warning(
+                    f'Using RMG-family-derived formed/broken bonds for reaction {self} '
+                    f'because no atom map is available.'
+                )
+                return formed, broken
         r_bonds, p_bonds = self.get_bonds()
         r_bonds, p_bonds = set(r_bonds), set(p_bonds)
         formed_bonds, broken_bonds = p_bonds - r_bonds, r_bonds - p_bonds
@@ -984,6 +1049,11 @@ class ARCReaction(object):
         Returns:
             list[tuple[int, int]]: The bonds that change their bond order.
         """
+        if self.atom_map is None and self.family and self.product_dicts:
+            family_bonds = self._get_reactive_bonds_from_family()
+            if family_bonds is not None:
+                _formed, _broken, changed = family_bonds
+                return changed
         r_bonds, p_bonds = self.get_bonds()
         r_bonds, p_bonds = set(r_bonds), set(p_bonds)
         shared_bonds = p_bonds.intersection(r_bonds)

--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -912,6 +912,36 @@ H       1.12853146   -0.86793870    0.06973060"""
         self.assertEqual(formed_bonds, [(0, 5)])
         self.assertEqual(broken_bonds, [(3, 5)])
 
+    def test_get_bonds_and_reactive_bonds_without_atom_map(self):
+        """
+        When atom_map cannot be built (e.g. fingerprint-based pair superposition
+        fails on positional-isomer radicals), get_bonds(r_bonds_only=True) must
+        still work, and get_formed_and_broken_bonds / get_changed_bonds must fall
+        back to the RMG family recipe + r_label_map instead of raising.
+        """
+        # Intermolecular H-abstraction between α- and β-radical of pentyl ether.
+        # map_two_species cannot superimpose the two radical cuts, so atom_map is None.
+        r1 = ARCSpecies(label='r1', smiles='CC[CH]OCC')
+        r2 = ARCSpecies(label='r2', smiles='CCCOCC')
+        p1 = ARCSpecies(label='p1', smiles='C[CH]OCCC')
+        p2 = ARCSpecies(label='p2', smiles='CCCOCC')
+        rxn = ARCReaction(r_species=[r1, r2], p_species=[p1, p2])
+        self.assertEqual(rxn.family, 'H_Abstraction')
+        self.assertTrue(rxn.product_dicts)
+        rxn.atom_map = None  # simulate mapping failure
+
+        r_bonds, p_bonds = rxn.get_bonds(r_bonds_only=True)
+        self.assertGreater(len(r_bonds), 0)
+        self.assertEqual(p_bonds, [])
+
+        r_label_map = rxn.product_dicts[0]['r_label_map']
+        star1, star2, star3 = r_label_map['*1'], r_label_map['*2'], r_label_map['*3']
+
+        formed, broken = rxn.get_formed_and_broken_bonds()
+        self.assertEqual(formed, [tuple(sorted((star2, star3)))])
+        self.assertEqual(broken, [tuple(sorted((star1, star2)))])
+        self.assertEqual(rxn.get_changed_bonds(), [])
+
     def test_get_changed_bonds(self):
         """Test the get_changed_bonds() function."""
         rxn_7 = ARCReaction(r_species=[ARCSpecies(label='C2H5NO2', smiles='[O-][N+](=O)CC',


### PR DESCRIPTION
## Summary

- Atom-mapping crashed in `glue_maps` for H-abstraction reactions where the two radicals on the radical side are positional isomers of the same skeleton (e.g. `CC[CH]OCC + CCCOCC <=> C[CH]OCCC + CCCOCC`), because `r_cut_p_cut_isomorphic` treated molecular-formula equality (`fingerprint`) as sufficient evidence of isomorphism and paired genuinely-different cuts.
- Switch `pairing_reactants_and_products_for_mapping` to a two-pass strategy: strict graph isomorphism first, then the original loose fingerprint-or-isomorphic fallback for any unmatched r-cuts (preserves `Intra_Disproportionation`, ring-opening C10H10 etc.).
- Add defensive None-handling in `glue_maps` and `map_rxn`, plus a family-recipe-based fallback in `reaction.get_formed_and_broken_bonds` / `get_changed_bonds` so NMD can still validate a TS even when atom-mapping truly fails.

## Commits

1. **mapping/engine: two-pass pairing to reject formula-only matches** — root cause fix + `glue_maps` guard.
2. **mapping/driver: surface failed pair mappings and retry next product dict** — clean error path replacing the subscript-None crash.
3. **reaction: derive reactive bonds from RMG family when atom_map is absent** — NMD safety net; moves `atom_map` check in `get_bonds` below the `r_bonds_only=True` short-circuit so reactant-only queries no longer require a map.

## Test plan

- [x] `arc.mapping.engine_test` (67 tests incl. new `test_r_cut_p_cut_isomorphic_strict` and `test_pairing_prefers_strict_match_for_formula_isomers`)
- [x] `arc.mapping.driver_test`
- [x] `arc.reaction.reaction_test` (incl. new `test_get_bonds_and_reactive_bonds_without_atom_map`)
- [x] `arc.checks.nmd_test`
- [x] 122/122 passing locally