### PR TITLE
Add sp_composite focal-point/CBS single-point protocols

### DIFF
--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 import re
 
-from pprint import pformat
 from typing import TYPE_CHECKING
 
 from arc.common import get_logger
@@ -493,21 +492,26 @@ def set_job_args(args: dict | None,
     """
     Set the job args considering args from ``level`` and from ``trsh``.
 
+    The caller (e.g. :meth:`arc.scheduler.Scheduler.run_job`) is expected to
+    have already merged any ``level.args`` content into ``args`` before calling
+    this function — ``run_job`` does so via ``args.update(level.args)``. When
+    the caller passes empty ``args`` and the level supplies ``args``, we fall
+    back to ``level.args`` for convenience.
+
     Args:
-        args (dict): The job specific arguments.
+        args (dict): The job-specific arguments.
         level (Level): The level of theory.
         job_name (str): The job name.
 
     Returns:
-        dict: The initialized job specific arguments.
+        dict: The initialized job-specific arguments, guaranteed to carry the
+        ``'keyword'``, ``'block'``, and ``'trsh'`` buckets (each a dict).
     """
-    # Ignore user-specified additional job arguments when troubleshooting.
-    if args is not None and args and any(val for val in args.values()) \
-            and level is not None and level.args and any(val for val in level.args.values()):
-        logger.warning(f'When troubleshooting {job_name}, ARC ignores the following user-specified options:\n'
-                       f'{pformat(level.args)}')
-    elif not args and level is not None:
+    # Convenience fallback: empty (or None) caller-args inherits level.args.
+    if not args and level is not None and level.args is not None:
         args = level.args
+    if args is None:
+        args = dict()
     for key in ['keyword', 'block', 'trsh']:
         if key not in args.keys():
             args[key] = dict()

--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 import re
 
-from pprint import pformat
 from typing import TYPE_CHECKING
 
 from arc.common import get_logger
@@ -494,21 +493,26 @@ def set_job_args(args: dict | None,
     """
     Set the job args considering args from ``level`` and from ``trsh``.
 
+    The caller (e.g. :meth:`arc.scheduler.Scheduler.run_job`) is expected to
+    have already merged any ``level.args`` content into ``args`` before calling
+    this function — ``run_job`` does so via ``args.update(level.args)``. When
+    the caller passes empty ``args`` and the level supplies ``args``, we fall
+    back to ``level.args`` for convenience.
+
     Args:
-        args (dict): The job specific arguments.
+        args (dict): The job-specific arguments.
         level (Level): The level of theory.
         job_name (str): The job name.
 
     Returns:
-        dict: The initialized job specific arguments.
+        dict: The initialized job-specific arguments, guaranteed to carry the
+        ``'keyword'``, ``'block'``, and ``'trsh'`` buckets (each a dict).
     """
-    # Ignore user-specified additional job arguments when troubleshooting.
-    if args is not None and args and any(val for val in args.values()) \
-            and level is not None and level.args and any(val for val in level.args.values()):
-        logger.warning(f'When troubleshooting {job_name}, ARC ignores the following user-specified options:\n'
-                       f'{pformat(level.args)}')
-    elif not args and level is not None:
+    # Convenience fallback: empty (or None) caller-args inherits level.args.
+    if not args and level is not None and level.args is not None:
         args = level.args
+    if args is None:
+        args = dict()
     for key in ['keyword', 'block', 'trsh']:
         if key not in args.keys():
             args[key] = dict()

--- a/arc/job/adapters/common_test.py
+++ b/arc/job/adapters/common_test.py
@@ -5,6 +5,7 @@
 This module contains unit tests of the arc.job.adapters.common module
 """
 
+import logging
 import os
 import shutil
 import unittest
@@ -165,6 +166,29 @@ class TestJobCommon(unittest.TestCase):
 
         args = common.set_job_args(args={'keyword': 'k1'}, level=Level(repr='CBS-QB3'), job_name='j1')
         self.assertEqual(args, {'keyword':'k1', 'block': dict(), 'trsh': dict()})
+
+    def test_set_job_args_no_spurious_warning_when_level_has_args(self):
+        """Regression: the previous "ARC ignores user-specified options" warning
+        fired on every first-run job whose level carried args, because
+        ``run_job`` had already merged ``level.args`` into ``args`` before
+        calling — nothing was actually being ignored. The warning should now
+        be silent on a normal first-run path."""
+        merged_args = {'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}}
+        level_with_args = Level(method='ccsd(t)', basis='cc-pCVTZ',
+                                args=merged_args)
+        with self.assertNoLogs(logger='arc', level=logging.WARNING):
+            result = common.set_job_args(args=merged_args,
+                                         level=level_with_args, job_name='j_first_run')
+        # Args content is preserved (not dropped).
+        self.assertEqual(result['keyword'], {'core': 'core,0,0,0,0,0,0,0,0;'})
+        self.assertEqual(result['trsh'], {})  # bucket added by guarantee
+
+    def test_set_job_args_args_none_preserves_level_args(self):
+        """When the caller passes None, fall back to level.args (legacy convenience)."""
+        level = Level(method='ccsd(t)', basis='cc-pVTZ',
+                      args={'keyword': {'general': 'foo'}, 'block': {}})
+        result = common.set_job_args(args=None, level=level, job_name='j1')
+        self.assertEqual(result['keyword'], {'general': 'foo'})
 
     def test_which(self):
         """Test the which() function"""

--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -35,6 +35,20 @@ default_job_settings, global_ess_settings, input_filenames, output_filenames, se
     settings['default_job_settings'], settings['global_ess_settings'], settings['input_filenames'], \
     settings['output_filenames'], settings['servers'], settings['submit_filenames']
 
+# Methods that native Molpro does not support but its MRCC plugin does.
+# When the level's method matches one of these (case-insensitive), the adapter
+# emits a ``{mrcc,method=...}`` plugin call instead of a bare directive that
+# Molpro's input parser would reject with "Unknown command or directive".
+# Compared against the lowercased ``Level.method``.
+MRCC_ROUTED_METHODS = frozenset({
+    'ccsdt',
+    'ccsdt(q)',
+    'ccsdtq',
+    'ccsdtq(p)',
+    'ccsdtqp',
+})
+
+
 input_template = """***,${label}
 memory,Total=${memory},m;
 
@@ -47,7 +61,7 @@ ${auxiliary_basis}
 ${cabs}
 int;
 
-{hf;${shift}
+{${hf_method};${shift}
  maxit,999;
  wf,spin=${spin},charge=${charge};
 }
@@ -229,9 +243,36 @@ class MolproAdapter(JobAdapter):
         input_dict['spin'] = self.multiplicity - 1
         input_dict['xyz'] = xyz_to_str(self.xyz)
         input_dict['orbitals'] = '\ngprint,orbitals;\n'
+        input_dict['hf_method'] = 'hf'  # default; overridden below for open-shell MRCC
 
         if not is_restricted(self):
             input_dict['restricted'] = 'u'
+
+        if self.level.method in MRCC_ROUTED_METHODS:
+            # Restriction is implicit from the preceding {hf;...} block; the
+            # MRCC plugin call does not accept a 'u'/'r' prefix.
+            input_dict['method'] = '{mrcc,method=' + self.level.method.upper() + '}'
+            input_dict['restricted'] = ''
+            if not is_restricted(self):
+                # Open-shell wavefunction + MRCC's approximate-CC family
+                # (CCSDT(Q), CCSDTQ(P), and the perturbative-(T) variants)
+                # refuses standard ROHF orbitals:
+                #   "Approximate CC methods are not implemented for standard
+                #    ROHF orbitals! Use semicanonical orbitals!"
+                # Solution: use UHF instead of (RO)HF as the SCF reference.
+                # UHF orbitals are semicanonical by construction (alpha and
+                # beta Fock matrices are separately diagonal) and live at the
+                # default record 2100.2, which MRCC reads. MRCC then reports
+                # ``Type=UHF/CANONICAL`` and accepts.
+                #
+                # An earlier attempt at this fix prepended ``{uccsd}`` to the
+                # MRCC call. {uccsd} does run UCCSD on top of ROHF, but the
+                # post-UCCSD canonical orbitals go to a separate record while
+                # the default 2100.2 still holds the original ROHF orbitals —
+                # MRCC reads 2100.2 by default and complained. Switching the
+                # SCF reference to UHF avoids this orbital-record bookkeeping
+                # entirely.
+                input_dict['hf_method'] = 'uhf'
 
         # Job type specific options
         if self.job_type in ['opt', 'optfreq', 'conf_opt']:

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -97,6 +97,24 @@ class TestMolproAdapter(unittest.TestCase):
                                                               'closed': [1, 0, 0, 0, 0, 0, 0, 0]})],
                                   testing=True,
                                   )
+        cls.job_mrcc_ccsdt = MolproAdapter(execution_type='queue',
+                                           job_type='sp',
+                                           level=Level(method='CCSDT', basis='cc-pVDZ'),
+                                           project='test',
+                                           project_directory=os.path.join(ARC_TESTING_PATH,
+                                                                          'test_MolproAdapter_mrcc_ccsdt'),
+                                           species=[ARCSpecies(label='spc1', xyz=['O 0 0 1'], multiplicity=3)],
+                                           testing=True,
+                                           )
+        cls.job_mrcc_ccsdtq = MolproAdapter(execution_type='queue',
+                                            job_type='sp',
+                                            level=Level(method='CCSDT(Q)', basis='cc-pVDZ'),
+                                            project='test',
+                                            project_directory=os.path.join(ARC_TESTING_PATH,
+                                                                           'test_MolproAdapter_mrcc_ccsdtq'),
+                                            species=[ARCSpecies(label='spc1', xyz=['O 0 0 1'], multiplicity=1)],
+                                            testing=True,
+                                            )
 
     def test_set_cpu_and_mem(self):
         """Test assigning number of cpu's and memory"""
@@ -440,6 +458,107 @@ int;
 
 """
         self.assertEqual(content_7, job_7_expected_input_file)
+
+    def test_write_input_file_mrcc_routing(self):
+        """Methods unsupported by native Molpro but supported by MRCC are routed through the MRCC plugin.
+
+        For an open-shell wavefunction, the SCF reference is switched from
+        ``{hf;...}`` (which gives Molpro's ROHF for open-shell) to
+        ``{uhf;...}``. MRCC's approximate-CC family (``CCSDT(Q)``,
+        ``CCSDTQ(P)``, and the perturbative-``(T)`` variants) refuses
+        standard ROHF orbitals with the error::
+
+            Approximate CC methods are not implemented for standard ROHF orbitals!
+            Use semicanonical orbitals!
+
+        UHF orbitals are semicanonical by construction (alpha and beta Fock
+        matrices are separately diagonal), saved to the default record 2100.2
+        which MRCC reads — MRCC then reports ``Type=UHF/CANONICAL`` and runs
+        the requested approximate-CC method.
+        """
+        self.job_mrcc_ccsdt.cpu_cores = 48
+        self.job_mrcc_ccsdt.set_input_file_memory()
+        self.job_mrcc_ccsdt.write_input_file()
+        with open(os.path.join(self.job_mrcc_ccsdt.local_path,
+                               input_filenames[self.job_mrcc_ccsdt.job_adapter]), 'r') as f:
+            content_ccsdt = f.read()
+        # spc1 has multiplicity=3 (open-shell triplet) — UHF reference expected.
+        expected_ccsdt = """***,spc1
+memory,Total=438,m;
+
+geometry={angstrom;
+O       0.00000000    0.00000000    1.00000000}
+
+gprint,orbitals;
+
+basis=cc-pvdz
+
+
+
+int;
+
+{uhf;
+ maxit,999;
+ wf,spin=2,charge=0;
+}
+
+{mrcc,method=CCSDT}
+
+
+
+---;
+
+"""
+        self.assertEqual(content_ccsdt, expected_ccsdt)
+        # Sanity: the bare directive Molpro rejects must NOT appear on its own line.
+        self.assertNotIn('\nccsdt;\n', content_ccsdt)
+        self.assertNotIn('\nuccsdt;\n', content_ccsdt)
+        # An earlier (insufficient) fix used `{uccsd}` between HF and MRCC —
+        # this contract has been replaced with UHF, so {uccsd} must NOT appear.
+        self.assertNotIn('{uccsd}', content_ccsdt)
+        # UHF must replace HF as the only SCF reference (no {hf;...} block).
+        self.assertNotIn('{hf;', content_ccsdt)
+        self.assertIn('{uhf;', content_ccsdt)
+
+        self.job_mrcc_ccsdtq.cpu_cores = 48
+        self.job_mrcc_ccsdtq.set_input_file_memory()
+        self.job_mrcc_ccsdtq.write_input_file()
+        with open(os.path.join(self.job_mrcc_ccsdtq.local_path,
+                               input_filenames[self.job_mrcc_ccsdtq.job_adapter]), 'r') as f:
+            content_ccsdtq = f.read()
+        expected_ccsdtq = """***,spc1
+memory,Total=438,m;
+
+geometry={angstrom;
+O       0.00000000    0.00000000    1.00000000}
+
+gprint,orbitals;
+
+basis=cc-pvdz
+
+
+
+int;
+
+{hf;
+ maxit,999;
+ wf,spin=0,charge=0;
+}
+
+{mrcc,method=CCSDT(Q)}
+
+
+
+---;
+
+"""
+        self.assertEqual(content_ccsdtq, expected_ccsdtq)
+        self.assertNotIn('\nccsdt(q);\n', content_ccsdtq)
+        # spc1 here has multiplicity=1 (closed-shell) — RHF gives canonical
+        # orbitals MRCC accepts directly. No UHF/UCCSD pre-step needed.
+        self.assertNotIn('{uccsd}', content_ccsdtq)
+        self.assertNotIn('{uhf;', content_ccsdtq)
+        self.assertIn('{hf;', content_ccsdtq)
 
     def test_set_files(self):
         """Test setting files"""

--- a/arc/job/adapters/orca.py
+++ b/arc/job/adapters/orca.py
@@ -92,9 +92,9 @@ default_job_settings, global_ess_settings, input_filenames, output_filenames, se
 # job_options_keywords: input keywords that control the job
 # method_class: 'HF' for wavefunction methods (hf, mp, cc, dlpno ...). 'KS' for DFT methods.
 # options: additional keywords to control job (e.g., TightSCF, NormalPNO ...)
-input_template = """!${restricted}${method_class} ${method} ${basis} ${auxiliary_basis}${cabs} ${keywords}
-!${job_type_1} 
-${job_type_2}
+input_template = """!${restricted}${method_class} ${method} ${basis} ${keywords}
+!${job_type_1}
+${job_type_2}${basis_block}
 %%maxcore ${memory}
 %%pal nprocs ${cpus} end
 
@@ -270,9 +270,19 @@ class OrcaAdapter(JobAdapter):
                     'keywords',
                     ]:
             input_dict[key] = ''
-        input_dict['auxiliary_basis'] = _format_orca_basis(self.level.auxiliary_basis or '')
         input_dict['basis'] = _format_orca_basis(self.level.basis or '')
-        input_dict['cabs'] = f' {_format_orca_basis(self.level.cabs)}' if self.level.cabs else ''
+        # In ORCA, the orbital basis is the only basis allowed on the `!` simple-input line.
+        # Auxiliary fitting bases (AuxC) and the F12 CABS must be declared inside a %basis block,
+        # otherwise ORCA raises "UNRECOGNIZED OR DUPLICATED KEYWORD(S) IN SIMPLE INPUT LINE".
+        basis_block_lines = []
+        auxiliary_basis = _format_orca_basis(self.level.auxiliary_basis or '')
+        if auxiliary_basis:
+            basis_block_lines.append(f'AuxC "{auxiliary_basis}"')
+        cabs = _format_orca_basis(self.level.cabs) if self.level.cabs else ''
+        if cabs:
+            basis_block_lines.append(f'CABS "{cabs}"')
+        input_dict['basis_block'] = '\n%basis\n' + '\n'.join(basis_block_lines) + '\nend\n' \
+            if basis_block_lines else ''
         input_dict['charge'] = self.charge
         input_dict['cpus'] = self.cpu_cores
         input_dict['label'] = self.species_label

--- a/arc/job/adapters/orca_test.py
+++ b/arc/job/adapters/orca_test.py
@@ -104,8 +104,12 @@ class TestOrcaAdapter(unittest.TestCase):
         self.job_1.write_input_file()
         with open(os.path.join(self.job_1.local_path, input_filenames[self.job_1.job_adapter]), 'r') as f:
             content_1 = f.read()
-        job_1_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
-!sp 
+        job_1_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp tightscf normalpno
+!sp
+
+%basis
+AuxC "def2-tzvp/c"
+end
 
 %maxcore 1792
 %pal nprocs 8 end
@@ -130,8 +134,12 @@ end
         self.job_2.write_input_file()
         with open(os.path.join(self.job_2.local_path, input_filenames[self.job_2.job_adapter]), 'r') as f:
             content_2 = f.read()
-        job_2_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
-!sp 
+        job_2_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp tightscf normalpno
+!sp
+
+%basis
+AuxC "def2-tzvp/c"
+end
 
 %maxcore 1792
 %pal nprocs 8 end
@@ -163,8 +171,12 @@ end
         self.job_3.write_input_file()
         with open(os.path.join(self.job_3.local_path, input_filenames[self.job_3.job_adapter]), 'r') as f:
             content_3 = f.read()
-        job_3_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp def2-tzvp/c tightscf normalpno
-!sp 
+        job_3_expected_input_file = """!uHF dlpno-ccsd(t) def2-tzvp tightscf normalpno
+!sp
+
+%basis
+AuxC "def2-tzvp/c"
+end
 
 %maxcore 1792
 %pal nprocs 8 end
@@ -189,7 +201,7 @@ end
         self.assertEqual(content_3, job_3_expected_input_file)
 
     def test_write_input_file_f12_with_cabs(self):
-        """F12 sp_level with a cabs basis emits the CABS token on the ! line."""
+        """F12 sp_level with a cabs basis emits the AuxC and CABS tokens in a %basis block."""
         job_f12 = OrcaAdapter(execution_type='queue',
                               job_type='sp',
                               level=Level(method='DLPNO-CCSD(T)-F12',
@@ -208,8 +220,13 @@ end
         bang_line = content.splitlines()[0]
         self.assertIn('dlpno-ccsd(t)-f12', bang_line)
         self.assertIn('cc-pvtz-f12', bang_line)
-        self.assertIn('aug-cc-pvtz/c', bang_line)
-        self.assertIn('cc-pvtz-f12-cabs', bang_line)
+        # Aux and CABS must NOT be on the ! line (ORCA rejects them there), only the orbital basis.
+        self.assertNotIn('aug-cc-pvtz/c', bang_line)
+        self.assertNotIn('cabs', bang_line.lower())
+        # They must appear inside a %basis block instead.
+        self.assertIn('%basis', content)
+        self.assertIn('AuxC "aug-cc-pvtz/c"', content)
+        self.assertIn('CABS "cc-pvtz-f12-cabs"', content)
 
     def test_write_input_file_f12_without_cabs_raises(self):
         """F12 sp_level without a cabs basis raises at input-file generation."""
@@ -255,8 +272,8 @@ end
         self.job_4.write_input_file()
         with open(os.path.join(self.job_4.local_path, input_filenames[self.job_4.job_adapter]), 'r') as f:
             content_4 = f.read()
-        job_4_expected_input_file = """!uHF  aug-cc-pvtz  tightscf
-!sp 
+        job_4_expected_input_file = """!uHF  aug-cc-pvtz tightscf
+!sp
 
 %maxcore 1792
 %pal nprocs 8 end

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -448,9 +448,10 @@ class SSHClient(object):
             list: lines of the node hostnames.
         """
         cluster_soft = servers[self.server]['cluster_soft'].lower()
-        if cluster_soft == 'htcondor':
+        if cluster_soft in ['htcondor', 'pbs']:
+            # Node listing is not implemented for these schedulers; return empty.
             return list()
-        cmd = list_available_nodes_command[cluster_soft]
+        cmd = list_available_nodes_command[servers[self.server]['cluster_soft']]
         stdout = self._send_command_to_server(command=cmd)[0]
         nodes = list()
         if cluster_soft.lower() in ['oge', 'sge']:

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -269,20 +269,34 @@ class SSHClient(object):
         Returns: list
             A list of job IDs.
         """
+        return list(self.check_running_jobs_ids_and_states().keys())
+
+    def check_running_jobs_ids_and_states(self) -> dict[str, str]:
+        """
+        Check all jobs submitted by the user on a server, including their queue states.
+
+        Returns: dict[str, str]
+            Job IDs as keys, normalized queue states ('running', 'pending', 'held',
+            'exiting', or 'unknown') as values.
+        """
         if servers[self.server]['cluster_soft'].lower() not in ['slurm', 'oge', 'sge', 'pbs', 'htcondor']:
             raise ValueError(f"Server cluster software {servers['local']['cluster_soft']} is not supported.")
-        running_job_ids = list()
+        job_states = dict()
         cmd = check_status_command[servers[self.server]['cluster_soft']]
         stdout = self._send_command_to_server(cmd)[0]
         i_dict = {'slurm': 0, 'oge': 1, 'sge': 1, 'pbs': 4, 'htcondor': -1}
         split_by_dict = {'slurm': ' ', 'oge': ' ', 'sge': ' ', 'pbs': '.', 'htcondor': ' '}
+        state_index_dict = {'slurm': 4, 'oge': 4, 'sge': 4, 'pbs': 9, 'htcondor': 1}
         cluster_soft = servers[self.server]['cluster_soft'].lower()
         for i, status_line in enumerate(stdout):
             if i > i_dict[cluster_soft]:
                 job_id = status_line.split(split_by_dict[cluster_soft])[0]
                 job_id = job_id.split('.')[0] if '.' in job_id else job_id
-                running_job_ids.append(job_id)
-        return running_job_ids
+                tokens = status_line.split()
+                state_index = state_index_dict[cluster_soft]
+                raw_state = tokens[state_index] if len(tokens) > state_index else ''
+                job_states[job_id] = normalize_queue_state(raw_state, cluster_soft)
+        return job_states
 
     def submit_job(self, remote_path: str,
                    recursion: bool = False,
@@ -451,21 +465,19 @@ class SSHClient(object):
         if cluster_soft in ['htcondor', 'pbs']:
             # Node listing is not implemented for these schedulers; return empty.
             return list()
-        cmd = list_available_nodes_command[servers[self.server]['cluster_soft']]
+        cmd = {key.lower(): val for key, val in list_available_nodes_command.items()}[cluster_soft]
         stdout = self._send_command_to_server(command=cmd)[0]
         nodes = list()
-        if cluster_soft.lower() in ['oge', 'sge']:
+        if cluster_soft in ['oge', 'sge']:
             # Stdout line example:
             # long1@node01.cluster           BIP   0/0/8          -NA-     lx24-amd64    aAdu
             nodes = [line.split()[0].split('@')[1]
                      for line in stdout if '0/0/8' in line]
-        elif cluster_soft.lower() == 'slurm':
+        elif cluster_soft == 'slurm':
             # Stdout line example:
             # node01 alloc 1.00 none
             nodes = [line.split()[0] for line in stdout
                      if line.split()[1] in ['mix', 'alloc', 'idle']]
-        elif cluster_soft.lower() in ['pbs', 'htcondor']:
-            logger.warning(f'Listing available nodes is not yet implemented for {cluster_soft}.')
         return nodes
 
     def change_mode(self,
@@ -536,6 +548,38 @@ class SSHClient(object):
         if stderr:
             raise ServerError(
                 f'Cannot create dir for the given path ({remote_path}).\nGot: {stderr}')
+
+
+def normalize_queue_state(raw_state: str, cluster_soft: str) -> str:
+    """
+    Normalize a raw queue state token to a common vocabulary.
+
+    Recognized states per cluster software: Slurm 'PD'/'R'/'CG'; PBS/OGE/SGE
+    'Q' (or 'qw'), 'R' (or 'r'), 'H' (any token containing it, e.g. 'hqw'), 'E';
+    HTCondor 'P'/'R'/'H'. Anything else maps to 'unknown'.
+
+    Args:
+        raw_state (str): The raw state token from the queue listing.
+        cluster_soft (str): The cluster software name (case insensitive).
+
+    Returns:
+        str: One of 'running', 'pending', 'held', 'exiting', or 'unknown'.
+    """
+    state = raw_state.strip().upper()
+    soft = cluster_soft.lower()
+    if soft == 'slurm':
+        return {'PD': 'pending', 'R': 'running', 'CG': 'exiting'}.get(state, 'unknown')
+    if soft == 'htcondor':
+        return {'P': 'pending', 'R': 'running', 'H': 'held'}.get(state, 'unknown')
+    if 'H' in state:
+        return 'held'
+    if 'R' in state or state == 'T':
+        return 'running'
+    if 'Q' in state or 'W' in state:
+        return 'pending'
+    if 'E' in state:
+        return 'exiting'
+    return 'unknown'
 
 
 def check_job_status_in_stdout(job_id: int,

--- a/arc/job/ssh_test.py
+++ b/arc/job/ssh_test.py
@@ -6,6 +6,7 @@ This module contains unit tests of the arc.job.ssh module
 """
 
 import unittest
+from unittest.mock import patch
 
 import arc.job.ssh as ssh
 
@@ -41,6 +42,202 @@ class TestSSH(unittest.TestCase):
         self.assertEqual(status1, 'running')
         status1 = ssh.check_job_status_in_stdout(job_id=4000, stdout=stdout_2, server='local')
         self.assertEqual(status1, 'done')
+
+    @staticmethod
+    def _make_client(server: str) -> ssh.SSHClient:
+        """
+        Create an SSHClient instance bound to a server name without connecting.
+
+        Args:
+            server (str): The server name to bind the client to.
+
+        Returns:
+            SSHClient: A client instance that has not opened any connection.
+        """
+        client = ssh.SSHClient.__new__(ssh.SSHClient)
+        client.server = server
+        client._ssh, client._sftp = None, None
+        return client
+
+    @staticmethod
+    def _fail_send(command: str) -> tuple:
+        """
+        A stand-in for ``_send_command_to_server`` that must not be reached.
+
+        Args:
+            command (str): The command that would have been sent.
+
+        Returns:
+            tuple: Never returns, always raises.
+        """
+        raise AssertionError(f'_send_command_to_server should not have been called (command: {command})')
+
+    def test_list_available_nodes_pbs_and_htcondor_return_empty(self):
+        """Test that PBS and HTCondor early-return an empty node list without sending a command"""
+        for cluster_soft in ['PBS', 'HTCondor', 'pbs', 'htcondor']:
+            with patch.dict(ssh.servers, {'node_test_server': {'cluster_soft': cluster_soft}}):
+                client = self._make_client('node_test_server')
+                client._send_command_to_server = self._fail_send
+                self.assertEqual(client.list_available_nodes(), list())
+
+    def test_list_available_nodes_slurm_command_resolution(self):
+        """Test command-key resolution and stdout parsing for a canonical-case Slurm config"""
+        sent_commands = list()
+        stdout = ['node01 alloc 1.00 none\n',
+                  'node02 idle 0.00 none\n',
+                  'node03 down 0.00 none\n']
+
+        def send(command: str) -> tuple:
+            sent_commands.append(command)
+            return stdout, list()
+
+        with patch.dict(ssh.servers, {'node_test_server': {'cluster_soft': 'Slurm'}}):
+            client = self._make_client('node_test_server')
+            client._send_command_to_server = send
+            nodes = client.list_available_nodes()
+        self.assertEqual(sent_commands, [ssh.list_available_nodes_command['Slurm']])
+        self.assertEqual(nodes, ['node01', 'node02'])
+
+    def test_list_available_nodes_lowercase_cluster_soft(self):
+        """Test that a lowercase user-configured cluster_soft ('slurm') resolves the command key"""
+        sent_commands = list()
+
+        def send(command: str) -> tuple:
+            sent_commands.append(command)
+            return ['node05 mix 1.00 none\n'], list()
+
+        with patch.dict(ssh.servers, {'node_test_server': {'cluster_soft': 'slurm'}}):
+            client = self._make_client('node_test_server')
+            client._send_command_to_server = send
+            nodes = client.list_available_nodes()
+        self.assertEqual(sent_commands, [ssh.list_available_nodes_command['Slurm']])
+        self.assertEqual(nodes, ['node05'])
+
+
+class TestCheckRunningJobsIdsAndStates(unittest.TestCase):
+    """
+    Contains unit tests for queue-state-aware job listing.
+    """
+
+    @staticmethod
+    def _make_client(server: str, stdout: list, sent_commands: list) -> ssh.SSHClient:
+        """
+        Create an SSHClient bound to a server with a canned _send_command_to_server.
+
+        Args:
+            server (str): The server name to bind the client to.
+            stdout (list): The canned stdout lines the fake command returns.
+            sent_commands (list): A list collecting the commands sent.
+
+        Returns:
+            SSHClient: A client instance that has not opened any connection.
+        """
+        client = ssh.SSHClient.__new__(ssh.SSHClient)
+        client.server = server
+        client._ssh, client._sftp = None, None
+
+        def send(command: str, remote_path: str = '') -> tuple:
+            sent_commands.append(command)
+            return stdout, list()
+
+        client._send_command_to_server = send
+        return client
+
+    def test_normalize_queue_state_trivial(self):
+        """Test normalizing a plain Slurm running state"""
+        self.assertEqual(ssh.normalize_queue_state('R', 'Slurm'), 'running')
+
+    def test_normalize_queue_state_per_cluster_soft(self):
+        """Test state normalization across cluster softwares"""
+        self.assertEqual(ssh.normalize_queue_state('PD', 'Slurm'), 'pending')
+        self.assertEqual(ssh.normalize_queue_state('CG', 'Slurm'), 'exiting')
+        self.assertEqual(ssh.normalize_queue_state('XX', 'Slurm'), 'unknown')
+        self.assertEqual(ssh.normalize_queue_state('r', 'OGE'), 'running')
+        self.assertEqual(ssh.normalize_queue_state('qw', 'OGE'), 'pending')
+        self.assertEqual(ssh.normalize_queue_state('hqw', 'OGE'), 'held')
+        self.assertEqual(ssh.normalize_queue_state('Eqw', 'OGE'), 'pending')
+        self.assertEqual(ssh.normalize_queue_state('R', 'PBS'), 'running')
+        self.assertEqual(ssh.normalize_queue_state('Q', 'PBS'), 'pending')
+        self.assertEqual(ssh.normalize_queue_state('H', 'PBS'), 'held')
+        self.assertEqual(ssh.normalize_queue_state('E', 'PBS'), 'exiting')
+        self.assertEqual(ssh.normalize_queue_state('P', 'HTCondor'), 'pending')
+        self.assertEqual(ssh.normalize_queue_state('R', 'HTCondor'), 'running')
+        self.assertEqual(ssh.normalize_queue_state('H', 'HTCondor'), 'held')
+
+    def test_check_running_jobs_ids_and_states_slurm(self):
+        """Test parsing job IDs and states from squeue output"""
+        stdout = ['JOBID PARTITION NAME USER ST TIME NODES NODELIST(REASON)\n',
+                  '14428 debug xq1371m2 user R 50-04:04:46 1 node06\n',
+                  '14429 debug xq1371m3 user PD 0:00 1 (Priority)\n',
+                  '14430 debug xq1371m4 user CG 0:01 1 node07\n']
+        sent = list()
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'Slurm'}}):
+            client = self._make_client('state_test_server', stdout, sent)
+            states = client.check_running_jobs_ids_and_states()
+        self.assertEqual(states, {'14428': 'running', '14429': 'pending', '14430': 'exiting'})
+        self.assertEqual(sent, [ssh.check_status_command['Slurm']])
+
+    def test_check_running_jobs_ids_and_states_oge(self):
+        """Test parsing job IDs and states from OGE qstat output"""
+        stdout = ['job-ID prior name user state submit/start at queue slots\n',
+                  '----------------------------------------------------------\n',
+                  '582682 0.45451 a9654 alongd r 04/17/2019 16:22:14 long5@node93 48\n',
+                  '588334 0.45451 pf1005a alongd qw 05/07/2019 16:24:31 48\n',
+                  '588345 0.45451 a14121 alongd hqw 05/08/2019 02:11:42 48\n']
+        sent = list()
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'OGE'}}):
+            client = self._make_client('state_test_server', stdout, sent)
+            states = client.check_running_jobs_ids_and_states()
+        self.assertEqual(states, {'582682': 'running', '588334': 'pending', '588345': 'held'})
+
+    def test_check_running_jobs_ids_and_states_pbs(self):
+        """Test parsing job IDs and states from PBS qstat output"""
+        stdout = ['server:\n',
+                  '\n',
+                  'Job ID Username Queue Jobname SessID NDS TSK Memory Time S Time\n',
+                  '------ -------- ----- ------- ------ --- --- ------ ---- - ----\n',
+                  'filler\n',
+                  '123456.zeus user workq spc1 1234 1 8 -- 24:00 R 01:23\n',
+                  '123457.zeus user workq spc2 -- 1 8 -- 24:00 Q --\n',
+                  '123458.zeus user workq spc3 -- 1 8 -- 24:00 H --\n',
+                  '123459.zeus user workq spc4 5678 1 8 -- 24:00 E 23:59\n']
+        sent = list()
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'PBS'}}):
+            client = self._make_client('state_test_server', stdout, sent)
+            states = client.check_running_jobs_ids_and_states()
+        self.assertEqual(states, {'123456': 'running', '123457': 'pending',
+                                  '123458': 'held', '123459': 'exiting'})
+
+    def test_check_running_jobs_ids_and_states_htcondor(self):
+        """Test parsing job IDs and states from condor_q output"""
+        stdout = ['5231.0 R 10 7885 a20596 130\n',
+                  '5241.0 P 10 7885 a20616 0\n',
+                  '5250.0 H 10 7885 a20620 0\n']
+        sent = list()
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'HTCondor'}}):
+            client = self._make_client('state_test_server', stdout, sent)
+            states = client.check_running_jobs_ids_and_states()
+        self.assertEqual(states, {'5231': 'running', '5241': 'pending', '5250': 'held'})
+
+    def test_check_running_jobs_ids_delegates(self):
+        """Test that check_running_jobs_ids returns the same IDs in the same order"""
+        stdout = ['JOBID PARTITION NAME USER ST TIME NODES NODELIST(REASON)\n',
+                  '14428 debug xq1371m2 user R 50-04:04:46 1 node06\n',
+                  '14429 debug xq1371m3 user PD 0:00 1 (Priority)\n']
+        sent = list()
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'Slurm'}}):
+            client = self._make_client('state_test_server', stdout, sent)
+            self.assertEqual(client.check_running_jobs_ids(), ['14428', '14429'])
+
+    def test_check_running_jobs_ids_and_states_unsupported_cluster_soft(self):
+        """Test that an unsupported cluster software raises a ValueError"""
+        with patch.dict(ssh.servers, {'state_test_server': {'cluster_soft': 'LSF'},
+                                      'local': {'cluster_soft': 'LSF'}}):
+            client = self._make_client('state_test_server', list(), list())
+            with self.assertRaises(ValueError):
+                client.check_running_jobs_ids_and_states()
+            with self.assertRaises(ValueError):
+                client.check_running_jobs_ids()
 
 
 if __name__ == '__main__':

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -399,17 +399,18 @@ def determine_ess_status(output_path: str,
             # because the underlying cause ("Use semicanonical orbitals!")
             # appears earlier in the file than the downstream "Fatal error in
             # mrcc." line — reverse iteration would otherwise classify the
-            # latter (generic) before the former (specific). Fix in the
-            # adapter prepends ``{uccsd}`` to generate semicanonical orbitals;
-            # this keyword surfaces the diagnostic for any legacy run that
-            # hits it.
-            joined = '\n'.join(lines) if isinstance(lines, list) else str(lines)
-            if 'standard ROHF orbitals' in joined or 'Use semicanonical orbitals' in joined:
-                rohf_line = next(
-                    (ln for ln in lines if 'standard ROHF orbitals' in ln
-                     or 'Use semicanonical orbitals' in ln),
-                    '',
-                )
+            # latter (generic) before the former (specific). The adapter
+            # avoids this on new runs by switching the SCF reference to UHF
+            # for open-shell species (UHF orbitals are semicanonical by
+            # construction); this keyword surfaces the diagnostic for any
+            # legacy run that hits it. Only classify as errored if the job
+            # did not terminate successfully, so a multi-step job that merely
+            # printed the note along the way is not misclassified.
+            rohf_line = next((ln for ln in lines if 'standard ROHF orbitals' in ln
+                              or 'Use semicanonical orbitals' in ln), None)
+            if rohf_line is not None \
+                    and not any('molpro calculation terminated' in ln.lower()
+                                or 'variable memory released' in ln.lower() for ln in reverse_lines):
                 return ('errored', ['MRCCRequiresSemicanonical'],
                         'MRCC requires semicanonical orbitals; ROHF orbitals '
                         'are not supported for approximate CC.',
@@ -419,16 +420,13 @@ def determine_ess_status(output_path: str,
                         or 'variable memory released' in line.lower():
                     return 'done', list(), '', ''
                 elif 'Fatal error in xmrcc' in line or 'Fatal error in mrcc' in line:
-                    # MRCC bailed for a tiny system where the requested CC
-                    # excitation rank exceeds the determinant space (e.g.
-                    # atomic H or H2 at CCSDT(Q)). The composite framework
-                    # should short-circuit a δ-term high leg with this
-                    # keyword to the corresponding low-leg energy (δ = 0,
-                    # which is correct for a degenerate-method case).
-                    keywords = ['MRCCDegenerateSystem']
-                    error = ('MRCC xmrcc fatal — the requested CC excitation '
-                             'rank exceeds the determinant space for this '
-                             'system (degenerate / too few electrons).')
+                    # MRCC's generic crash banner — printed alike for OOM,
+                    # disk-full, and internal errors, so it carries no
+                    # diagnostic specificity. Classify as a generic MRCC
+                    # failure and let the normal Molpro troubleshooting
+                    # ladder apply.
+                    keywords = ['MRCC']
+                    error = f'MRCC terminated with a fatal error: {line.strip()}'
                     break
                 elif 'No convergence' in line and '?No convergence in rhfpr' not in line:
                     keywords = ['Unconverged']

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -1066,27 +1066,38 @@ def trsh_ess_job(label: str,
             raise TrshError(f'DLPNO methods are incompatible with single-electron species {label} in Orca. '
                             f'This should have been caught by the Scheduler before job submission.')
         elif 'Memory' in job_status['keywords']:
-            # Increase memory allocation.
+            # Increase the memory per cpu core.
             # job_status will be for example
             # `Error  (ORCA_SCF): Not enough memory available! Please increase MaxCore to more than: 289 MB`.
+            # Whether ARC already attempted to increase the memory for this job. If so, simply requesting more
+            # total memory tends to keep failing (e.g. DLPNO-CCSD(T) triples need a large per-core MaxCore rather
+            # than more total node memory), so ARC reduces the number of cpu cores to raise the memory per core
+            # instead of resubmitting a near-identical job (which previously caused an endless retry loop).
+            memory_increased_before = 'memory' in ess_trsh_methods
             if 'memory' not in ess_trsh_methods:
                 ess_trsh_methods.append('memory')
+            per_cpu_core_memory = np.ceil(memory_gb / cpu_cores * 1024)  # MB currently allocated per cpu core
             try:
-                # parse Orca's memory requirement in MB
+                # parse Orca's explicit per cpu core memory requirement in MB (e.g., Orca 4.2.x)
                 estimated_mem_per_core = float(job_status['error'].split()[-2])
             except ValueError:
-                estimated_mem_per_core = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms,
+                # Orca did not report an explicit requirement (e.g. Orca 5.x 'Insufficient job memory.').
+                # Aim for at least double the per-core memory already given so that reducing the number of cpu
+                # cores meaningfully raises the memory per core; never go below ARC's heuristic estimate.
+                heuristic_mem_per_core = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms,
                                                                            server=server,
                                                                            consider_server_limits=True)[1]/cpu_cores
+                estimated_mem_per_core = max(2.0 * per_cpu_core_memory, heuristic_mem_per_core)
             # round up to the next hundred
             estimated_mem_per_core = int(np.ceil(estimated_mem_per_core / 100.0)) * 100
-            if 'max_total_job_memory' in job_status['keywords']:
-                per_cpu_core_memory = np.ceil(memory_gb / cpu_cores * 1024)
+            if 'max_total_job_memory' in job_status['keywords'] or memory_increased_before:
+                reason = 'the job had already requested the maximum amount of available total node memory' \
+                    if 'max_total_job_memory' in job_status['keywords'] \
+                    else 'increasing the total job memory had already been attempted and the job still ran out of memory'
                 logger.info(f'The crashed Orca job {label} was ran with {cpu_cores} cpu cores and '
                             f'{per_cpu_core_memory} MB memory per cpu core. It requires at least '
-                            f'{estimated_mem_per_core} MB per cpu core. Since the job had already requested the '
-                            f'maximum amount of available total node memory, ARC will attempt to reduce the number '
-                            f'of cpu cores to increase memory per cpu core.')
+                            f'{estimated_mem_per_core} MB per cpu core. Since {reason}, ARC will attempt to reduce '
+                            f'the number of cpu cores to increase memory per cpu core.')
                 if 'cpu' not in ess_trsh_methods:
                     ess_trsh_methods.append('cpu')
                 cpu_cores = math.floor(cpu_cores * per_cpu_core_memory / estimated_mem_per_core) - 2  # be conservative

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -395,10 +395,41 @@ def determine_ess_status(output_path: str,
             return 'errored', keywords, error, line
 
         elif software == 'molpro':
+            # MRCC ROHF-incompatibility check BEFORE the generic reverse scan
+            # because the underlying cause ("Use semicanonical orbitals!")
+            # appears earlier in the file than the downstream "Fatal error in
+            # mrcc." line — reverse iteration would otherwise classify the
+            # latter (generic) before the former (specific). Fix in the
+            # adapter prepends ``{uccsd}`` to generate semicanonical orbitals;
+            # this keyword surfaces the diagnostic for any legacy run that
+            # hits it.
+            joined = '\n'.join(lines) if isinstance(lines, list) else str(lines)
+            if 'standard ROHF orbitals' in joined or 'Use semicanonical orbitals' in joined:
+                rohf_line = next(
+                    (ln for ln in lines if 'standard ROHF orbitals' in ln
+                     or 'Use semicanonical orbitals' in ln),
+                    '',
+                )
+                return ('errored', ['MRCCRequiresSemicanonical'],
+                        'MRCC requires semicanonical orbitals; ROHF orbitals '
+                        'are not supported for approximate CC.',
+                        rohf_line)
             for line in reverse_lines:
                 if 'molpro calculation terminated' in line.lower() \
                         or 'variable memory released' in line.lower():
                     return 'done', list(), '', ''
+                elif 'Fatal error in xmrcc' in line or 'Fatal error in mrcc' in line:
+                    # MRCC bailed for a tiny system where the requested CC
+                    # excitation rank exceeds the determinant space (e.g.
+                    # atomic H or H2 at CCSDT(Q)). The composite framework
+                    # should short-circuit a δ-term high leg with this
+                    # keyword to the corresponding low-leg energy (δ = 0,
+                    # which is correct for a degenerate-method case).
+                    keywords = ['MRCCDegenerateSystem']
+                    error = ('MRCC xmrcc fatal — the requested CC excitation '
+                             'rank exceeds the determinant space for this '
+                             'system (degenerate / too few electrons).')
+                    break
                 elif 'No convergence' in line and '?No convergence in rhfpr' not in line:
                     keywords = ['Unconverged']
                     error = 'Unconverged'
@@ -1719,13 +1750,12 @@ def scan_quality_check(label: str,
             logger.warning(message)
             return invalidate, invalidation_reason, message, actions
         else:
-            logger.warning(f'The maximal barrier for rotor {pivots} of {label} is '
-                           f'{(np.max(energies) - np.min(energies)):.2f} kJ/mol, which is higher than the set threshold '
-                           f'of {maximum_barrier} kJ/mol. Since this mode when treated as torsion has {num_wells}, '
-                           f'this mode is not invalidated: treating it as a vibrational mode will be less accurate than '
-                           f'the hindered rotor treatment, since the entropy contribution from the population of '
-                           f'this species at the higher wells will not be taken into account. NOT invalidating this '
-                           f'torsional mode.')
+            barrier_kJmol = np.max(energies) - np.min(energies)
+            logger.warning(f'Rotor {pivots} of {label}: barrier {barrier_kJmol:.2f} kJ/mol '
+                           f'exceeds the {maximum_barrier} kJ/mol threshold, but the mode has '
+                           f'{num_wells} wells. Keeping the hindered-rotor treatment — '
+                           f'demoting to a harmonic vibration would miss the entropic '
+                           f'contribution from the upper well(s).')
 
     if preserve_params is not None:
         success = True

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -399,10 +399,41 @@ def determine_ess_status(output_path: str,
             return 'errored', keywords, error, line
 
         elif software == 'molpro':
+            # MRCC ROHF-incompatibility check BEFORE the generic reverse scan
+            # because the underlying cause ("Use semicanonical orbitals!")
+            # appears earlier in the file than the downstream "Fatal error in
+            # mrcc." line — reverse iteration would otherwise classify the
+            # latter (generic) before the former (specific). Fix in the
+            # adapter prepends ``{uccsd}`` to generate semicanonical orbitals;
+            # this keyword surfaces the diagnostic for any legacy run that
+            # hits it.
+            joined = '\n'.join(lines) if isinstance(lines, list) else str(lines)
+            if 'standard ROHF orbitals' in joined or 'Use semicanonical orbitals' in joined:
+                rohf_line = next(
+                    (ln for ln in lines if 'standard ROHF orbitals' in ln
+                     or 'Use semicanonical orbitals' in ln),
+                    '',
+                )
+                return ('errored', ['MRCCRequiresSemicanonical'],
+                        'MRCC requires semicanonical orbitals; ROHF orbitals '
+                        'are not supported for approximate CC.',
+                        rohf_line)
             for line in reverse_lines:
                 if 'molpro calculation terminated' in line.lower() \
                         or 'variable memory released' in line.lower():
                     return 'done', list(), '', ''
+                elif 'Fatal error in xmrcc' in line or 'Fatal error in mrcc' in line:
+                    # MRCC bailed for a tiny system where the requested CC
+                    # excitation rank exceeds the determinant space (e.g.
+                    # atomic H or H2 at CCSDT(Q)). The composite framework
+                    # should short-circuit a δ-term high leg with this
+                    # keyword to the corresponding low-leg energy (δ = 0,
+                    # which is correct for a degenerate-method case).
+                    keywords = ['MRCCDegenerateSystem']
+                    error = ('MRCC xmrcc fatal — the requested CC excitation '
+                             'rank exceeds the determinant space for this '
+                             'system (degenerate / too few electrons).')
+                    break
                 elif 'No convergence' in line and '?No convergence in rhfpr' not in line:
                     keywords = ['Unconverged']
                     error = 'Unconverged'
@@ -1759,13 +1790,12 @@ def scan_quality_check(label: str,
             logger.warning(message)
             return invalidate, invalidation_reason, message, actions
         else:
-            logger.warning(f'The maximal barrier for rotor {pivots} of {label} is '
-                           f'{(np.max(energies) - np.min(energies)):.2f} kJ/mol, which is higher than the set threshold '
-                           f'of {maximum_barrier} kJ/mol. Since this mode when treated as torsion has {num_wells}, '
-                           f'this mode is not invalidated: treating it as a vibrational mode will be less accurate than '
-                           f'the hindered rotor treatment, since the entropy contribution from the population of '
-                           f'this species at the higher wells will not be taken into account. NOT invalidating this '
-                           f'torsional mode.')
+            barrier_kJmol = np.max(energies) - np.min(energies)
+            logger.warning(f'Rotor {pivots} of {label}: barrier {barrier_kJmol:.2f} kJ/mol '
+                           f'exceeds the {maximum_barrier} kJ/mol threshold, but the mode has '
+                           f'{num_wells} wells. Keeping the hindered-rotor treatment — '
+                           f'demoting to a harmonic vibration would miss the entropic '
+                           f'contribution from the upper well(s).')
 
     if preserve_params is not None:
         success = True

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -403,17 +403,18 @@ def determine_ess_status(output_path: str,
             # because the underlying cause ("Use semicanonical orbitals!")
             # appears earlier in the file than the downstream "Fatal error in
             # mrcc." line — reverse iteration would otherwise classify the
-            # latter (generic) before the former (specific). Fix in the
-            # adapter prepends ``{uccsd}`` to generate semicanonical orbitals;
-            # this keyword surfaces the diagnostic for any legacy run that
-            # hits it.
-            joined = '\n'.join(lines) if isinstance(lines, list) else str(lines)
-            if 'standard ROHF orbitals' in joined or 'Use semicanonical orbitals' in joined:
-                rohf_line = next(
-                    (ln for ln in lines if 'standard ROHF orbitals' in ln
-                     or 'Use semicanonical orbitals' in ln),
-                    '',
-                )
+            # latter (generic) before the former (specific). The adapter
+            # avoids this on new runs by switching the SCF reference to UHF
+            # for open-shell species (UHF orbitals are semicanonical by
+            # construction); this keyword surfaces the diagnostic for any
+            # legacy run that hits it. Only classify as errored if the job
+            # did not terminate successfully, so a multi-step job that merely
+            # printed the note along the way is not misclassified.
+            rohf_line = next((ln for ln in lines if 'standard ROHF orbitals' in ln
+                              or 'Use semicanonical orbitals' in ln), None)
+            if rohf_line is not None \
+                    and not any('molpro calculation terminated' in ln.lower()
+                                or 'variable memory released' in ln.lower() for ln in reverse_lines):
                 return ('errored', ['MRCCRequiresSemicanonical'],
                         'MRCC requires semicanonical orbitals; ROHF orbitals '
                         'are not supported for approximate CC.',
@@ -423,16 +424,13 @@ def determine_ess_status(output_path: str,
                         or 'variable memory released' in line.lower():
                     return 'done', list(), '', ''
                 elif 'Fatal error in xmrcc' in line or 'Fatal error in mrcc' in line:
-                    # MRCC bailed for a tiny system where the requested CC
-                    # excitation rank exceeds the determinant space (e.g.
-                    # atomic H or H2 at CCSDT(Q)). The composite framework
-                    # should short-circuit a δ-term high leg with this
-                    # keyword to the corresponding low-leg energy (δ = 0,
-                    # which is correct for a degenerate-method case).
-                    keywords = ['MRCCDegenerateSystem']
-                    error = ('MRCC xmrcc fatal — the requested CC excitation '
-                             'rank exceeds the determinant space for this '
-                             'system (degenerate / too few electrons).')
+                    # MRCC's generic crash banner — printed alike for OOM,
+                    # disk-full, and internal errors, so it carries no
+                    # diagnostic specificity. Classify as a generic MRCC
+                    # failure and let the normal Molpro troubleshooting
+                    # ladder apply.
+                    keywords = ['MRCC']
+                    error = f'MRCC terminated with a fatal error: {line.strip()}'
                     break
                 elif 'No convergence' in line and '?No convergence in rhfpr' not in line:
                     keywords = ['Unconverged']

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -1106,27 +1106,38 @@ def trsh_ess_job(label: str,
             raise TrshError(f'DLPNO methods are incompatible with single-electron species {label} in Orca. '
                             f'This should have been caught by the Scheduler before job submission.')
         elif 'Memory' in job_status['keywords']:
-            # Increase memory allocation.
+            # Increase the memory per cpu core.
             # job_status will be for example
             # `Error  (ORCA_SCF): Not enough memory available! Please increase MaxCore to more than: 289 MB`.
+            # Whether ARC already attempted to increase the memory for this job. If so, simply requesting more
+            # total memory tends to keep failing (e.g. DLPNO-CCSD(T) triples need a large per-core MaxCore rather
+            # than more total node memory), so ARC reduces the number of cpu cores to raise the memory per core
+            # instead of resubmitting a near-identical job (which previously caused an endless retry loop).
+            memory_increased_before = 'memory' in ess_trsh_methods
             if 'memory' not in ess_trsh_methods:
                 ess_trsh_methods.append('memory')
+            per_cpu_core_memory = np.ceil(memory_gb / cpu_cores * 1024)  # MB currently allocated per cpu core
             try:
-                # parse Orca's memory requirement in MB
+                # parse Orca's explicit per cpu core memory requirement in MB (e.g., Orca 4.2.x)
                 estimated_mem_per_core = float(job_status['error'].split()[-2])
             except ValueError:
-                estimated_mem_per_core = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms,
+                # Orca did not report an explicit requirement (e.g. Orca 5.x 'Insufficient job memory.').
+                # Aim for at least double the per-core memory already given so that reducing the number of cpu
+                # cores meaningfully raises the memory per core; never go below ARC's heuristic estimate.
+                heuristic_mem_per_core = estimate_orca_mem_cpu_requirement(num_heavy_atoms=num_heavy_atoms,
                                                                            server=server,
                                                                            consider_server_limits=True)[1]/cpu_cores
+                estimated_mem_per_core = max(2.0 * per_cpu_core_memory, heuristic_mem_per_core)
             # round up to the next hundred
             estimated_mem_per_core = int(np.ceil(estimated_mem_per_core / 100.0)) * 100
-            if 'max_total_job_memory' in job_status['keywords']:
-                per_cpu_core_memory = np.ceil(memory_gb / cpu_cores * 1024)
+            if 'max_total_job_memory' in job_status['keywords'] or memory_increased_before:
+                reason = 'the job had already requested the maximum amount of available total node memory' \
+                    if 'max_total_job_memory' in job_status['keywords'] \
+                    else 'increasing the total job memory had already been attempted and the job still ran out of memory'
                 logger.info(f'The crashed Orca job {label} was ran with {cpu_cores} cpu cores and '
                             f'{per_cpu_core_memory} MB memory per cpu core. It requires at least '
-                            f'{estimated_mem_per_core} MB per cpu core. Since the job had already requested the '
-                            f'maximum amount of available total node memory, ARC will attempt to reduce the number '
-                            f'of cpu cores to increase memory per cpu core.')
+                            f'{estimated_mem_per_core} MB per cpu core. Since {reason}, ARC will attempt to reduce '
+                            f'the number of cpu cores to increase memory per cpu core.')
                 if 'cpu' not in ess_trsh_methods:
                     ess_trsh_methods.append('cpu')
                 cpu_cores = math.floor(cpu_cores * per_cpu_core_memory / estimated_mem_per_core) - 2  # be conservative

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -171,6 +171,32 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, "Unrecognized basis set 6-311G**")
         self.assertIn(" ? Basis library exhausted", line)  # line includes '\n'
 
+        # Molpro + MRCC: degenerate small system (e.g. atomic H, H2 at CCSDT(Q)).
+        # MRCC's xmrcc bails because there's no determinant space at the
+        # requested excitation rank. Trsh must classify this so the framework
+        # knows to short-circuit the sub-job (delta = 0) instead of cycling
+        # the generic ladder (shift / vdz / memory).
+        path = os.path.join(self.base_path["molpro"], "mrcc_xmrcc_fatal.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="H", job_type="sp"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["MRCCDegenerateSystem"])
+        self.assertIn("xmrcc", error.lower())
+        self.assertIn("Fatal error in xmrcc", line)
+
+        # Molpro + MRCC: ROHF orbitals incompatible with approximate CC methods
+        # (open-shell radicals). Trsh classifies and the adapter's UCCSD
+        # prefix should prevent this from happening on new runs; the keyword
+        # is the diagnostic for any legacy runs that don't have the prefix.
+        path = os.path.join(self.base_path["molpro"], "mrcc_rohf_unsupported.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="OH", job_type="sp"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["MRCCRequiresSemicanonical"])
+        self.assertIn("semicanonical", error.lower())
+
         # Orca
 
         # test detection of a successful job

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -171,24 +171,23 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, "Unrecognized basis set 6-311G**")
         self.assertIn(" ? Basis library exhausted", line)  # line includes '\n'
 
-        # Molpro + MRCC: degenerate small system (e.g. atomic H, H2 at CCSDT(Q)).
-        # MRCC's xmrcc bails because there's no determinant space at the
-        # requested excitation rank. Trsh must classify this so the framework
-        # knows to short-circuit the sub-job (delta = 0) instead of cycling
-        # the generic ladder (shift / vdz / memory).
+        # Molpro + MRCC: 'Fatal error in (x)mrcc' is MRCC's GENERIC crash
+        # banner — OOM, disk-full, and internal errors all print it. It must
+        # classify as a generic MRCC failure that routes to the normal
+        # troubleshooting ladder, never as a special-cased degenerate system.
         path = os.path.join(self.base_path["molpro"], "mrcc_xmrcc_fatal.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="H", job_type="sp"
         )
         self.assertEqual(status, "errored")
-        self.assertEqual(keywords, ["MRCCDegenerateSystem"])
-        self.assertIn("xmrcc", error.lower())
+        self.assertEqual(keywords, ["MRCC"])
+        self.assertIn("mrcc", error.lower())
         self.assertIn("Fatal error in xmrcc", line)
 
         # Molpro + MRCC: ROHF orbitals incompatible with approximate CC methods
-        # (open-shell radicals). Trsh classifies and the adapter's UCCSD
-        # prefix should prevent this from happening on new runs; the keyword
-        # is the diagnostic for any legacy runs that don't have the prefix.
+        # (open-shell radicals). Trsh classifies and the adapter's UHF SCF
+        # reference should prevent this from happening on new runs; the
+        # keyword is the diagnostic for any legacy runs without that fix.
         path = os.path.join(self.base_path["molpro"], "mrcc_rohf_unsupported.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="OH", job_type="sp"
@@ -196,6 +195,17 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(status, "errored")
         self.assertEqual(keywords, ["MRCCRequiresSemicanonical"])
         self.assertIn("semicanonical", error.lower())
+
+        # Molpro + MRCC: an early semicanonical-orbitals note must not
+        # override a successful termination of a multi-step job.
+        path = os.path.join(self.base_path["molpro"], "mrcc_semicanonical_note_success.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="OH", job_type="sp"
+        )
+        self.assertEqual(status, "done")
+        self.assertEqual(keywords, list())
+        self.assertEqual(error, "")
+        self.assertEqual(line, "")
 
         # Orca
 

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -738,8 +738,11 @@ class TestTrsh(unittest.TestCase):
 
         # Test Orca
         # Orca: test 1
-        # Test troubleshooting insufficient memory issue
-        # Automatically increase memory provided not exceeding maximum available memory
+        # Test troubleshooting insufficient memory issue.
+        # When merely increasing total memory has already been attempted ('memory' is already in
+        # ess_trsh_methods), simply requesting more total memory keeps failing (and previously caused
+        # ARC to resubmit near-identical jobs in an endless loop). Instead, ARC reduces the number of
+        # cpu cores to raise the memory per core (Orca's MaxCore).
         label = 'test'
         level_of_theory = {'method': 'dlpno-ccsd(T)'}
         server = 'server1'
@@ -759,8 +762,9 @@ class TestTrsh(unittest.TestCase):
                                                                        job_type, software, fine, memory_gb,
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
         self.assertIn('memory', ess_trsh_methods)
-        self.assertEqual(cpu_cores, 32)
-        self.assertAlmostEqual(memory, 327)
+        self.assertIn('cpu', ess_trsh_methods)
+        self.assertEqual(cpu_cores, 22)
+        self.assertAlmostEqual(memory, 227)
 
         # Orca: test 2
         # Test troubleshooting insufficient memory issue
@@ -813,6 +817,36 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('memory', ess_trsh_methods)
         self.assertEqual(couldnt_trsh, True)
         self.assertLess(cpu_cores, 1)  # can't really run job with less than 1 cpu ^o^
+
+        # Orca: test 3b
+        # Regression test for the Orca 5.x DLPNO-CCSD(T) "out of memory in the triples" loop.
+        # In Orca 5.x the message is "Please increase MaxCore - Skipping calculation" with no explicit
+        # per-core requirement, so determine_ess_status returns 'Insufficient job memory.'. Increasing
+        # total memory was already attempted (ess_trsh_methods=['memory']) and the node is NOT at its
+        # memory ceiling (no 'max_total_job_memory' keyword). Previously ARC kept resubmitting a nearly
+        # identical job forever; instead it must reduce the number of cpu cores so that the memory per
+        # core (Orca's MaxCore) actually increases.
+        label = 'test'
+        level_of_theory = {'method': 'dlpno-ccsd(T)'}
+        server = 'server2'
+        job_type = 'sp'
+        software = 'orca'
+        fine = False
+        memory_gb = 37
+        cpu_cores = 16
+        num_heavy_atoms = 16
+        ess_trsh_methods = ['memory']
+        job_status = {'keywords': ['MDCI', 'Memory'], 'error': 'Insufficient job memory.'}
+        mem_per_core_before = memory_gb / cpu_cores
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        self.assertIn('cpu', ess_trsh_methods)
+        self.assertFalse(couldnt_trsh)
+        self.assertEqual(cpu_cores, 5)  # cpu cores reduced (this breaks the endless retry loop)
+        self.assertAlmostEqual(memory, 29)
+        self.assertGreater(memory / cpu_cores, mem_per_core_before)  # memory per core increased
 
         # Orca: test 4
         # Test troubleshooting too many cpu cores

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -740,8 +740,11 @@ class TestTrsh(unittest.TestCase):
 
         # Test Orca
         # Orca: test 1
-        # Test troubleshooting insufficient memory issue
-        # Automatically increase memory provided not exceeding maximum available memory
+        # Test troubleshooting insufficient memory issue.
+        # When merely increasing total memory has already been attempted ('memory' is already in
+        # ess_trsh_methods), simply requesting more total memory keeps failing (and previously caused
+        # ARC to resubmit near-identical jobs in an endless loop). Instead, ARC reduces the number of
+        # cpu cores to raise the memory per core (Orca's MaxCore).
         label = 'test'
         level_of_theory = {'method': 'dlpno-ccsd(T)'}
         server = 'server1'
@@ -761,8 +764,9 @@ class TestTrsh(unittest.TestCase):
                                                                        job_type, software, fine, memory_gb,
                                                                        num_heavy_atoms, cpu_cores, ess_trsh_methods)
         self.assertIn('memory', ess_trsh_methods)
-        self.assertEqual(cpu_cores, 32)
-        self.assertAlmostEqual(memory, 327)
+        self.assertIn('cpu', ess_trsh_methods)
+        self.assertEqual(cpu_cores, 22)
+        self.assertAlmostEqual(memory, 227)
 
         # Orca: test 2
         # Test troubleshooting insufficient memory issue
@@ -815,6 +819,36 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('memory', ess_trsh_methods)
         self.assertEqual(couldnt_trsh, True)
         self.assertLess(cpu_cores, 1)  # can't really run job with less than 1 cpu ^o^
+
+        # Orca: test 3b
+        # Regression test for the Orca 5.x DLPNO-CCSD(T) "out of memory in the triples" loop.
+        # In Orca 5.x the message is "Please increase MaxCore - Skipping calculation" with no explicit
+        # per-core requirement, so determine_ess_status returns 'Insufficient job memory.'. Increasing
+        # total memory was already attempted (ess_trsh_methods=['memory']) and the node is NOT at its
+        # memory ceiling (no 'max_total_job_memory' keyword). Previously ARC kept resubmitting a nearly
+        # identical job forever; instead it must reduce the number of cpu cores so that the memory per
+        # core (Orca's MaxCore) actually increases.
+        label = 'test'
+        level_of_theory = {'method': 'dlpno-ccsd(T)'}
+        server = 'server2'
+        job_type = 'sp'
+        software = 'orca'
+        fine = False
+        memory_gb = 37
+        cpu_cores = 16
+        num_heavy_atoms = 16
+        ess_trsh_methods = ['memory']
+        job_status = {'keywords': ['MDCI', 'Memory'], 'error': 'Insufficient job memory.'}
+        mem_per_core_before = memory_gb / cpu_cores
+        output_errors, ess_trsh_methods, remove_checkfile, level_of_theory, software, job_type, fine, trsh_keyword, \
+            memory, shift, cpu_cores, couldnt_trsh = trsh.trsh_ess_job(label, level_of_theory, server, job_status,
+                                                                       job_type, software, fine, memory_gb,
+                                                                       num_heavy_atoms, cpu_cores, ess_trsh_methods)
+        self.assertIn('cpu', ess_trsh_methods)
+        self.assertFalse(couldnt_trsh)
+        self.assertEqual(cpu_cores, 5)  # cpu cores reduced (this breaks the endless retry loop)
+        self.assertAlmostEqual(memory, 29)
+        self.assertGreater(memory / cpu_cores, mem_per_core_before)  # memory per core increased
 
         # Orca: test 4
         # Test troubleshooting too many cpu cores

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -173,6 +173,32 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, "Unrecognized basis set 6-311G**")
         self.assertIn(" ? Basis library exhausted", line)  # line includes '\n'
 
+        # Molpro + MRCC: degenerate small system (e.g. atomic H, H2 at CCSDT(Q)).
+        # MRCC's xmrcc bails because there's no determinant space at the
+        # requested excitation rank. Trsh must classify this so the framework
+        # knows to short-circuit the sub-job (delta = 0) instead of cycling
+        # the generic ladder (shift / vdz / memory).
+        path = os.path.join(self.base_path["molpro"], "mrcc_xmrcc_fatal.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="H", job_type="sp"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["MRCCDegenerateSystem"])
+        self.assertIn("xmrcc", error.lower())
+        self.assertIn("Fatal error in xmrcc", line)
+
+        # Molpro + MRCC: ROHF orbitals incompatible with approximate CC methods
+        # (open-shell radicals). Trsh classifies and the adapter's UCCSD
+        # prefix should prevent this from happening on new runs; the keyword
+        # is the diagnostic for any legacy runs that don't have the prefix.
+        path = os.path.join(self.base_path["molpro"], "mrcc_rohf_unsupported.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="OH", job_type="sp"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["MRCCRequiresSemicanonical"])
+        self.assertIn("semicanonical", error.lower())
+
         # Orca
 
         # test detection of a successful job

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -173,24 +173,23 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, "Unrecognized basis set 6-311G**")
         self.assertIn(" ? Basis library exhausted", line)  # line includes '\n'
 
-        # Molpro + MRCC: degenerate small system (e.g. atomic H, H2 at CCSDT(Q)).
-        # MRCC's xmrcc bails because there's no determinant space at the
-        # requested excitation rank. Trsh must classify this so the framework
-        # knows to short-circuit the sub-job (delta = 0) instead of cycling
-        # the generic ladder (shift / vdz / memory).
+        # Molpro + MRCC: 'Fatal error in (x)mrcc' is MRCC's GENERIC crash
+        # banner — OOM, disk-full, and internal errors all print it. It must
+        # classify as a generic MRCC failure that routes to the normal
+        # troubleshooting ladder, never as a special-cased degenerate system.
         path = os.path.join(self.base_path["molpro"], "mrcc_xmrcc_fatal.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="H", job_type="sp"
         )
         self.assertEqual(status, "errored")
-        self.assertEqual(keywords, ["MRCCDegenerateSystem"])
-        self.assertIn("xmrcc", error.lower())
+        self.assertEqual(keywords, ["MRCC"])
+        self.assertIn("mrcc", error.lower())
         self.assertIn("Fatal error in xmrcc", line)
 
         # Molpro + MRCC: ROHF orbitals incompatible with approximate CC methods
-        # (open-shell radicals). Trsh classifies and the adapter's UCCSD
-        # prefix should prevent this from happening on new runs; the keyword
-        # is the diagnostic for any legacy runs that don't have the prefix.
+        # (open-shell radicals). Trsh classifies and the adapter's UHF SCF
+        # reference should prevent this from happening on new runs; the
+        # keyword is the diagnostic for any legacy runs without that fix.
         path = os.path.join(self.base_path["molpro"], "mrcc_rohf_unsupported.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="OH", job_type="sp"
@@ -198,6 +197,17 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(status, "errored")
         self.assertEqual(keywords, ["MRCCRequiresSemicanonical"])
         self.assertIn("semicanonical", error.lower())
+
+        # Molpro + MRCC: an early semicanonical-orbitals note must not
+        # override a successful termination of a multi-step job.
+        path = os.path.join(self.base_path["molpro"], "mrcc_semicanonical_note_success.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="OH", job_type="sp"
+        )
+        self.assertEqual(status, "done")
+        self.assertEqual(keywords, list())
+        self.assertEqual(error, "")
+        self.assertEqual(line, "")
 
         # Orca
 

--- a/arc/job/zombie.py
+++ b/arc/job/zombie.py
@@ -9,13 +9,23 @@ live here.
 
 import datetime
 import os
+from collections.abc import Collection
+from typing import TYPE_CHECKING
 
 from arc.common import get_logger
 from arc.imports import settings
 from arc.job.ssh import SSHClient
 
+if TYPE_CHECKING:
+    from arc.job.adapter import JobAdapter
+
 
 logger = get_logger()
+
+
+class RemoteStatError(RuntimeError):
+    """Raised when the remote stat of a job's output file failed (e.g., a transient
+    SSH error), as opposed to a successful stat that found no output file."""
 
 
 # NOTE: submit templates that redirect ESS output to a node scratch dir and only
@@ -23,7 +33,12 @@ logger = get_logger()
 # heuristic blind to live progress, so any job past the grace looks like a zombie.
 # Keep the grace well above the longest legitimate job (TS opt ~1 h, high-level
 # single points up to several hours) to avoid killing healthy long jobs.
-ZOMBIE_GRACE_SECONDS = 21600  # 6 h (was 3600 = 1 h, which killed slow TS opts)
+# Must exceed the longest legitimate quiet period; 1 h proved too short for
+# slow TS opts during development.
+# The effective grace is settings['zombie_grace_seconds'] with an optional
+# per-server 'zombie_grace_seconds' override in the servers dict (see
+# get_zombie_grace_seconds); this constant is the importable fallback.
+ZOMBIE_GRACE_SECONDS = 21600  # 6 h
 
 ZOMBIE_OUTPUT_FILENAME_FALLBACK = 'out.txt'
 
@@ -36,7 +51,27 @@ ESS_PERIODIC_WRITERS = frozenset({
 })
 
 
-def output_mtime(job) -> datetime.datetime | None:
+def get_zombie_grace_seconds(server: str | None = None) -> int:
+    """
+    Resolve the effective zombie grace period for a server.
+
+    The per-server 'zombie_grace_seconds' key in the servers settings dict takes
+    precedence, then the global 'zombie_grace_seconds' setting, then the
+    :data:`ZOMBIE_GRACE_SECONDS` fallback.
+
+    Args:
+        server (str, optional): The server name to resolve the override for.
+
+    Returns:
+        int: The grace period in seconds.
+    """
+    default = settings.get('zombie_grace_seconds', ZOMBIE_GRACE_SECONDS)
+    if server:
+        return settings.get('servers', {}).get(server, {}).get('zombie_grace_seconds', default)
+    return default
+
+
+def output_mtime(job: 'JobAdapter') -> datetime.datetime | None:
     """Return the latest mtime of the job's ESS output file.
 
     Tries the configured ESS output filename first and falls back to the
@@ -44,13 +79,18 @@ def output_mtime(job) -> datetime.datetime | None:
     ``SSHClient.get_last_modified_time`` against ``job.remote_path``.
 
     Args:
-        job: A ``JobAdapter`` (duck-typed). Required attributes: ``job_adapter``,
-            ``server``, ``local_path``, ``local_path_to_output_file``,
-            ``remote_path``, ``job_name``.
+        job (JobAdapter): The job whose output file should be stat'ed. Required
+            attributes: ``job_adapter``, ``server``, ``local_path``,
+            ``local_path_to_output_file``, ``remote_path``, ``job_name``.
 
     Returns:
-        datetime.datetime | None: The output file's mtime, or ``None`` if no
-        candidate output file exists or the remote stat failed.
+        datetime.datetime | None: The output file's mtime, or ``None`` if the
+        stat succeeded but no candidate output file exists.
+
+    Raises:
+        RemoteStatError: If the remote stat itself failed (e.g., a transient
+            SSH error), so callers can skip the check rather than treat the
+            job as having no output.
     """
     out_filename = settings.get('output_filenames', {}).get(job.job_adapter)
     if job.server is None or job.server in ('', 'local'):
@@ -72,10 +112,14 @@ def output_mtime(job) -> datetime.datetime | None:
             f'Could not stat remote output for job {job.job_name} on '
             f'{job.server} ({type(exc).__name__}: {exc}); skipping zombie check.'
         )
-        return None
+        raise RemoteStatError(f'Failed to stat remote output for job {job.job_name} on {job.server}') from exc
 
 
-def is_zombie(job, server_job_ids, now: datetime.datetime | None = None) -> bool:
+def is_zombie(job: 'JobAdapter',
+              server_job_ids: Collection[int | str],
+              now: datetime.datetime | None = None,
+              running_since: datetime.datetime | None = None,
+              ) -> bool:
     """Decide whether a job is a zombie.
 
     Pure decision: takes the queue's running set rather than reaching into a
@@ -84,19 +128,27 @@ def is_zombie(job, server_job_ids, now: datetime.datetime | None = None) -> bool
     * Its ``execution_type`` is not ``'incore'``.
     * Its ESS is in :data:`ESS_PERIODIC_WRITERS`.
     * The queue still reports it as running (``job.job_id in server_job_ids``).
-    * It has been past :data:`ZOMBIE_GRACE_SECONDS` since spawn
-      (``job.initial_time``).
-    * Its output file is missing, or its mtime is at-or-before spawn time.
+    * It has been past the grace period (:func:`get_zombie_grace_seconds`,
+      resolved for ``job.server``) since the clock start ``t0``, where ``t0``
+      is ``running_since`` if given, else ``job.initial_time``.
+    * Its output file is missing, or its mtime is at-or-before ``t0``.
+
+    If the remote stat itself failed (:class:`RemoteStatError`), the check is
+    skipped and ``False`` is returned: a transient SSH failure must not flag a
+    healthy job as a zombie.
 
     Args:
-        job: A ``JobAdapter`` (duck-typed). Required attributes: ``execution_type``,
-            ``job_adapter``, ``job_id``, ``initial_time``, plus everything
-            :func:`output_mtime` needs.
-        server_job_ids: A collection of queue job IDs the scheduler currently
-            considers running. Membership is tested with ``in``.
+        job (JobAdapter): The job to check. Required attributes:
+            ``execution_type``, ``job_adapter``, ``job_id``, ``initial_time``,
+            plus everything :func:`output_mtime` needs.
+        server_job_ids (Collection[int | str]): The queue job IDs the scheduler
+            currently considers running. Membership is tested with ``in``.
         now (datetime.datetime, optional): Reference "current time" for the
             grace-period check. Defaults to ``datetime.datetime.now()``;
             override in tests for determinism.
+        running_since (datetime.datetime, optional): The first time the job was
+            observed in a RUNNING queue state. Supersedes ``job.initial_time``
+            as the grace-clock start, so time spent queued does not count.
 
     Returns:
         bool: ``True`` if the job is a zombie, ``False`` otherwise.
@@ -108,12 +160,16 @@ def is_zombie(job, server_job_ids, now: datetime.datetime | None = None) -> bool
         return False
     if job.job_id is None or job.job_id not in server_job_ids:
         return False
-    if job.initial_time is None:
+    t0 = running_since or job.initial_time
+    if t0 is None:
         return False
     now = now or datetime.datetime.now()
-    if (now - job.initial_time).total_seconds() < ZOMBIE_GRACE_SECONDS:
+    if (now - t0).total_seconds() < get_zombie_grace_seconds(getattr(job, 'server', None)):
         return False
-    mtime = output_mtime(job)
+    try:
+        mtime = output_mtime(job)
+    except RemoteStatError:
+        return False
     if mtime is None:
         return True
-    return mtime <= job.initial_time
+    return mtime <= t0

--- a/arc/job/zombie.py
+++ b/arc/job/zombie.py
@@ -1,0 +1,119 @@
+"""Zombie-job detection helpers.
+
+A "zombie" is a queue-running job that has produced no output traffic by the
+grace period: scheduler reports it as RUNNING, but the ESS process has wedged
+or never started. The orchestration (kill + resubmit + per-(species, job_type)
+cap) lives on the Scheduler; the pure decision logic and ESS classification
+live here.
+"""
+
+import datetime
+import os
+
+from arc.common import get_logger
+from arc.imports import settings
+from arc.job.ssh import SSHClient
+
+
+logger = get_logger()
+
+
+# NOTE: submit templates that redirect ESS output to a node scratch dir and only
+# copy it back to remote_path at job end (as on zeus) make the "no output traffic"
+# heuristic blind to live progress, so any job past the grace looks like a zombie.
+# Keep the grace well above the longest legitimate job (TS opt ~1 h, high-level
+# single points up to several hours) to avoid killing healthy long jobs.
+ZOMBIE_GRACE_SECONDS = 21600  # 6 h (was 3600 = 1 h, which killed slow TS opts)
+
+ZOMBIE_OUTPUT_FILENAME_FALLBACK = 'out.txt'
+
+# ESS that flush login-visible output as the job runs (per SCF / per CC iter
+# / per opt step). For these, absence of any output traffic after the grace
+# period is a strong "zombie" signal. Incore-only or near-instant ESS
+# (xtb / torchani / openbabel / mockter) are exempt.
+ESS_PERIODIC_WRITERS = frozenset({
+    'cfour', 'gaussian', 'molpro', 'orca', 'psi4', 'qchem', 'terachem',
+})
+
+
+def output_mtime(job) -> datetime.datetime | None:
+    """Return the latest mtime of the job's ESS output file.
+
+    Tries the configured ESS output filename first and falls back to the
+    wrapper log. Local jobs use ``os.path.getmtime``; remote jobs use
+    ``SSHClient.get_last_modified_time`` against ``job.remote_path``.
+
+    Args:
+        job: A ``JobAdapter`` (duck-typed). Required attributes: ``job_adapter``,
+            ``server``, ``local_path``, ``local_path_to_output_file``,
+            ``remote_path``, ``job_name``.
+
+    Returns:
+        datetime.datetime | None: The output file's mtime, or ``None`` if no
+        candidate output file exists or the remote stat failed.
+    """
+    out_filename = settings.get('output_filenames', {}).get(job.job_adapter)
+    if job.server is None or job.server in ('', 'local'):
+        candidates = [job.local_path_to_output_file]
+        if out_filename:
+            candidates.append(os.path.join(job.local_path, out_filename))
+        for path in candidates:
+            if path and os.path.isfile(path):
+                return datetime.datetime.fromtimestamp(os.path.getmtime(path))
+        return None
+    try:
+        with SSHClient(job.server) as ssh:
+            p1 = os.path.join(job.remote_path, out_filename) if out_filename else None
+            p2 = os.path.join(job.remote_path, ZOMBIE_OUTPUT_FILENAME_FALLBACK)
+            return ssh.get_last_modified_time(remote_file_path_1=p1 or p2,
+                                              remote_file_path_2=p2)
+    except Exception as exc:
+        logger.warning(
+            f'Could not stat remote output for job {job.job_name} on '
+            f'{job.server} ({type(exc).__name__}: {exc}); skipping zombie check.'
+        )
+        return None
+
+
+def is_zombie(job, server_job_ids, now: datetime.datetime | None = None) -> bool:
+    """Decide whether a job is a zombie.
+
+    Pure decision: takes the queue's running set rather than reaching into a
+    ``Scheduler``. A job is a zombie iff all of these hold:
+
+    * Its ``execution_type`` is not ``'incore'``.
+    * Its ESS is in :data:`ESS_PERIODIC_WRITERS`.
+    * The queue still reports it as running (``job.job_id in server_job_ids``).
+    * It has been past :data:`ZOMBIE_GRACE_SECONDS` since spawn
+      (``job.initial_time``).
+    * Its output file is missing, or its mtime is at-or-before spawn time.
+
+    Args:
+        job: A ``JobAdapter`` (duck-typed). Required attributes: ``execution_type``,
+            ``job_adapter``, ``job_id``, ``initial_time``, plus everything
+            :func:`output_mtime` needs.
+        server_job_ids: A collection of queue job IDs the scheduler currently
+            considers running. Membership is tested with ``in``.
+        now (datetime.datetime, optional): Reference "current time" for the
+            grace-period check. Defaults to ``datetime.datetime.now()``;
+            override in tests for determinism.
+
+    Returns:
+        bool: ``True`` if the job is a zombie, ``False`` otherwise.
+    """
+    if job.execution_type == 'incore':
+        return False
+    adapter_name = (getattr(job, 'job_adapter', None) or '').lower()
+    if adapter_name not in ESS_PERIODIC_WRITERS:
+        return False
+    if job.job_id is None or job.job_id not in server_job_ids:
+        return False
+    if job.initial_time is None:
+        return False
+    now = now or datetime.datetime.now()
+    if (now - job.initial_time).total_seconds() < ZOMBIE_GRACE_SECONDS:
+        return False
+    mtime = output_mtime(job)
+    if mtime is None:
+        return True
+    return mtime <= job.initial_time

--- a/arc/job/zombie_test.py
+++ b/arc/job/zombie_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""Unit tests for arc.job.zombie — pure helpers and ESS classification."""
+
+import datetime
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from arc.job import zombie
+
+
+def _stub_job(job_adapter='molpro', job_type='sp', execution_type='queue',
+              initial_offset_seconds=zombie.ZOMBIE_GRACE_SECONDS + 3600,
+              job_name='sp_a3177', job_id=12345,
+              server='server1', remote_path='/remote/no/such/path',
+              local_path='/tmp/no/such/path',
+              local_path_to_output_file='/tmp/no/such/output.out'):
+    return SimpleNamespace(
+        job_name=job_name, job_type=job_type, job_id=job_id,
+        job_adapter=job_adapter, execution_type=execution_type,
+        initial_time=datetime.datetime.now() - datetime.timedelta(seconds=initial_offset_seconds),
+        server=server,
+        local_path=local_path, local_path_to_output_file=local_path_to_output_file,
+        remote_path=remote_path,
+    )
+
+
+class TestEssPeriodicWritersClassification(unittest.TestCase):
+    def test_periodic_writers_set(self):
+        self.assertEqual(
+            zombie.ESS_PERIODIC_WRITERS,
+            frozenset({'cfour', 'gaussian', 'molpro', 'orca', 'psi4', 'qchem', 'terachem'}),
+        )
+
+    def test_grace_period_default(self):
+        self.assertEqual(zombie.ZOMBIE_GRACE_SECONDS, 21600)
+
+
+class TestIsZombie(unittest.TestCase):
+    def test_zombie_when_no_output_after_grace(self):
+        job = _stub_job()
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertTrue(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_not_zombie_when_output_fresh(self):
+        job = _stub_job()
+        fresh = job.initial_time + datetime.timedelta(seconds=2000)
+        with patch('arc.job.zombie.output_mtime', return_value=fresh):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_zombie_when_output_mtime_at_spawn_time(self):
+        """An output file whose mtime equals spawn_time means ARC's own input
+        write — no ESS progress. Treat as zombie."""
+        job = _stub_job()
+        with patch('arc.job.zombie.output_mtime', return_value=job.initial_time):
+            self.assertTrue(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_grace_period_blocks(self):
+        job = _stub_job(initial_offset_seconds=1800)  # 30 min
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_non_periodic_writer_skipped(self):
+        job = _stub_job(job_adapter='xtb')
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_incore_skipped(self):
+        job = _stub_job(execution_type='incore')
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_queue_done_skipped(self):
+        job = _stub_job()
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[]))
+
+    def test_no_initial_time_skipped(self):
+        job = _stub_job()
+        job.initial_time = None
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_now_argument_overrides_clock(self):
+        """Pass an explicit ``now`` to remove wall-clock dependency in tests."""
+        job = _stub_job(initial_offset_seconds=0)
+        spawn = job.initial_time
+        within_grace = spawn + datetime.timedelta(seconds=zombie.ZOMBIE_GRACE_SECONDS - 1)
+        past_grace = spawn + datetime.timedelta(seconds=zombie.ZOMBIE_GRACE_SECONDS + 1)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, [job.job_id], now=within_grace))
+            self.assertTrue(zombie.is_zombie(job, [job.job_id], now=past_grace))
+
+
+class TestOutputMtimeLocal(unittest.TestCase):
+    def test_local_output_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, 'output.out')
+            with open(out_path, 'w') as fh:
+                fh.write('x')
+            job = _stub_job(server='local', local_path=tmp, local_path_to_output_file=out_path)
+            mtime = zombie.output_mtime(job)
+            self.assertIsNotNone(mtime)
+            self.assertIsInstance(mtime, datetime.datetime)
+
+    def test_local_output_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            job = _stub_job(server='local', local_path=tmp,
+                            local_path_to_output_file=os.path.join(tmp, 'nope.out'))
+            self.assertIsNone(zombie.output_mtime(job))
+
+    def test_local_server_none_treated_as_local(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, 'output.out')
+            with open(out_path, 'w') as fh:
+                fh.write('x')
+            job = _stub_job(server=None, local_path=tmp, local_path_to_output_file=out_path)
+            self.assertIsNotNone(zombie.output_mtime(job))
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/job/zombie_test.py
+++ b/arc/job/zombie_test.py
@@ -95,6 +95,99 @@ class TestIsZombie(unittest.TestCase):
             self.assertFalse(zombie.is_zombie(job, [job.job_id], now=within_grace))
             self.assertTrue(zombie.is_zombie(job, [job.job_id], now=past_grace))
 
+    def test_running_since_supersedes_initial_time(self):
+        """A job PENDING for 8 h that only started RUNNING 1 h ago must not be flagged."""
+        job = _stub_job(initial_offset_seconds=8 * 3600)
+        recently = datetime.datetime.now() - datetime.timedelta(seconds=3600)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertFalse(zombie.is_zombie(job, [job.job_id], running_since=recently))
+
+    def test_running_since_past_grace_is_flagged(self):
+        """No output past the grace measured from running_since → zombie, even for a young job."""
+        job = _stub_job(initial_offset_seconds=1800)
+        long_ago = datetime.datetime.now() - datetime.timedelta(seconds=zombie.ZOMBIE_GRACE_SECONDS + 3600)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            self.assertTrue(zombie.is_zombie(job, [job.job_id], running_since=long_ago))
+
+    def test_stalled_output_measured_from_running_since(self):
+        """An output last touched before running_since means no traffic since the run began."""
+        job = _stub_job()
+        running_since = datetime.datetime.now() - datetime.timedelta(seconds=zombie.ZOMBIE_GRACE_SECONDS + 60)
+        stale = running_since - datetime.timedelta(seconds=600)
+        with patch('arc.job.zombie.output_mtime', return_value=stale):
+            self.assertTrue(zombie.is_zombie(job, [job.job_id], running_since=running_since))
+
+
+class TestGraceSettings(unittest.TestCase):
+    def test_default_grace(self):
+        self.assertEqual(zombie.get_zombie_grace_seconds(), 21600)
+        self.assertEqual(zombie.get_zombie_grace_seconds('no_such_server'), 21600)
+
+    def test_global_settings_value_used(self):
+        with patch.dict(zombie.settings, {'zombie_grace_seconds': 50}):
+            self.assertEqual(zombie.get_zombie_grace_seconds(), 50)
+            self.assertEqual(zombie.get_zombie_grace_seconds('no_such_server'), 50)
+
+    def test_per_server_override(self):
+        with patch.dict(zombie.settings,
+                        {'servers': {'fast': {'cluster_soft': 'Slurm', 'zombie_grace_seconds': 100}}}):
+            self.assertEqual(zombie.get_zombie_grace_seconds('fast'), 100)
+            self.assertEqual(zombie.get_zombie_grace_seconds('other'), 21600)
+
+    def test_is_zombie_honors_per_server_override(self):
+        job = _stub_job(server='fast', initial_offset_seconds=200)
+        with patch.dict(zombie.settings, {'servers': {'fast': {'zombie_grace_seconds': 100}}}):
+            with patch('arc.job.zombie.output_mtime', return_value=None):
+                self.assertTrue(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+        with patch.dict(zombie.settings, {'servers': {'fast': {}}}):
+            with patch('arc.job.zombie.output_mtime', return_value=None):
+                self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+
+class FakeSSHClientRaises:
+    """A stand-in for ``SSHClient`` whose construction fails like a broken SSH connection."""
+
+    def __init__(self, server: str) -> None:
+        raise ConnectionError('ssh down')
+
+
+class FakeSSHClientFileAbsent:
+    """A stand-in for ``SSHClient`` where the connection succeeds but no output file exists."""
+
+    def __init__(self, server: str) -> None:
+        self.server = server
+
+    def __enter__(self) -> 'FakeSSHClientFileAbsent':
+        return self
+
+    def __exit__(self, *args) -> bool:
+        return False
+
+    def get_last_modified_time(self, remote_file_path_1: str, remote_file_path_2: str = None):
+        return None
+
+
+class TestRemoteStatFailure(unittest.TestCase):
+    def test_output_mtime_raises_on_ssh_failure(self):
+        """A failed remote stat must be distinguishable from a missing output file."""
+        job = _stub_job()
+        with patch('arc.job.zombie.SSHClient', FakeSSHClientRaises):
+            with self.assertRaises(zombie.RemoteStatError):
+                zombie.output_mtime(job)
+
+    def test_ssh_failure_skips_zombie_check(self):
+        """A transient SSH failure must not flag a healthy job as a zombie."""
+        job = _stub_job()
+        with patch('arc.job.zombie.SSHClient', FakeSSHClientRaises):
+            self.assertFalse(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
+    def test_remote_file_absent_is_still_zombie(self):
+        """A successful stat that finds no output file past the grace is a zombie."""
+        job = _stub_job()
+        with patch('arc.job.zombie.SSHClient', FakeSSHClientFileAbsent):
+            self.assertIsNone(zombie.output_mtime(job))
+            self.assertTrue(zombie.is_zombie(job, server_job_ids=[job.job_id]))
+
 
 class TestOutputMtimeLocal(unittest.TestCase):
     def test_local_output_present(self):

--- a/arc/level/__init__.py
+++ b/arc/level/__init__.py
@@ -1,0 +1,25 @@
+"""
+``arc.level`` — level-of-theory abstractions for ARC.
+
+This package hosts the :class:`~arc.level.level.Level` class (representing a
+single QM level: method, basis, dispersion, solvation, ESS-specific options).
+Historically ``Level`` lived in ``arc/level.py``; it is now ``arc/level/level.py``.
+All public symbols are re-exported here so existing call sites
+(``from arc.level import Level`` etc.) keep working without modification.
+"""
+
+from arc.level.level import (
+    Level,
+    assign_frequency_scale_factor,
+    levels_ess,
+    logger,
+    supported_ess,
+)
+
+__all__ = [
+    "Level",
+    "assign_frequency_scale_factor",
+    "levels_ess",
+    "logger",
+    "supported_ess",
+]

--- a/arc/level/__init__.py
+++ b/arc/level/__init__.py
@@ -1,11 +1,43 @@
 """
 ``arc.level`` — level-of-theory abstractions for ARC.
 
-This package hosts the :class:`~arc.level.level.Level` class (representing a
-single QM level: method, basis, dispersion, solvation, ESS-specific options).
-Historically ``Level`` lived in ``arc/level.py``; it is now ``arc/level/level.py``.
-All public symbols are re-exported here so existing call sites
-(``from arc.level import Level`` etc.) keep working without modification.
+This package groups everything related to specifying *how* an electronic-structure
+calculation is performed:
+
+* The legacy :class:`~arc.level.level.Level` class, which represents a single QM level
+  (method, basis, dispersion, solvation, ESS-specific options) and is unchanged from
+  ``arc/level.py`` prior to its relocation into this package.
+* New composite single-point abstractions added in Phase 1 of the ``sp_composite`` work:
+  protocols, terms, presets, CBS extrapolation, and reporting helpers. These let a
+  user define the final electronic energy of a stationary point as a sum of multiple
+  SP corrections — a HEAT-style focal-point analysis (Tajti et al.,
+  *J. Chem. Phys.* **121**, 11599 (2004); DOI: 10.1063/1.1804498).
+
+Backwards compatibility
+-----------------------
+
+All public symbols that historically lived in ``arc/level.py`` are re-exported here so
+that existing call sites (``from arc.level import Level`` etc.) continue to work
+without modification. New code should prefer the qualified imports
+``from arc.level.protocol import CompositeProtocol`` etc. when reaching for the new
+machinery.
+
+References
+----------
+
+* Allen, East, Császár, *Structures and Conformations of Non-Rigid Molecules* — review
+  of focal-point analysis methodology.
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1804498 — HEAT protocol.
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation-energy CBS extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0 —
+  two-point HF-energy CBS extrapolation.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996).
+  DOI: 10.1016/0009-2614(96)00898-6 — three-point Schwartz-style extrapolation.
+* Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153 — correlation-
+  consistent basis-set families used by the cardinal-number deduction logic.
 """
 
 from arc.level.level import (
@@ -15,6 +47,11 @@ from arc.level.level import (
     logger,
     supported_ess,
 )
+from arc.level.species_state import (
+    INHERIT,
+    SP_COMPOSITE_STATES,
+    active_composite_for,
+)
 
 __all__ = [
     "Level",
@@ -22,4 +59,7 @@ __all__ = [
     "levels_ess",
     "logger",
     "supported_ess",
+    "INHERIT",
+    "SP_COMPOSITE_STATES",
+    "active_composite_for",
 ]

--- a/arc/level/__init__.py
+++ b/arc/level/__init__.py
@@ -1,11 +1,46 @@
 """
 ``arc.level`` — level-of-theory abstractions for ARC.
 
-This package hosts the :class:`~arc.level.level.Level` class (representing a
-single QM level: method, basis, dispersion, solvation, ESS-specific options).
-Historically ``Level`` lived in ``arc/level.py``; it is now ``arc/level/level.py``.
-All public symbols are re-exported here so existing call sites
-(``from arc.level import Level`` etc.) keep working without modification.
+This package groups everything related to specifying *how* an electronic-structure
+calculation is performed:
+
+* The legacy :class:`~arc.level.level.Level` class, which represents a single QM level
+  (method, basis, dispersion, solvation, ESS-specific options) and is unchanged from
+  ``arc/level.py`` prior to its relocation into this package.
+* New composite single-point abstractions added in Phase 1 of the ``sp_composite`` work:
+  protocols, terms, presets, CBS extrapolation, and reporting helpers. These let a
+  user define the final electronic energy of a stationary point as a sum of multiple
+  SP corrections — a HEAT-style focal-point analysis (Tajti et al.,
+  *J. Chem. Phys.* **121**, 11599 (2004); DOI: 10.1063/1.1811608).
+
+Backwards compatibility
+-----------------------
+
+All public symbols that historically lived in ``arc/level.py`` are re-exported here so
+that existing call sites (``from arc.level import Level`` etc.) continue to work
+without modification. New code should prefer the qualified imports
+``from arc.level.protocol import CompositeProtocol`` etc. when reaching for the new
+machinery.
+
+References
+----------
+
+* Allen, East, Császár, *Structures and Conformations of Non-Rigid Molecules* — review
+  of focal-point analysis methodology.
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT protocol.
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation-energy CBS extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0 —
+  extends the two-point correlation-energy CBS extrapolation to Ne, N₂, H₂O.
+* Halkier, Helgaker, Jørgensen, Klopper, Olsen,
+  *Chem. Phys. Lett.* **302**, 437-446 (1999). DOI: 10.1016/S0009-2614(99)00179-7 —
+  two-point HF-energy CBS extrapolation; source of the fitted ``α = 1.63``.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996).
+  DOI: 10.1016/0009-2614(96)00898-6 — three-point Schwartz-style extrapolation.
+* Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153 — correlation-
+  consistent basis-set families used by the cardinal-number deduction logic.
 """
 
 from arc.level.level import (
@@ -15,6 +50,11 @@ from arc.level.level import (
     logger,
     supported_ess,
 )
+from arc.level.species_state import (
+    INHERIT,
+    SP_COMPOSITE_STATES,
+    active_composite_for,
+)
 
 __all__ = [
     "Level",
@@ -22,4 +62,7 @@ __all__ = [
     "levels_ess",
     "logger",
     "supported_ess",
+    "INHERIT",
+    "SP_COMPOSITE_STATES",
+    "active_composite_for",
 ]

--- a/arc/level/__init__.py
+++ b/arc/level/__init__.py
@@ -7,7 +7,7 @@ calculation is performed:
 * The legacy :class:`~arc.level.level.Level` class, which represents a single QM level
   (method, basis, dispersion, solvation, ESS-specific options) and is unchanged from
   ``arc/level.py`` prior to its relocation into this package.
-* New composite single-point abstractions added in Phase 1 of the ``sp_composite`` work:
+* New composite single-point abstractions for the ``sp_composite`` feature:
   protocols, terms, presets, CBS extrapolation, and reporting helpers. These let a
   user define the final electronic energy of a stationary point as a sum of multiple
   SP corrections — a HEAT-style focal-point analysis (Tajti et al.,

--- a/arc/level/cbs.py
+++ b/arc/level/cbs.py
@@ -1,0 +1,387 @@
+"""
+``arc.level.cbs`` — Complete-Basis-Set extrapolation primitives.
+
+This module implements the building blocks needed by
+:class:`~arc.level.protocol.CBSExtrapolationTerm`: the cardinal-number deduction from
+basis-set names, the three built-in extrapolation formulas shipped with ARC, and a
+sandboxed evaluator for user-supplied formula strings.
+
+The CBS step in a focal-point analysis takes ≥2 single-point energies computed at the
+*same* method but at *different* basis-set cardinalities X (cc-pVDZ → 2, cc-pVTZ → 3,
+cc-pVQZ → 4, ...) and combines them according to a closed-form expression that
+extrapolates to the (formally infinite) basis-set limit.
+
+Built-in formulas
+-----------------
+
+``helgaker_corr_2pt``
+    Two-point correlation-energy extrapolation
+    ``E_CBS = (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)``.
+    Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997),
+    Eq. 4. DOI: 10.1063/1.473863.
+
+``helgaker_hf_2pt``
+    Two-point HF-energy extrapolation
+    ``E(X) = E_CBS + A·exp(-α·X)``, default ``α = 1.63``.
+    Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+    *Chem. Phys. Lett.* **286**, 243-252 (1998), Table 2.
+    DOI: 10.1016/S0009-2614(98)00111-0.
+
+``martin_3pt``
+    Three-point Schwartz-style extrapolation
+    ``E(L) = E_CBS + b·(L+½)^(-4) + c·(L+½)^(-6)`` solved exactly for the three
+    unknowns. Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996), Eq. 5.
+    DOI: 10.1016/0009-2614(96)00898-6.
+
+Cardinal numbers follow the Dunning correlation-consistent convention introduced in
+Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153.
+"""
+
+import ast
+import math
+import re
+from typing import Callable, Dict, Mapping
+
+import numpy as np
+
+from arc.exceptions import InputError
+
+
+# ----------------------------------------------------------------------------- #
+#  Cardinal-number deduction                                                    #
+# ----------------------------------------------------------------------------- #
+
+# Map letter labels in correlation-consistent basis sets to cardinal numbers.
+# D=2, T=3, Q=4 (Dunning, J. Chem. Phys. 90, 1007 (1989)).
+_LETTER_CARDINAL = {"D": 2, "T": 3, "Q": 4}
+
+# Pattern: optional aug- prefix, cc-p, optional C, V, then cardinal letter or digit, Z.
+# Accepts cc-pVDZ, cc-pVTZ, cc-pVQZ, cc-pV5Z, cc-pV6Z, cc-pV7Z, cc-pCV*, aug-cc-pV*.
+_DUNNING_RE = re.compile(
+    r"^(?:aug-)?cc-p(?:c)?v(?P<card>[dtq2-7])z(?:-[a-z0-9]+)?$",
+    re.IGNORECASE,
+)
+
+# Pattern for the def2 family (Weigend & Ahlrichs): SVP=2, TZVP=3, QZVP=4, plus PP variants.
+_DEF2_RE = re.compile(
+    r"^def2-(?P<card>s|tz|qz)vp+(?:d?)?$",
+    re.IGNORECASE,
+)
+
+_DEF2_CARDINAL = {"S": 2, "TZ": 3, "QZ": 4}
+
+
+def cardinal_from_basis(basis: str) -> int:
+    """Return the cardinal number X for a correlation-consistent or def2 basis set.
+
+    Parameters
+    ----------
+    basis : str
+        Basis-set name (case-insensitive). Supported families:
+
+        * ``cc-pV{D,T,Q,5,6,7}Z`` — Dunning correlation-consistent.
+        * ``aug-cc-pV{D,T,Q,5,6,7}Z`` — diffuse-augmented variants.
+        * ``cc-pCV{D,T,Q,5,6}Z`` and ``aug-cc-pCV*`` — core-valence variants.
+        * ``def2-{SVP,TZVP,QZVP}`` and the ``...PP`` variants (Weigend & Ahlrichs).
+
+    Returns
+    -------
+    int
+        Cardinal X (2 for double-zeta, 3 for triple-zeta, etc.).
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``basis`` does not match a known correlation-consistent or def2 pattern.
+        CBS extrapolation requires a known cardinal; non-systematic basis sets such
+        as ``6-31G*`` or ``STO-3G`` are rejected explicitly.
+    """
+    if not basis:
+        raise InputError("Cannot deduce cardinal number from an empty basis-set name.")
+    text = basis.strip()
+    m = _DUNNING_RE.match(text)
+    if m:
+        card = m.group("card").upper()
+        if card.isdigit():
+            return int(card)
+        return _LETTER_CARDINAL[card]
+    m = _DEF2_RE.match(text)
+    if m:
+        return _DEF2_CARDINAL[m.group("card").upper()]
+    raise InputError(
+        f"Cannot deduce a CBS cardinal number from basis '{basis}'. "
+        "Only correlation-consistent (cc-pV*Z, aug-cc-pV*Z, cc-pCV*Z) and def2 "
+        "(def2-SVP, def2-TZVP, def2-QZVP) families are supported. Use one of "
+        "these families for the levels of a cbs_extrapolation term, or add a "
+        "new pattern to this function if you need a different basis family."
+    )
+
+
+# ----------------------------------------------------------------------------- #
+#  Built-in CBS formulas                                                        #
+# ----------------------------------------------------------------------------- #
+
+
+def _sorted_pairs(energies: Mapping[int, float], expected: int) -> list:
+    """Return ``[(X, E_X), ...]`` sorted by cardinal, validating count & uniqueness."""
+    pairs = sorted(energies.items())
+    if len(pairs) != expected:
+        raise InputError(
+            f"Expected exactly {expected} (cardinal, energy) pairs, got {len(pairs)}."
+        )
+    cardinals = [X for X, _ in pairs]
+    if len(set(cardinals)) != len(cardinals):
+        raise InputError(f"Cardinals must be distinct, got {cardinals}.")
+    return pairs
+
+
+def helgaker_corr_2pt(energies: Mapping[int, float]) -> float:
+    """Two-point correlation-energy CBS extrapolation.
+
+    Implements ``E_CBS = (X³·E_X − Y³·E_Y) / (X³ − Y³)`` per
+    Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997), Eq. 4.
+    DOI: 10.1063/1.473863.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly two entries. Insertion order is
+        irrelevant: pairs are sorted by ascending cardinal internally.
+
+    Returns
+    -------
+    float
+        Extrapolated energy in the same units as the inputs.
+    """
+    (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
+    return (X ** 3 * E_X - Y ** 3 * E_Y) / (X ** 3 - Y ** 3)
+
+
+def helgaker_hf_2pt(energies: Mapping[int, float], alpha: float = 1.63) -> float:
+    """Two-point HF (or other exponentially-converging) CBS extrapolation.
+
+    Solves ``E(X) = E_CBS + A·exp(-α·X)`` for two cardinals analytically:
+    ``E_CBS = (E_X·exp(-α·Y) − E_Y·exp(-α·X)) / (exp(-α·Y) − exp(-α·X))``.
+
+    Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+    *Chem. Phys. Lett.* **286**, 243-252 (1998), Table 2 reports the fitted value
+    ``α = 1.63`` averaged across small molecules. DOI: 10.1016/S0009-2614(98)00111-0.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly two entries.
+    alpha : float, optional
+        Exponential decay parameter. Defaults to 1.63 (Halkier et al. 1998).
+
+    Returns
+    -------
+    float
+        Extrapolated energy.
+    """
+    (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
+    e_x = math.exp(-alpha * X)
+    e_y = math.exp(-alpha * Y)
+    return (E_X * e_y - E_Y * e_x) / (e_y - e_x)
+
+
+def martin_3pt(energies: Mapping[int, float]) -> float:
+    """Three-point Schwartz-style CBS extrapolation.
+
+    Solves the linear system
+
+        E(L) = E_CBS + b·(L+½)⁻⁴ + c·(L+½)⁻⁶
+
+    exactly for ``E_CBS`` given three (L, E(L)) pairs.
+
+    Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996), Eq. 5.
+    DOI: 10.1016/0009-2614(96)00898-6.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly three entries.
+
+    Returns
+    -------
+    float
+        Extrapolated energy.
+    """
+    pairs = _sorted_pairs(energies, expected=3)
+    A = np.array(
+        [[1.0, (L + 0.5) ** -4, (L + 0.5) ** -6] for L, _ in pairs],
+        dtype=float,
+    )
+    b = np.array([E for _, E in pairs], dtype=float)
+    e_cbs, _b, _c = np.linalg.solve(A, b)
+    return float(e_cbs)
+
+
+# String → callable registry advertised to user input. New built-in formulas are
+# added by inserting an entry here (and a corresponding test).
+BUILTIN_FORMULAS: Dict[str, Callable[..., float]] = {
+    "helgaker_corr_2pt": helgaker_corr_2pt,
+    "helgaker_hf_2pt": helgaker_hf_2pt,
+    "martin_3pt": martin_3pt,
+}
+
+
+# ----------------------------------------------------------------------------- #
+#  Safe AST evaluator for user-supplied formula strings                         #
+# ----------------------------------------------------------------------------- #
+
+# Functions a user formula may call. Restricted to a tiny math whitelist; no
+# I/O, no introspection, no attribute access whatsoever.
+_ALLOWED_CALLS = {
+    "exp": math.exp,
+    "log": math.log,
+    "sqrt": math.sqrt,
+    "pow": math.pow,
+}
+
+# AST node classes the walker accepts. Anything else is rejected with InputError.
+# Notably absent: Attribute, Subscript, Lambda, Comprehensions, NamedExpr (walrus),
+# Starred, JoinedStr, FormattedValue, IfExp, Compare, BoolOp.
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    ast.Name,
+    ast.Load,
+    ast.Call,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Pow,
+    ast.Mod,
+    ast.FloorDiv,
+    ast.UAdd,
+    ast.USub,
+)
+
+
+def _validate_ast(node: ast.AST, env_names: set) -> None:
+    """Raise :class:`InputError` if any descendant of ``node`` is non-whitelisted."""
+    for child in ast.walk(node):
+        if not isinstance(child, _ALLOWED_NODES):
+            raise InputError(
+                f"Disallowed expression element {type(child).__name__!r} in user "
+                "formula. Only basic arithmetic (+ - * / ** %), unary +/-, "
+                "numeric literals, named variables, and calls to "
+                f"{sorted(_ALLOWED_CALLS)} are permitted."
+            )
+        if isinstance(child, ast.Constant) and not isinstance(child.value, (int, float)):
+            raise InputError(
+                f"Only numeric constants are allowed in user formulas; got "
+                f"{type(child.value).__name__} ({child.value!r})."
+            )
+        if isinstance(child, ast.Name) and child.id not in env_names \
+                and child.id not in _ALLOWED_CALLS:
+            raise InputError(
+                f"Unknown name '{child.id}' in user formula. Allowed names: "
+                f"variables {sorted(env_names)} and functions {sorted(_ALLOWED_CALLS)}."
+            )
+        if isinstance(child, ast.Call):
+            if not isinstance(child.func, ast.Name) or child.func.id not in _ALLOWED_CALLS:
+                raise InputError(
+                    f"Disallowed function call in user formula. Only "
+                    f"{sorted(_ALLOWED_CALLS)} may be called."
+                )
+
+
+def validate_formula(expression: str, allowed_names: set) -> None:
+    """Parse and whitelist-validate ``expression`` without evaluating it.
+
+    Useful at construction time to surface malformed user formulas eagerly,
+    independent of any specific numeric inputs (which might cause spurious
+    runtime errors like division by zero on a probe environment).
+
+    Raises :class:`InputError` on any non-whitelisted construct.
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    _validate_ast(tree, set(allowed_names))
+
+
+def safe_eval_formula(expression: str, env: Mapping[str, float]) -> float:
+    """Evaluate an arithmetic expression against ``env`` without using :func:`eval`.
+
+    Parses ``expression`` to an AST, validates every node against a strict whitelist
+    (basic arithmetic, unary ±, numeric literals, named variables drawn from
+    ``env``, and calls to :func:`math.exp`, :func:`math.log`, :func:`math.sqrt`,
+    :func:`math.pow`), then walks the tree to compute the result.
+
+    Parameters
+    ----------
+    expression : str
+        Arithmetic expression. Examples:
+        ``"(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"``,
+        ``"E_X - sqrt(E_Y)"``.
+    env : Mapping[str, float]
+        Variable bindings. Names referenced by ``expression`` must appear here
+        (or be one of the allowed function names).
+
+    Returns
+    -------
+    float
+        Numerical value of the expression.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If the expression is syntactically invalid, references unknown names, or
+        uses any AST construct outside the whitelist (attribute access,
+        subscript, lambdas, comprehensions, walrus, string literals, etc.).
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    env_names = set(env.keys())
+    _validate_ast(tree, env_names)
+    return _eval_node(tree.body, env)
+
+
+def _eval_node(node: ast.AST, env: Mapping[str, float]) -> float:
+    """Recursively evaluate a whitelisted AST node."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id in env:
+            return env[node.id]
+        # _validate_ast already rejected unknown names, so this is unreachable.
+        raise InputError(f"Unknown name '{node.id}'.")
+    if isinstance(node, ast.UnaryOp):
+        operand = _eval_node(node.operand, env)
+        if isinstance(node.op, ast.UAdd):
+            return +operand
+        if isinstance(node.op, ast.USub):
+            return -operand
+        raise InputError(f"Unsupported unary operator {type(node.op).__name__}.")
+    if isinstance(node, ast.BinOp):
+        left = _eval_node(node.left, env)
+        right = _eval_node(node.right, env)
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        if isinstance(node.op, ast.Div):
+            return left / right
+        if isinstance(node.op, ast.Pow):
+            return left ** right
+        if isinstance(node.op, ast.Mod):
+            return left % right
+        if isinstance(node.op, ast.FloorDiv):
+            return left // right
+        raise InputError(f"Unsupported binary operator {type(node.op).__name__}.")
+    if isinstance(node, ast.Call):
+        func = _ALLOWED_CALLS[node.func.id]
+        args = [_eval_node(a, env) for a in node.args]
+        return func(*args)
+    raise InputError(f"Unsupported AST node {type(node).__name__}.")

--- a/arc/level/cbs.py
+++ b/arc/level/cbs.py
@@ -1,0 +1,389 @@
+"""
+``arc.level.cbs`` — Complete-Basis-Set extrapolation primitives.
+
+This module implements the building blocks needed by
+:class:`~arc.level.protocol.CBSExtrapolationTerm`: the cardinal-number deduction from
+basis-set names, the three built-in extrapolation formulas shipped with ARC, and a
+sandboxed evaluator for user-supplied formula strings.
+
+The CBS step in a focal-point analysis takes ≥2 single-point energies computed at the
+*same* method but at *different* basis-set cardinalities X (cc-pVDZ → 2, cc-pVTZ → 3,
+cc-pVQZ → 4, ...) and combines them according to a closed-form expression that
+extrapolates to the (formally infinite) basis-set limit.
+
+Built-in formulas
+-----------------
+
+``helgaker_corr_2pt``
+    Two-point correlation-energy extrapolation
+    ``E_CBS = (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)``.
+    Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997),
+    Eq. 4. DOI: 10.1063/1.473863.
+
+``helgaker_hf_2pt``
+    Two-point HF-energy extrapolation
+    ``E(X) = E_CBS + A·exp(-α·X)``, default ``α = 1.63``.
+    Halkier, Helgaker, Jørgensen, Klopper, Olsen,
+    *Chem. Phys. Lett.* **302**, 437-446 (1999), "Basis-set convergence of the
+    energy in molecular Hartree–Fock calculations".
+    DOI: 10.1016/S0009-2614(99)00179-7.
+
+``martin_3pt``
+    Three-point Schwartz-style extrapolation
+    ``E(L) = E_CBS + b·(L+½)^(-4) + c·(L+½)^(-6)`` solved exactly for the three
+    unknowns. Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996), Eq. 5.
+    DOI: 10.1016/0009-2614(96)00898-6.
+
+Cardinal numbers follow the Dunning correlation-consistent convention introduced in
+Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153.
+"""
+
+import ast
+import math
+import re
+from collections.abc import Callable, Mapping
+
+import numpy as np
+
+from arc.exceptions import InputError
+
+
+# ----------------------------------------------------------------------------- #
+#  Cardinal-number deduction                                                    #
+# ----------------------------------------------------------------------------- #
+
+# Map letter labels in correlation-consistent basis sets to cardinal numbers.
+# D=2, T=3, Q=4 (Dunning, J. Chem. Phys. 90, 1007 (1989)).
+_LETTER_CARDINAL = {"D": 2, "T": 3, "Q": 4}
+
+# Pattern: optional aug- prefix, cc-p, optional C, V, then cardinal letter or digit, Z.
+# Accepts cc-pVDZ, cc-pVTZ, cc-pVQZ, cc-pV5Z, cc-pV6Z, cc-pV7Z, cc-pCV*, aug-cc-pV*.
+_DUNNING_RE = re.compile(
+    r"^(?:aug-)?cc-p(?:c)?v(?P<card>[dtq2-7])z(?:-[a-z0-9]+)?$",
+    re.IGNORECASE,
+)
+
+# Pattern for the def2 family (Weigend & Ahlrichs): SVP=2, TZVP=3, QZVP=4, plus PP variants.
+_DEF2_RE = re.compile(
+    r"^def2-(?P<card>s|tz|qz)vp+(?:d?)?$",
+    re.IGNORECASE,
+)
+
+_DEF2_CARDINAL = {"S": 2, "TZ": 3, "QZ": 4}
+
+
+def cardinal_from_basis(basis: str) -> int:
+    """Return the cardinal number X for a correlation-consistent or def2 basis set.
+
+    Parameters
+    ----------
+    basis : str
+        Basis-set name (case-insensitive). Supported families:
+
+        * ``cc-pV{D,T,Q,5,6,7}Z`` — Dunning correlation-consistent.
+        * ``aug-cc-pV{D,T,Q,5,6,7}Z`` — diffuse-augmented variants.
+        * ``cc-pCV{D,T,Q,5,6}Z`` and ``aug-cc-pCV*`` — core-valence variants.
+        * ``def2-{SVP,TZVP,QZVP}`` and the ``...PP`` variants (Weigend & Ahlrichs).
+
+    Returns
+    -------
+    int
+        Cardinal X (2 for double-zeta, 3 for triple-zeta, etc.).
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``basis`` does not match a known correlation-consistent or def2 pattern.
+        CBS extrapolation requires a known cardinal; non-systematic basis sets such
+        as ``6-31G*`` or ``STO-3G`` are rejected explicitly.
+    """
+    if not basis:
+        raise InputError("Cannot deduce cardinal number from an empty basis-set name.")
+    text = basis.strip()
+    m = _DUNNING_RE.match(text)
+    if m:
+        card = m.group("card").upper()
+        if card.isdigit():
+            return int(card)
+        return _LETTER_CARDINAL[card]
+    m = _DEF2_RE.match(text)
+    if m:
+        return _DEF2_CARDINAL[m.group("card").upper()]
+    raise InputError(
+        f"Cannot deduce a CBS cardinal number from basis '{basis}'. "
+        "Only correlation-consistent (cc-pV*Z, aug-cc-pV*Z, cc-pCV*Z) and def2 "
+        "(def2-SVP, def2-TZVP, def2-QZVP) families are supported. Use one of "
+        "these families for the levels of a cbs_extrapolation term, or add a "
+        "new pattern to this function if you need a different basis family."
+    )
+
+
+# ----------------------------------------------------------------------------- #
+#  Built-in CBS formulas                                                        #
+# ----------------------------------------------------------------------------- #
+
+
+def _sorted_pairs(energies: Mapping[int, float], expected: int) -> list:
+    """Return ``[(X, E_X), ...]`` sorted by cardinal, validating count & uniqueness."""
+    pairs = sorted(energies.items())
+    if len(pairs) != expected:
+        raise InputError(
+            f"Expected exactly {expected} (cardinal, energy) pairs, got {len(pairs)}."
+        )
+    cardinals = [X for X, _ in pairs]
+    if len(set(cardinals)) != len(cardinals):
+        raise InputError(f"Cardinals must be distinct, got {cardinals}.")
+    return pairs
+
+
+def helgaker_corr_2pt(energies: Mapping[int, float]) -> float:
+    """Two-point correlation-energy CBS extrapolation.
+
+    Implements ``E_CBS = (X³·E_X − Y³·E_Y) / (X³ − Y³)`` per
+    Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997), Eq. 4.
+    DOI: 10.1063/1.473863.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly two entries. Insertion order is
+        irrelevant: pairs are sorted by ascending cardinal internally.
+
+    Returns
+    -------
+    float
+        Extrapolated energy in the same units as the inputs.
+    """
+    (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
+    return (X ** 3 * E_X - Y ** 3 * E_Y) / (X ** 3 - Y ** 3)
+
+
+def helgaker_hf_2pt(energies: Mapping[int, float], alpha: float = 1.63) -> float:
+    """Two-point HF (or other exponentially-converging) CBS extrapolation.
+
+    Solves ``E(X) = E_CBS + A·exp(-α·X)`` for two cardinals analytically:
+    ``E_CBS = (E_X·exp(-α·Y) − E_Y·exp(-α·X)) / (exp(-α·Y) − exp(-α·X))``.
+
+    Halkier, Helgaker, Jørgensen, Klopper, Olsen, *Chem. Phys. Lett.* **302**,
+    437-446 (1999), "Basis-set convergence of the energy in molecular
+    Hartree–Fock calculations" reports the fitted value ``α = 1.63`` averaged
+    across small molecules. DOI: 10.1016/S0009-2614(99)00179-7.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly two entries.
+    alpha : float, optional
+        Exponential decay parameter. Defaults to 1.63 (Halkier et al. 1999).
+
+    Returns
+    -------
+    float
+        Extrapolated energy.
+    """
+    (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
+    e_x = math.exp(-alpha * X)
+    e_y = math.exp(-alpha * Y)
+    return (E_X * e_y - E_Y * e_x) / (e_y - e_x)
+
+
+def martin_3pt(energies: Mapping[int, float]) -> float:
+    """Three-point Schwartz-style CBS extrapolation.
+
+    Solves the linear system
+
+        E(L) = E_CBS + b·(L+½)⁻⁴ + c·(L+½)⁻⁶
+
+    exactly for ``E_CBS`` given three (L, E(L)) pairs.
+
+    Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996), Eq. 5.
+    DOI: 10.1016/0009-2614(96)00898-6.
+
+    Parameters
+    ----------
+    energies : Mapping[int, float]
+        Mapping ``{cardinal: energy}`` with exactly three entries.
+
+    Returns
+    -------
+    float
+        Extrapolated energy.
+    """
+    pairs = _sorted_pairs(energies, expected=3)
+    A = np.array(
+        [[1.0, (L + 0.5) ** -4, (L + 0.5) ** -6] for L, _ in pairs],
+        dtype=float,
+    )
+    b = np.array([E for _, E in pairs], dtype=float)
+    e_cbs, _b, _c = np.linalg.solve(A, b)
+    return float(e_cbs)
+
+
+# String → callable registry advertised to user input. New built-in formulas are
+# added by inserting an entry here (and a corresponding test).
+BUILTIN_FORMULAS: dict[str, Callable[..., float]] = {
+    "helgaker_corr_2pt": helgaker_corr_2pt,
+    "helgaker_hf_2pt": helgaker_hf_2pt,
+    "martin_3pt": martin_3pt,
+}
+
+
+# ----------------------------------------------------------------------------- #
+#  Safe AST evaluator for user-supplied formula strings                         #
+# ----------------------------------------------------------------------------- #
+
+# Functions a user formula may call. Restricted to a tiny math whitelist; no
+# I/O, no introspection, no attribute access whatsoever.
+_ALLOWED_CALLS = {
+    "exp": math.exp,
+    "log": math.log,
+    "sqrt": math.sqrt,
+    "pow": math.pow,
+}
+
+# AST node classes the walker accepts. Anything else is rejected with InputError.
+# Notably absent: Attribute, Subscript, Lambda, Comprehensions, NamedExpr (walrus),
+# Starred, JoinedStr, FormattedValue, IfExp, Compare, BoolOp.
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    ast.Name,
+    ast.Load,
+    ast.Call,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Pow,
+    ast.Mod,
+    ast.FloorDiv,
+    ast.UAdd,
+    ast.USub,
+)
+
+
+def _validate_ast(node: ast.AST, env_names: set) -> None:
+    """Raise :class:`InputError` if any descendant of ``node`` is non-whitelisted."""
+    for child in ast.walk(node):
+        if not isinstance(child, _ALLOWED_NODES):
+            raise InputError(
+                f"Disallowed expression element {type(child).__name__!r} in user "
+                "formula. Only basic arithmetic (+ - * / ** %), unary +/-, "
+                "numeric literals, named variables, and calls to "
+                f"{sorted(_ALLOWED_CALLS)} are permitted."
+            )
+        if isinstance(child, ast.Constant) and not isinstance(child.value, (int, float)):
+            raise InputError(
+                f"Only numeric constants are allowed in user formulas; got "
+                f"{type(child.value).__name__} ({child.value!r})."
+            )
+        if isinstance(child, ast.Name) and child.id not in env_names \
+                and child.id not in _ALLOWED_CALLS:
+            raise InputError(
+                f"Unknown name '{child.id}' in user formula. Allowed names: "
+                f"variables {sorted(env_names)} and functions {sorted(_ALLOWED_CALLS)}."
+            )
+        if isinstance(child, ast.Call):
+            if not isinstance(child.func, ast.Name) or child.func.id not in _ALLOWED_CALLS:
+                raise InputError(
+                    f"Disallowed function call in user formula. Only "
+                    f"{sorted(_ALLOWED_CALLS)} may be called."
+                )
+
+
+def validate_formula(expression: str, allowed_names: set) -> None:
+    """Parse and whitelist-validate ``expression`` without evaluating it.
+
+    Useful at construction time to surface malformed user formulas eagerly,
+    independent of any specific numeric inputs (which might cause spurious
+    runtime errors like division by zero on a probe environment).
+
+    Raises :class:`InputError` on any non-whitelisted construct.
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    _validate_ast(tree, set(allowed_names))
+
+
+def safe_eval_formula(expression: str, env: Mapping[str, float]) -> float:
+    """Evaluate an arithmetic expression against ``env`` without using :func:`eval`.
+
+    Parses ``expression`` to an AST, validates every node against a strict whitelist
+    (basic arithmetic, unary ±, numeric literals, named variables drawn from
+    ``env``, and calls to :func:`math.exp`, :func:`math.log`, :func:`math.sqrt`,
+    :func:`math.pow`), then walks the tree to compute the result.
+
+    Parameters
+    ----------
+    expression : str
+        Arithmetic expression. Examples:
+        ``"(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"``,
+        ``"E_X - sqrt(E_Y)"``.
+    env : Mapping[str, float]
+        Variable bindings. Names referenced by ``expression`` must appear here
+        (or be one of the allowed function names).
+
+    Returns
+    -------
+    float
+        Numerical value of the expression.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If the expression is syntactically invalid, references unknown names, or
+        uses any AST construct outside the whitelist (attribute access,
+        subscript, lambdas, comprehensions, walrus, string literals, etc.).
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    env_names = set(env.keys())
+    _validate_ast(tree, env_names)
+    return _eval_node(tree.body, env)
+
+
+def _eval_node(node: ast.AST, env: Mapping[str, float]) -> float:
+    """Recursively evaluate a whitelisted AST node."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id in env:
+            return env[node.id]
+        # _validate_ast already rejected unknown names, so this is unreachable.
+        raise InputError(f"Unknown name '{node.id}'.")
+    if isinstance(node, ast.UnaryOp):
+        operand = _eval_node(node.operand, env)
+        if isinstance(node.op, ast.UAdd):
+            return +operand
+        if isinstance(node.op, ast.USub):
+            return -operand
+        raise InputError(f"Unsupported unary operator {type(node.op).__name__}.")
+    if isinstance(node, ast.BinOp):
+        left = _eval_node(node.left, env)
+        right = _eval_node(node.right, env)
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        if isinstance(node.op, ast.Div):
+            return left / right
+        if isinstance(node.op, ast.Pow):
+            return left ** right
+        if isinstance(node.op, ast.Mod):
+            return left % right
+        if isinstance(node.op, ast.FloorDiv):
+            return left // right
+        raise InputError(f"Unsupported binary operator {type(node.op).__name__}.")
+    if isinstance(node, ast.Call):
+        func = _ALLOWED_CALLS[node.func.id]
+        args = [_eval_node(a, env) for a in node.args]
+        return func(*args)
+    raise InputError(f"Unsupported AST node {type(node).__name__}.")

--- a/arc/level/cbs.py
+++ b/arc/level/cbs.py
@@ -11,8 +11,7 @@ The CBS step in a focal-point analysis takes ≥2 single-point energies computed
 cc-pVQZ → 4, ...) and combines them according to a closed-form expression that
 extrapolates to the (formally infinite) basis-set limit.
 
-Built-in formulas
------------------
+Built-in formulas:
 
 ``helgaker_corr_2pt``
     Two-point correlation-energy extrapolation
@@ -73,29 +72,25 @@ _DEF2_CARDINAL = {"S": 2, "TZ": 3, "QZ": 4}
 
 
 def cardinal_from_basis(basis: str) -> int:
-    """Return the cardinal number X for a correlation-consistent or def2 basis set.
+    """
+    Return the cardinal number X for a correlation-consistent or def2 basis set.
 
-    Parameters
-    ----------
-    basis : str
-        Basis-set name (case-insensitive). Supported families:
+    Args:
+        basis (str): Basis-set name (case-insensitive). Supported families:
 
-        * ``cc-pV{D,T,Q,5,6,7}Z`` — Dunning correlation-consistent.
-        * ``aug-cc-pV{D,T,Q,5,6,7}Z`` — diffuse-augmented variants.
-        * ``cc-pCV{D,T,Q,5,6}Z`` and ``aug-cc-pCV*`` — core-valence variants.
-        * ``def2-{SVP,TZVP,QZVP}`` and the ``...PP`` variants (Weigend & Ahlrichs).
+            * ``cc-pV{D,T,Q,5,6,7}Z`` — Dunning correlation-consistent.
+            * ``aug-cc-pV{D,T,Q,5,6,7}Z`` — diffuse-augmented variants.
+            * ``cc-pCV{D,T,Q,5,6}Z`` and ``aug-cc-pCV*`` — core-valence variants.
+            * ``def2-{SVP,TZVP,QZVP}`` and the ``...PP`` variants (Weigend & Ahlrichs).
 
-    Returns
-    -------
-    int
-        Cardinal X (2 for double-zeta, 3 for triple-zeta, etc.).
+    Returns:
+        int: Cardinal X (2 for double-zeta, 3 for triple-zeta, etc.).
 
-    Raises
-    ------
-    arc.exceptions.InputError
-        If ``basis`` does not match a known correlation-consistent or def2 pattern.
-        CBS extrapolation requires a known cardinal; non-systematic basis sets such
-        as ``6-31G*`` or ``STO-3G`` are rejected explicitly.
+    Raises:
+        InputError: If ``basis`` does not match a known correlation-consistent or
+            def2 pattern. CBS extrapolation requires a known cardinal;
+            non-systematic basis sets such as ``6-31G*`` or ``STO-3G`` are
+            rejected explicitly.
     """
     if not basis:
         raise InputError("Cannot deduce cardinal number from an empty basis-set name.")
@@ -124,42 +119,53 @@ def cardinal_from_basis(basis: str) -> int:
 
 
 def _sorted_pairs(energies: Mapping[int, float], expected: int) -> list:
-    """Return ``[(X, E_X), ...]`` sorted by cardinal, validating count & uniqueness."""
+    """
+    Return ``[(X, E_X), ...]`` sorted by ascending cardinal, validating the count.
+
+    Mapping keys are unique by construction, so distinct cardinals need no
+    separate check: repeated cardinals collapse and fail the count check.
+
+    Args:
+        energies (Mapping[int, float]): Mapping ``{cardinal: energy}``.
+        expected (int): The exact number of pairs the formula requires.
+
+    Returns:
+        list: ``(cardinal, energy)`` tuples sorted by ascending cardinal.
+
+    Raises:
+        InputError: If the number of pairs differs from ``expected``.
+    """
     pairs = sorted(energies.items())
     if len(pairs) != expected:
         raise InputError(
             f"Expected exactly {expected} (cardinal, energy) pairs, got {len(pairs)}."
         )
-    cardinals = [X for X, _ in pairs]
-    if len(set(cardinals)) != len(cardinals):
-        raise InputError(f"Cardinals must be distinct, got {cardinals}.")
     return pairs
 
 
 def helgaker_corr_2pt(energies: Mapping[int, float]) -> float:
-    """Two-point correlation-energy CBS extrapolation.
+    """
+    Two-point correlation-energy CBS extrapolation.
 
     Implements ``E_CBS = (X³·E_X − Y³·E_Y) / (X³ − Y³)`` per
     Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997), Eq. 4.
     DOI: 10.1063/1.473863.
 
-    Parameters
-    ----------
-    energies : Mapping[int, float]
-        Mapping ``{cardinal: energy}`` with exactly two entries. Insertion order is
-        irrelevant: pairs are sorted by ascending cardinal internally.
+    Args:
+        energies (Mapping[int, float]): Mapping ``{cardinal: energy}`` with exactly
+            two entries. Insertion order is irrelevant: pairs are sorted by
+            ascending cardinal internally.
 
-    Returns
-    -------
-    float
-        Extrapolated energy in the same units as the inputs.
+    Returns:
+        float: Extrapolated energy in the same units as the inputs.
     """
     (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
     return (X ** 3 * E_X - Y ** 3 * E_Y) / (X ** 3 - Y ** 3)
 
 
 def helgaker_hf_2pt(energies: Mapping[int, float], alpha: float = 1.63) -> float:
-    """Two-point HF (or other exponentially-converging) CBS extrapolation.
+    """
+    Two-point HF (or other exponentially-converging) CBS extrapolation.
 
     Solves ``E(X) = E_CBS + A·exp(-α·X)`` for two cardinals analytically:
     ``E_CBS = (E_X·exp(-α·Y) − E_Y·exp(-α·X)) / (exp(-α·Y) − exp(-α·X))``.
@@ -169,17 +175,14 @@ def helgaker_hf_2pt(energies: Mapping[int, float], alpha: float = 1.63) -> float
     Hartree–Fock calculations" reports the fitted value ``α = 1.63`` averaged
     across small molecules. DOI: 10.1016/S0009-2614(99)00179-7.
 
-    Parameters
-    ----------
-    energies : Mapping[int, float]
-        Mapping ``{cardinal: energy}`` with exactly two entries.
-    alpha : float, optional
-        Exponential decay parameter. Defaults to 1.63 (Halkier et al. 1999).
+    Args:
+        energies (Mapping[int, float]): Mapping ``{cardinal: energy}`` with exactly
+            two entries.
+        alpha (float): Exponential decay parameter. Defaults to 1.63
+            (Halkier et al. 1999).
 
-    Returns
-    -------
-    float
-        Extrapolated energy.
+    Returns:
+        float: Extrapolated energy.
     """
     (X, E_X), (Y, E_Y) = _sorted_pairs(energies, expected=2)
     e_x = math.exp(-alpha * X)
@@ -188,7 +191,8 @@ def helgaker_hf_2pt(energies: Mapping[int, float], alpha: float = 1.63) -> float
 
 
 def martin_3pt(energies: Mapping[int, float]) -> float:
-    """Three-point Schwartz-style CBS extrapolation.
+    """
+    Three-point Schwartz-style CBS extrapolation.
 
     Solves the linear system
 
@@ -199,15 +203,12 @@ def martin_3pt(energies: Mapping[int, float]) -> float:
     Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996), Eq. 5.
     DOI: 10.1016/0009-2614(96)00898-6.
 
-    Parameters
-    ----------
-    energies : Mapping[int, float]
-        Mapping ``{cardinal: energy}`` with exactly three entries.
+    Args:
+        energies (Mapping[int, float]): Mapping ``{cardinal: energy}`` with exactly
+            three entries.
 
-    Returns
-    -------
-    float
-        Extrapolated energy.
+    Returns:
+        float: Extrapolated energy.
     """
     pairs = _sorted_pairs(energies, expected=3)
     A = np.array(
@@ -219,18 +220,34 @@ def martin_3pt(energies: Mapping[int, float]) -> float:
     return float(e_cbs)
 
 
-# String → callable registry advertised to user input. New built-in formulas are
-# added by inserting an entry here (and a corresponding test).
+# Single source of truth for the built-in formulas advertised to user input:
+# name → (callable, required number of (cardinal, energy) pairs). New built-in
+# formulas are added by inserting an entry here (and a corresponding test).
+_BUILTIN_FORMULA_SPECS: dict[str, tuple[Callable[..., float], int]] = {
+    "helgaker_corr_2pt": (helgaker_corr_2pt, 2),
+    "helgaker_hf_2pt": (helgaker_hf_2pt, 2),
+    "martin_3pt": (martin_3pt, 3),
+}
+
+# Public views of the registry, derived so they can never fall out of sync.
 BUILTIN_FORMULAS: dict[str, Callable[..., float]] = {
-    "helgaker_corr_2pt": helgaker_corr_2pt,
-    "helgaker_hf_2pt": helgaker_hf_2pt,
-    "martin_3pt": martin_3pt,
+    name: func for name, (func, _arity) in _BUILTIN_FORMULA_SPECS.items()
+}
+BUILTIN_FORMULA_ARITY: dict[str, int] = {
+    name: arity for name, (_func, arity) in _BUILTIN_FORMULA_SPECS.items()
 }
 
 
 # ----------------------------------------------------------------------------- #
 #  Safe AST evaluator for user-supplied formula strings                         #
 # ----------------------------------------------------------------------------- #
+
+# Guardrails against resource-exhaustion through user formulas: an exponent
+# like ``9**9**9`` passes syntactic validation but creates an astronomically
+# large integer, and an oversized or deeply nested expression can exhaust the
+# parser or the recursive evaluator. Both are rejected with InputError.
+_MAX_POW_EXPONENT = 100
+_MAX_AST_NODES = 200
 
 # Functions a user formula may call. Restricted to a tiny math whitelist; no
 # I/O, no introspection, no attribute access whatsoever.
@@ -265,7 +282,23 @@ _ALLOWED_NODES = (
 
 
 def _validate_ast(node: ast.AST, env_names: set) -> None:
-    """Raise :class:`InputError` if any descendant of ``node`` is non-whitelisted."""
+    """
+    Raise :class:`InputError` if any descendant of ``node`` is non-whitelisted.
+
+    Args:
+        node (ast.AST): The root node to validate.
+        env_names (set): Variable names a formula may legally reference.
+
+    Raises:
+        InputError: If the tree is oversized or contains any non-whitelisted
+            node, constant type, name, or function call.
+    """
+    n_nodes = sum(1 for _ in ast.walk(node))
+    if n_nodes > _MAX_AST_NODES:
+        raise InputError(
+            f"User formula is too large: {n_nodes} AST nodes exceed the allowed "
+            f"maximum of {_MAX_AST_NODES}."
+        )
     for child in ast.walk(node):
         if not isinstance(child, _ALLOWED_NODES):
             raise InputError(
@@ -293,56 +326,76 @@ def _validate_ast(node: ast.AST, env_names: set) -> None:
                 )
 
 
+def _parse_formula(expression: str) -> ast.Expression:
+    """
+    Parse ``expression`` in eval mode, mapping parser failures to InputError.
+
+    Args:
+        expression (str): The user formula string.
+
+    Returns:
+        ast.Expression: The parsed AST.
+
+    Raises:
+        InputError: If parsing fails — including pathological inputs that
+            overflow the CPython parser with RecursionError or MemoryError
+            rather than the usual SyntaxError.
+    """
+    try:
+        return ast.parse(expression, mode="eval")
+    except (SyntaxError, RecursionError, MemoryError) as exc:
+        snippet = expression if len(expression) <= 100 else f"{expression[:100]}..."
+        raise InputError(
+            f"User formula failed to parse: {snippet!r} ({type(exc).__name__}: {exc})"
+        )
+
+
 def validate_formula(expression: str, allowed_names: set) -> None:
-    """Parse and whitelist-validate ``expression`` without evaluating it.
+    """
+    Parse and whitelist-validate ``expression`` without evaluating it.
 
     Useful at construction time to surface malformed user formulas eagerly,
     independent of any specific numeric inputs (which might cause spurious
     runtime errors like division by zero on a probe environment).
 
-    Raises :class:`InputError` on any non-whitelisted construct.
+    Args:
+        expression (str): The user formula string.
+        allowed_names (set): Variable names the formula may reference.
+
+    Raises:
+        InputError: On any parse failure or non-whitelisted construct.
     """
-    try:
-        tree = ast.parse(expression, mode="eval")
-    except SyntaxError as exc:
-        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    tree = _parse_formula(expression)
     _validate_ast(tree, set(allowed_names))
 
 
 def safe_eval_formula(expression: str, env: Mapping[str, float]) -> float:
-    """Evaluate an arithmetic expression against ``env`` without using :func:`eval`.
+    """
+    Evaluate an arithmetic expression against ``env`` without using :func:`eval`.
 
     Parses ``expression`` to an AST, validates every node against a strict whitelist
     (basic arithmetic, unary ±, numeric literals, named variables drawn from
     ``env``, and calls to :func:`math.exp`, :func:`math.log`, :func:`math.sqrt`,
     :func:`math.pow`), then walks the tree to compute the result.
 
-    Parameters
-    ----------
-    expression : str
-        Arithmetic expression. Examples:
-        ``"(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"``,
-        ``"E_X - sqrt(E_Y)"``.
-    env : Mapping[str, float]
-        Variable bindings. Names referenced by ``expression`` must appear here
-        (or be one of the allowed function names).
+    Args:
+        expression (str): Arithmetic expression. Examples:
+            ``"(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"``,
+            ``"E_X - sqrt(E_Y)"``.
+        env (Mapping[str, float]): Variable bindings. Names referenced by
+            ``expression`` must appear here (or be one of the allowed function names).
 
-    Returns
-    -------
-    float
-        Numerical value of the expression.
+    Returns:
+        float: Numerical value of the expression.
 
-    Raises
-    ------
-    arc.exceptions.InputError
-        If the expression is syntactically invalid, references unknown names, or
-        uses any AST construct outside the whitelist (attribute access,
-        subscript, lambdas, comprehensions, walrus, string literals, etc.).
+    Raises:
+        InputError: If the expression is syntactically invalid, oversized,
+            references unknown names, uses any AST construct outside the
+            whitelist (attribute access, subscript, lambdas, comprehensions,
+            walrus, string literals, etc.), or exponentiates with a magnitude
+            above the allowed maximum.
     """
-    try:
-        tree = ast.parse(expression, mode="eval")
-    except SyntaxError as exc:
-        raise InputError(f"User formula failed to parse: {expression!r} ({exc})")
+    tree = _parse_formula(expression)
     env_names = set(env.keys())
     _validate_ast(tree, env_names)
     return _eval_node(tree.body, env)
@@ -376,6 +429,13 @@ def _eval_node(node: ast.AST, env: Mapping[str, float]) -> float:
         if isinstance(node.op, ast.Div):
             return left / right
         if isinstance(node.op, ast.Pow):
+            # Cap the exponent magnitude: huge integer exponents (e.g. the
+            # outer step of 9**9**9) would hang or exhaust memory.
+            if abs(right) > _MAX_POW_EXPONENT:
+                raise InputError(
+                    f"Exponent {right} in user formula exceeds the allowed "
+                    f"magnitude of {_MAX_POW_EXPONENT}."
+                )
             return left ** right
         if isinstance(node.op, ast.Mod):
             return left % right

--- a/arc/level/cbs_test.py
+++ b/arc/level/cbs_test.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.cbs`` — basis-set cardinal inference, built-in CBS
+extrapolation formulas, and the safe AST evaluator for user-supplied formulas.
+
+References whose values are checked here:
+
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0
+  — two-point HF extrapolation, Table 2 reports α = 1.63.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996).
+  DOI: 10.1016/0009-2614(96)00898-6 — three-point Schwartz expansion.
+"""
+
+import math
+import unittest
+
+from arc.exceptions import InputError
+from arc.level.cbs import (
+    BUILTIN_FORMULAS,
+    cardinal_from_basis,
+    helgaker_corr_2pt,
+    helgaker_hf_2pt,
+    martin_3pt,
+    safe_eval_formula,
+)
+
+
+class TestCardinalFromBasis(unittest.TestCase):
+    """``cardinal_from_basis`` covers the common Dunning families and def2."""
+
+    def test_cc_pvxz(self):
+        self.assertEqual(cardinal_from_basis("cc-pVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("cc-pVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("cc-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("cc-pV5Z"), 5)
+        self.assertEqual(cardinal_from_basis("cc-pV6Z"), 6)
+
+    def test_aug_cc_pvxz(self):
+        self.assertEqual(cardinal_from_basis("aug-cc-pVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("aug-cc-pVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("aug-cc-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("aug-cc-pV5Z"), 5)
+
+    def test_cc_pcvxz_core_valence(self):
+        self.assertEqual(cardinal_from_basis("cc-pCVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("cc-pCVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("cc-pCVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("aug-cc-pCVTZ"), 3)
+
+    def test_def2_family(self):
+        self.assertEqual(cardinal_from_basis("def2-SVP"), 2)
+        self.assertEqual(cardinal_from_basis("def2-TZVP"), 3)
+        self.assertEqual(cardinal_from_basis("def2-QZVP"), 4)
+        self.assertEqual(cardinal_from_basis("def2-TZVPP"), 3)
+        self.assertEqual(cardinal_from_basis("def2-QZVPP"), 4)
+
+    def test_case_insensitive(self):
+        self.assertEqual(cardinal_from_basis("cc-pvtz"), 3)
+        self.assertEqual(cardinal_from_basis("CC-PVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("Aug-CC-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("DEF2-tzvp"), 3)
+
+    def test_unknown_basis_raises(self):
+        with self.assertRaises(InputError):
+            cardinal_from_basis("6-31G*")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("STO-3G")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("not-a-basis-set")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("")
+
+
+class TestHelgakerCorr2Pt(unittest.TestCase):
+    """``helgaker_corr_2pt`` implements (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)."""
+
+    def test_known_values(self):
+        # E_T = 1.0, E_Q = 1.05  ->  (27*1.0 - 64*1.05) / (27 - 64) = -40.2 / -37
+        result = helgaker_corr_2pt({3: 1.0, 4: 1.05})
+        self.assertAlmostEqual(result, 40.2 / 37, places=12)
+
+    def test_invariance_to_dict_insertion_order(self):
+        a = helgaker_corr_2pt({3: -1.0, 4: -1.05})
+        b = helgaker_corr_2pt({4: -1.05, 3: -1.0})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_higher_basis_dominates(self):
+        # E_CBS should be closer to E_Q than to E_T (since cc-pVQZ is more accurate).
+        e_t, e_q = -100.0, -100.05
+        cbs = helgaker_corr_2pt({3: e_t, 4: e_q})
+        self.assertLess(abs(cbs - e_q), abs(cbs - e_t))
+
+    def test_real_h2o_correlation_extrapolation(self):
+        # Synthetic but representative: CCSD(T) corr energy at TZ vs QZ.
+        # E_corr_TZ = -0.30, E_corr_QZ = -0.31 (Hartree)  -> CBS ≈ -0.31730
+        result = helgaker_corr_2pt({3: -0.30, 4: -0.31})
+        expected = (27 * (-0.30) - 64 * (-0.31)) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+        self.assertAlmostEqual(result, -0.31729729729729728, places=10)
+
+    def test_requires_exactly_two_points(self):
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0})
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0, 4: -1.05, 5: -1.06})
+
+    def test_rejects_equal_cardinals(self):
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0, 3: -1.05})  # noqa: F601 — Python collapses; size=1 path
+
+    def test_q5_pair_reproduces_formula(self):
+        # X=4, Y=5; E_Q = -0.310, E_5 = -0.315
+        result = helgaker_corr_2pt({4: -0.310, 5: -0.315})
+        expected = (4**3 * -0.310 - 5**3 * -0.315) / (4**3 - 5**3)
+        self.assertAlmostEqual(result, expected, places=12)
+
+
+class TestHelgakerHF2Pt(unittest.TestCase):
+    """``helgaker_hf_2pt`` extrapolates HF energies via E(X) = E_CBS + A·exp(-α·X)."""
+
+    def test_default_alpha_is_halkier_value(self):
+        # Halkier et al. 1998 fitted α = 1.63 (Table 2).
+        # Pick numbers and verify the formula uses α=1.63 by default.
+        e_t, e_q = -76.0500, -76.0510
+        from_default = helgaker_hf_2pt({3: e_t, 4: e_q})
+        from_explicit = helgaker_hf_2pt({3: e_t, 4: e_q}, alpha=1.63)
+        self.assertAlmostEqual(from_default, from_explicit, places=12)
+
+    def test_known_value(self):
+        # E_CBS = (E_X · exp(-α·Y) - E_Y · exp(-α·X)) / (exp(-α·Y) - exp(-α·X))
+        e_t, e_q = -76.0500, -76.0510
+        alpha = 1.63
+        expected = (
+            e_t * math.exp(-alpha * 4) - e_q * math.exp(-alpha * 3)
+        ) / (math.exp(-alpha * 4) - math.exp(-alpha * 3))
+        result = helgaker_hf_2pt({3: e_t, 4: e_q})
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_alpha_override(self):
+        e_t, e_q = -76.0500, -76.0510
+        alpha = 1.50
+        expected = (
+            e_t * math.exp(-alpha * 4) - e_q * math.exp(-alpha * 3)
+        ) / (math.exp(-alpha * 4) - math.exp(-alpha * 3))
+        self.assertAlmostEqual(helgaker_hf_2pt({3: e_t, 4: e_q}, alpha=alpha), expected, places=12)
+
+    def test_invariance_to_dict_insertion_order(self):
+        a = helgaker_hf_2pt({3: -76.05, 4: -76.051})
+        b = helgaker_hf_2pt({4: -76.051, 3: -76.05})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_requires_exactly_two_points(self):
+        with self.assertRaises(InputError):
+            helgaker_hf_2pt({3: -76.05})
+        with self.assertRaises(InputError):
+            helgaker_hf_2pt({3: -76.05, 4: -76.051, 5: -76.0512})
+
+
+class TestMartin3Pt(unittest.TestCase):
+    """``martin_3pt`` solves E(L) = E_CBS + b·(L+½)⁻⁴ + c·(L+½)⁻⁶ exactly."""
+
+    def test_recovers_constant_term(self):
+        # If we feed E(L) = -1.0 + 0.05/(L+0.5)**4 + 0.01/(L+0.5)**6 for L=2,3,4
+        # then E_CBS must come back as -1.0 to high precision.
+        def model(L):
+            return -1.0 + 0.05 / (L + 0.5) ** 4 + 0.01 / (L + 0.5) ** 6
+
+        result = martin_3pt({2: model(2), 3: model(3), 4: model(4)})
+        self.assertAlmostEqual(result, -1.0, places=10)
+
+    def test_higher_cardinals(self):
+        def model(L):
+            return -100.0 + 0.123 / (L + 0.5) ** 4 - 0.045 / (L + 0.5) ** 6
+
+        result = martin_3pt({3: model(3), 4: model(4), 5: model(5)})
+        self.assertAlmostEqual(result, -100.0, places=10)
+
+    def test_invariance_to_dict_insertion_order(self):
+        e = {3: -1.0, 4: -1.05, 5: -1.06}
+        a = martin_3pt(e)
+        b = martin_3pt({5: e[5], 3: e[3], 4: e[4]})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_requires_exactly_three_points(self):
+        with self.assertRaises(InputError):
+            martin_3pt({3: -1.0, 4: -1.05})
+        with self.assertRaises(InputError):
+            martin_3pt({3: -1.0, 4: -1.05, 5: -1.06, 6: -1.065})
+
+
+class TestBuiltinFormulasRegistry(unittest.TestCase):
+    """The string→callable registry advertised to user input."""
+
+    def test_helgaker_corr_2pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["helgaker_corr_2pt"], helgaker_corr_2pt)
+
+    def test_helgaker_hf_2pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["helgaker_hf_2pt"], helgaker_hf_2pt)
+
+    def test_martin_3pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["martin_3pt"], martin_3pt)
+
+    def test_no_other_entries(self):
+        self.assertEqual(
+            set(BUILTIN_FORMULAS.keys()),
+            {"helgaker_corr_2pt", "helgaker_hf_2pt", "martin_3pt"},
+        )
+
+
+class TestSafeEvalFormula(unittest.TestCase):
+    """``safe_eval_formula`` accepts arithmetic + math whitelist; rejects everything else."""
+
+    def test_basic_arithmetic(self):
+        self.assertEqual(safe_eval_formula("1 + 2", {}), 3)
+        self.assertEqual(safe_eval_formula("3 * 4 - 5", {}), 7)
+        self.assertEqual(safe_eval_formula("10 / 4", {}), 2.5)
+        self.assertEqual(safe_eval_formula("2 ** 8", {}), 256)
+        self.assertEqual(safe_eval_formula("-5 + 3", {}), -2)
+        self.assertEqual(safe_eval_formula("+(7)", {}), 7)
+
+    def test_helgaker_corr_2pt_via_safe_eval(self):
+        # Reproduce the helgaker_corr_2pt formula by string.
+        formula = "(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"
+        env = {"X": 3, "Y": 4, "E_X": -0.30, "E_Y": -0.31}
+        result = safe_eval_formula(formula, env)
+        self.assertAlmostEqual(result, helgaker_corr_2pt({3: -0.30, 4: -0.31}), places=12)
+
+    def test_allowed_math_calls(self):
+        self.assertAlmostEqual(safe_eval_formula("exp(1)", {}), math.e, places=12)
+        self.assertAlmostEqual(safe_eval_formula("log(exp(2.5))", {}), 2.5, places=12)
+        self.assertAlmostEqual(safe_eval_formula("sqrt(16)", {}), 4.0, places=12)
+        self.assertAlmostEqual(safe_eval_formula("pow(2, 10)", {}), 1024.0, places=12)
+
+    def test_user_variables_resolved(self):
+        self.assertEqual(safe_eval_formula("E_X * 2", {"E_X": 5}), 10)
+
+    def test_unknown_name_raises(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("os.system('rm')", {})
+        with self.assertRaises(InputError):
+            safe_eval_formula("E_Z", {"E_X": 1})
+
+    def test_dunder_attribute_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(0).__class__", {})
+
+    def test_attribute_access_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(0.0).real", {})
+
+    def test_subscript_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("[1,2,3][0]", {})
+
+    def test_lambda_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(lambda x: x)(1)", {})
+
+    def test_comprehension_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("[i for i in range(3)]", {})
+
+    def test_call_to_unwhitelisted_function_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("eval('1')", {})
+        with self.assertRaises(InputError):
+            safe_eval_formula("__import__('os')", {})
+
+    def test_walrus_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(x := 5)", {})
+
+    def test_string_literal_rejected(self):
+        # Numeric constants only.
+        with self.assertRaises(InputError):
+            safe_eval_formula("'hello'", {})
+
+    def test_syntax_error_propagates_as_input_error(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("1 +", {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/cbs_test.py
+++ b/arc/level/cbs_test.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.cbs`` — basis-set cardinal inference, built-in CBS
+extrapolation formulas, and the safe AST evaluator for user-supplied formulas.
+
+References whose values are checked here:
+
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Olsen, *Chem. Phys. Lett.* **302**,
+  437-446 (1999). DOI: 10.1016/S0009-2614(99)00179-7 — two-point HF
+  extrapolation; source of the fitted α = 1.63.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996).
+  DOI: 10.1016/0009-2614(96)00898-6 — three-point Schwartz expansion.
+"""
+
+import math
+import unittest
+
+from arc.exceptions import InputError
+from arc.level.cbs import (
+    BUILTIN_FORMULAS,
+    cardinal_from_basis,
+    helgaker_corr_2pt,
+    helgaker_hf_2pt,
+    martin_3pt,
+    safe_eval_formula,
+)
+
+
+class TestCardinalFromBasis(unittest.TestCase):
+    """``cardinal_from_basis`` covers the common Dunning families and def2."""
+
+    def test_cc_pvxz(self):
+        self.assertEqual(cardinal_from_basis("cc-pVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("cc-pVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("cc-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("cc-pV5Z"), 5)
+        self.assertEqual(cardinal_from_basis("cc-pV6Z"), 6)
+
+    def test_aug_cc_pvxz(self):
+        self.assertEqual(cardinal_from_basis("aug-cc-pVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("aug-cc-pVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("aug-cc-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("aug-cc-pV5Z"), 5)
+
+    def test_cc_pcvxz_core_valence(self):
+        self.assertEqual(cardinal_from_basis("cc-pCVDZ"), 2)
+        self.assertEqual(cardinal_from_basis("cc-pCVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("cc-pCVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("aug-cc-pCVTZ"), 3)
+
+    def test_def2_family(self):
+        self.assertEqual(cardinal_from_basis("def2-SVP"), 2)
+        self.assertEqual(cardinal_from_basis("def2-TZVP"), 3)
+        self.assertEqual(cardinal_from_basis("def2-QZVP"), 4)
+        self.assertEqual(cardinal_from_basis("def2-TZVPP"), 3)
+        self.assertEqual(cardinal_from_basis("def2-QZVPP"), 4)
+
+    def test_case_insensitive(self):
+        self.assertEqual(cardinal_from_basis("cc-pvtz"), 3)
+        self.assertEqual(cardinal_from_basis("CC-PVTZ"), 3)
+        self.assertEqual(cardinal_from_basis("Aug-CC-pVQZ"), 4)
+        self.assertEqual(cardinal_from_basis("DEF2-tzvp"), 3)
+
+    def test_unknown_basis_raises(self):
+        with self.assertRaises(InputError):
+            cardinal_from_basis("6-31G*")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("STO-3G")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("not-a-basis-set")
+        with self.assertRaises(InputError):
+            cardinal_from_basis("")
+
+
+class TestHelgakerCorr2Pt(unittest.TestCase):
+    """``helgaker_corr_2pt`` implements (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)."""
+
+    def test_known_values(self):
+        # E_T = 1.0, E_Q = 1.05  ->  (27*1.0 - 64*1.05) / (27 - 64) = -40.2 / -37
+        result = helgaker_corr_2pt({3: 1.0, 4: 1.05})
+        self.assertAlmostEqual(result, 40.2 / 37, places=12)
+
+    def test_invariance_to_dict_insertion_order(self):
+        a = helgaker_corr_2pt({3: -1.0, 4: -1.05})
+        b = helgaker_corr_2pt({4: -1.05, 3: -1.0})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_higher_basis_dominates(self):
+        # E_CBS should be closer to E_Q than to E_T (since cc-pVQZ is more accurate).
+        e_t, e_q = -100.0, -100.05
+        cbs = helgaker_corr_2pt({3: e_t, 4: e_q})
+        self.assertLess(abs(cbs - e_q), abs(cbs - e_t))
+
+    def test_real_h2o_correlation_extrapolation(self):
+        # Synthetic but representative: CCSD(T) corr energy at TZ vs QZ.
+        # E_corr_TZ = -0.30, E_corr_QZ = -0.31 (Hartree)  -> CBS ≈ -0.31730
+        result = helgaker_corr_2pt({3: -0.30, 4: -0.31})
+        expected = (27 * (-0.30) - 64 * (-0.31)) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+        self.assertAlmostEqual(result, -0.31729729729729728, places=10)
+
+    def test_requires_exactly_two_points(self):
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0})
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0, 4: -1.05, 5: -1.06})
+
+    def test_rejects_equal_cardinals(self):
+        with self.assertRaises(InputError):
+            helgaker_corr_2pt({3: -1.0, 3: -1.05})  # noqa: F601 — Python collapses; size=1 path
+
+    def test_q5_pair_reproduces_formula(self):
+        # X=4, Y=5; E_Q = -0.310, E_5 = -0.315
+        result = helgaker_corr_2pt({4: -0.310, 5: -0.315})
+        expected = (4**3 * -0.310 - 5**3 * -0.315) / (4**3 - 5**3)
+        self.assertAlmostEqual(result, expected, places=12)
+
+
+class TestHelgakerHF2Pt(unittest.TestCase):
+    """``helgaker_hf_2pt`` extrapolates HF energies via E(X) = E_CBS + A·exp(-α·X)."""
+
+    def test_default_alpha_is_halkier_value(self):
+        # Halkier et al. 1999 fitted α = 1.63.
+        # Pick numbers and verify the formula uses α=1.63 by default.
+        e_t, e_q = -76.0500, -76.0510
+        from_default = helgaker_hf_2pt({3: e_t, 4: e_q})
+        from_explicit = helgaker_hf_2pt({3: e_t, 4: e_q}, alpha=1.63)
+        self.assertAlmostEqual(from_default, from_explicit, places=12)
+
+    def test_known_value(self):
+        # E_CBS = (E_X · exp(-α·Y) - E_Y · exp(-α·X)) / (exp(-α·Y) - exp(-α·X))
+        e_t, e_q = -76.0500, -76.0510
+        alpha = 1.63
+        expected = (
+            e_t * math.exp(-alpha * 4) - e_q * math.exp(-alpha * 3)
+        ) / (math.exp(-alpha * 4) - math.exp(-alpha * 3))
+        result = helgaker_hf_2pt({3: e_t, 4: e_q})
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_alpha_override(self):
+        e_t, e_q = -76.0500, -76.0510
+        alpha = 1.50
+        expected = (
+            e_t * math.exp(-alpha * 4) - e_q * math.exp(-alpha * 3)
+        ) / (math.exp(-alpha * 4) - math.exp(-alpha * 3))
+        self.assertAlmostEqual(helgaker_hf_2pt({3: e_t, 4: e_q}, alpha=alpha), expected, places=12)
+
+    def test_invariance_to_dict_insertion_order(self):
+        a = helgaker_hf_2pt({3: -76.05, 4: -76.051})
+        b = helgaker_hf_2pt({4: -76.051, 3: -76.05})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_requires_exactly_two_points(self):
+        with self.assertRaises(InputError):
+            helgaker_hf_2pt({3: -76.05})
+        with self.assertRaises(InputError):
+            helgaker_hf_2pt({3: -76.05, 4: -76.051, 5: -76.0512})
+
+
+class TestMartin3Pt(unittest.TestCase):
+    """``martin_3pt`` solves E(L) = E_CBS + b·(L+½)⁻⁴ + c·(L+½)⁻⁶ exactly."""
+
+    def test_recovers_constant_term(self):
+        # If we feed E(L) = -1.0 + 0.05/(L+0.5)**4 + 0.01/(L+0.5)**6 for L=2,3,4
+        # then E_CBS must come back as -1.0 to high precision.
+        def model(L):
+            return -1.0 + 0.05 / (L + 0.5) ** 4 + 0.01 / (L + 0.5) ** 6
+
+        result = martin_3pt({2: model(2), 3: model(3), 4: model(4)})
+        self.assertAlmostEqual(result, -1.0, places=10)
+
+    def test_higher_cardinals(self):
+        def model(L):
+            return -100.0 + 0.123 / (L + 0.5) ** 4 - 0.045 / (L + 0.5) ** 6
+
+        result = martin_3pt({3: model(3), 4: model(4), 5: model(5)})
+        self.assertAlmostEqual(result, -100.0, places=10)
+
+    def test_invariance_to_dict_insertion_order(self):
+        e = {3: -1.0, 4: -1.05, 5: -1.06}
+        a = martin_3pt(e)
+        b = martin_3pt({5: e[5], 3: e[3], 4: e[4]})
+        self.assertAlmostEqual(a, b, places=12)
+
+    def test_requires_exactly_three_points(self):
+        with self.assertRaises(InputError):
+            martin_3pt({3: -1.0, 4: -1.05})
+        with self.assertRaises(InputError):
+            martin_3pt({3: -1.0, 4: -1.05, 5: -1.06, 6: -1.065})
+
+
+class TestBuiltinFormulasRegistry(unittest.TestCase):
+    """The string→callable registry advertised to user input."""
+
+    def test_helgaker_corr_2pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["helgaker_corr_2pt"], helgaker_corr_2pt)
+
+    def test_helgaker_hf_2pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["helgaker_hf_2pt"], helgaker_hf_2pt)
+
+    def test_martin_3pt_registered(self):
+        self.assertIs(BUILTIN_FORMULAS["martin_3pt"], martin_3pt)
+
+    def test_no_other_entries(self):
+        self.assertEqual(
+            set(BUILTIN_FORMULAS.keys()),
+            {"helgaker_corr_2pt", "helgaker_hf_2pt", "martin_3pt"},
+        )
+
+
+class TestSafeEvalFormula(unittest.TestCase):
+    """``safe_eval_formula`` accepts arithmetic + math whitelist; rejects everything else."""
+
+    def test_basic_arithmetic(self):
+        self.assertEqual(safe_eval_formula("1 + 2", {}), 3)
+        self.assertEqual(safe_eval_formula("3 * 4 - 5", {}), 7)
+        self.assertEqual(safe_eval_formula("10 / 4", {}), 2.5)
+        self.assertEqual(safe_eval_formula("2 ** 8", {}), 256)
+        self.assertEqual(safe_eval_formula("-5 + 3", {}), -2)
+        self.assertEqual(safe_eval_formula("+(7)", {}), 7)
+
+    def test_helgaker_corr_2pt_via_safe_eval(self):
+        # Reproduce the helgaker_corr_2pt formula by string.
+        formula = "(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)"
+        env = {"X": 3, "Y": 4, "E_X": -0.30, "E_Y": -0.31}
+        result = safe_eval_formula(formula, env)
+        self.assertAlmostEqual(result, helgaker_corr_2pt({3: -0.30, 4: -0.31}), places=12)
+
+    def test_allowed_math_calls(self):
+        self.assertAlmostEqual(safe_eval_formula("exp(1)", {}), math.e, places=12)
+        self.assertAlmostEqual(safe_eval_formula("log(exp(2.5))", {}), 2.5, places=12)
+        self.assertAlmostEqual(safe_eval_formula("sqrt(16)", {}), 4.0, places=12)
+        self.assertAlmostEqual(safe_eval_formula("pow(2, 10)", {}), 1024.0, places=12)
+
+    def test_user_variables_resolved(self):
+        self.assertEqual(safe_eval_formula("E_X * 2", {"E_X": 5}), 10)
+
+    def test_unknown_name_raises(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("os.system('rm')", {})
+        with self.assertRaises(InputError):
+            safe_eval_formula("E_Z", {"E_X": 1})
+
+    def test_dunder_attribute_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(0).__class__", {})
+
+    def test_attribute_access_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(0.0).real", {})
+
+    def test_subscript_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("[1,2,3][0]", {})
+
+    def test_lambda_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(lambda x: x)(1)", {})
+
+    def test_comprehension_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("[i for i in range(3)]", {})
+
+    def test_call_to_unwhitelisted_function_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("eval('1')", {})
+        with self.assertRaises(InputError):
+            safe_eval_formula("__import__('os')", {})
+
+    def test_walrus_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("(x := 5)", {})
+
+    def test_string_literal_rejected(self):
+        # Numeric constants only.
+        with self.assertRaises(InputError):
+            safe_eval_formula("'hello'", {})
+
+    def test_syntax_error_propagates_as_input_error(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("1 +", {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/cbs_test.py
+++ b/arc/level/cbs_test.py
@@ -21,6 +21,7 @@ import unittest
 
 from arc.exceptions import InputError
 from arc.level.cbs import (
+    BUILTIN_FORMULA_ARITY,
     BUILTIN_FORMULAS,
     cardinal_from_basis,
     helgaker_corr_2pt,
@@ -109,9 +110,13 @@ class TestHelgakerCorr2Pt(unittest.TestCase):
         with self.assertRaises(InputError):
             helgaker_corr_2pt({3: -1.0, 4: -1.05, 5: -1.06})
 
-    def test_rejects_equal_cardinals(self):
+    def test_duplicate_cardinals_collapse_to_too_few_points(self):
+        """Mapping keys are unique by construction, so repeated cardinals collapse
+        to a single entry, which then fails the pair-count check."""
+        collapsed = dict([(3, -1.0), (3, -1.05)])
+        self.assertEqual(len(collapsed), 1)
         with self.assertRaises(InputError):
-            helgaker_corr_2pt({3: -1.0, 3: -1.05})  # noqa: F601 — Python collapses; size=1 path
+            helgaker_corr_2pt(collapsed)
 
     def test_q5_pair_reproduces_formula(self):
         # X=4, Y=5; E_Q = -0.310, E_5 = -0.315
@@ -211,6 +216,12 @@ class TestBuiltinFormulasRegistry(unittest.TestCase):
             {"helgaker_corr_2pt", "helgaker_hf_2pt", "martin_3pt"},
         )
 
+    def test_arity_registered_for_every_formula(self):
+        self.assertEqual(
+            BUILTIN_FORMULA_ARITY,
+            {"helgaker_corr_2pt": 2, "helgaker_hf_2pt": 2, "martin_3pt": 3},
+        )
+
 
 class TestSafeEvalFormula(unittest.TestCase):
     """``safe_eval_formula`` accepts arithmetic + math whitelist; rejects everything else."""
@@ -283,6 +294,29 @@ class TestSafeEvalFormula(unittest.TestCase):
     def test_syntax_error_propagates_as_input_error(self):
         with self.assertRaises(InputError):
             safe_eval_formula("1 +", {})
+
+    def test_moderate_exponent_allowed(self):
+        self.assertEqual(safe_eval_formula("2**100", {}), 2 ** 100)
+
+    def test_huge_chained_power_rejected(self):
+        # 9**9**9 is right-associative: the outer exponent is 9**9 = 387420489,
+        # which would exhaust memory if evaluated. Must be rejected, not hang.
+        with self.assertRaises(InputError):
+            safe_eval_formula("9**9**9", {})
+
+    def test_large_negative_exponent_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("2**-101", {})
+
+    def test_oversized_expression_rejected(self):
+        with self.assertRaises(InputError):
+            safe_eval_formula("+".join(["1"] * 300), {})
+
+    def test_pathological_nesting_raises_input_error(self):
+        # Deep unary chains overflow the CPython parser (RecursionError /
+        # MemoryError depending on version); must surface as InputError.
+        with self.assertRaises(InputError):
+            safe_eval_formula("-" * 1_000_000 + "1", {})
 
 
 if __name__ == "__main__":

--- a/arc/level/examples_test.py
+++ b/arc/level/examples_test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Tests that every ``examples/Composite/*/input.yml`` example is valid YAML and
+that its ``sp_composite`` block (or per-species ``sp_composite`` entries)
+builds a valid :class:`CompositeProtocol` via
+:meth:`CompositeProtocol.from_user_input`. Keeps the docs + examples honest.
+"""
+
+import glob
+import os
+import unittest
+
+import yaml
+
+from arc.common import ARC_PATH
+from arc.level.protocol import CompositeProtocol
+
+
+EXAMPLES_DIR = os.path.join(ARC_PATH, "examples", "Composite")
+
+
+class TestCompositeExamples(unittest.TestCase):
+    """Parse every shipped example and validate its sp_composite payload."""
+
+    def _example_files(self):
+        pattern = os.path.join(EXAMPLES_DIR, "*", "input.yml")
+        return sorted(glob.glob(pattern))
+
+    def test_examples_directory_ships_at_least_four_inputs(self):
+        self.assertGreaterEqual(len(self._example_files()), 4)
+
+    def test_examples_readme_exists(self):
+        self.assertTrue(os.path.isfile(os.path.join(EXAMPLES_DIR, "README.md")))
+
+    def test_every_example_is_valid_yaml(self):
+        for path in self._example_files():
+            with self.subTest(path=path):
+                with open(path, "r") as fh:
+                    data = yaml.safe_load(fh)
+                self.assertIsInstance(data, dict)
+                self.assertIn("project", data)
+                self.assertIn("species", data)
+
+    def test_every_project_level_sp_composite_builds(self):
+        """Project-level ``sp_composite`` (if present) is parseable."""
+        for path in self._example_files():
+            with open(path, "r") as fh:
+                data = yaml.safe_load(fh)
+            sp = data.get("sp_composite")
+            if sp is None:
+                continue
+            with self.subTest(path=path):
+                protocol = CompositeProtocol.from_user_input(sp)
+                self.assertIsInstance(protocol, CompositeProtocol)
+
+    def test_every_species_sp_composite_builds_if_explicit(self):
+        """Per-species ``sp_composite`` (string/dict, not null) is parseable."""
+        for path in self._example_files():
+            with open(path, "r") as fh:
+                data = yaml.safe_load(fh)
+            for spc in data.get("species", []):
+                sp = spc.get("sp_composite", "__missing__")
+                if sp == "__missing__":
+                    continue
+                if sp is None:
+                    continue
+                with self.subTest(path=path, label=spc.get("label")):
+                    protocol = CompositeProtocol.from_user_input(sp)
+                    self.assertIsInstance(protocol, CompositeProtocol)
+
+    def test_all_four_forms_covered(self):
+        """Each of the four documented YAML forms must appear at least once."""
+        form1 = form2 = form3 = form4 = False
+        for path in self._example_files():
+            with open(path, "r") as fh:
+                data = yaml.safe_load(fh)
+            sp = data.get("sp_composite")
+            if isinstance(sp, str):
+                form1 = True
+            elif isinstance(sp, dict) and "preset" in sp:
+                form2 = True
+            elif isinstance(sp, dict) and "base" in sp:
+                form3 = True
+            for spc in data.get("species", []):
+                if "sp_composite" in spc:
+                    form4 = True
+        self.assertTrue(form1, "Form 1 (preset by name) not demonstrated.")
+        self.assertTrue(form2, "Form 2 (preset + override) not demonstrated.")
+        self.assertTrue(form3, "Form 3 (fully explicit recipe) not demonstrated.")
+        self.assertTrue(form4, "Form 4 (per-species override) not demonstrated.")
+
+    def test_explicit_recipe_example_includes_cbs_extrapolation(self):
+        path = os.path.join(EXAMPLES_DIR, "explicit_fpa", "input.yml")
+        with open(path, "r") as fh:
+            data = yaml.safe_load(fh)
+        corrections = data["sp_composite"]["corrections"]
+        term_types = {c["type"] for c in corrections}
+        self.assertIn("cbs_extrapolation", term_types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/examples_test.py
+++ b/arc/level/examples_test.py
@@ -91,13 +91,14 @@ class TestCompositeExamples(unittest.TestCase):
         self.assertTrue(form3, "Form 3 (fully explicit recipe) not demonstrated.")
         self.assertTrue(form4, "Form 4 (per-species override) not demonstrated.")
 
-    def test_explicit_recipe_example_includes_cbs_extrapolation(self):
+    def test_explicit_recipe_example_uses_cbs_as_base(self):
         path = os.path.join(EXAMPLES_DIR, "explicit_fpa", "input.yml")
         with open(path, "r") as fh:
             data = yaml.safe_load(fh)
-        corrections = data["sp_composite"]["corrections"]
-        term_types = {c["type"] for c in corrections}
-        self.assertIn("cbs_extrapolation", term_types)
+        sp = data["sp_composite"]
+        self.assertEqual(sp["base"]["type"], "cbs_extrapolation")
+        self.assertNotIn("cbs_extrapolation", {c["type"] for c in sp["corrections"]})
+        self.assertNotIn("f12", str(sp).lower())
 
 
 if __name__ == "__main__":

--- a/arc/level/legacy_imports_test.py
+++ b/arc/level/legacy_imports_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Backward-compatibility tests for the ``arc.level`` package.
+
+These tests assert that every public symbol that used to live in the legacy
+``arc/level.py`` module is still importable from ``arc.level`` after the package
+relocation. They guard the public surface so an accidental re-organisation of
+the new package internals cannot break the existing 50+ external call sites.
+"""
+
+import importlib
+import unittest
+
+
+class TestLegacyArcLevelImports(unittest.TestCase):
+    """Verify the public surface of ``arc.level`` is preserved."""
+
+    def test_from_arc_level_import_Level(self):
+        """``from arc.level import Level`` resolves to the legacy class."""
+        from arc.level import Level
+
+        instance = Level(method="b3lyp", basis="def2tzvp")
+        self.assertEqual(instance.method, "b3lyp")
+        self.assertEqual(instance.basis, "def2tzvp")
+
+    def test_from_arc_level_import_assign_frequency_scale_factor(self):
+        """``assign_frequency_scale_factor`` is still re-exported."""
+        from arc.level import assign_frequency_scale_factor
+
+        self.assertTrue(callable(assign_frequency_scale_factor))
+
+    def test_from_arc_level_import_module_singletons(self):
+        """``levels_ess`` and ``supported_ess`` are still accessible."""
+        from arc.level import levels_ess, supported_ess
+
+        self.assertIsNotNone(levels_ess)
+        self.assertIsNotNone(supported_ess)
+
+    def test_import_arc_level_as_module(self):
+        """``import arc.level`` succeeds (the side-effect import in arc/__init__.py).
+
+        Loaded via importlib so this test file's source contains only
+        ``from arc.level import …`` statements (CodeQL flags mixing both
+        styles in the same module).
+        """
+        module = importlib.import_module("arc.level")
+        self.assertTrue(hasattr(module, "Level"))
+        self.assertTrue(hasattr(module, "assign_frequency_scale_factor"))
+
+    def test_alias_import(self):
+        """``from arc.level import Level as Lvl`` keeps working (used in tests)."""
+        from arc.level import Level as Lvl
+
+        self.assertIs(Lvl.__name__, "Level")
+
+    def test_level_class_is_a_real_class(self):
+        """Sanity check: re-export is the actual class, not a re-binding."""
+        from arc.level import Level
+        from arc.level.level import Level as LevelDirect
+
+        self.assertIs(Level, LevelDirect)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/level.py
+++ b/arc/level/level.py
@@ -288,8 +288,11 @@ class Level(object):
                                      f'Got {arg} which is a {type(arg)} in {self.args}.')
             self.args = ' '.join([arg.lower() for arg in self.args])
         if isinstance(self.args, str):
-            self.args = {'keyword': {'general': args.lower()}, 'block': dict()}
-        elif self.args is not None and not isinstance(args, dict):
+            # Phase 5.5 fix: previously ``args.lower()`` (the local *dict*), which
+            # raised AttributeError. The intent is to lowercase the user-supplied
+            # string that was just assigned to self.args.
+            self.args = {'keyword': {'general': self.args.lower()}, 'block': dict()}
+        elif self.args is not None and not isinstance(self.args, dict):
             raise ValueError(f'The args argument must be either a string, an iterable or a dictionary.\n'
                              f'Got {self.args} which is a {type(self.args)}.')
 

--- a/arc/level/level.py
+++ b/arc/level/level.py
@@ -112,13 +112,43 @@ class Level(object):
             # it wasn't set by the user, try determining it
             self.deduce_software()
 
+    # Attributes that participate in structural equality. These are the user-
+    # provided / round-trippable fields; derived attributes (``method_type``,
+    # ``compatible_ess``) are intentionally excluded because they are computed
+    # from the others and would create false-negative equalities when only
+    # one of the operands has been resolved.
+    _EQ_ATTRS = (
+        'method', 'basis', 'auxiliary_basis', 'dispersion', 'cabs',
+        'software', 'software_version',
+        'solvation_method', 'solvent', 'solvation_scheme_level',
+        'args', 'year',
+    )
+
     def __eq__(self, other: Level) -> bool:
         """
-        Determine equality between Level object instances.
+        Determine structural equality between Level instances.
+
+        Compares every user-relevant attribute (method/basis/dispersion/cabs/
+        solvation/software/version/year/args) one-by-one rather than relying on
+        :meth:`__str__`, because ``__str__`` historically dropped ``args`` when
+        any ``args`` bucket (e.g. an empty ``block``) was falsy — which let two
+        protocols whose ``args.keyword`` differed (e.g. an all-electron
+        ``core,...`` directive vs the molpro frozen-core default) compare equal
+        and silently collapse into one sub-job at composite-spawn time.
         """
-        if isinstance(other, Level):
-            return str(self) == str(other)
-        return False
+        if not isinstance(other, Level):
+            return False
+        for attr in self._EQ_ATTRS:
+            if getattr(self, attr, None) != getattr(other, attr, None):
+                return False
+        return True
+
+    # ``__eq__`` without ``__hash__`` makes the class unhashable in Python.
+    # Level was already unhashable (no ``__hash__`` was previously defined),
+    # and nothing in the codebase uses Level as a dict key or set element, so
+    # we keep that contract — explicitly setting ``__hash__ = None`` documents
+    # the intent.
+    __hash__ = None
 
     def __str__(self) -> str:
         """
@@ -148,12 +178,13 @@ class Level(object):
             str_ += f', software: {self.software}'
             if self.software_version is not None:
                 str_ += f', software_version: {self.software_version}'
-        if self.args is not None and self.args and all([val for val in self.args.values()]):
-            if any([key == 'keyword' for key in self.args.keys()]):
-                str_ += ', keyword args:'
-                for key, arg in self.args.items():
-                    if key == 'keyword':
-                        str_ += f' {arg}'
+        # Emit ``args.keyword`` whenever it carries content, regardless of
+        # whether sibling buckets (e.g. ``args.block``) are empty. The previous
+        # ``all(values)`` guard hid keyword content (such as a frozen-core
+        # ``core,...`` directive) when ``block`` was an empty dict, which made
+        # two protocols comparing only on str() look identical.
+        if self.args and self.args.get('keyword'):
+            str_ += f", keyword args: {self.args['keyword']}"
         return str_
 
     def copy(self):
@@ -183,11 +214,20 @@ class Level(object):
         """
         Returns a minimal dictionary representation from which the object can be reconstructed.
         Useful for ARC restart files.
+
+        ``args`` is included whenever any of its buckets carries content.
+        Previously a falsy sibling bucket (e.g. an empty ``block``) caused the
+        whole ``args`` dict to be dropped from the serialised form — which lost
+        meaningful settings such as ``args.keyword.core,...`` and made
+        round-tripped Levels compare equal to ones that never had those args.
         """
         original_dict = self.__dict__
         clean_dict = {}
         for key, val in original_dict.items():
-            if val is not None and key != 'args' or key == 'args' and all([v for v in self.args.values()]):
+            if key == 'args':
+                if val and any(val.values()):
+                    clean_dict[key] = val
+            elif val is not None:
                 clean_dict[key] = val
         return clean_dict
 

--- a/arc/level/level.py
+++ b/arc/level/level.py
@@ -328,9 +328,8 @@ class Level(object):
                                      f'Got {arg} which is a {type(arg)} in {self.args}.')
             self.args = ' '.join([arg.lower() for arg in self.args])
         if isinstance(self.args, str):
-            # Phase 5.5 fix: previously ``args.lower()`` (the local *dict*), which
-            # raised AttributeError. The intent is to lowercase the user-supplied
-            # string that was just assigned to self.args.
+            # Lowercase the user-supplied string (``self.args``), not the local
+            # ``args`` dict — calling ``.lower()`` on the dict raised AttributeError.
             self.args = {'keyword': {'general': self.args.lower()}, 'block': dict()}
         elif self.args is not None and not isinstance(self.args, dict):
             raise ValueError(f'The args argument must be either a string, an iterable or a dictionary.\n'

--- a/arc/level/level_test.py
+++ b/arc/level/level_test.py
@@ -199,6 +199,21 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(assign_frequency_scale_factor(Level(method='CBS-QB3')), 1.004)
         self.assertEqual(assign_frequency_scale_factor(Level(method='PM6')), 1.093)
 
+    def test_level_accepts_string_args(self):
+        """Regression: Level.lower() used to crash on string `args` because the
+        code called ``.lower()`` on the local args dict instead of self.args."""
+        level = Level(method='B3LYP', basis='cc-pVTZ', args='EmpiricalDispersion=GD3')
+        self.assertIsInstance(level.args, dict)
+        self.assertEqual(level.args['keyword']['general'], 'empiricaldispersion=gd3')
+        self.assertEqual(level.args['block'], {})
+
+    def test_level_accepts_iterable_args(self):
+        """Iterable → space-joined string → dict path should also work."""
+        level = Level(method='B3LYP', basis='cc-pVTZ',
+                      args=['EmpiricalDispersion=GD3', 'Int=UltraFine'])
+        self.assertEqual(level.args['keyword']['general'],
+                         'empiricaldispersion=gd3 int=ultrafine')
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/level/level_test.py
+++ b/arc/level/level_test.py
@@ -204,6 +204,21 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(assign_frequency_scale_factor(Level(method='CBS-QB3')), 1.004)
         self.assertEqual(assign_frequency_scale_factor(Level(method='PM6')), 1.093)
 
+    def test_level_accepts_string_args(self):
+        """Regression: Level.lower() used to crash on string `args` because the
+        code called ``.lower()`` on the local args dict instead of self.args."""
+        level = Level(method='B3LYP', basis='cc-pVTZ', args='EmpiricalDispersion=GD3')
+        self.assertIsInstance(level.args, dict)
+        self.assertEqual(level.args['keyword']['general'], 'empiricaldispersion=gd3')
+        self.assertEqual(level.args['block'], {})
+
+    def test_level_accepts_iterable_args(self):
+        """Iterable → space-joined string → dict path should also work."""
+        level = Level(method='B3LYP', basis='cc-pVTZ',
+                      args=['EmpiricalDispersion=GD3', 'Int=UltraFine'])
+        self.assertEqual(level.args['keyword']['general'],
+                         'empiricaldispersion=gd3 int=ultrafine')
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/level/level_test.py
+++ b/arc/level/level_test.py
@@ -219,6 +219,72 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(level.args['keyword']['general'],
                          'empiricaldispersion=gd3 int=ultrafine')
 
+    # --- structural __eq__ + as_dict args fix (sp_composite Bug B) -------- #
+
+    def test_eq_distinguishes_args_keyword_differences(self):
+        """Two Levels identical in method+basis but differing only in
+        ``args.keyword`` must NOT compare equal.
+
+        Pre-fix: ``__eq__`` delegated to ``str(self)`` which dropped ``args``
+        whenever any sibling bucket was empty (``block: {}``). That let HEAT
+        protocol's δ_CV high (all-electron ``core,...``) and low (default
+        frozen-core) Levels collapse into one job at composite-spawn time —
+        silently producing δ_CV = 0.
+        """
+        ae_level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        fc_level = Level(method='ccsd(t)', basis='cc-pCVTZ')
+        self.assertNotEqual(ae_level, fc_level)
+
+    def test_eq_identical_levels_remain_equal(self):
+        """Sanity: the strict __eq__ doesn't make every Level construction unique."""
+        a = Level(method='wb97xd', basis='def2-TZVP')
+        b = Level(method='wb97xd', basis='def2-TZVP')
+        self.assertEqual(a, b)
+
+    def test_as_dict_includes_args_when_keyword_set_and_block_empty(self):
+        """as_dict() must serialise ``args`` whenever any bucket has content.
+
+        Pre-fix the ``all(values)`` guard skipped ``args`` when ``block`` was
+        empty, dropping the keyword half on round-trip.
+        """
+        level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        d = level.as_dict()
+        self.assertIn('args', d)
+        self.assertIn('keyword', d['args'])
+        self.assertEqual(d['args']['keyword']['core'], 'core,0,0,0,0,0,0,0,0;')
+
+    def test_as_dict_omits_args_when_all_buckets_empty(self):
+        """No content anywhere ⇒ args is omitted from the serialised form."""
+        level = Level(method='hf', basis='cc-pVTZ')
+        self.assertNotIn('args', level.as_dict())
+
+    def test_str_includes_keyword_when_block_empty(self):
+        """str(Level) used to drop ``keyword`` info when ``block`` was empty."""
+        level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        self.assertIn('keyword args:', str(level))
+        self.assertIn('core,0,0,0,0,0,0,0,0', str(level))
+
+    def test_level_is_unhashable(self):
+        """Custom __eq__ without a matching __hash__ ⇒ unhashable.
+        Locks the contract; nothing in the codebase puts Level into a set/dict-key.
+
+        We assert this via the ``__hash__`` class marker (Python's documented
+        mechanism for making instances unhashable) rather than by calling
+        ``hash()`` on an instance and expecting ``TypeError``. The behavioural
+        form trips CodeQL's ``py/hash-of-unhashable-value`` query — and that
+        query's pattern is *exactly* the contract under test, so suppressing
+        it via the dunder check is more direct than annotating around it."""
+        self.assertIsNone(Level.__hash__)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/level/level_test.py
+++ b/arc/level/level_test.py
@@ -221,6 +221,72 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(level.args['keyword']['general'],
                          'empiricaldispersion=gd3 int=ultrafine')
 
+    # --- structural __eq__ + as_dict args fix (sp_composite Bug B) -------- #
+
+    def test_eq_distinguishes_args_keyword_differences(self):
+        """Two Levels identical in method+basis but differing only in
+        ``args.keyword`` must NOT compare equal.
+
+        Pre-fix: ``__eq__`` delegated to ``str(self)`` which dropped ``args``
+        whenever any sibling bucket was empty (``block: {}``). That let HEAT
+        protocol's δ_CV high (all-electron ``core,...``) and low (default
+        frozen-core) Levels collapse into one job at composite-spawn time —
+        silently producing δ_CV = 0.
+        """
+        ae_level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        fc_level = Level(method='ccsd(t)', basis='cc-pCVTZ')
+        self.assertNotEqual(ae_level, fc_level)
+
+    def test_eq_identical_levels_remain_equal(self):
+        """Sanity: the strict __eq__ doesn't make every Level construction unique."""
+        a = Level(method='wb97xd', basis='def2-TZVP')
+        b = Level(method='wb97xd', basis='def2-TZVP')
+        self.assertEqual(a, b)
+
+    def test_as_dict_includes_args_when_keyword_set_and_block_empty(self):
+        """as_dict() must serialise ``args`` whenever any bucket has content.
+
+        Pre-fix the ``all(values)`` guard skipped ``args`` when ``block`` was
+        empty, dropping the keyword half on round-trip.
+        """
+        level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        d = level.as_dict()
+        self.assertIn('args', d)
+        self.assertIn('keyword', d['args'])
+        self.assertEqual(d['args']['keyword']['core'], 'core,0,0,0,0,0,0,0,0;')
+
+    def test_as_dict_omits_args_when_all_buckets_empty(self):
+        """No content anywhere ⇒ args is omitted from the serialised form."""
+        level = Level(method='hf', basis='cc-pVTZ')
+        self.assertNotIn('args', level.as_dict())
+
+    def test_str_includes_keyword_when_block_empty(self):
+        """str(Level) used to drop ``keyword`` info when ``block`` was empty."""
+        level = Level(
+            method='ccsd(t)', basis='cc-pCVTZ',
+            args={'keyword': {'core': 'core,0,0,0,0,0,0,0,0;'}, 'block': {}},
+        )
+        self.assertIn('keyword args:', str(level))
+        self.assertIn('core,0,0,0,0,0,0,0,0', str(level))
+
+    def test_level_is_unhashable(self):
+        """Custom __eq__ without a matching __hash__ ⇒ unhashable.
+        Locks the contract; nothing in the codebase puts Level into a set/dict-key.
+
+        We assert this via the ``__hash__`` class marker (Python's documented
+        mechanism for making instances unhashable) rather than by calling
+        ``hash()`` on an instance and expecting ``TypeError``. The behavioural
+        form trips CodeQL's ``py/hash-of-unhashable-value`` query — and that
+        query's pattern is *exactly* the contract under test, so suppressing
+        it via the dunder check is more direct than annotating around it."""
+        self.assertIsNone(Level.__hash__)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/level/level_test.py
+++ b/arc/level/level_test.py
@@ -206,6 +206,21 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(assign_frequency_scale_factor(Level(method='CBS-QB3')), 1.004)
         self.assertEqual(assign_frequency_scale_factor(Level(method='PM6')), 1.093)
 
+    def test_level_accepts_string_args(self):
+        """Regression: Level.lower() used to crash on string `args` because the
+        code called ``.lower()`` on the local args dict instead of self.args."""
+        level = Level(method='B3LYP', basis='cc-pVTZ', args='EmpiricalDispersion=GD3')
+        self.assertIsInstance(level.args, dict)
+        self.assertEqual(level.args['keyword']['general'], 'empiricaldispersion=gd3')
+        self.assertEqual(level.args['block'], {})
+
+    def test_level_accepts_iterable_args(self):
+        """Iterable → space-joined string → dict path should also work."""
+        level = Level(method='B3LYP', basis='cc-pVTZ',
+                      args=['EmpiricalDispersion=GD3', 'Int=UltraFine'])
+        self.assertEqual(level.args['keyword']['general'],
+                         'empiricaldispersion=gd3 int=ultrafine')
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/level/presets.py
+++ b/arc/level/presets.py
@@ -1,0 +1,206 @@
+"""
+``arc.level.presets`` — named composite-protocol presets shipped with ARC.
+
+Presets are loaded from the data file ``presets.yml`` located alongside this module.
+Each entry maps a preset name (e.g. ``"HEAT-345Q"``) to a recipe dict in the same
+shape that :meth:`arc.level.protocol.CompositeProtocol.from_user_input` accepts
+(``base:`` + ``corrections:`` + ``reference:``).
+
+The :func:`expand_preset` helper resolves a preset name (with optional per-term
+overrides) to a fresh, independent recipe dict suitable for handing to
+``CompositeProtocol.from_user_input``. Returned dicts are deep copies so that
+caller-side mutation cannot pollute the cached registry.
+
+References
+----------
+
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT.
+* East, Allen, *J. Chem. Phys.* **99**, 4638 (1993). DOI: 10.1063/1.466062 — focal-
+  point analysis methodology.
+"""
+
+import copy
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import yaml
+
+from arc.exceptions import InputError
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PRESETS_PATH = os.path.join(_HERE, "presets.yml")
+
+
+def _load_presets(path: str) -> dict[str, dict[str, Any]]:
+    """Load ``presets.yml`` once; return the parsed mapping."""
+    with open(path, "r") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise InputError(f"Preset file {path} must parse to a mapping, got {type(data).__name__}.")
+    return data
+
+
+# Module-level cache. Loaded once at import time; a single source of truth.
+PRESETS: dict[str, dict[str, Any]] = _load_presets(_PRESETS_PATH)
+REGISTERED_PRESET_NAMES: list[str] = sorted(PRESETS.keys())
+
+
+# Fields that may appear on a preset term by its ``type`` discriminator.
+# Used to reject typos in preset overrides (e.g. ``delta_T.hihg``). The key
+# ``"base"`` is not a term type — it's the protocol's base level dict, for
+# which we accept any Level-level keyword plus ``label``.
+_ALLOWED_OVERRIDE_FIELDS_BY_TYPE: dict[str, set] = {
+    "single_point": {"label", "type", "level"},
+    "delta": {"label", "type", "high", "low"},
+    "cbs_extrapolation": {"label", "type", "formula", "components", "levels"},
+}
+
+# Level dict keys — accepted on the ``base`` target and on any ``high``/``low``/
+# ``level`` sub-dict the user is replacing wholesale. Kept in sync with
+# ``Level.__init__`` parameters (see ``arc/level/level.py``).
+_ALLOWED_LEVEL_FIELDS = {
+    "repr", "method", "basis", "auxiliary_basis", "dispersion", "cabs",
+    "method_type", "software", "software_version", "compatible_ess",
+    "solvation_method", "solvent", "solvation_scheme_level", "args", "year",
+    # Also valid in the base-of-a-preset context (YAML shorthand):
+    "label", "type", "level",
+}
+
+
+def _deep_merge_level_dict(target: dict[str, Any], patch: dict[str, Any]) -> None:
+    """Shallow-merge ``patch`` into ``target`` with one level of nesting for
+    ``high``/``low``/``level`` — replacing fields of the inner dict rather than
+    the whole dict. Mutates ``target`` in place.
+
+    Rationale: overriding ``delta_T: {high: {basis: cc-pVTZ}}`` on a preset
+    where ``high`` was ``{method: ccsdt, basis: cc-pVDZ}`` should produce
+    ``{method: ccsdt, basis: cc-pVTZ}`` — not discard the method. Only the
+    nested Level dicts (high/low/level) get this treatment; scalar or
+    list-valued fields (formula, levels) still replace wholesale.
+    """
+    for key, new_val in patch.items():
+        existing = target.get(key)
+        if (
+            key in {"high", "low", "level", "base"}
+            and isinstance(existing, dict)
+            and isinstance(new_val, dict)
+        ):
+            merged = dict(existing)
+            merged.update(new_val)
+            target[key] = merged
+        else:
+            target[key] = new_val
+
+
+def _validate_override_fields(term_or_base: dict[str, Any],
+                              patch: dict[str, Any],
+                              target_name: str) -> None:
+    """Reject typos in override patch keys.
+
+    For a correction term, patch keys must match the term's ``type``-specific
+    allowed fields. For ``base``, patch keys must be valid Level-dict keys
+    (plus the usual level-dict extensions).
+    """
+    if target_name == "base":
+        allowed = _ALLOWED_LEVEL_FIELDS
+    else:
+        term_type = term_or_base.get("type")
+        allowed = _ALLOWED_OVERRIDE_FIELDS_BY_TYPE.get(term_type)
+        if allowed is None:
+            raise InputError(
+                f"Cannot validate override for term '{target_name}': its type "
+                f"'{term_type}' is not one of "
+                f"{sorted(_ALLOWED_OVERRIDE_FIELDS_BY_TYPE)}."
+            )
+    unknown = set(patch.keys()) - allowed
+    if unknown:
+        raise InputError(
+            f"Override for '{target_name}' has unknown field(s) "
+            f"{sorted(unknown)}. Allowed for this target: {sorted(allowed)}."
+        )
+
+
+def _apply_overrides(
+    recipe: dict[str, Any],
+    overrides: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge per-term ``overrides`` into a recipe and return the result.
+
+    ``overrides`` is a mapping ``{term_label: {field_name: new_value}}``. The
+    special key ``"base"`` targets the protocol's base level rather than a
+    correction.
+
+    * **Unknown term labels** raise :class:`InputError` so a typo can't silently no-op.
+    * **Unknown fields within a known term** also raise :class:`InputError` —
+      see ``_validate_override_fields``.
+    * Nested Level dicts (``high`` / ``low`` / ``level`` / ``base``) are
+      **deep-merged** when both old and new values are dicts: overriding
+      ``{high: {basis: cc-pVTZ}}`` preserves the existing ``method``. Other
+      fields (``formula``, ``levels``, scalar values) replace wholesale.
+    """
+    if not overrides:
+        return recipe
+
+    correction_labels = {c["label"] for c in recipe.get("corrections", [])}
+    valid_targets = correction_labels | {"base"}
+
+    for target, patch in overrides.items():
+        if target not in valid_targets:
+            raise InputError(
+                f"Override target '{target}' is not a known term in this preset. "
+                f"Valid targets: {sorted(valid_targets)}."
+            )
+        if not isinstance(patch, dict):
+            raise InputError(
+                f"Override for '{target}' must be a dict; got {type(patch).__name__}."
+            )
+        if target == "base":
+            _validate_override_fields(recipe.get("base") or {}, patch, target)
+            base = recipe["base"]
+            if isinstance(base, dict):
+                _deep_merge_level_dict(base, patch)
+            else:
+                # Base was a string shorthand; replace wholesale with the patch dict.
+                recipe["base"] = dict(patch)
+        else:
+            term = next(c for c in recipe["corrections"] if c["label"] == target)
+            _validate_override_fields(term, patch, target)
+            _deep_merge_level_dict(term, patch)
+    return recipe
+
+
+def expand_preset(
+    name: str,
+    overrides: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve a preset name (with optional overrides) to an independent recipe dict.
+
+    Parameters
+    ----------
+    name : str
+        One of the keys in :data:`PRESETS`. Lookup is case-sensitive.
+    overrides : Mapping[str, Any], optional
+        Mapping of term label → field patch. See :func:`_apply_overrides`.
+
+    Returns
+    -------
+    dict
+        A deep-copied recipe dict in the explicit form
+        (``{base: ..., corrections: [...]}``) ready to be handed to
+        :meth:`arc.level.protocol.CompositeProtocol.from_user_input`.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``name`` is unknown or the overrides target a non-existent term.
+    """
+    if name not in PRESETS:
+        raise InputError(
+            f"Unknown sp_composite preset '{name}'. "
+            f"Available presets: {REGISTERED_PRESET_NAMES}."
+        )
+    recipe = copy.deepcopy(PRESETS[name])
+    return _apply_overrides(recipe, overrides or {})

--- a/arc/level/presets.py
+++ b/arc/level/presets.py
@@ -1,0 +1,205 @@
+"""
+``arc.level.presets`` — named composite-protocol presets shipped with ARC.
+
+Presets are loaded from the data file ``presets.yml`` located alongside this module.
+Each entry maps a preset name (e.g. ``"HEAT-345Q"``) to a recipe dict in the same
+shape that :meth:`arc.level.protocol.CompositeProtocol.from_user_input` accepts
+(``base:`` + ``corrections:`` + ``reference:``).
+
+The :func:`expand_preset` helper resolves a preset name (with optional per-term
+overrides) to a fresh, independent recipe dict suitable for handing to
+``CompositeProtocol.from_user_input``. Returned dicts are deep copies so that
+caller-side mutation cannot pollute the cached registry.
+
+References
+----------
+
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1804498 — HEAT.
+* East, Allen, *J. Chem. Phys.* **99**, 4638 (1993). DOI: 10.1063/1.466062 — focal-
+  point analysis methodology.
+"""
+
+import copy
+import os
+from typing import Any, Dict, List, Mapping, Optional
+
+import yaml
+
+from arc.exceptions import InputError
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PRESETS_PATH = os.path.join(_HERE, "presets.yml")
+
+
+def _load_presets(path: str) -> Dict[str, Dict[str, Any]]:
+    """Load ``presets.yml`` once; return the parsed mapping."""
+    with open(path, "r") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise InputError(f"Preset file {path} must parse to a mapping, got {type(data).__name__}.")
+    return data
+
+
+# Module-level cache. Loaded once at import time; a single source of truth.
+PRESETS: Dict[str, Dict[str, Any]] = _load_presets(_PRESETS_PATH)
+REGISTERED_PRESET_NAMES: List[str] = sorted(PRESETS.keys())
+
+
+# Fields that may appear on a preset term by its ``type`` discriminator.
+# Used to reject typos in preset overrides (e.g. ``delta_T.hihg``). The key
+# ``"base"`` is not a term type — it's the protocol's base level dict, for
+# which we accept any Level-level keyword plus ``label``.
+_ALLOWED_OVERRIDE_FIELDS_BY_TYPE: Dict[str, set] = {
+    "single_point": {"label", "type", "level"},
+    "delta": {"label", "type", "high", "low"},
+    "cbs_extrapolation": {"label", "type", "formula", "components", "levels"},
+}
+
+# Level dict keys — accepted on the ``base`` target and on any ``high``/``low``/
+# ``level`` sub-dict the user is replacing wholesale. Kept in sync with
+# ``Level.__init__`` parameters (see ``arc/level/level.py``).
+_ALLOWED_LEVEL_FIELDS = {
+    "repr", "method", "basis", "auxiliary_basis", "dispersion", "cabs",
+    "method_type", "software", "software_version", "compatible_ess",
+    "solvation_method", "solvent", "solvation_scheme_level", "args", "year",
+    # Also valid in the base-of-a-preset context (YAML shorthand):
+    "label", "type", "level",
+}
+
+
+def _deep_merge_level_dict(target: Dict[str, Any], patch: Dict[str, Any]) -> None:
+    """Shallow-merge ``patch`` into ``target`` with one level of nesting for
+    ``high``/``low``/``level`` — replacing fields of the inner dict rather than
+    the whole dict. Mutates ``target`` in place.
+
+    Rationale: overriding ``delta_T: {high: {basis: cc-pVTZ}}`` on a preset
+    where ``high`` was ``{method: ccsdt, basis: cc-pVDZ}`` should produce
+    ``{method: ccsdt, basis: cc-pVTZ}`` — not discard the method. Only the
+    nested Level dicts (high/low/level) get this treatment; scalar or
+    list-valued fields (formula, levels) still replace wholesale.
+    """
+    for key, new_val in patch.items():
+        existing = target.get(key)
+        if (
+            key in {"high", "low", "level", "base"}
+            and isinstance(existing, dict)
+            and isinstance(new_val, dict)
+        ):
+            merged = dict(existing)
+            merged.update(new_val)
+            target[key] = merged
+        else:
+            target[key] = new_val
+
+
+def _validate_override_fields(term_or_base: Dict[str, Any],
+                              patch: Dict[str, Any],
+                              target_name: str) -> None:
+    """Reject typos in override patch keys.
+
+    For a correction term, patch keys must match the term's ``type``-specific
+    allowed fields. For ``base``, patch keys must be valid Level-dict keys
+    (plus the usual level-dict extensions).
+    """
+    if target_name == "base":
+        allowed = _ALLOWED_LEVEL_FIELDS
+    else:
+        term_type = term_or_base.get("type")
+        allowed = _ALLOWED_OVERRIDE_FIELDS_BY_TYPE.get(term_type)
+        if allowed is None:
+            raise InputError(
+                f"Cannot validate override for term '{target_name}': its type "
+                f"'{term_type}' is not one of "
+                f"{sorted(_ALLOWED_OVERRIDE_FIELDS_BY_TYPE)}."
+            )
+    unknown = set(patch.keys()) - allowed
+    if unknown:
+        raise InputError(
+            f"Override for '{target_name}' has unknown field(s) "
+            f"{sorted(unknown)}. Allowed for this target: {sorted(allowed)}."
+        )
+
+
+def _apply_overrides(
+    recipe: Dict[str, Any],
+    overrides: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Merge per-term ``overrides`` into a recipe and return the result.
+
+    ``overrides`` is a mapping ``{term_label: {field_name: new_value}}``. The
+    special key ``"base"`` targets the protocol's base level rather than a
+    correction.
+
+    * **Unknown term labels** raise :class:`InputError` so a typo can't silently no-op.
+    * **Unknown fields within a known term** also raise :class:`InputError` —
+      see ``_validate_override_fields``.
+    * Nested Level dicts (``high`` / ``low`` / ``level`` / ``base``) are
+      **deep-merged** when both old and new values are dicts: overriding
+      ``{high: {basis: cc-pVTZ}}`` preserves the existing ``method``. Other
+      fields (``formula``, ``levels``, scalar values) replace wholesale.
+    """
+    if not overrides:
+        return recipe
+
+    correction_labels = {c["label"] for c in recipe.get("corrections", [])}
+    valid_targets = correction_labels | {"base"}
+
+    for target, patch in overrides.items():
+        if target not in valid_targets:
+            raise InputError(
+                f"Override target '{target}' is not a known term in this preset. "
+                f"Valid targets: {sorted(valid_targets)}."
+            )
+        if not isinstance(patch, dict):
+            raise InputError(
+                f"Override for '{target}' must be a dict; got {type(patch).__name__}."
+            )
+        if target == "base":
+            _validate_override_fields(recipe.get("base") or {}, patch, target)
+            base = recipe["base"]
+            if isinstance(base, dict):
+                _deep_merge_level_dict(base, patch)
+            else:
+                # Base was a string shorthand; replace wholesale with the patch dict.
+                recipe["base"] = dict(patch)
+        else:
+            term = next(c for c in recipe["corrections"] if c["label"] == target)
+            _validate_override_fields(term, patch, target)
+            _deep_merge_level_dict(term, patch)
+    return recipe
+
+
+def expand_preset(
+    name: str,
+    overrides: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Resolve a preset name (with optional overrides) to an independent recipe dict.
+
+    Parameters
+    ----------
+    name : str
+        One of the keys in :data:`PRESETS`. Lookup is case-sensitive.
+    overrides : Mapping[str, Any], optional
+        Mapping of term label → field patch. See :func:`_apply_overrides`.
+
+    Returns
+    -------
+    dict
+        A deep-copied recipe dict in the explicit form
+        (``{base: ..., corrections: [...]}``) ready to be handed to
+        :meth:`arc.level.protocol.CompositeProtocol.from_user_input`.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``name`` is unknown or the overrides target a non-existent term.
+    """
+    if name not in PRESETS:
+        raise InputError(
+            f"Unknown sp_composite preset '{name}'. "
+            f"Available presets: {REGISTERED_PRESET_NAMES}."
+        )
+    recipe = copy.deepcopy(PRESETS[name])
+    return _apply_overrides(recipe, overrides or {})

--- a/arc/level/presets.py
+++ b/arc/level/presets.py
@@ -11,8 +11,7 @@ overrides) to a fresh, independent recipe dict suitable for handing to
 ``CompositeProtocol.from_user_input``. Returned dicts are deep copies so that
 caller-side mutation cannot pollute the cached registry.
 
-References
-----------
+References:
 
 * Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
   *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT.
@@ -25,8 +24,7 @@ import os
 from collections.abc import Mapping
 from typing import Any
 
-import yaml
-
+from arc.common import read_yaml_file
 from arc.exceptions import InputError
 
 
@@ -35,9 +33,19 @@ _PRESETS_PATH = os.path.join(_HERE, "presets.yml")
 
 
 def _load_presets(path: str) -> dict[str, dict[str, Any]]:
-    """Load ``presets.yml`` once; return the parsed mapping."""
-    with open(path, "r") as fh:
-        data = yaml.safe_load(fh) or {}
+    """
+    Load ``presets.yml`` once; return the parsed mapping.
+
+    Args:
+        path (str): Path to the presets YAML file.
+
+    Returns:
+        dict[str, dict[str, Any]]: Preset name → recipe dict.
+
+    Raises:
+        InputError: If the file is missing or does not parse to a mapping.
+    """
+    data = read_yaml_file(path) or {}
     if not isinstance(data, dict):
         raise InputError(f"Preset file {path} must parse to a mapping, got {type(data).__name__}.")
     return data
@@ -71,7 +79,8 @@ _ALLOWED_LEVEL_FIELDS = {
 
 
 def _deep_merge_level_dict(target: dict[str, Any], patch: dict[str, Any]) -> None:
-    """Shallow-merge ``patch`` into ``target`` with one level of nesting for
+    """
+    Shallow-merge ``patch`` into ``target`` with one level of nesting for
     ``high``/``low``/``level`` — replacing fields of the inner dict rather than
     the whole dict. Mutates ``target`` in place.
 
@@ -80,6 +89,10 @@ def _deep_merge_level_dict(target: dict[str, Any], patch: dict[str, Any]) -> Non
     ``{method: ccsdt, basis: cc-pVTZ}`` — not discard the method. Only the
     nested Level dicts (high/low/level) get this treatment; scalar or
     list-valued fields (formula, levels) still replace wholesale.
+
+    Args:
+        target (dict[str, Any]): The term or base dict to mutate.
+        patch (dict[str, Any]): Field patch to merge in.
     """
     for key, new_val in patch.items():
         existing = target.get(key)
@@ -98,13 +111,26 @@ def _deep_merge_level_dict(target: dict[str, Any], patch: dict[str, Any]) -> Non
 def _validate_override_fields(term_or_base: dict[str, Any],
                               patch: dict[str, Any],
                               target_name: str) -> None:
-    """Reject typos in override patch keys.
+    """
+    Reject typos in override patch keys.
 
     For a correction term, patch keys must match the term's ``type``-specific
     allowed fields. For ``base``, patch keys must be valid Level-dict keys
-    (plus the usual level-dict extensions).
+    (plus the usual level-dict extensions) — unless the base dict carries a
+    ``type`` discriminator (e.g. a CBS-as-base term), in which case the patch
+    is validated against that term type's allowed fields.
+
+    Args:
+        term_or_base (dict[str, Any]): The targeted term dict (or base dict).
+        patch (dict[str, Any]): The override patch being applied.
+        target_name (str): The override target label (term label or ``"base"``).
+
+    Raises:
+        InputError: If the patch carries unknown fields, or the term's type
+            cannot be validated.
     """
-    if target_name == "base":
+    is_typed_term = isinstance(term_or_base, dict) and "type" in term_or_base
+    if target_name == "base" and not is_typed_term:
         allowed = _ALLOWED_LEVEL_FIELDS
     else:
         term_type = term_or_base.get("type")
@@ -127,7 +153,8 @@ def _apply_overrides(
     recipe: dict[str, Any],
     overrides: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Merge per-term ``overrides`` into a recipe and return the result.
+    """
+    Merge per-term ``overrides`` into a recipe and return the result.
 
     ``overrides`` is a mapping ``{term_label: {field_name: new_value}}``. The
     special key ``"base"`` targets the protocol's base level rather than a
@@ -140,6 +167,16 @@ def _apply_overrides(
       **deep-merged** when both old and new values are dicts: overriding
       ``{high: {basis: cc-pVTZ}}`` preserves the existing ``method``. Other
       fields (``formula``, ``levels``, scalar values) replace wholesale.
+
+    Args:
+        recipe (dict[str, Any]): The recipe dict to merge into (mutated in place).
+        overrides (Mapping[str, Any]): Mapping of term label → field patch.
+
+    Returns:
+        dict[str, Any]: The merged recipe (same object as ``recipe``).
+
+    Raises:
+        InputError: On unknown targets, non-dict patches, or unknown fields.
     """
     if not overrides:
         return recipe
@@ -176,26 +213,22 @@ def expand_preset(
     name: str,
     overrides: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Resolve a preset name (with optional overrides) to an independent recipe dict.
+    """
+    Resolve a preset name (with optional overrides) to an independent recipe dict.
 
-    Parameters
-    ----------
-    name : str
-        One of the keys in :data:`PRESETS`. Lookup is case-sensitive.
-    overrides : Mapping[str, Any], optional
-        Mapping of term label → field patch. See :func:`_apply_overrides`.
+    Args:
+        name (str): One of the keys in :data:`PRESETS`. Lookup is case-sensitive.
+        overrides (Mapping[str, Any], optional): Mapping of term label → field
+            patch. See :func:`_apply_overrides`.
 
-    Returns
-    -------
-    dict
-        A deep-copied recipe dict in the explicit form
+    Returns:
+        dict: A deep-copied recipe dict in the explicit form
         (``{base: ..., corrections: [...]}``) ready to be handed to
         :meth:`arc.level.protocol.CompositeProtocol.from_user_input`.
 
-    Raises
-    ------
-    arc.exceptions.InputError
-        If ``name`` is unknown or the overrides target a non-existent term.
+    Raises:
+        InputError: If ``name`` is unknown or the overrides target a
+            non-existent term.
     """
     if name not in PRESETS:
         raise InputError(

--- a/arc/level/presets.yml
+++ b/arc/level/presets.yml
@@ -1,0 +1,377 @@
+# sp_composite presets shipped with ARC.
+#
+# Each entry defines a CompositeProtocol that ARC can instantiate via
+# `sp_composite: <preset_name>` in the project YAML. The shape of each entry
+# matches the explicit form accepted by CompositeProtocol.from_user_input:
+#   - base:        a level (string "method/basis" or dict)
+#   - corrections: a list of term dicts (each with type / label / level fields)
+#   - reference:   a free-text citation including a DOI, surfaced in logs,
+#                  notebook provenance headers, and validated by the test suite.
+#
+# Notes on the recipes themselves:
+#
+# These presets are *adapted for ARC use* — the canonical Tajti-et-al HEAT
+# protocol was designed for atomization energies of small molecules, with the
+# HF energy itself CBS-extrapolated to the basis-set limit. ARC's
+# CompositeProtocol pins the absolute base to a single SinglePointTerm, so
+# the recipes below pick a sensible high-quality "anchor" SP (CCSD(T)-F12 in
+# the cc-pVTZ-F12 basis) and apply the post-(T) and other corrections on top.
+# This matches the typical focal-point workflow when refining TS barriers
+# (see e.g. Nguyen, Stanton, Barker for CHO2 PES).
+#
+# ESS-specific syntax used below
+# ------------------------------
+# The δ_CV (core-valence) and δ_rel (scalar-relativistic, DKH2) corrections
+# require ESS-specific keywords to be injected into the SP input. Native ARC
+# presets target Molpro syntax via ``args.keyword``:
+#
+#   * δ_CV "high" leg = all-electron correlation:
+#       ``args.keyword.core: 'core,0,0,0,0,0,0,0,0;'``
+#     places ``core,0,0,0,0,0,0,0,0;`` between the basis declaration and the
+#     ``int;`` directive in the Molpro template, setting the global frozen-core
+#     specification to zero in every irreducible representation. Trailing zeros
+#     are harmless for lower-symmetry point groups (Molpro reads only the
+#     irreps that exist).
+#
+#   * δ_CV "low" leg = Molpro's default frozen-core (no extra args). For
+#     first-row elements this freezes 1s; for second-row 1s2s2p.
+#
+#   * δ_rel "high" leg = DKH2 scalar-relativistic on the cc-pVTZ-DK
+#     recontracted basis:
+#       ``args.keyword.dkho: 'SET,DKHO=2;'``
+#     The Molpro manual (https://www.molpro.net/manual/doku.php?id=relativistic_corrections)
+#     explicitly recommends ``SET,DKHO=n`` over the legacy ``DKROLL`` form
+#     ("In order to avoid confusion, it is recommended only to use DKHO and
+#     never set DKROLL"). The directive is placed before ``int;`` so the
+#     integrals are evaluated with the DK-transformed Hamiltonian. The
+#     ``cc-pVTZ-DK`` recontracted basis is required — without ``SET,DKHO=2``
+#     Molpro uses the standard non-relativistic Hamiltonian on it.
+#
+#   * δ_rel "low" leg = vanilla CCSD(T)/cc-pVTZ.
+#
+# Other ESSes (CFOUR/Orca) have different syntax for these corrections; the
+# presets below will write the wrong directives if pointed at a non-Molpro
+# adapter for the δ_CV/δ_rel SPs. Until a per-ESS preset family lands, users
+# running through CFOUR/Orca should either supply an explicit recipe or use
+# the ``HEAT-345_noC`` / ``HEAT-345Q_noC`` variants below, which omit the
+# δ_CV term (the most ESS-syntax-sensitive one).
+
+HEAT-345:
+  reference: "Inspired by Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1811608. Adapted for use as a TS barrier refinement protocol within ARC. The δ_CV and δ_rel terms below assume a Molpro adapter (see preset comment header for ESS-specific syntax)."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      # All-electron CCSD(T)/cc-pCVTZ via Molpro's ``core,0,...`` directive.
+      high: {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      # Frozen-core CCSD(T)/cc-pCVTZ — Molpro's default, no extra args.
+      low:  {method: ccsd(t),  basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      # DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK via Molpro's ``dkroll=2`` directive.
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      # Non-relativistic CCSD(T)/cc-pVTZ.
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+HEAT-345Q:
+  reference: "Inspired by the HEAT-345(Q) protocol used by Nguyen, Stanton, Barker for the CHO2 PES (citing Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1811608). Adds a perturbative δ[CCSDT(Q)] term on top of HEAT-345. The δ_CV and δ_rel terms below assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+# "_noC" variants drop the core-valence (δ_CV) correction but keep everything
+# else. Use these when you cannot run an all-electron CCSD(T)/cc-pCVTZ pair
+# (e.g. when targeting an ESS other than Molpro and you don't have CFOUR/Orca
+# core-valence syntax wired up). These variants are NOT silently equivalent
+# to HEAT-345 / HEAT-345Q — the missing δ_CV is acknowledged in the name and
+# in the reference string so users can cite the protocol honestly.
+
+HEAT-345_noC:
+  reference: "Inspired by Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1811608. Adapted for ARC, with the δ_CV (core-valence) correction OMITTED — see preset name. Suitable when the ESS lacks a clean all-electron syntax or when the core-valence contribution is known to be negligible (e.g. first-row systems where δ_CV is typically < 0.5 kJ/mol)."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+HEAT-345Q_noC:
+  reference: "Inspired by HEAT-345(Q) (Nguyen/Stanton/Barker for CHO2; Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1811608) with the δ_CV (core-valence) correction OMITTED — see preset name. Use when ESS-specific all-electron syntax is unavailable; cite as 'HEAT-345Q_noC' to make the omission explicit rather than as 'HEAT-345Q'."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+# HEAT-345QP extends HEAT-345Q with full quadruples (CCSDTQ) and perturbative
+# pentuples (CCSDTQ(P)) corrections. The δ_QQ and δ_P legs route through the
+# MRCC interface — modern Molpro builds with the MRCC interface linked in
+# accept ``ccsdtq`` and ``ccsdtq(p)`` directly (the same path used today for
+# ``ccsdt`` and ``ccsdt(q)`` in HEAT-345Q). CFOUR-NCC is an alternative back
+# end. A plain Molpro install without MRCC will not run these sub-jobs.
+HEAT-345QP:
+  reference: "Extension of HEAT-345Q (Bomble, Vázquez, Kállay, Michauk, Szalay, Császár, Gauss, Stanton, J. Chem. Phys. 125, 064108 (2006); DOI: 10.1063/1.2206789) with full-quadruples and perturbative-pentuples post-(T) corrections. The δ_QQ (CCSDTQ) and δ_P (CCSDTQ(P)) legs require an ESS that exposes those methods — Molpro built with the MRCC interface, or CFOUR-NCC. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,     basis: cc-pVDZ}
+      low:  {method: ccsd(t),   basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q),  basis: cc-pVDZ}
+      low:  {method: ccsdt,     basis: cc-pVDZ}
+    - label: delta_QQ
+      type: delta
+      high: {method: ccsdtq,    basis: cc-pVDZ}
+      low:  {method: ccsdt(q),  basis: cc-pVDZ}
+    - label: delta_P
+      type: delta
+      high: {method: ccsdtq(p), basis: cc-pVDZ}
+      low:  {method: ccsdtq,    basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t),   basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t),   basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),   basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t),   basis: cc-pVTZ}
+
+# HEAT-456Q has the same correction structure as HEAT-345Q but a tighter HF/
+# CCSD(T) CBS reference (cardinals {Q,5,6} rather than {T,Q,5}). ARC's
+# CompositeProtocol pins the absolute base to a single SinglePointTerm, so
+# this adaptation tightens the anchor by promoting the F12 base from
+# cc-pVTZ-F12 to cc-pVQZ-F12 (effectively near-CBS quality at QZ-5Z-6Z).
+HEAT-456Q:
+  reference: "Inspired by HEAT-456Q (Bomble, Vázquez, Kállay, Michauk, Szalay, Császár, Gauss, Stanton, J. Chem. Phys. 125, 064108 (2006); DOI: 10.1063/1.2206789). Same correction structure as HEAT-345Q with a tighter base — ARC adaptation pins the anchor to CCSD(T)-F12/cc-pVQZ-F12 to mirror the {Q,5,6}-cardinal HF/CCSD(T) extrapolation. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVQZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+FPA-min:
+  reference: "Minimal Allen / East / Császár focal-point analysis recipe; review: East, Allen, J. Chem. Phys. 99, 4638 (1993); DOI: 10.1063/1.466062."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: cbs_corr
+      type: cbs_extrapolation
+      formula: helgaker_corr_2pt
+      # components currently must be "total"; adapter-level correlation-only
+      # parsing is a future addition. The formula name (`helgaker_corr_2pt`)
+      # still documents intent for the user.
+      components: total
+      levels:
+        - {method: ccsd(t), basis: cc-pVTZ}
+        - {method: ccsd(t), basis: cc-pVQZ}
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,   basis: cc-pVDZ}
+      low:  {method: ccsd(t), basis: cc-pVDZ}
+
+# ----------------------------------------------------------------------- #
+# Weizmann-n (W2, W3, W4) family — Karton/Martin and predecessors.
+#
+# The canonical W*n* protocols build their absolute energy from a stack of
+# basis-set CBS extrapolations (HF, CCSD, (T) at progressively smaller
+# basis) plus δ-corrections. ARC's CompositeProtocol pins the absolute
+# base to a single SinglePointTerm, so the recipes below pick a high-
+# quality CCSD(T) or CCSD(T)-F12 anchor and apply the canonical post-(T)
+# / δ_CV / δ_rel corrections on top. The original W*n* basis-cardinal
+# extrapolations of the (T) component are absorbed into the anchor —
+# this is faithful to the W*n* spirit (stacked corrections beyond
+# CCSD(T)/CBS) but not byte-identical to the published prescription.
+# Cite as 'W2 (ARC adaptation)' etc. to acknowledge the difference.
+#
+# As with the HEAT family, δ_CV and δ_rel use Molpro-specific
+# ``args.keyword`` directives (see the file header for syntax notes).
+# ----------------------------------------------------------------------- #
+
+W2:
+  reference: "Inspired by W2 (Martin, de Oliveira, J. Chem. Phys. 111, 1843 (1999); DOI: 10.1063/1.479454). ARC adaptation pins the anchor to CCSD(T)/aug-cc-pVQZ and applies the canonical δ_CV (core-valence) and δ_rel (DKH2 scalar-relativistic) corrections; the original W2 HF/CCSD/(T) basis-cardinal CBS extrapolations are absorbed into the anchor (single-anchor model). δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)
+    basis: aug-cc-pVQZ
+  corrections:
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+W2-F12:
+  reference: "Inspired by W2-F12 (Karton, Martin, J. Chem. Phys. 136, 124114 (2012); DOI: 10.1063/1.3697678). F12-accelerated W2; ARC adaptation pins the anchor to CCSD(T)-F12/cc-pVQZ-F12 (near-CBS quality from a single SP) and applies the canonical δ_CV and δ_rel corrections. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVQZ-f12
+  corrections:
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+W3:
+  reference: "Inspired by W3 (Boese, Oren, Atasoylu, Martin, Kállay, Gauss, J. Chem. Phys. 120, 4129 (2004); DOI: 10.1063/1.1638736). Adds a δ[CCSDT] post-(T) correction on top of W2. ARC adaptation pins the anchor to CCSD(T)/aug-cc-pVQZ. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)
+    basis: aug-cc-pVQZ
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+W3-F12:
+  reference: "ARC-defined extension of the W*n*-F12 family by analogy: 'W3 = W2 + δ[CCSDT]' (Boese et al., J. Chem. Phys. 120, 4129 (2004); DOI: 10.1063/1.1638736) applied to the F12 anchor introduced in W2-F12 (Karton, Martin, J. Chem. Phys. 136, 124114 (2012); DOI: 10.1063/1.3697678). There is no canonical primary publication titled 'W3-F12'; cite as 'W3-F12 (ARC adaptation)'. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVQZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+# W4 and W4-F12 add δ[CCSDT(Q)] and δ[CCSDTQ] (full quadruples) on top of
+# the W3 stack. The δ_QQ leg routes through the MRCC interface — modern
+# Molpro builds with MRCC linked in accept ``ccsdtq`` directly (same path
+# already used for ``ccsdt`` / ``ccsdt(q)`` in W3 / HEAT-345Q). CFOUR-NCC
+# is the alternative back end. A plain Molpro install without MRCC cannot
+# run these sub-jobs. Cite as 'W4 (ARC adaptation)' etc.
+
+W4:
+  reference: "Inspired by W4 (Karton, Rabinovich, Martin, Ruscic, J. Chem. Phys. 125, 144108 (2006); DOI: 10.1063/1.2348881). Adds δ[CCSDT(Q)] and δ[CCSDTQ] on top of W3. The δ_QQ (CCSDTQ) leg requires an ESS that exposes the method — Molpro built with the MRCC interface, or CFOUR-NCC. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)
+    basis: aug-cc-pVQZ
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_QQ
+      type: delta
+      high: {method: ccsdtq,   basis: cc-pVDZ}
+      low:  {method: ccsdt(q), basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+W4-F12:
+  reference: "Inspired by W4-F12 (Sylvetsky, Peterson, Karton, Martin, J. Chem. Phys. 144, 214101 (2016); DOI: 10.1063/1.4952410, 'Toward a W4-F12 approach: Can explicitly correlated and orbital-based ab initio CCSD(T) limits be reconciled?'). F12-accelerated W4. The δ_QQ (CCSDTQ) leg requires an ESS that exposes the method — Molpro built with the MRCC interface, or CFOUR-NCC. δ_CV and δ_rel assume a Molpro adapter."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVQZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_QQ
+      type: delta
+      high: {method: ccsdtq,   basis: cc-pVDZ}
+      low:  {method: ccsdt(q), basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t), basis: cc-pCVTZ, args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pCVTZ}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t), basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+      low:  {method: ccsd(t), basis: cc-pVTZ}

--- a/arc/level/presets.yml
+++ b/arc/level/presets.yml
@@ -1,0 +1,83 @@
+# sp_composite presets shipped with ARC.
+#
+# Each entry defines a CompositeProtocol that ARC can instantiate via
+# `sp_composite: <preset_name>` in the project YAML. The shape of each entry
+# matches the explicit form accepted by CompositeProtocol.from_user_input:
+#   - base:        a level (string "method/basis" or dict)
+#   - corrections: a list of term dicts (each with type / label / level fields)
+#   - reference:   a free-text citation including a DOI, surfaced in logs,
+#                  notebook provenance headers, and validated by the test suite.
+#
+# Notes on the recipes themselves:
+#
+# These presets are *adapted for ARC use* — the canonical Tajti-et-al HEAT
+# protocol was designed for atomization energies of small molecules, with the
+# HF energy itself CBS-extrapolated to the basis-set limit. ARC's
+# CompositeProtocol pins the absolute base to a single SinglePointTerm, so
+# the recipes below pick a sensible high-quality "anchor" SP (CCSD(T)-F12 in
+# the cc-pVTZ-F12 basis) and apply the post-(T) and other corrections on top.
+# This matches the typical focal-point workflow when refining TS barriers
+# (see e.g. Nguyen, Stanton, Barker for CHO2 PES).
+
+HEAT-345:
+  reference: "Inspired by Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1804498. Adapted for use as a TS barrier refinement protocol within ARC."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {fc: '0'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {fc: '1'}, block: {}}}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {rel: dkh2}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+HEAT-345Q:
+  reference: "Inspired by the HEAT-345(Q) protocol used by Nguyen, Stanton, Barker for the CHO2 PES (citing Tajti et al., J. Chem. Phys. 121, 11599 (2004); DOI: 10.1063/1.1804498). Adds a perturbative δ[CCSDT(Q)] term on top of HEAT-345."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,    basis: cc-pVDZ}
+      low:  {method: ccsd(t),  basis: cc-pVDZ}
+    - label: delta_Q
+      type: delta
+      high: {method: ccsdt(q), basis: cc-pVDZ}
+      low:  {method: ccsdt,    basis: cc-pVDZ}
+    - label: delta_CV
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {fc: '0'}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pCVTZ, args: {keyword: {fc: '1'}, block: {}}}
+    - label: delta_rel
+      type: delta
+      high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {rel: dkh2}, block: {}}}
+      low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+FPA-min:
+  reference: "Minimal Allen / East / Császár focal-point analysis recipe; review: East, Allen, J. Chem. Phys. 99, 4638 (1993); DOI: 10.1063/1.466062."
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: cbs_corr
+      type: cbs_extrapolation
+      formula: helgaker_corr_2pt
+      # components currently must be "total"; adapter-level correlation-only
+      # parsing is a future addition. The formula name (`helgaker_corr_2pt`)
+      # still documents intent for the user.
+      components: total
+      levels:
+        - {method: ccsd(t), basis: cc-pVTZ}
+        - {method: ccsd(t), basis: cc-pVQZ}
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,   basis: cc-pVDZ}
+      low:  {method: ccsd(t), basis: cc-pVDZ}

--- a/arc/level/presets.yml
+++ b/arc/level/presets.yml
@@ -12,12 +12,12 @@
 #
 # These presets are *adapted for ARC use* — the canonical Tajti-et-al HEAT
 # protocol was designed for atomization energies of small molecules, with the
-# HF energy itself CBS-extrapolated to the basis-set limit. ARC's
-# CompositeProtocol pins the absolute base to a single SinglePointTerm, so
-# the recipes below pick a sensible high-quality "anchor" SP (CCSD(T)-F12 in
-# the cc-pVTZ-F12 basis) and apply the post-(T) and other corrections on top.
-# This matches the typical focal-point workflow when refining TS barriers
-# (see e.g. Nguyen, Stanton, Barker for CHO2 PES).
+# HF energy itself CBS-extrapolated to the basis-set limit. The HEAT recipes
+# below deliberately pick a single high-quality "anchor" SP (CCSD(T)-F12 in
+# the cc-pVTZ-F12 basis) as the base and apply the post-(T) and other
+# corrections on top (a CBS extrapolation base is also supported by ARC —
+# see FPA-min). This matches the typical focal-point workflow when refining
+# TS barriers (see e.g. Nguyen, Stanton, Barker for CHO2 PES).
 #
 # ESS-specific syntax used below
 # ------------------------------
@@ -74,7 +74,7 @@ HEAT-345:
       low:  {method: ccsd(t),  basis: cc-pCVTZ}
     - label: delta_rel
       type: delta
-      # DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK via Molpro's ``dkroll=2`` directive.
+      # DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK via Molpro's ``SET,DKHO=2`` directive.
       high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
       # Non-relativistic CCSD(T)/cc-pVTZ.
       low:  {method: ccsd(t),  basis: cc-pVTZ}
@@ -181,10 +181,10 @@ HEAT-345QP:
       low:  {method: ccsd(t),   basis: cc-pVTZ}
 
 # HEAT-456Q has the same correction structure as HEAT-345Q but a tighter HF/
-# CCSD(T) CBS reference (cardinals {Q,5,6} rather than {T,Q,5}). ARC's
-# CompositeProtocol pins the absolute base to a single SinglePointTerm, so
-# this adaptation tightens the anchor by promoting the F12 base from
-# cc-pVTZ-F12 to cc-pVQZ-F12 (effectively near-CBS quality at QZ-5Z-6Z).
+# CCSD(T) CBS reference (cardinals {Q,5,6} rather than {T,Q,5}). This ARC
+# adaptation keeps the single-anchor design of the HEAT family and tightens
+# the anchor by promoting the F12 base from cc-pVTZ-F12 to cc-pVQZ-F12
+# (effectively near-CBS quality at QZ-5Z-6Z).
 HEAT-456Q:
   reference: "Inspired by HEAT-456Q (Bomble, Vázquez, Kállay, Michauk, Szalay, Császár, Gauss, Stanton, J. Chem. Phys. 125, 064108 (2006); DOI: 10.1063/1.2206789). Same correction structure as HEAT-345Q with a tighter base — ARC adaptation pins the anchor to CCSD(T)-F12/cc-pVQZ-F12 to mirror the {Q,5,6}-cardinal HF/CCSD(T) extrapolation. δ_CV and δ_rel assume a Molpro adapter."
   base:
@@ -208,22 +208,23 @@ HEAT-456Q:
       high: {method: ccsd(t),  basis: cc-pVTZ-DK, args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
       low:  {method: ccsd(t),  basis: cc-pVTZ}
 
+# FPA-min uses CBS-as-base: the absolute energy is the two-point Helgaker
+# X^-3 extrapolation of CCSD(T)/cc-pVTZ + cc-pVQZ TOTAL energies (the only
+# energy component ARC's parsers currently surface). The X^-3 form was
+# derived for the correlation energy; applying it to totals mis-treats the
+# exponentially-converging HF component, but at {T,Q} the residual is small
+# and this is common practice — the reference string says so explicitly.
 FPA-min:
-  reference: "Minimal Allen / East / Császár focal-point analysis recipe; review: East, Allen, J. Chem. Phys. 99, 4638 (1993); DOI: 10.1063/1.466062."
+  reference: "Minimal Allen / East / Császár focal-point analysis recipe; review: East, Allen, J. Chem. Phys. 99, 4638 (1993); DOI: 10.1063/1.466062. Base: two-point X^-3 CBS extrapolation (Helgaker et al., J. Chem. Phys. 106, 9639 (1997); DOI: 10.1063/1.473863) applied to CCSD(T)/cc-pVTZ + cc-pVQZ TOTAL energies — the HF component converges exponentially and is technically mis-treated by the X^-3 form; at {T,Q} the residual is small and extrapolating totals is common practice."
   base:
-    method: ccsd(t)-f12
-    basis: cc-pVTZ-f12
+    label: base
+    type: cbs_extrapolation
+    formula: helgaker_corr_2pt
+    components: total
+    levels:
+      - {method: ccsd(t), basis: cc-pVTZ}
+      - {method: ccsd(t), basis: cc-pVQZ}
   corrections:
-    - label: cbs_corr
-      type: cbs_extrapolation
-      formula: helgaker_corr_2pt
-      # components currently must be "total"; adapter-level correlation-only
-      # parsing is a future addition. The formula name (`helgaker_corr_2pt`)
-      # still documents intent for the user.
-      components: total
-      levels:
-        - {method: ccsd(t), basis: cc-pVTZ}
-        - {method: ccsd(t), basis: cc-pVQZ}
     - label: delta_T
       type: delta
       high: {method: ccsdt,   basis: cc-pVDZ}
@@ -234,11 +235,10 @@ FPA-min:
 #
 # The canonical W*n* protocols build their absolute energy from a stack of
 # basis-set CBS extrapolations (HF, CCSD, (T) at progressively smaller
-# basis) plus δ-corrections. ARC's CompositeProtocol pins the absolute
-# base to a single SinglePointTerm, so the recipes below pick a high-
-# quality CCSD(T) or CCSD(T)-F12 anchor and apply the canonical post-(T)
-# / δ_CV / δ_rel corrections on top. The original W*n* basis-cardinal
-# extrapolations of the (T) component are absorbed into the anchor —
+# basis) plus δ-corrections. The recipes below deliberately pick a high-
+# quality CCSD(T) or CCSD(T)-F12 anchor as a single-SP base and apply the
+# canonical post-(T) / δ_CV / δ_rel corrections on top. The original W*n*
+# basis-cardinal extrapolations of the (T) component are absorbed into the anchor —
 # this is faithful to the W*n* spirit (stacked corrections beyond
 # CCSD(T)/CBS) but not byte-identical to the published prescription.
 # Cite as 'W2 (ARC adaptation)' etc. to acknowledge the difference.

--- a/arc/level/presets_test.py
+++ b/arc/level/presets_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.presets`` — preset loading and override merging.
+
+Presets are data: every entry in ``presets.yml`` should round-trip through
+:meth:`CompositeProtocol.from_user_input` and through :meth:`CompositeProtocol.from_dict`
+without loss. Preset overrides may replace named keys on individual terms but may not
+introduce new term labels or unknown fields.
+"""
+
+import unittest
+
+from arc.exceptions import InputError
+from arc.level.presets import PRESETS, REGISTERED_PRESET_NAMES, expand_preset
+from arc.level.protocol import CompositeProtocol
+
+
+class TestPresetRegistry(unittest.TestCase):
+    """The ``presets.yml`` data file ships at least three named protocols."""
+
+    def test_registry_non_empty(self):
+        self.assertGreaterEqual(len(REGISTERED_PRESET_NAMES), 3)
+
+    def test_known_presets_present(self):
+        for name in ("HEAT-345", "HEAT-345Q", "FPA-min"):
+            self.assertIn(name, REGISTERED_PRESET_NAMES)
+
+    def test_each_preset_carries_a_reference_field(self):
+        """Every preset entry must include a `reference:` string with citation + DOI."""
+        for name in REGISTERED_PRESET_NAMES:
+            entry = PRESETS[name]
+            self.assertIn("reference", entry, f"Preset '{name}' missing 'reference' field.")
+            ref = entry["reference"]
+            self.assertIsInstance(ref, str)
+            self.assertGreater(len(ref), 20, f"Preset '{name}' reference too short.")
+            self.assertIn("DOI", ref.upper(), f"Preset '{name}' reference must mention a DOI.")
+
+    def test_each_preset_round_trips_to_protocol(self):
+        for name in REGISTERED_PRESET_NAMES:
+            with self.subTest(name=name):
+                protocol = CompositeProtocol.from_user_input(name)
+                rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+                self.assertEqual(rebuilt.base.label, protocol.base.label)
+                self.assertEqual(
+                    [t.label for t in rebuilt.corrections],
+                    [t.label for t in protocol.corrections],
+                )
+
+
+class TestExpandPreset(unittest.TestCase):
+    def test_unknown_preset_raises(self):
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("not_a_real_preset")
+        # The error message should help the user discover the available presets.
+        self.assertIn("HEAT-345", str(ctx.exception))
+
+    def test_returns_dict_with_base_and_corrections(self):
+        recipe = expand_preset("HEAT-345Q")
+        self.assertIn("base", recipe)
+        self.assertIn("corrections", recipe)
+        self.assertIsInstance(recipe["corrections"], list)
+
+    def test_no_overrides_returns_canonical_recipe(self):
+        a = expand_preset("HEAT-345Q")
+        b = expand_preset("HEAT-345Q")
+        self.assertEqual(a, b)
+
+    def test_returns_a_deep_copy(self):
+        """Mutating the returned recipe must not affect later calls."""
+        recipe = expand_preset("HEAT-345Q")
+        recipe["base"] = "tampered"
+        recipe["corrections"].clear()
+        again = expand_preset("HEAT-345Q")
+        self.assertNotEqual(again["base"], "tampered")
+        self.assertGreater(len(again["corrections"]), 0)
+
+
+class TestExpandPresetOverrides(unittest.TestCase):
+    """Overrides target named term labels and replace specific fields on them."""
+
+    def test_override_replaces_basis_on_named_delta_term(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        delta_t = next(c for c in recipe["corrections"] if c["label"] == "delta_T")
+        self.assertEqual(delta_t["high"]["basis"], "cc-pVTZ")
+
+    def test_override_only_touches_named_term(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        delta_q = next(c for c in recipe["corrections"] if c["label"] == "delta_Q")
+        # delta_Q should be untouched.
+        original = expand_preset("HEAT-345Q")
+        original_delta_q = next(c for c in original["corrections"] if c["label"] == "delta_Q")
+        self.assertEqual(delta_q, original_delta_q)
+
+    def test_override_unknown_label_raises(self):
+        with self.assertRaises(InputError):
+            expand_preset("HEAT-345Q", overrides={"not_a_term": {"high": "hf/cc-pVDZ"}})
+
+    def test_override_base_replaces_base_level(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"base": {"method": "ccsd(t)-f12", "basis": "cc-pVQZ-f12"}},
+        )
+        self.assertEqual(recipe["base"]["basis"], "cc-pVQZ-f12")
+
+    def test_overridden_preset_still_parses_into_a_protocol(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        protocol = CompositeProtocol.from_user_input(recipe)
+        delta_t = next(c for c in protocol.corrections if c.label == "delta_T")
+        self.assertEqual(delta_t.high.basis, "cc-pvtz")
+
+    # --- Phase 5.5 hardening --------------------------------------------- #
+
+    def test_override_unknown_field_on_delta_rejected(self):
+        """Typo guard: ``hihg`` is not a valid field of a delta term."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("HEAT-345Q", overrides={
+                "delta_T": {"hihg": {"method": "ccsdt", "basis": "cc-pVTZ"}},
+            })
+        self.assertIn("hihg", str(ctx.exception))
+
+    def test_override_unknown_field_on_base_rejected(self):
+        """``methhod`` is not a valid Level field."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("HEAT-345Q", overrides={
+                "base": {"methhod": "hf"},
+            })
+        self.assertIn("methhod", str(ctx.exception))
+
+    def test_override_unknown_field_on_cbs_rejected(self):
+        """Typo on a cbs_extrapolation term is caught (FPA-min has a CBS term)."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("FPA-min", overrides={
+                "cbs_corr": {"formla": "helgaker_corr_2pt"},
+            })
+        self.assertIn("formla", str(ctx.exception))
+
+    def test_override_deep_merges_high_level_dict(self):
+        """Overriding ``delta_T.high.basis`` preserves the existing ``method``."""
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"basis": "cc-pVTZ"}}},
+        )
+        delta_t = next(c for c in recipe["corrections"] if c["label"] == "delta_T")
+        self.assertEqual(delta_t["high"]["basis"], "cc-pVTZ")
+        # Original method ("ccsdt") is preserved by the deep-merge.
+        self.assertEqual(delta_t["high"]["method"], "ccsdt")
+
+    def test_override_deep_merges_base_dict(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"base": {"basis": "cc-pVQZ-f12"}},
+        )
+        self.assertEqual(recipe["base"]["basis"], "cc-pVQZ-f12")
+        # Existing method ("ccsd(t)-f12") preserved.
+        self.assertEqual(recipe["base"]["method"], "ccsd(t)-f12")
+
+
+class TestPresetIntegrationWithFromUserInput(unittest.TestCase):
+    def test_string_form_dispatches_to_preset(self):
+        protocol = CompositeProtocol.from_user_input("HEAT-345Q")
+        self.assertIsInstance(protocol, CompositeProtocol)
+
+    def test_preset_with_overrides_form(self):
+        protocol = CompositeProtocol.from_user_input({
+            "preset": "HEAT-345Q",
+            "overrides": {"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        })
+        delta_t = next(c for c in protocol.corrections if c.label == "delta_T")
+        self.assertEqual(delta_t.high.basis, "cc-pvtz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/presets_test.py
+++ b/arc/level/presets_test.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.presets`` — preset loading and override merging.
+
+Presets are data: every entry in ``presets.yml`` should round-trip through
+:meth:`CompositeProtocol.from_user_input` and through :meth:`CompositeProtocol.from_dict`
+without loss. Preset overrides may replace named keys on individual terms but may not
+introduce new term labels or unknown fields.
+"""
+
+import unittest
+
+from arc.exceptions import InputError
+from arc.level import Level
+from arc.level.presets import PRESETS, REGISTERED_PRESET_NAMES, expand_preset
+from arc.level.protocol import CompositeProtocol
+
+
+class TestPresetRegistry(unittest.TestCase):
+    """The ``presets.yml`` data file ships at least three named protocols."""
+
+    def test_registry_non_empty(self):
+        self.assertGreaterEqual(len(REGISTERED_PRESET_NAMES), 3)
+
+    def test_known_presets_present(self):
+        for name in (
+            "HEAT-345", "HEAT-345Q", "HEAT-345_noC", "HEAT-345Q_noC",
+            "HEAT-345QP", "HEAT-456Q", "FPA-min",
+            "W2", "W2-F12", "W3", "W3-F12", "W4", "W4-F12",
+        ):
+            self.assertIn(name, REGISTERED_PRESET_NAMES)
+
+    def test_noC_variants_omit_delta_CV_term(self):
+        """``_noC`` variants must NOT carry a delta_CV correction; the
+        omission is part of the contract their name advertises."""
+        for name in ("HEAT-345_noC", "HEAT-345Q_noC"):
+            with self.subTest(name=name):
+                recipe = expand_preset(name)
+                labels = [c["label"] for c in recipe["corrections"]]
+                self.assertNotIn("delta_CV", labels,
+                                 f"{name} must not include delta_CV "
+                                 f"(found: {labels})")
+                self.assertIn("delta_T", labels)
+                self.assertIn("delta_rel", labels)
+
+    def test_noC_reference_calls_out_omission(self):
+        """The reference string of every ``_noC`` variant must explicitly say
+        the core-valence correction was omitted, so users cite honestly."""
+        for name in ("HEAT-345_noC", "HEAT-345Q_noC"):
+            with self.subTest(name=name):
+                ref = PRESETS[name]["reference"]
+                self.assertIn("OMITTED", ref.upper())
+                self.assertIn("CORE-VALENCE", ref.upper())
+
+    def test_HEAT_protocols_delta_CV_legs_compare_unequal(self):
+        """Regression for sp_composite Bug B: HEAT-345Q's δ_CV high (all-electron
+        ``core,...``) and low (default frozen-core) Levels must not collapse to
+        a single sub-job at composite-spawn time. Extended in Phase 5+ to cover
+        every shipped preset that carries a δ_CV term — the Molpro-keyword
+        round-trip is the load-bearing piece, and silent dedup would defeat the
+        whole correction regardless of which protocol introduces it."""
+        for name in (
+            "HEAT-345", "HEAT-345Q", "HEAT-345QP", "HEAT-456Q",
+            "W2", "W2-F12", "W3", "W3-F12", "W4", "W4-F12",
+        ):
+            with self.subTest(name=name):
+                recipe = expand_preset(name)
+                cv = next(
+                    (c for c in recipe["corrections"] if c["label"] == "delta_CV"),
+                    None,
+                )
+                self.assertIsNotNone(
+                    cv, f"{name} expected to ship a delta_CV term; check preset."
+                )
+                high = Level(repr=cv["high"])
+                low = Level(repr=cv["low"])
+                self.assertNotEqual(high, low,
+                                    f"{name} δ_CV legs collapsed to equal Levels — "
+                                    f"composite-spawn would silently dedupe to one job.")
+
+    def test_each_preset_carries_a_reference_field(self):
+        """Every preset entry must include a `reference:` string with citation + DOI."""
+        for name in REGISTERED_PRESET_NAMES:
+            entry = PRESETS[name]
+            self.assertIn("reference", entry, f"Preset '{name}' missing 'reference' field.")
+            ref = entry["reference"]
+            self.assertIsInstance(ref, str)
+            self.assertGreater(len(ref), 20, f"Preset '{name}' reference too short.")
+            self.assertIn("DOI", ref.upper(), f"Preset '{name}' reference must mention a DOI.")
+
+    def test_each_preset_round_trips_to_protocol(self):
+        for name in REGISTERED_PRESET_NAMES:
+            with self.subTest(name=name):
+                protocol = CompositeProtocol.from_user_input(name)
+                rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+                self.assertEqual(rebuilt.base.label, protocol.base.label)
+                self.assertEqual(
+                    [t.label for t in rebuilt.corrections],
+                    [t.label for t in protocol.corrections],
+                )
+
+
+class TestExpandPreset(unittest.TestCase):
+    def test_unknown_preset_raises(self):
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("not_a_real_preset")
+        # The error message should help the user discover the available presets.
+        self.assertIn("HEAT-345", str(ctx.exception))
+
+    def test_returns_dict_with_base_and_corrections(self):
+        recipe = expand_preset("HEAT-345Q")
+        self.assertIn("base", recipe)
+        self.assertIn("corrections", recipe)
+        self.assertIsInstance(recipe["corrections"], list)
+
+    def test_no_overrides_returns_canonical_recipe(self):
+        a = expand_preset("HEAT-345Q")
+        b = expand_preset("HEAT-345Q")
+        self.assertEqual(a, b)
+
+    def test_returns_a_deep_copy(self):
+        """Mutating the returned recipe must not affect later calls."""
+        recipe = expand_preset("HEAT-345Q")
+        recipe["base"] = "tampered"
+        recipe["corrections"].clear()
+        again = expand_preset("HEAT-345Q")
+        self.assertNotEqual(again["base"], "tampered")
+        self.assertGreater(len(again["corrections"]), 0)
+
+
+class TestExpandPresetOverrides(unittest.TestCase):
+    """Overrides target named term labels and replace specific fields on them."""
+
+    def test_override_replaces_basis_on_named_delta_term(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        delta_t = next(c for c in recipe["corrections"] if c["label"] == "delta_T")
+        self.assertEqual(delta_t["high"]["basis"], "cc-pVTZ")
+
+    def test_override_only_touches_named_term(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        delta_q = next(c for c in recipe["corrections"] if c["label"] == "delta_Q")
+        # delta_Q should be untouched.
+        original = expand_preset("HEAT-345Q")
+        original_delta_q = next(c for c in original["corrections"] if c["label"] == "delta_Q")
+        self.assertEqual(delta_q, original_delta_q)
+
+    def test_override_unknown_label_raises(self):
+        with self.assertRaises(InputError):
+            expand_preset("HEAT-345Q", overrides={"not_a_term": {"high": "hf/cc-pVDZ"}})
+
+    def test_override_base_replaces_base_level(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"base": {"method": "ccsd(t)-f12", "basis": "cc-pVQZ-f12"}},
+        )
+        self.assertEqual(recipe["base"]["basis"], "cc-pVQZ-f12")
+
+    def test_overridden_preset_still_parses_into_a_protocol(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        )
+        protocol = CompositeProtocol.from_user_input(recipe)
+        delta_t = next(c for c in protocol.corrections if c.label == "delta_T")
+        self.assertEqual(delta_t.high.basis, "cc-pvtz")
+
+    # --- Phase 5.5 hardening --------------------------------------------- #
+
+    def test_override_unknown_field_on_delta_rejected(self):
+        """Typo guard: ``hihg`` is not a valid field of a delta term."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("HEAT-345Q", overrides={
+                "delta_T": {"hihg": {"method": "ccsdt", "basis": "cc-pVTZ"}},
+            })
+        self.assertIn("hihg", str(ctx.exception))
+
+    def test_override_unknown_field_on_base_rejected(self):
+        """``methhod`` is not a valid Level field."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("HEAT-345Q", overrides={
+                "base": {"methhod": "hf"},
+            })
+        self.assertIn("methhod", str(ctx.exception))
+
+    def test_override_unknown_field_on_cbs_rejected(self):
+        """Typo on a cbs_extrapolation term is caught (FPA-min has a CBS term)."""
+        with self.assertRaises(InputError) as ctx:
+            expand_preset("FPA-min", overrides={
+                "cbs_corr": {"formla": "helgaker_corr_2pt"},
+            })
+        self.assertIn("formla", str(ctx.exception))
+
+    def test_override_deep_merges_high_level_dict(self):
+        """Overriding ``delta_T.high.basis`` preserves the existing ``method``."""
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"delta_T": {"high": {"basis": "cc-pVTZ"}}},
+        )
+        delta_t = next(c for c in recipe["corrections"] if c["label"] == "delta_T")
+        self.assertEqual(delta_t["high"]["basis"], "cc-pVTZ")
+        # Original method ("ccsdt") is preserved by the deep-merge.
+        self.assertEqual(delta_t["high"]["method"], "ccsdt")
+
+    def test_override_deep_merges_base_dict(self):
+        recipe = expand_preset(
+            "HEAT-345Q",
+            overrides={"base": {"basis": "cc-pVQZ-f12"}},
+        )
+        self.assertEqual(recipe["base"]["basis"], "cc-pVQZ-f12")
+        # Existing method ("ccsd(t)-f12") preserved.
+        self.assertEqual(recipe["base"]["method"], "ccsd(t)-f12")
+
+
+class TestPresetIntegrationWithFromUserInput(unittest.TestCase):
+    def test_string_form_dispatches_to_preset(self):
+        protocol = CompositeProtocol.from_user_input("HEAT-345Q")
+        self.assertIsInstance(protocol, CompositeProtocol)
+
+    def test_preset_with_overrides_form(self):
+        protocol = CompositeProtocol.from_user_input({
+            "preset": "HEAT-345Q",
+            "overrides": {"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}},
+        })
+        delta_t = next(c for c in protocol.corrections if c.label == "delta_T")
+        self.assertEqual(delta_t.high.basis, "cc-pvtz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/presets_test.py
+++ b/arc/level/presets_test.py
@@ -15,7 +15,7 @@ import unittest
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.level.presets import PRESETS, REGISTERED_PRESET_NAMES, expand_preset
-from arc.level.protocol import CompositeProtocol
+from arc.level.protocol import CBSExtrapolationTerm, CompositeProtocol
 
 
 class TestPresetRegistry(unittest.TestCase):
@@ -55,12 +55,12 @@ class TestPresetRegistry(unittest.TestCase):
                 self.assertIn("CORE-VALENCE", ref.upper())
 
     def test_HEAT_protocols_delta_CV_legs_compare_unequal(self):
-        """Regression for sp_composite Bug B: HEAT-345Q's δ_CV high (all-electron
-        ``core,...``) and low (default frozen-core) Levels must not collapse to
-        a single sub-job at composite-spawn time. Extended in Phase 5+ to cover
-        every shipped preset that carries a δ_CV term — the Molpro-keyword
-        round-trip is the load-bearing piece, and silent dedup would defeat the
-        whole correction regardless of which protocol introduces it."""
+        """Regression: HEAT-345Q's δ_CV high (all-electron ``core,...``) and
+        low (default frozen-core) Levels must not collapse to a single sub-job
+        at composite-spawn time. Covers every shipped preset that carries a
+        δ_CV term — the Molpro-keyword round-trip is the load-bearing piece,
+        and silent dedup would defeat the whole correction regardless of which
+        protocol introduces it."""
         for name in (
             "HEAT-345", "HEAT-345Q", "HEAT-345QP", "HEAT-456Q",
             "W2", "W2-F12", "W3", "W3-F12", "W4", "W4-F12",
@@ -100,6 +100,36 @@ class TestPresetRegistry(unittest.TestCase):
                     [t.label for t in rebuilt.corrections],
                     [t.label for t in protocol.corrections],
                 )
+
+
+class TestFPAMinPreset(unittest.TestCase):
+    """FPA-min uses CBS-as-base: the absolute energy is a two-point CBS
+    extrapolation of CCSD(T)/cc-pVTZ + cc-pVQZ total energies."""
+
+    def test_recipe_base_is_cbs_extrapolation(self):
+        recipe = expand_preset("FPA-min")
+        self.assertEqual(recipe["base"]["type"], "cbs_extrapolation")
+        self.assertEqual(recipe["base"]["formula"], "helgaker_corr_2pt")
+        bases = [lvl["basis"] for lvl in recipe["base"]["levels"]]
+        self.assertEqual(sorted(b.lower() for b in bases), ["cc-pvqz", "cc-pvtz"])
+
+    def test_expands_to_protocol_with_cbs_base(self):
+        protocol = CompositeProtocol.from_user_input("FPA-min")
+        self.assertIsInstance(protocol.base, CBSExtrapolationTerm)
+        self.assertEqual(protocol.base_sub_labels, ["base__card_3", "base__card_4"])
+        self.assertEqual([t.label for t in protocol.corrections], ["delta_T"])
+
+    def test_no_f12_claims(self):
+        """The old FPA-min anchored on CCSD(T)-F12/cc-pVTZ-F12; the rewritten
+        preset must not mention F12 in either the recipe or the reference."""
+        recipe = expand_preset("FPA-min")
+        self.assertNotIn("f12", str(recipe).lower())
+        self.assertNotIn("f12", PRESETS["FPA-min"]["reference"].lower())
+
+    def test_reference_documents_totals_extrapolation(self):
+        """The X^-3 formula is applied to TOTAL energies (HF mis-treated) —
+        the reference string must say so honestly."""
+        self.assertIn("total", PRESETS["FPA-min"]["reference"].lower())
 
 
 class TestExpandPreset(unittest.TestCase):
@@ -172,7 +202,7 @@ class TestExpandPresetOverrides(unittest.TestCase):
         delta_t = next(c for c in protocol.corrections if c.label == "delta_T")
         self.assertEqual(delta_t.high.basis, "cc-pvtz")
 
-    # --- Phase 5.5 hardening --------------------------------------------- #
+    # --- override-field hardening ----------------------------------------- #
 
     def test_override_unknown_field_on_delta_rejected(self):
         """Typo guard: ``hihg`` is not a valid field of a delta term."""
@@ -191,10 +221,10 @@ class TestExpandPresetOverrides(unittest.TestCase):
         self.assertIn("methhod", str(ctx.exception))
 
     def test_override_unknown_field_on_cbs_rejected(self):
-        """Typo on a cbs_extrapolation term is caught (FPA-min has a CBS term)."""
+        """Typo on a cbs_extrapolation term is caught (FPA-min has a CBS base)."""
         with self.assertRaises(InputError) as ctx:
             expand_preset("FPA-min", overrides={
-                "cbs_corr": {"formla": "helgaker_corr_2pt"},
+                "base": {"formla": "helgaker_corr_2pt"},
             })
         self.assertIn("formla", str(ctx.exception))
 

--- a/arc/level/protocol.py
+++ b/arc/level/protocol.py
@@ -1,0 +1,587 @@
+"""
+``arc.level.protocol`` — composite-energy protocol data model.
+
+A ``CompositeProtocol`` describes how to compute the final electronic energy of a
+stationary point as a sum of contributions, each evaluated at a different level of
+theory. The motivation is HEAT-style focal-point analysis (Tajti, Szalay, Császár,
+Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton, *J. Chem. Phys.* **121**, 11599
+(2004); DOI: 10.1063/1.1804498) and CBS extrapolation (Helgaker et al. 1997, Halkier
+et al. 1998, Martin 1996), where small post-CCSD(T) corrections accumulate to
+several kJ/mol — exactly the range that affects TS barriers in kinetics.
+
+Data model
+----------
+
+A ``CompositeProtocol`` consists of:
+
+* ``base`` — a single :class:`SinglePointTerm` providing the absolute electronic
+  energy. By convention this is the "main" SP that the scheduler runs first; it is
+  also the level used for AEC (atom-energy-correction) lookups when the protocol
+  is wired into Arkane in a later phase.
+* ``corrections`` — an ordered list of additional :class:`Term` objects of any
+  subtype: :class:`SinglePointTerm`, :class:`DeltaTerm`, or
+  :class:`CBSExtrapolationTerm`.
+
+The final energy is ``base.evaluate(...) + Σ correction.evaluate(...)``.
+
+Sub-job naming
+--------------
+
+Each ``Term`` describes the QM single-point jobs it needs via
+:meth:`Term.required_levels`, returning ``[(sub_label, Level), ...]`` pairs. The
+sub_labels are *globally* unique within the protocol and follow the convention:
+
+* ``SinglePointTerm`` → ``"<term_label>"`` (one sub-job).
+* ``DeltaTerm`` → ``"<term_label>__high"``, ``"<term_label>__low"``.
+* ``CBSExtrapolationTerm`` → ``"<term_label>__card_<X>"`` for each cardinal ``X``.
+
+The Phase 2 scheduler integration uses these sub_labels to track per-sub-job state
+across restarts.
+"""
+
+import copy
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from arc.exceptions import InputError
+from arc.level.cbs import (
+    BUILTIN_FORMULAS,
+    cardinal_from_basis,
+    safe_eval_formula,
+    validate_formula,
+)
+from arc.level.level import Level
+from arc.level.presets import expand_preset
+
+
+# --------------------------------------------------------------------------- #
+#  Term hierarchy                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class Term(ABC):
+    """Abstract base class for any contribution to a composite electronic energy.
+
+    A ``Term`` knows three things:
+
+    1. Its ``label`` — a unique name used by the scheduler and reporter to
+       identify the term in logs and the provenance notebook.
+    2. The QM sub-jobs it needs, via :meth:`required_levels`.
+    3. How to combine those sub-jobs' parsed energies into a single number, via
+       :meth:`evaluate`.
+    """
+
+    label: str
+
+    @abstractmethod
+    def required_levels(self) -> List[Tuple[str, Level]]:
+        """Return ``[(sub_label, Level), ...]`` pairs for every SP this term needs."""
+
+    @abstractmethod
+    def evaluate(self, energies: Dict[str, float]) -> float:
+        """Combine sub-job energies into this term's contribution.
+
+        The keys of ``energies`` are the ``sub_label`` strings yielded by
+        :meth:`required_levels`. Units are passed through unchanged (kJ/mol in the
+        ARC scheduler, but the data model is unit-agnostic).
+        """
+
+    @abstractmethod
+    def as_dict(self) -> Dict[str, Any]:
+        """Serialise to a JSON/YAML-friendly dict including a discriminator ``type``."""
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Term":
+        """Reconstruct a ``Term`` subclass from its serialised dict.
+
+        Dispatches on the ``type`` discriminator written by :meth:`as_dict`.
+        """
+        if not isinstance(data, dict) or "type" not in data:
+            raise InputError(
+                "Term dict must include a 'type' discriminator "
+                "('single_point', 'delta', or 'cbs_extrapolation')."
+            )
+        kind = data["type"]
+        if kind == "single_point":
+            return SinglePointTerm._from_dict(data)
+        if kind == "delta":
+            return DeltaTerm._from_dict(data)
+        if kind == "cbs_extrapolation":
+            return CBSExtrapolationTerm._from_dict(data)
+        raise InputError(
+            f"Unknown term type '{kind}'. Allowed: "
+            "'single_point', 'delta', 'cbs_extrapolation'."
+        )
+
+
+def _coerce_level(value: Union[str, Dict[str, Any], Level]) -> Level:
+    """Accept either a string, dict, or Level; return a Level instance."""
+    if isinstance(value, Level):
+        return value
+    if isinstance(value, (str, dict)):
+        return Level(repr=value)
+    raise InputError(
+        f"Cannot interpret {value!r} (type {type(value).__name__}) as a Level."
+    )
+
+
+class SinglePointTerm(Term):
+    """One absolute single-point energy at one level of theory."""
+
+    def __init__(self, label: str, level: Union[str, Dict[str, Any], Level]):
+        if not label:
+            raise InputError("SinglePointTerm requires a non-empty label.")
+        self.label = label
+        self.level = _coerce_level(level)
+
+    def required_levels(self) -> List[Tuple[str, Level]]:
+        return [(self.label, self.level)]
+
+    def evaluate(self, energies: Dict[str, float]) -> float:
+        return energies[self.label]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "single_point",
+            "label": self.label,
+            "level": self.level.as_dict(),
+        }
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "SinglePointTerm":
+        return cls(label=data["label"], level=data["level"])
+
+
+class DeltaTerm(Term):
+    """A correction ``E[high] − E[low]`` between two levels of theory.
+
+    Used to capture, e.g., the post-(T) correction
+    ``δ[CCSDT] = E[CCSDT/cc-pVDZ] − E[CCSD(T)/cc-pVDZ]``.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        high: Optional[Union[str, Dict[str, Any], Level]],
+        low: Optional[Union[str, Dict[str, Any], Level]],
+    ):
+        if not label:
+            raise InputError("DeltaTerm requires a non-empty label.")
+        if high is None or low is None:
+            raise InputError(
+                f"DeltaTerm '{label}' requires both 'high' and 'low' levels; "
+                f"got high={high!r}, low={low!r}."
+            )
+        self.label = label
+        self.high = _coerce_level(high)
+        self.low = _coerce_level(low)
+
+    def _sub(self, suffix: str) -> str:
+        return f"{self.label}__{suffix}"
+
+    def required_levels(self) -> List[Tuple[str, Level]]:
+        return [(self._sub("high"), self.high), (self._sub("low"), self.low)]
+
+    def evaluate(self, energies: Dict[str, float]) -> float:
+        return energies[self._sub("high")] - energies[self._sub("low")]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "delta",
+            "label": self.label,
+            "high": self.high.as_dict(),
+            "low": self.low.as_dict(),
+        }
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "DeltaTerm":
+        return cls(label=data["label"], high=data["high"], low=data["low"])
+
+
+# Currently only "total" is supported: the energies fed to CBS formulas come
+# from ``arc.parser.parse_e_elect``, which returns the total electronic energy
+# of a single-point job. There is no parser pathway that surfaces correlation-
+# only or HF-only components yet, so accepting ``components='corr'`` or
+# ``'hf'`` would silently extrapolate *total* energies while pretending to be
+# component-specific — a correctness hazard. When adapter-level component
+# parsing is added, widen this tuple and add tests that the right component is
+# actually routed per sub-job.
+_ALLOWED_COMPONENTS = ("total",)
+
+
+class CBSExtrapolationTerm(Term):
+    """Complete-Basis-Set extrapolated contribution.
+
+    Computes one term in the composite from ≥2 single-point energies at the same
+    method but different basis-set cardinalities, combined via a closed-form
+    formula. ``formula`` may be the name of a built-in
+    (:data:`arc.level.cbs.BUILTIN_FORMULAS`) or a user-supplied arithmetic
+    expression evaluated by :func:`arc.level.cbs.safe_eval_formula`.
+
+    Parameters
+    ----------
+    label : str
+        Term identifier.
+    formula : str
+        Built-in name or arithmetic expression. User expressions may reference
+        ``X``, ``Y``, ``Z`` (cardinal numbers) and ``E_X``, ``E_Y``, ``E_Z``
+        (corresponding energies), bound by ascending cardinal order.
+        User formulas with more than 3 levels are rejected: expose only the
+        first three cardinal variables we bind.
+    levels : list of Level
+        ≥2 levels, all with the same method, all with deducible distinct cardinals.
+    components : {'total'}
+        Which energy component the extrapolation applies to. **Only ``'total'``
+        is currently accepted.** Other values are rejected at construction time
+        until component-specific parsing exists — see ``_ALLOWED_COMPONENTS``
+        above for rationale.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        formula: str,
+        levels: List[Union[str, Dict[str, Any], Level]],
+        components: str = "total",
+    ):
+        if not label:
+            raise InputError("CBSExtrapolationTerm requires a non-empty label.")
+        if components not in _ALLOWED_COMPONENTS:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': components={components!r} not in "
+                f"{_ALLOWED_COMPONENTS}."
+            )
+        coerced = [_coerce_level(lvl) for lvl in levels]
+        if len(coerced) < 2:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}' needs at least 2 levels, got {len(coerced)}."
+            )
+        methods = {lvl.method for lvl in coerced}
+        if len(methods) > 1:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': all levels must share one method, "
+                f"got {sorted(methods)}."
+            )
+        cardinals = [cardinal_from_basis(lvl.basis) for lvl in coerced]
+        if len(set(cardinals)) != len(cardinals):
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': cardinals must be distinct, got "
+                f"{cardinals}."
+            )
+        # Sort levels and cardinals together by ascending cardinal so callers can rely
+        # on a canonical ordering downstream.
+        ordered = sorted(zip(cardinals, coerced))
+        self._cardinals = [c for c, _ in ordered]
+        self.levels = [lvl for _, lvl in ordered]
+        self.label = label
+        self.components = components
+        self.formula = formula
+        self._formula_callable = self._resolve_formula(formula, len(self.levels))
+
+    # Arity required by each shipped built-in formula. Surfacing this at
+    # construction time catches "martin_3pt with 2 levels" before a sub-job
+    # ever runs. When new built-ins are added, update this table alongside
+    # the entry in arc.level.cbs.BUILTIN_FORMULAS.
+    _BUILTIN_FORMULA_ARITY: Dict[str, int] = {
+        "helgaker_corr_2pt": 2,
+        "helgaker_hf_2pt": 2,
+        "martin_3pt": 3,
+    }
+
+    # Upper bound for user-supplied formula arity: the safe-eval variable
+    # binder exposes only X/Y/Z (and E_X/E_Y/E_Z). Supporting more would
+    # require extending both the binder and the safe-eval allow-list tests.
+    _USER_FORMULA_MAX_LEVELS = 3
+
+    @staticmethod
+    def _resolve_formula(formula: str, n_levels: int):
+        """Validate ``formula`` against the built-in registry and (if user-supplied)
+        the safe-eval whitelist; return a callable taking ``{cardinal: energy}``.
+
+        Built-in formulas additionally have their required arity enforced here
+        (Phase 5.5) so a recipe with the wrong number of levels fails at
+        construction, not at sub-job-completion time.
+        """
+        if formula in BUILTIN_FORMULAS:
+            required = CBSExtrapolationTerm._BUILTIN_FORMULA_ARITY.get(formula)
+            if required is not None and n_levels != required:
+                raise InputError(
+                    f"Built-in CBS formula '{formula}' requires exactly "
+                    f"{required} levels; got {n_levels}."
+                )
+            return BUILTIN_FORMULAS[formula]
+        # User expression: validate the AST eagerly so malformed formulas raise
+        # at construction, not when sub-job energies are first plugged in. We
+        # advertise X/Y/Z and E_X/E_Y/E_Z up to the number of levels.
+        if n_levels > CBSExtrapolationTerm._USER_FORMULA_MAX_LEVELS:
+            raise InputError(
+                f"User CBS formulas currently support at most "
+                f"{CBSExtrapolationTerm._USER_FORMULA_MAX_LEVELS} levels "
+                f"(X/Y/Z and E_X/E_Y/E_Z variables); got {n_levels}."
+            )
+        allowed = {f"E_{var}" for var in ("X", "Y", "Z")[:n_levels]}
+        allowed.update({var for var in ("X", "Y", "Z")[:n_levels]})
+        validate_formula(formula, allowed)
+
+        def _user_fn(energies):
+            env = {}
+            for idx, (X, E) in enumerate(sorted(energies.items())):
+                var = ("X", "Y", "Z")[idx]
+                env[var] = X
+                env[f"E_{var}"] = E
+            return safe_eval_formula(formula, env)
+
+        return _user_fn
+
+    def _sub(self, cardinal: int) -> str:
+        return f"{self.label}__card_{cardinal}"
+
+    def required_levels(self) -> List[Tuple[str, Level]]:
+        return [(self._sub(c), lvl) for c, lvl in zip(self._cardinals, self.levels)]
+
+    def evaluate(self, energies: Dict[str, float]) -> float:
+        cardinal_to_energy = {c: energies[self._sub(c)] for c in self._cardinals}
+        return self._formula_callable(cardinal_to_energy)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "cbs_extrapolation",
+            "label": self.label,
+            "formula": self.formula,
+            "components": self.components,
+            "levels": [lvl.as_dict() for lvl in self.levels],
+        }
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "CBSExtrapolationTerm":
+        return cls(
+            label=data["label"],
+            formula=data["formula"],
+            levels=data["levels"],
+            components=data.get("components", "total"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  CompositeProtocol                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class CompositeProtocol:
+    """An ordered sum of :class:`Term` objects defining the final electronic energy.
+
+    The protocol's electronic energy is ``base.evaluate(...) + Σ correction.evaluate(...)``.
+
+    Optional metadata:
+
+    * ``preset_name`` — the name of the preset this protocol was expanded from
+      (``"HEAT-345Q"`` etc.), or ``None`` for explicit recipes. Populated
+      automatically by :meth:`from_user_input` when the input is a preset name
+      or a ``{preset: ..., overrides: ...}`` dict; carried through ``as_dict``
+      and restored by ``from_dict``.
+    * ``reference`` — a citation string (typically a DOI) describing the source
+      of the protocol. For presets, this comes from ``presets.yml``'s
+      ``reference:`` field; for explicit recipes, users may supply a
+      ``reference:`` key at the top level of their recipe dict.
+    """
+
+    def __init__(
+        self,
+        base: SinglePointTerm,
+        corrections: Optional[List[Term]] = None,
+        preset_name: Optional[str] = None,
+        reference: Optional[str] = None,
+    ):
+        if not isinstance(base, SinglePointTerm):
+            raise InputError(
+                "CompositeProtocol.base must be a SinglePointTerm; "
+                f"got {type(base).__name__}."
+            )
+        corrections = list(corrections) if corrections else []
+        labels = [base.label] + [t.label for t in corrections]
+        if len(set(labels)) != len(labels):
+            raise InputError(
+                f"All term labels must be unique within a CompositeProtocol; "
+                f"got duplicates in {labels}."
+            )
+        # sub_labels are a *global* namespace within a protocol — they key the
+        # scheduler's pending dict and the output-dict's 'paths/sp_composite'.
+        # A collision (e.g. SinglePointTerm(label='delta_T__high') plus a
+        # DeltaTerm(label='delta_T', ...) whose 'high' sub-leg also ends up as
+        # 'delta_T__high') would overwrite state silently. Reject at construction.
+        sub_labels: List[str] = []
+        for term in [base, *corrections]:
+            for sub_label, _level in term.required_levels():
+                sub_labels.append(sub_label)
+        if len(set(sub_labels)) != len(sub_labels):
+            duplicates = sorted({s for s in sub_labels if sub_labels.count(s) > 1})
+            raise InputError(
+                f"CompositeProtocol has colliding sub_labels across terms: "
+                f"{duplicates}. Rename the offending term(s) so their "
+                f"sub_labels ('<label>', '<label>__high', '<label>__low', "
+                f"'<label>__card_<X>') don't clash."
+            )
+        self.base = base
+        self.corrections = corrections
+        self.preset_name = preset_name
+        self.reference = reference
+
+    @property
+    def terms(self) -> List[Term]:
+        """Convenience: ``[base, *corrections]`` in protocol order."""
+        return [self.base, *self.corrections]
+
+    def evaluate(self, energies: Dict[str, float]) -> float:
+        """Combine all sub-job energies into the protocol's electronic energy."""
+        return sum(term.evaluate(energies) for term in self.terms)
+
+    def iter_required_jobs(self) -> Iterable[Tuple[str, str, Level]]:
+        """Yield ``(term_label, sub_label, Level)`` triples for every required SP."""
+        for term in self.terms:
+            for sub_label, level in term.required_levels():
+                yield (term.label, sub_label, level)
+
+    def as_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "base": self.base.as_dict(),
+            "corrections": [t.as_dict() for t in self.corrections],
+        }
+        if self.preset_name is not None:
+            out["preset_name"] = self.preset_name
+        if self.reference is not None:
+            out["reference"] = self.reference
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CompositeProtocol":
+        """Inverse of :meth:`as_dict`. Each entry must already include its discriminator."""
+        if not isinstance(data, dict) or "base" not in data:
+            raise InputError(
+                "CompositeProtocol dict must include a 'base' entry."
+            )
+        base_data = data["base"]
+        if isinstance(base_data, dict) and "type" not in base_data:
+            base = SinglePointTerm(
+                label=base_data.get("label", "base"),
+                level=base_data.get("level", base_data),
+            )
+        else:
+            term = Term.from_dict(base_data)
+            if not isinstance(term, SinglePointTerm):
+                raise InputError("CompositeProtocol.base must be a SinglePointTerm.")
+            base = term
+        corrections = [Term.from_dict(d) for d in data.get("corrections", [])]
+        return cls(
+            base=base,
+            corrections=corrections,
+            preset_name=data.get("preset_name"),
+            reference=data.get("reference"),
+        )
+
+    @classmethod
+    def from_user_input(cls, raw: Union[str, Dict[str, Any]]) -> "CompositeProtocol":
+        """Accept the YAML-shaped user input and produce a validated protocol.
+
+        Three forms are accepted:
+
+        * A *string* — interpreted as a preset name. Delegates to
+          :func:`arc.level.presets.expand_preset`.
+        * A *dict with* ``preset:`` *key* — preset with overrides. Delegates to
+          :func:`arc.level.presets.expand_preset`.
+        * A *dict with* ``base:`` *and* ``corrections:`` keys — fully explicit
+          recipe. ``base`` may be a Level shorthand (``"method/basis"``), a Level
+          dict, or a serialised SinglePointTerm. Each entry in ``corrections``
+          must include a ``type`` discriminator.
+
+        Raises
+        ------
+        arc.exceptions.InputError
+            On any malformed input.
+        """
+        preset_name: Optional[str] = None
+        if isinstance(raw, str):
+            preset_name = raw
+            raw = expand_preset(raw)
+        elif isinstance(raw, dict) and "preset" in raw:
+            preset_name = raw["preset"]
+            raw = expand_preset(raw["preset"], overrides=raw.get("overrides"))
+        elif isinstance(raw, dict):
+            # Explicit recipe (or serialised ``as_dict()`` output). Deep-copy so
+            # we never mutate caller-owned state — downstream code pops fields
+            # off dicts when reading legacy forms.
+            raw = copy.deepcopy(raw)
+        else:
+            raise InputError(
+                f"sp_composite must be a preset name (str) or a dict; "
+                f"got {type(raw).__name__}."
+            )
+
+        if "base" not in raw:
+            raise InputError("sp_composite recipe must include a 'base' level.")
+
+        # Preserve preset_name when the caller handed us a serialised ``as_dict()``
+        # payload (which carries the 'preset_name' key from a prior
+        # ``from_user_input`` run). Preset name from the current call wins.
+        if preset_name is None:
+            preset_name = raw.get("preset_name")
+        reference = raw.get("reference")
+
+        # base may be: string ("method/basis"), Level dict, or explicit
+        # SinglePointTerm dict (with type='single_point').
+        base_raw = raw["base"]
+        if isinstance(base_raw, str):
+            base = SinglePointTerm(label="base", level=base_raw)
+        elif isinstance(base_raw, dict) and base_raw.get("type") == "single_point":
+            base = SinglePointTerm(
+                label=base_raw.get("label", "base"),
+                level=base_raw["level"],
+            )
+        elif isinstance(base_raw, dict):
+            # Legacy/shorthand form: the dict is a Level spec that optionally
+            # carries a 'label' key. Separate them without mutating the caller's
+            # state (base_raw is already a deep copy from above, but be explicit).
+            base_dict = {k: v for k, v in base_raw.items() if k != "label"}
+            label = base_raw.get("label", "base")
+            base = SinglePointTerm(label=label, level=base_dict)
+        else:
+            raise InputError(
+                f"sp_composite 'base' must be a level string, level dict, or "
+                f"SinglePointTerm dict; got {type(base_raw).__name__}."
+            )
+
+        corrections: List[Term] = []
+        for entry in raw.get("corrections", []):
+            if not isinstance(entry, dict):
+                raise InputError(
+                    f"Each correction must be a dict; got {type(entry).__name__}."
+                )
+            corrections.append(Term.from_dict(entry))
+        return cls(
+            base=base,
+            corrections=corrections,
+            preset_name=preset_name,
+            reference=reference,
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Public adapter                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def build_protocol(value: Any) -> CompositeProtocol:
+    """Coerce any supported user input into a :class:`CompositeProtocol`.
+
+    * If ``value`` is already a :class:`CompositeProtocol`, returns it unchanged.
+    * If it is a string or dict, delegates to
+      :meth:`CompositeProtocol.from_user_input`.
+    * Otherwise raises :class:`InputError`.
+    """
+    if isinstance(value, CompositeProtocol):
+        return value
+    if isinstance(value, (str, dict)):
+        return CompositeProtocol.from_user_input(value)
+    raise InputError(
+        f"Cannot build a CompositeProtocol from {type(value).__name__}; "
+        "expected str, dict, or CompositeProtocol."
+    )

--- a/arc/level/protocol.py
+++ b/arc/level/protocol.py
@@ -1,0 +1,594 @@
+"""
+``arc.level.protocol`` — composite-energy protocol data model.
+
+A ``CompositeProtocol`` describes how to compute the final electronic energy of a
+stationary point as a sum of contributions, each evaluated at a different level of
+theory. The motivation is HEAT-style focal-point analysis (Tajti, Szalay, Császár,
+Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton, *J. Chem. Phys.* **121**, 11599
+(2004); DOI: 10.1063/1.1811608) and CBS extrapolation (Helgaker et al. 1997, Halkier
+et al. 1998, Martin 1996), where small post-CCSD(T) corrections accumulate to
+several kJ/mol — exactly the range that affects TS barriers in kinetics.
+
+Data model
+----------
+
+A ``CompositeProtocol`` consists of:
+
+* ``base`` — a single :class:`SinglePointTerm` providing the absolute electronic
+  energy. By convention this is the "main" SP that the scheduler runs first; it is
+  also the level used for AEC (atom-energy-correction) lookups when the protocol
+  is wired into Arkane in a later phase.
+* ``corrections`` — an ordered list of additional :class:`Term` objects of any
+  subtype: :class:`SinglePointTerm`, :class:`DeltaTerm`, or
+  :class:`CBSExtrapolationTerm`.
+
+The final energy is ``base.evaluate(...) + Σ correction.evaluate(...)``.
+
+Sub-job naming
+--------------
+
+Each ``Term`` describes the QM single-point jobs it needs via
+:meth:`Term.required_levels`, returning ``[(sub_label, Level), ...]`` pairs. The
+sub_labels are *globally* unique within the protocol and follow the convention:
+
+* ``SinglePointTerm`` → ``"<term_label>"`` (one sub-job).
+* ``DeltaTerm`` → ``"<term_label>__high"``, ``"<term_label>__low"``.
+* ``CBSExtrapolationTerm`` → ``"<term_label>__card_<X>"`` for each cardinal ``X``.
+
+The Phase 2 scheduler integration uses these sub_labels to track per-sub-job state
+across restarts.
+"""
+
+import copy
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from arc.exceptions import InputError
+from arc.level.cbs import (
+    BUILTIN_FORMULAS,
+    cardinal_from_basis,
+    safe_eval_formula,
+    validate_formula,
+)
+from arc.level.level import Level
+from arc.level.presets import expand_preset
+
+
+# --------------------------------------------------------------------------- #
+#  Term hierarchy                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class Term(ABC):
+    """Abstract base class for any contribution to a composite electronic energy.
+
+    A ``Term`` knows three things:
+
+    1. Its ``label`` — a unique name used by the scheduler and reporter to
+       identify the term in logs and the provenance notebook.
+    2. The QM sub-jobs it needs, via :meth:`required_levels`.
+    3. How to combine those sub-jobs' parsed energies into a single number, via
+       :meth:`evaluate`.
+    """
+
+    label: str
+
+    @abstractmethod
+    def required_levels(self) -> list[tuple[str, Level]]:
+        """Return ``[(sub_label, Level), ...]`` pairs for every SP this term needs."""
+
+    @abstractmethod
+    def evaluate(self, energies: dict[str, float]) -> float:
+        """Combine sub-job energies into this term's contribution.
+
+        The keys of ``energies`` are the ``sub_label`` strings yielded by
+        :meth:`required_levels`. Units are passed through unchanged (kJ/mol in the
+        ARC scheduler, but the data model is unit-agnostic).
+        """
+
+    @abstractmethod
+    def as_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON/YAML-friendly dict including a discriminator ``type``."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Term":
+        """Reconstruct a ``Term`` subclass from its serialised dict.
+
+        Dispatches on the ``type`` discriminator written by :meth:`as_dict`.
+        """
+        if not isinstance(data, dict) or "type" not in data:
+            raise InputError(
+                "Term dict must include a 'type' discriminator "
+                "('single_point', 'delta', or 'cbs_extrapolation')."
+            )
+        kind = data["type"]
+        if kind == "single_point":
+            return SinglePointTerm._from_dict(data)
+        if kind == "delta":
+            return DeltaTerm._from_dict(data)
+        if kind == "cbs_extrapolation":
+            return CBSExtrapolationTerm._from_dict(data)
+        raise InputError(
+            f"Unknown term type '{kind}'. Allowed: "
+            "'single_point', 'delta', 'cbs_extrapolation'."
+        )
+
+
+def _coerce_level(value: str | dict[str, Any] | Level) -> Level:
+    """Accept either a string, dict, or Level; return a Level instance."""
+    if isinstance(value, Level):
+        return value
+    if isinstance(value, (str, dict)):
+        return Level(repr=value)
+    raise InputError(
+        f"Cannot interpret {value!r} (type {type(value).__name__}) as a Level."
+    )
+
+
+class SinglePointTerm(Term):
+    """One absolute single-point energy at one level of theory."""
+
+    def __init__(self, label: str, level: str | dict[str, Any] | Level):
+        if not label:
+            raise InputError("SinglePointTerm requires a non-empty label.")
+        self.label = label
+        self.level = _coerce_level(level)
+
+    def required_levels(self) -> list[tuple[str, Level]]:
+        return [(self.label, self.level)]
+
+    def evaluate(self, energies: dict[str, float]) -> float:
+        return energies[self.label]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": "single_point",
+            "label": self.label,
+            "level": self.level.as_dict(),
+        }
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, Any]) -> "SinglePointTerm":
+        return cls(label=data["label"], level=data["level"])
+
+
+class DeltaTerm(Term):
+    """A correction ``E[high] − E[low]`` between two levels of theory.
+
+    Used to capture, e.g., the post-(T) correction
+    ``δ[CCSDT] = E[CCSDT/cc-pVDZ] − E[CCSD(T)/cc-pVDZ]``.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        high: str | dict[str, Any] | Level | None,
+        low: str | dict[str, Any] | Level | None,
+    ):
+        if not label:
+            raise InputError("DeltaTerm requires a non-empty label.")
+        if high is None or low is None:
+            raise InputError(
+                f"DeltaTerm '{label}' requires both 'high' and 'low' levels; "
+                f"got high={high!r}, low={low!r}."
+            )
+        self.label = label
+        self.high = _coerce_level(high)
+        self.low = _coerce_level(low)
+
+    def _sub(self, suffix: str) -> str:
+        return f"{self.label}__{suffix}"
+
+    def required_levels(self) -> list[tuple[str, Level]]:
+        return [(self._sub("high"), self.high), (self._sub("low"), self.low)]
+
+    def evaluate(self, energies: dict[str, float]) -> float:
+        return energies[self._sub("high")] - energies[self._sub("low")]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": "delta",
+            "label": self.label,
+            "high": self.high.as_dict(),
+            "low": self.low.as_dict(),
+        }
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, Any]) -> "DeltaTerm":
+        return cls(label=data["label"], high=data["high"], low=data["low"])
+
+
+# Currently only "total" is supported: the energies fed to CBS formulas come
+# from ``arc.parser.parse_e_elect``, which returns the total electronic energy
+# of a single-point job. There is no parser pathway that surfaces correlation-
+# only or HF-only components yet, so accepting ``components='corr'`` or
+# ``'hf'`` would silently extrapolate *total* energies while pretending to be
+# component-specific — a correctness hazard. When adapter-level component
+# parsing is added, widen this tuple and add tests that the right component is
+# actually routed per sub-job.
+_ALLOWED_COMPONENTS = ("total",)
+
+
+class CBSExtrapolationTerm(Term):
+    """Complete-Basis-Set extrapolated contribution.
+
+    Computes one term in the composite from ≥2 single-point energies at the same
+    method but different basis-set cardinalities, combined via a closed-form
+    formula. ``formula`` may be the name of a built-in
+    (:data:`arc.level.cbs.BUILTIN_FORMULAS`) or a user-supplied arithmetic
+    expression evaluated by :func:`arc.level.cbs.safe_eval_formula`.
+
+    Parameters
+    ----------
+    label : str
+        Term identifier.
+    formula : str
+        Built-in name or arithmetic expression. User expressions may reference
+        ``X``, ``Y``, ``Z`` (cardinal numbers) and ``E_X``, ``E_Y``, ``E_Z``
+        (corresponding energies), bound by ascending cardinal order.
+        User formulas with more than 3 levels are rejected: expose only the
+        first three cardinal variables we bind.
+    levels : list of Level
+        ≥2 levels, all with the same method, all with deducible distinct cardinals.
+    components : {'total'}
+        Which energy component the extrapolation applies to. **Only ``'total'``
+        is currently accepted.** Other values are rejected at construction time
+        until component-specific parsing exists — see ``_ALLOWED_COMPONENTS``
+        above for rationale.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        formula: str,
+        levels: list[str | dict[str, Any] | Level],
+        components: str = "total",
+    ):
+        if not label:
+            raise InputError("CBSExtrapolationTerm requires a non-empty label.")
+        if components not in _ALLOWED_COMPONENTS:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': components={components!r} not in "
+                f"{_ALLOWED_COMPONENTS}."
+            )
+        coerced = [_coerce_level(lvl) for lvl in levels]
+        if len(coerced) < 2:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}' needs at least 2 levels, got {len(coerced)}."
+            )
+        methods = {lvl.method for lvl in coerced}
+        if len(methods) > 1:
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': all levels must share one method, "
+                f"got {sorted(methods)}."
+            )
+        cardinals = [cardinal_from_basis(lvl.basis) for lvl in coerced]
+        if len(set(cardinals)) != len(cardinals):
+            raise InputError(
+                f"CBSExtrapolationTerm '{label}': cardinals must be distinct, got "
+                f"{cardinals}."
+            )
+        # Sort levels and cardinals together by ascending cardinal so callers can rely
+        # on a canonical ordering downstream.
+        ordered = sorted(zip(cardinals, coerced))
+        self._cardinals = [c for c, _ in ordered]
+        self.levels = [lvl for _, lvl in ordered]
+        self.label = label
+        self.components = components
+        self.formula = formula
+        self._formula_callable = self._resolve_formula(formula, len(self.levels))
+
+    # Arity required by each shipped built-in formula. Surfacing this at
+    # construction time catches "martin_3pt with 2 levels" before a sub-job
+    # ever runs. When new built-ins are added, update this table alongside
+    # the entry in arc.level.cbs.BUILTIN_FORMULAS.
+    _BUILTIN_FORMULA_ARITY: dict[str, int] = {
+        "helgaker_corr_2pt": 2,
+        "helgaker_hf_2pt": 2,
+        "martin_3pt": 3,
+    }
+
+    # Upper bound for user-supplied formula arity: the safe-eval variable
+    # binder exposes only X/Y/Z (and E_X/E_Y/E_Z). Supporting more would
+    # require extending both the binder and the safe-eval allow-list tests.
+    _USER_FORMULA_MAX_LEVELS = 3
+
+    @staticmethod
+    def _resolve_formula(formula: str, n_levels: int) -> Callable[[dict[int, float]], float]:
+        """Validate ``formula`` against the built-in registry and (if user-supplied)
+        the safe-eval whitelist; return a callable taking ``{cardinal: energy}``.
+
+        Built-in formulas additionally have their required arity enforced here
+        (Phase 5.5) so a recipe with the wrong number of levels fails at
+        construction, not at sub-job-completion time.
+        """
+        if formula in BUILTIN_FORMULAS:
+            required = CBSExtrapolationTerm._BUILTIN_FORMULA_ARITY.get(formula)
+            if required is not None and n_levels != required:
+                raise InputError(
+                    f"Built-in CBS formula '{formula}' requires exactly "
+                    f"{required} levels; got {n_levels}."
+                )
+            return BUILTIN_FORMULAS[formula]
+        # User expression: validate the AST eagerly so malformed formulas raise
+        # at construction, not when sub-job energies are first plugged in. We
+        # advertise X/Y/Z and E_X/E_Y/E_Z up to the number of levels.
+        if n_levels > CBSExtrapolationTerm._USER_FORMULA_MAX_LEVELS:
+            raise InputError(
+                f"User CBS formulas currently support at most "
+                f"{CBSExtrapolationTerm._USER_FORMULA_MAX_LEVELS} levels "
+                f"(X/Y/Z and E_X/E_Y/E_Z variables); got {n_levels}."
+            )
+        allowed = {f"E_{var}" for var in ("X", "Y", "Z")[:n_levels]}
+        allowed.update({var for var in ("X", "Y", "Z")[:n_levels]})
+        validate_formula(formula, allowed)
+
+        def _user_fn(energies: dict[int, float]) -> float:
+            env: dict[str, float] = {}
+            for idx, (X, E) in enumerate(sorted(energies.items())):
+                var = ("X", "Y", "Z")[idx]
+                env[var] = X
+                env[f"E_{var}"] = E
+            try:
+                return safe_eval_formula(formula, env)
+            except ZeroDivisionError as exc:
+                raise InputError(
+                    f"User CBS formula {formula!r} raised division by zero "
+                    f"for inputs {energies}."
+                ) from exc
+
+        return _user_fn
+
+    def _sub(self, cardinal: int) -> str:
+        return f"{self.label}__card_{cardinal}"
+
+    def required_levels(self) -> list[tuple[str, Level]]:
+        return [(self._sub(c), lvl) for c, lvl in zip(self._cardinals, self.levels)]
+
+    def evaluate(self, energies: dict[str, float]) -> float:
+        cardinal_to_energy = {c: energies[self._sub(c)] for c in self._cardinals}
+        return self._formula_callable(cardinal_to_energy)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": "cbs_extrapolation",
+            "label": self.label,
+            "formula": self.formula,
+            "components": self.components,
+            "levels": [lvl.as_dict() for lvl in self.levels],
+        }
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, Any]) -> "CBSExtrapolationTerm":
+        return cls(
+            label=data["label"],
+            formula=data["formula"],
+            levels=data["levels"],
+            components=data.get("components", "total"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  CompositeProtocol                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class CompositeProtocol:
+    """An ordered sum of :class:`Term` objects defining the final electronic energy.
+
+    The protocol's electronic energy is ``base.evaluate(...) + Σ correction.evaluate(...)``.
+
+    Optional metadata:
+
+    * ``preset_name`` — the name of the preset this protocol was expanded from
+      (``"HEAT-345Q"`` etc.), or ``None`` for explicit recipes. Populated
+      automatically by :meth:`from_user_input` when the input is a preset name
+      or a ``{preset: ..., overrides: ...}`` dict; carried through ``as_dict``
+      and restored by ``from_dict``.
+    * ``reference`` — a citation string (typically a DOI) describing the source
+      of the protocol. For presets, this comes from ``presets.yml``'s
+      ``reference:`` field; for explicit recipes, users may supply a
+      ``reference:`` key at the top level of their recipe dict.
+    """
+
+    def __init__(
+        self,
+        base: SinglePointTerm,
+        corrections: list[Term] | None = None,
+        preset_name: str | None = None,
+        reference: str | None = None,
+    ):
+        if not isinstance(base, SinglePointTerm):
+            raise InputError(
+                "CompositeProtocol.base must be a SinglePointTerm; "
+                f"got {type(base).__name__}."
+            )
+        corrections = list(corrections) if corrections else []
+        labels = [base.label] + [t.label for t in corrections]
+        if len(set(labels)) != len(labels):
+            raise InputError(
+                f"All term labels must be unique within a CompositeProtocol; "
+                f"got duplicates in {labels}."
+            )
+        # sub_labels are a *global* namespace within a protocol — they key the
+        # scheduler's pending dict and the output-dict's 'paths/sp_composite'.
+        # A collision (e.g. SinglePointTerm(label='delta_T__high') plus a
+        # DeltaTerm(label='delta_T', ...) whose 'high' sub-leg also ends up as
+        # 'delta_T__high') would overwrite state silently. Reject at construction.
+        sub_labels: list[str] = []
+        for term in [base, *corrections]:
+            for sub_label, _level in term.required_levels():
+                sub_labels.append(sub_label)
+        if len(set(sub_labels)) != len(sub_labels):
+            duplicates = sorted({s for s in sub_labels if sub_labels.count(s) > 1})
+            raise InputError(
+                f"CompositeProtocol has colliding sub_labels across terms: "
+                f"{duplicates}. Rename the offending term(s) so their "
+                f"sub_labels ('<label>', '<label>__high', '<label>__low', "
+                f"'<label>__card_<X>') don't clash."
+            )
+        self.base = base
+        self.corrections = corrections
+        self.preset_name = preset_name
+        self.reference = reference
+
+    @property
+    def terms(self) -> list[Term]:
+        """Convenience: ``[base, *corrections]`` in protocol order."""
+        return [self.base, *self.corrections]
+
+    def evaluate(self, energies: dict[str, float]) -> float:
+        """Combine all sub-job energies into the protocol's electronic energy."""
+        return sum(term.evaluate(energies) for term in self.terms)
+
+    def iter_required_jobs(self) -> Iterable[tuple[str, str, Level]]:
+        """Yield ``(term_label, sub_label, Level)`` triples for every required SP."""
+        for term in self.terms:
+            for sub_label, level in term.required_levels():
+                yield (term.label, sub_label, level)
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "base": self.base.as_dict(),
+            "corrections": [t.as_dict() for t in self.corrections],
+        }
+        if self.preset_name is not None:
+            out["preset_name"] = self.preset_name
+        if self.reference is not None:
+            out["reference"] = self.reference
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CompositeProtocol":
+        """Inverse of :meth:`as_dict`. Each entry must already include its discriminator."""
+        if not isinstance(data, dict) or "base" not in data:
+            raise InputError(
+                "CompositeProtocol dict must include a 'base' entry."
+            )
+        base_data = data["base"]
+        if isinstance(base_data, dict) and "type" not in base_data:
+            base = SinglePointTerm(
+                label=base_data.get("label", "base"),
+                level=base_data.get("level", base_data),
+            )
+        else:
+            term = Term.from_dict(base_data)
+            if not isinstance(term, SinglePointTerm):
+                raise InputError("CompositeProtocol.base must be a SinglePointTerm.")
+            base = term
+        corrections = [Term.from_dict(d) for d in data.get("corrections", [])]
+        return cls(
+            base=base,
+            corrections=corrections,
+            preset_name=data.get("preset_name"),
+            reference=data.get("reference"),
+        )
+
+    @classmethod
+    def from_user_input(cls, raw: str | dict[str, Any]) -> "CompositeProtocol":
+        """Accept the YAML-shaped user input and produce a validated protocol.
+
+        Three forms are accepted:
+
+        * A *string* — interpreted as a preset name. Delegates to
+          :func:`arc.level.presets.expand_preset`.
+        * A *dict with* ``preset:`` *key* — preset with overrides. Delegates to
+          :func:`arc.level.presets.expand_preset`.
+        * A *dict with* ``base:`` *and* ``corrections:`` keys — fully explicit
+          recipe. ``base`` may be a Level shorthand (``"method/basis"``), a Level
+          dict, or a serialised SinglePointTerm. Each entry in ``corrections``
+          must include a ``type`` discriminator.
+
+        Raises
+        ------
+        arc.exceptions.InputError
+            On any malformed input.
+        """
+        preset_name: str | None = None
+        if isinstance(raw, str):
+            preset_name = raw
+            raw = expand_preset(raw)
+        elif isinstance(raw, dict) and "preset" in raw:
+            preset_name = raw["preset"]
+            raw = expand_preset(raw["preset"], overrides=raw.get("overrides"))
+        elif isinstance(raw, dict):
+            # Explicit recipe (or serialised ``as_dict()`` output). Deep-copy so
+            # we never mutate caller-owned state — downstream code pops fields
+            # off dicts when reading legacy forms.
+            raw = copy.deepcopy(raw)
+        else:
+            raise InputError(
+                f"sp_composite must be a preset name (str) or a dict; "
+                f"got {type(raw).__name__}."
+            )
+
+        if "base" not in raw:
+            raise InputError("sp_composite recipe must include a 'base' level.")
+
+        # Preserve preset_name when the caller handed us a serialised ``as_dict()``
+        # payload (which carries the 'preset_name' key from a prior
+        # ``from_user_input`` run). Preset name from the current call wins.
+        if preset_name is None:
+            preset_name = raw.get("preset_name")
+        reference = raw.get("reference")
+
+        # base may be: string ("method/basis"), Level dict, or explicit
+        # SinglePointTerm dict (with type='single_point').
+        base_raw = raw["base"]
+        if isinstance(base_raw, str):
+            base = SinglePointTerm(label="base", level=base_raw)
+        elif isinstance(base_raw, dict) and base_raw.get("type") == "single_point":
+            base = SinglePointTerm(
+                label=base_raw.get("label", "base"),
+                level=base_raw["level"],
+            )
+        elif isinstance(base_raw, dict):
+            # Legacy/shorthand form: the dict is a Level spec that optionally
+            # carries a 'label' key. Separate them without mutating the caller's
+            # state (base_raw is already a deep copy from above, but be explicit).
+            base_dict = {k: v for k, v in base_raw.items() if k != "label"}
+            label = base_raw.get("label", "base")
+            base = SinglePointTerm(label=label, level=base_dict)
+        else:
+            raise InputError(
+                f"sp_composite 'base' must be a level string, level dict, or "
+                f"SinglePointTerm dict; got {type(base_raw).__name__}."
+            )
+
+        corrections: list[Term] = []
+        for entry in raw.get("corrections", []):
+            if not isinstance(entry, dict):
+                raise InputError(
+                    f"Each correction must be a dict; got {type(entry).__name__}."
+                )
+            corrections.append(Term.from_dict(entry))
+        return cls(
+            base=base,
+            corrections=corrections,
+            preset_name=preset_name,
+            reference=reference,
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Public adapter                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def build_protocol(value: Any) -> CompositeProtocol:
+    """Coerce any supported user input into a :class:`CompositeProtocol`.
+
+    * If ``value`` is already a :class:`CompositeProtocol`, returns it unchanged.
+    * If it is a string or dict, delegates to
+      :meth:`CompositeProtocol.from_user_input`.
+    * Otherwise raises :class:`InputError`.
+    """
+    if isinstance(value, CompositeProtocol):
+        return value
+    if isinstance(value, (str, dict)):
+        return CompositeProtocol.from_user_input(value)
+    raise InputError(
+        f"Cannot build a CompositeProtocol from {type(value).__name__}; "
+        "expected str, dict, or CompositeProtocol."
+    )

--- a/arc/level/protocol.py
+++ b/arc/level/protocol.py
@@ -9,23 +9,26 @@ Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton, *J. Chem. Phys.* **121**, 11
 et al. 1998, Martin 1996), where small post-CCSD(T) corrections accumulate to
 several kJ/mol — exactly the range that affects TS barriers in kinetics.
 
-Data model
-----------
+Data model:
 
 A ``CompositeProtocol`` consists of:
 
-* ``base`` — a single :class:`SinglePointTerm` providing the absolute electronic
-  energy. By convention this is the "main" SP that the scheduler runs first; it is
-  also the level used for AEC (atom-energy-correction) lookups when the protocol
-  is wired into Arkane in a later phase.
-* ``corrections`` — an ordered list of additional :class:`Term` objects of any
-  subtype: :class:`SinglePointTerm`, :class:`DeltaTerm`, or
-  :class:`CBSExtrapolationTerm`.
+* ``base`` — a :class:`Term` providing the absolute electronic energy: either a
+  :class:`SinglePointTerm` (one anchor SP) or a :class:`CBSExtrapolationTerm`
+  (the canonical FPA shape — the absolute energy is the CBS-extrapolated value
+  of ≥2 SPs at increasing basis cardinality). The protocol's
+  ``primary_base_level`` (the single level, or the largest-cardinal leg for a
+  CBS base) is the level used for AEC (atom-energy-correction) lookups and for
+  ``sp_level`` defaulting in :mod:`arc.main`.
+* ``corrections`` — an ordered list of additional :class:`Term` objects:
+  :class:`SinglePointTerm` or :class:`DeltaTerm`. A
+  :class:`CBSExtrapolationTerm` is *not* accepted as a correction: with
+  ``components='total'`` (the only supported value) it evaluates to an absolute
+  energy, which would double-count the base. Use it as the ``base`` instead.
 
 The final energy is ``base.evaluate(...) + Σ correction.evaluate(...)``.
 
-Sub-job naming
---------------
+Sub-job naming:
 
 Each ``Term`` describes the QM single-point jobs it needs via
 :meth:`Term.required_levels`, returning ``[(sub_label, Level), ...]`` pairs. The
@@ -35,17 +38,19 @@ sub_labels are *globally* unique within the protocol and follow the convention:
 * ``DeltaTerm`` → ``"<term_label>__high"``, ``"<term_label>__low"``.
 * ``CBSExtrapolationTerm`` → ``"<term_label>__card_<X>"`` for each cardinal ``X``.
 
-The Phase 2 scheduler integration uses these sub_labels to track per-sub-job state
+The scheduler integration uses these sub_labels to track per-sub-job state
 across restarts.
 """
 
 import copy
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from typing import Any
 
 from arc.exceptions import InputError
 from arc.level.cbs import (
+    BUILTIN_FORMULA_ARITY,
     BUILTIN_FORMULAS,
     cardinal_from_basis,
     safe_eval_formula,
@@ -53,6 +58,60 @@ from arc.level.cbs import (
 )
 from arc.level.level import Level
 from arc.level.presets import expand_preset
+
+
+# --------------------------------------------------------------------------- #
+#  Coupled-cluster excitation ranks                                           #
+# --------------------------------------------------------------------------- #
+
+
+_CC_RANK_BY_LETTER = {'s': 1, 'd': 2, 't': 3, 'q': 4, 'p': 5}
+_CC_METHOD_REGEX = re.compile(r'^[ur]?cc(?P<iterative>sd[tq]*)(?:\((?P<perturbative>[tqp])\))?$')
+_F12_SUFFIX_REGEX = re.compile(r'-f12[abx]?$')
+
+
+def _parse_cc_method(method: str) -> tuple[int, int] | None:
+    """
+    Parse a coupled-cluster method string into its excitation ranks.
+
+    Case-insensitive; explicitly-correlated ``-f12`` (``-f12a``/``-f12b``)
+    suffixes and ``u``/``r`` spin-restriction prefixes are stripped.
+
+    Args:
+        method (str): The method name, e.g. ``'CCSD(T)-F12'`` or ``'ccsdt(q)'``.
+
+    Returns:
+        tuple[int, int] | None: ``(total_rank, iterative_rank)`` where the total
+        rank counts a perturbative top level (the ``(T)`` in CCSD(T)) the same
+        as an iterative one, or ``None`` if ``method`` is not a recognised
+        coupled-cluster method.
+    """
+    stripped = _F12_SUFFIX_REGEX.sub('', method.strip().lower())
+    match = _CC_METHOD_REGEX.match(stripped)
+    if match is None:
+        return None
+    iterative_rank = max(_CC_RANK_BY_LETTER[char] for char in match.group('iterative'))
+    perturbative = match.group('perturbative')
+    total_rank = max(iterative_rank, _CC_RANK_BY_LETTER[perturbative]) if perturbative \
+        else iterative_rank
+    return total_rank, iterative_rank
+
+
+def excitation_rank(method: str) -> int | None:
+    """
+    Return the coupled-cluster excitation rank of a method string.
+
+    ``ccsd`` → 2, ``ccsd(t)`` / ``ccsdt`` → 3, ``ccsdt(q)`` / ``ccsdtq`` → 4,
+    ``ccsdtq(p)`` → 5. Perturbative top levels count the same as iterative ones.
+
+    Args:
+        method (str): The method name (case-insensitive; ``-f12`` suffixes stripped).
+
+    Returns:
+        int | None: The excitation rank, or ``None`` for non-CC methods.
+    """
+    parsed = _parse_cc_method(method)
+    return parsed[0] if parsed is not None else None
 
 
 # --------------------------------------------------------------------------- #
@@ -70,13 +129,33 @@ class Term(ABC):
     2. The QM sub-jobs it needs, via :meth:`required_levels`.
     3. How to combine those sub-jobs' parsed energies into a single number, via
        :meth:`evaluate`.
+
+    Terms whose :meth:`evaluate` yields an *absolute* electronic energy (rather
+    than a difference) set ``provides_absolute_energy = True`` and may serve as
+    a :class:`CompositeProtocol` base. Every term also exposes a *primary* leg —
+    its most complete sub-job — via :attr:`primary_sub_label` /
+    :attr:`primary_level`, so callers never need to dispatch on term type.
     """
 
     label: str
 
+    # True for terms whose evaluate() returns an absolute electronic energy
+    # (SinglePointTerm, CBSExtrapolationTerm); False for difference terms.
+    provides_absolute_energy: bool = False
+
     @abstractmethod
     def required_levels(self) -> list[tuple[str, Level]]:
         """Return ``[(sub_label, Level), ...]`` pairs for every SP this term needs."""
+
+    @property
+    @abstractmethod
+    def primary_level(self) -> Level:
+        """The Level of this term's primary (most complete) sub-job."""
+
+    @property
+    @abstractmethod
+    def primary_sub_label(self) -> str:
+        """The sub_label of this term's primary (most complete) sub-job."""
 
     @abstractmethod
     def evaluate(self, energies: dict[str, float]) -> float:
@@ -129,11 +208,23 @@ def _coerce_level(value: str | dict[str, Any] | Level) -> Level:
 class SinglePointTerm(Term):
     """One absolute single-point energy at one level of theory."""
 
+    provides_absolute_energy = True
+
     def __init__(self, label: str, level: str | dict[str, Any] | Level):
         if not label:
             raise InputError("SinglePointTerm requires a non-empty label.")
         self.label = label
         self.level = _coerce_level(level)
+
+    @property
+    def primary_level(self) -> Level:
+        """The term's only Level."""
+        return self.level
+
+    @property
+    def primary_sub_label(self) -> str:
+        """The term's only sub_label (its label)."""
+        return self.label
 
     def required_levels(self) -> list[tuple[str, Level]]:
         return [(self.label, self.level)]
@@ -180,11 +271,48 @@ class DeltaTerm(Term):
     def _sub(self, suffix: str) -> str:
         return f"{self.label}__{suffix}"
 
+    @property
+    def primary_level(self) -> Level:
+        """The high leg's Level."""
+        return self.high
+
+    @property
+    def primary_sub_label(self) -> str:
+        """The high leg's sub_label."""
+        return self._sub("high")
+
     def required_levels(self) -> list[tuple[str, Level]]:
         return [(self._sub("high"), self.high), (self._sub("low"), self.low)]
 
     def evaluate(self, energies: dict[str, float]) -> float:
         return energies[self._sub("high")] - energies[self._sub("low")]
+
+    def is_trivially_zero(self, n_correlated: int) -> bool:
+        """
+        Whether ``E[high] − E[low]`` is identically zero for a species with
+        ``n_correlated`` correlated electrons.
+
+        A coupled-cluster method reproduces the exact (FCI) energy when its
+        *iterative* excitation rank covers every correlated electron; a
+        perturbative top level — the ``(T)`` in CCSD(T) — then vanishes too,
+        because excitations beyond the electron count cannot exist. The delta
+        is provably zero only when BOTH legs are exact by this criterion; a
+        non-CC leg (HF, MP2, DFT) is never considered exact. For a high leg
+        with a perturbative top this reduces to the rank test
+        ``n_correlated < excitation_rank(high.method)``.
+
+        Args:
+            n_correlated (int): The species' correlated electron count
+                (total electrons minus two per frozen-core orbital).
+
+        Returns:
+            bool: ``True`` if the delta correction is identically zero.
+        """
+        high = _parse_cc_method(self.high.method)
+        low = _parse_cc_method(self.low.method)
+        if high is None or low is None:
+            return False
+        return n_correlated <= high[1] and n_correlated <= low[1]
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -219,23 +347,33 @@ class CBSExtrapolationTerm(Term):
     (:data:`arc.level.cbs.BUILTIN_FORMULAS`) or a user-supplied arithmetic
     expression evaluated by :func:`arc.level.cbs.safe_eval_formula`.
 
-    Parameters
-    ----------
-    label : str
-        Term identifier.
-    formula : str
-        Built-in name or arithmetic expression. User expressions may reference
-        ``X``, ``Y``, ``Z`` (cardinal numbers) and ``E_X``, ``E_Y``, ``E_Z``
-        (corresponding energies), bound by ascending cardinal order.
-        User formulas with more than 3 levels are rejected: expose only the
-        first three cardinal variables we bind.
-    levels : list of Level
-        ≥2 levels, all with the same method, all with deducible distinct cardinals.
-    components : {'total'}
-        Which energy component the extrapolation applies to. **Only ``'total'``
-        is currently accepted.** Other values are rejected at construction time
-        until component-specific parsing exists — see ``_ALLOWED_COMPONENTS``
-        above for rationale.
+    With ``components='total'`` (the only supported value) the formula is applied
+    to TOTAL electronic energies, so the term evaluates to an *absolute* CBS
+    energy — it serves as a :class:`CompositeProtocol` base, not as a correction.
+
+    A note on the formula choice: a two-point ``X^-3`` extrapolation (e.g.
+    ``helgaker_corr_2pt``) applied to total energies technically mis-treats the
+    HF component, which converges exponentially with cardinal number rather than
+    as ``X^-3`` — the formula was derived for the correlation energy alone. At
+    {T,Q} and higher cardinals the HF residual is small and extrapolating totals
+    this way is common practice; the residual error is well below the other
+    approximations in a typical focal-point stack. For a strictly component-wise
+    treatment, wait for (or contribute) adapter-level HF/correlation component
+    parsing, which will unlock ``components='hf'`` / ``'corr'``.
+
+    Args:
+        label (str): Term identifier.
+        formula (str): Built-in name or arithmetic expression. User expressions
+            may reference ``X``, ``Y``, ``Z`` (cardinal numbers) and ``E_X``,
+            ``E_Y``, ``E_Z`` (corresponding energies), bound by ascending
+            cardinal order. User formulas with more than 3 levels are rejected:
+            expose only the first three cardinal variables we bind.
+        levels (list): ≥2 levels, all with the same method, all with deducible
+            distinct cardinals.
+        components (str): Which energy component the extrapolation applies to.
+            **Only ``'total'`` is currently accepted.** Other values are
+            rejected at construction time until component-specific parsing
+            exists — see ``_ALLOWED_COMPONENTS`` above for rationale.
     """
 
     def __init__(
@@ -279,16 +417,6 @@ class CBSExtrapolationTerm(Term):
         self.formula = formula
         self._formula_callable = self._resolve_formula(formula, len(self.levels))
 
-    # Arity required by each shipped built-in formula. Surfacing this at
-    # construction time catches "martin_3pt with 2 levels" before a sub-job
-    # ever runs. When new built-ins are added, update this table alongside
-    # the entry in arc.level.cbs.BUILTIN_FORMULAS.
-    _BUILTIN_FORMULA_ARITY: dict[str, int] = {
-        "helgaker_corr_2pt": 2,
-        "helgaker_hf_2pt": 2,
-        "martin_3pt": 3,
-    }
-
     # Upper bound for user-supplied formula arity: the safe-eval variable
     # binder exposes only X/Y/Z (and E_X/E_Y/E_Z). Supporting more would
     # require extending both the binder and the safe-eval allow-list tests.
@@ -296,16 +424,29 @@ class CBSExtrapolationTerm(Term):
 
     @staticmethod
     def _resolve_formula(formula: str, n_levels: int) -> Callable[[dict[int, float]], float]:
-        """Validate ``formula`` against the built-in registry and (if user-supplied)
+        """
+        Validate ``formula`` against the built-in registry and (if user-supplied)
         the safe-eval whitelist; return a callable taking ``{cardinal: energy}``.
 
-        Built-in formulas additionally have their required arity enforced here
-        (Phase 5.5) so a recipe with the wrong number of levels fails at
-        construction, not at sub-job-completion time.
+        Built-in formulas additionally have their required arity (from
+        :data:`arc.level.cbs.BUILTIN_FORMULA_ARITY`) enforced here so a recipe
+        with the wrong number of levels fails at construction, not at
+        sub-job-completion time.
+
+        Args:
+            formula (str): Built-in formula name or user arithmetic expression.
+            n_levels (int): Number of levels supplied to the term.
+
+        Returns:
+            Callable[[dict[int, float]], float]: The formula callable.
+
+        Raises:
+            InputError: If a built-in formula's arity doesn't match ``n_levels``,
+                or a user formula is malformed or uses too many levels.
         """
         if formula in BUILTIN_FORMULAS:
-            required = CBSExtrapolationTerm._BUILTIN_FORMULA_ARITY.get(formula)
-            if required is not None and n_levels != required:
+            required = BUILTIN_FORMULA_ARITY[formula]
+            if n_levels != required:
                 raise InputError(
                     f"Built-in CBS formula '{formula}' requires exactly "
                     f"{required} levels; got {n_levels}."
@@ -340,8 +481,20 @@ class CBSExtrapolationTerm(Term):
 
         return _user_fn
 
+    provides_absolute_energy = True
+
     def _sub(self, cardinal: int) -> str:
         return f"{self.label}__card_{cardinal}"
+
+    @property
+    def primary_level(self) -> Level:
+        """The largest-cardinal leg's Level (levels are sorted ascending)."""
+        return self.levels[-1]
+
+    @property
+    def primary_sub_label(self) -> str:
+        """The largest-cardinal leg's sub_label."""
+        return self._sub(self._cardinals[-1])
 
     def required_levels(self) -> list[tuple[str, Level]]:
         return [(self._sub(c), lvl) for c, lvl in zip(self._cardinals, self.levels)]
@@ -394,17 +547,27 @@ class CompositeProtocol:
 
     def __init__(
         self,
-        base: SinglePointTerm,
+        base: Term,
         corrections: list[Term] | None = None,
         preset_name: str | None = None,
         reference: str | None = None,
     ):
-        if not isinstance(base, SinglePointTerm):
+        if not isinstance(base, Term) or not base.provides_absolute_energy:
             raise InputError(
-                "CompositeProtocol.base must be a SinglePointTerm; "
+                "CompositeProtocol.base must be a Term providing an absolute "
+                "electronic energy (SinglePointTerm or CBSExtrapolationTerm); "
                 f"got {type(base).__name__}."
             )
         corrections = list(corrections) if corrections else []
+        for term in corrections:
+            if isinstance(term, CBSExtrapolationTerm):
+                raise InputError(
+                    f"CBS extrapolation term '{term.label}' cannot be a correction: "
+                    f"with components='total' it extrapolates absolute energies and "
+                    f"would double-count the base. Use the CBS term as the protocol's "
+                    f"'base' (CBS-as-base, the canonical FPA shape), or pick one of "
+                    f"the HEAT / W-n presets."
+                )
         labels = [base.label] + [t.label for t in corrections]
         if len(set(labels)) != len(labels):
             raise InputError(
@@ -437,6 +600,21 @@ class CompositeProtocol:
     def terms(self) -> list[Term]:
         """Convenience: ``[base, *corrections]`` in protocol order."""
         return [self.base, *self.corrections]
+
+    @property
+    def base_sub_labels(self) -> list[str]:
+        """All sub_labels of the base term, in ascending-cardinal order."""
+        return [sub_label for sub_label, _level in self.base.required_levels()]
+
+    @property
+    def primary_base_sub_label(self) -> str:
+        """The base's primary sub_label (largest-cardinal leg for a CBS base)."""
+        return self.base.primary_sub_label
+
+    @property
+    def primary_base_level(self) -> Level:
+        """The base's primary Level (largest-cardinal leg for a CBS base)."""
+        return self.base.primary_level
 
     def evaluate(self, energies: dict[str, float]) -> float:
         """Combine all sub-job energies into the protocol's electronic energy."""
@@ -473,10 +651,13 @@ class CompositeProtocol:
                 level=base_data.get("level", base_data),
             )
         else:
-            term = Term.from_dict(base_data)
-            if not isinstance(term, SinglePointTerm):
-                raise InputError("CompositeProtocol.base must be a SinglePointTerm.")
-            base = term
+            base = Term.from_dict(base_data)
+            if not base.provides_absolute_energy:
+                raise InputError(
+                    "CompositeProtocol.base must provide an absolute electronic "
+                    "energy (single_point or cbs_extrapolation); got "
+                    f"'{base_data.get('type')}'."
+                )
         corrections = [Term.from_dict(d) for d in data.get("corrections", [])]
         return cls(
             base=base,
@@ -497,13 +678,18 @@ class CompositeProtocol:
           :func:`arc.level.presets.expand_preset`.
         * A *dict with* ``base:`` *and* ``corrections:`` keys — fully explicit
           recipe. ``base`` may be a Level shorthand (``"method/basis"``), a Level
-          dict, or a serialised SinglePointTerm. Each entry in ``corrections``
-          must include a ``type`` discriminator.
+          dict, or a serialised term dict (``type: single_point`` or
+          ``type: cbs_extrapolation``). Each entry in ``corrections`` must
+          include a ``type`` discriminator.
 
-        Raises
-        ------
-        arc.exceptions.InputError
-            On any malformed input.
+        Args:
+            raw (str | dict): The user input, in one of the three forms above.
+
+        Returns:
+            CompositeProtocol: The validated protocol.
+
+        Raises:
+            InputError: On any malformed input.
         """
         preset_name: str | None = None
         if isinstance(raw, str):
@@ -533,16 +719,23 @@ class CompositeProtocol:
             preset_name = raw.get("preset_name")
         reference = raw.get("reference")
 
-        # base may be: string ("method/basis"), Level dict, or explicit
-        # SinglePointTerm dict (with type='single_point').
+        # base may be: string ("method/basis"), Level dict, or an explicit
+        # term dict with a 'type' discriminator ('single_point' or
+        # 'cbs_extrapolation'). A typed base dict defaults to label 'base' so
+        # CBS-base sub_labels ('base__card_<X>') stay deterministic for restart.
         base_raw = raw["base"]
         if isinstance(base_raw, str):
             base = SinglePointTerm(label="base", level=base_raw)
-        elif isinstance(base_raw, dict) and base_raw.get("type") == "single_point":
-            base = SinglePointTerm(
-                label=base_raw.get("label", "base"),
-                level=base_raw["level"],
-            )
+        elif isinstance(base_raw, dict) and "type" in base_raw:
+            base_data = dict(base_raw)
+            base_data.setdefault("label", "base")
+            base = Term.from_dict(base_data)
+            if not base.provides_absolute_energy:
+                raise InputError(
+                    "sp_composite 'base' must provide an absolute electronic "
+                    "energy (single_point or cbs_extrapolation); got "
+                    f"'{base_raw['type']}'."
+                )
         elif isinstance(base_raw, dict):
             # Legacy/shorthand form: the dict is a Level spec that optionally
             # carries a 'label' key. Separate them without mutating the caller's

--- a/arc/level/protocol_test.py
+++ b/arc/level/protocol_test.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.protocol`` — the data model behind ``sp_composite``.
+
+These tests cover only the pure data-model layer (no scheduler, no IO). They verify:
+* ``Term`` subclasses know which sub-jobs they need and how to combine results.
+* ``CompositeProtocol`` sums correctly and survives YAML round-trips.
+* Construction-time validation rejects malformed inputs with :class:`InputError`.
+"""
+
+import copy
+import unittest
+
+from arc.exceptions import InputError
+from arc.level import Level
+from arc.level.protocol import (
+    CBSExtrapolationTerm,
+    CompositeProtocol,
+    DeltaTerm,
+    SinglePointTerm,
+    Term,
+    build_protocol,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Term subclasses                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestSinglePointTerm(unittest.TestCase):
+    def test_required_levels_one_entry(self):
+        lvl = Level(method="ccsd(t)-f12", basis="cc-pVTZ-f12")
+        t = SinglePointTerm(label="base", level=lvl)
+        self.assertEqual(t.required_levels(), [("base", lvl)])
+
+    def test_evaluate_returns_input(self):
+        lvl = Level(method="hf", basis="cc-pVTZ")
+        t = SinglePointTerm(label="base", level=lvl)
+        self.assertEqual(t.evaluate({"base": -76.0}), -76.0)
+
+    def test_evaluate_missing_key_raises(self):
+        t = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        with self.assertRaises(KeyError):
+            t.evaluate({"other": -1.0})
+
+    def test_round_trip_dict(self):
+        original = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        as_dict = original.as_dict()
+        self.assertEqual(as_dict["type"], "single_point")
+        self.assertEqual(as_dict["label"], "base")
+        rebuilt = Term.from_dict(as_dict)
+        self.assertIsInstance(rebuilt, SinglePointTerm)
+        self.assertEqual(rebuilt.level.method, "hf")
+
+
+class TestDeltaTerm(unittest.TestCase):
+    def setUp(self):
+        self.high = Level(method="ccsdt", basis="cc-pVDZ")
+        self.low = Level(method="ccsd(t)", basis="cc-pVDZ")
+
+    def test_required_levels_returns_high_and_low(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        pairs = dict(t.required_levels())
+        self.assertEqual(set(pairs.keys()), {"delta_T__high", "delta_T__low"})
+        self.assertIs(pairs["delta_T__high"], self.high)
+        self.assertIs(pairs["delta_T__low"], self.low)
+
+    def test_evaluate_high_minus_low(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        result = t.evaluate({"delta_T__high": -100.0, "delta_T__low": -98.0})
+        self.assertEqual(result, -2.0)
+
+    def test_evaluate_independent_of_other_keys(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        result = t.evaluate(
+            {"delta_T__high": -100.0, "delta_T__low": -98.0, "noise": 999.0}
+        )
+        self.assertEqual(result, -2.0)
+
+    def test_round_trip_dict(self):
+        original = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        rebuilt = Term.from_dict(original.as_dict())
+        self.assertIsInstance(rebuilt, DeltaTerm)
+        self.assertEqual(rebuilt.label, "delta_T")
+        self.assertEqual(rebuilt.high.method, "ccsdt")
+        self.assertEqual(rebuilt.low.method, "ccsd(t)")
+
+    def test_construction_requires_both_high_and_low(self):
+        with self.assertRaises(InputError):
+            DeltaTerm(label="bad", high=self.high, low=None)
+        with self.assertRaises(InputError):
+            DeltaTerm(label="bad", high=None, low=self.low)
+
+
+class TestCBSExtrapolationTerm(unittest.TestCase):
+    def setUp(self):
+        self.tz = Level(method="ccsd(t)", basis="cc-pVTZ")
+        self.qz = Level(method="ccsd(t)", basis="cc-pVQZ")
+        self.fz = Level(method="ccsd(t)", basis="cc-pV5Z")
+
+    def test_required_levels_uses_cardinal_in_sub_label(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        keys = set(k for k, _ in term.required_levels())
+        self.assertEqual(keys, {"cbs_corr__card_3", "cbs_corr__card_4"})
+
+    def test_evaluate_calls_builtin_formula(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        # Same formula as cbs_test::test_known_values:
+        # E_CBS = (27*(-0.30) - 64*(-0.31)) / (27 - 64)
+        result = term.evaluate({"cbs_corr__card_3": -0.30, "cbs_corr__card_4": -0.31})
+        expected = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_evaluate_user_formula(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_user",
+            formula="(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)",
+            levels=[self.tz, self.qz],
+        )
+        result = term.evaluate({"cbs_user__card_3": -0.30, "cbs_user__card_4": -0.31})
+        expected = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_three_point_martin(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_m", formula="martin_3pt", levels=[self.tz, self.qz, self.fz]
+        )
+        # Synthetic E(L) = -1 + 0.05/(L+0.5)^4 + 0.01/(L+0.5)^6
+        e3 = -1.0 + 0.05 / 3.5**4 + 0.01 / 3.5**6
+        e4 = -1.0 + 0.05 / 4.5**4 + 0.01 / 4.5**6
+        e5 = -1.0 + 0.05 / 5.5**4 + 0.01 / 5.5**6
+        result = term.evaluate(
+            {"cbs_m__card_3": e3, "cbs_m__card_4": e4, "cbs_m__card_5": e5}
+        )
+        self.assertAlmostEqual(result, -1.0, places=10)
+
+    def test_round_trip_dict(self):
+        original = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        rebuilt = Term.from_dict(original.as_dict())
+        self.assertIsInstance(rebuilt, CBSExtrapolationTerm)
+        self.assertEqual(rebuilt.formula, "helgaker_corr_2pt")
+        self.assertEqual(len(rebuilt.levels), 2)
+
+    def test_validate_too_few_levels(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(label="x", formula="helgaker_corr_2pt", levels=[self.tz])
+
+    def test_validate_method_mismatch_across_levels(self):
+        mixed = Level(method="ccsdt", basis="cc-pVQZ")
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, mixed]
+            )
+
+    def test_validate_indistinct_cardinals(self):
+        another_tz = Level(method="ccsd(t)", basis="cc-pVTZ")
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, another_tz]
+            )
+
+    def test_validate_unknown_builtin_formula(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="not_a_real_formula_2pt", levels=[self.tz, self.qz]
+            )
+
+    def test_user_formula_accepted_at_construction(self):
+        term = CBSExtrapolationTerm(
+            label="x",
+            formula="E_X + E_Y",
+            levels=[self.tz, self.qz],
+        )
+        self.assertEqual(term.formula, "E_X + E_Y")
+
+    def test_user_formula_with_disallowed_node_rejected_at_construction(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x",
+                formula="(0).__class__",
+                levels=[self.tz, self.qz],
+            )
+
+    def test_components_default_total(self):
+        term = CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        self.assertEqual(term.components, "total")
+
+    def test_components_total_is_default_and_valid(self):
+        term = CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+        )
+        self.assertEqual(term.components, "total")
+
+    def test_components_total_explicit_accepted(self):
+        CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+            components="total",
+        )
+
+    def test_components_corr_rejected_until_component_parsing_exists(self):
+        """Phase 5.5: reject components != 'total'. parse_e_elect returns total
+        energies, so extrapolating them while claiming 'corr' or 'hf' would
+        silently produce a wrong answer."""
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+                components="corr",
+            )
+
+    def test_components_hf_rejected_until_component_parsing_exists(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_hf_2pt", levels=[self.tz, self.qz],
+                components="hf",
+            )
+
+    def test_components_bogus_rejected(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+                components="bogus",
+            )
+
+    # --- Phase 5.5: formula arity at construction ---------------------------- #
+
+    def test_martin_3pt_with_2_levels_rejected_at_construction(self):
+        """martin_3pt needs exactly 3 levels — rejected eagerly."""
+        with self.assertRaises(InputError) as ctx:
+            CBSExtrapolationTerm(
+                label="m", formula="martin_3pt",
+                levels=[self.tz, self.qz],
+            )
+        self.assertIn("martin_3pt", str(ctx.exception))
+        self.assertIn("3", str(ctx.exception))
+
+    def test_helgaker_corr_2pt_with_3_levels_rejected_at_construction(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="h", formula="helgaker_corr_2pt",
+                levels=[self.tz, self.qz, self.fz],
+            )
+
+    def test_user_formula_with_4_levels_rejected(self):
+        """User formulas expose only X/Y/Z; 4+ levels are rejected."""
+        fourth = Level(method="ccsd(t)", basis="cc-pV6Z")
+        with self.assertRaises(InputError) as ctx:
+            CBSExtrapolationTerm(
+                label="u", formula="E_X + E_Y + E_Z",
+                levels=[self.tz, self.qz, self.fz, fourth],
+            )
+        self.assertIn("3", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+#  CompositeProtocol                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _hf_base():
+    return SinglePointTerm(label="base", level=Level(method="ccsd(t)-f12", basis="cc-pVTZ-f12"))
+
+
+def _delta_t():
+    return DeltaTerm(
+        label="delta_T",
+        high=Level(method="ccsdt", basis="cc-pVDZ"),
+        low=Level(method="ccsd(t)", basis="cc-pVDZ"),
+    )
+
+
+def _delta_q():
+    return DeltaTerm(
+        label="delta_Q",
+        high=Level(method="ccsdt(q)", basis="cc-pVDZ"),
+        low=Level(method="ccsdt", basis="cc-pVDZ"),
+    )
+
+
+class TestCompositeProtocolBasics(unittest.TestCase):
+    def test_evaluate_two_term(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t()])
+        energies = {"base": -100.0, "delta_T__high": -100.5, "delta_T__low": -100.4}
+        # base + (high - low) = -100.0 + (-100.5 - -100.4) = -100.1
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.1, places=12)
+
+    def test_evaluate_three_term(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_q()])
+        energies = {
+            "base": -100.0,
+            "delta_T__high": -100.5, "delta_T__low": -100.4,    # δT = -0.1
+            "delta_Q__high": -100.55, "delta_Q__low": -100.5,   # δQ = -0.05
+        }
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.15, places=12)
+
+    def test_evaluate_with_cbs_term(self):
+        cbs_term = CBSExtrapolationTerm(
+            label="cbs_corr",
+            formula="helgaker_corr_2pt",
+            levels=[Level(method="ccsd(t)", basis="cc-pVTZ"),
+                    Level(method="ccsd(t)", basis="cc-pVQZ")],
+        )
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[cbs_term])
+        energies = {
+            "base": -100.0,
+            "cbs_corr__card_3": -0.30,
+            "cbs_corr__card_4": -0.31,
+        }
+        cbs_value = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.0 + cbs_value, places=12)
+
+    def test_iter_required_jobs_yields_every_sub_job(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_q()])
+        triples = list(protocol.iter_required_jobs())
+        sub_labels = sorted(t[1] for t in triples)
+        self.assertEqual(
+            sub_labels,
+            sorted(["base", "delta_T__high", "delta_T__low",
+                    "delta_Q__high", "delta_Q__low"]),
+        )
+        # Each triple is (term_label, sub_label, Level).
+        for term_label, sub_label, level in triples:
+            self.assertIsInstance(level, Level)
+            self.assertTrue(sub_label.startswith(term_label))
+
+    def test_base_is_a_single_point_term(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_delta_t(), corrections=[])
+
+    def test_duplicate_term_labels_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_t()])
+
+    def test_label_collision_with_base_rejected(self):
+        clash = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_hf_base(), corrections=[clash])
+
+    def test_sub_label_collision_across_terms_rejected(self):
+        """Phase 5.5: a SinglePointTerm whose label matches a DeltaTerm's
+        generated sub_label must be rejected at construction time. Without this
+        check, the scheduler's pending/completed maps would get silent overwrites."""
+        with self.assertRaises(InputError) as ctx:
+            CompositeProtocol(
+                base=_hf_base(),
+                corrections=[
+                    SinglePointTerm(
+                        label="delta_T__high",
+                        level=Level(method="hf", basis="cc-pVDZ"),
+                    ),
+                    _delta_t(),  # produces sub_labels delta_T__high, delta_T__low
+                ],
+            )
+        self.assertIn("delta_T__high", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+#  YAML / dict round-trip                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestCompositeProtocolFromDict(unittest.TestCase):
+    def test_explicit_form_round_trip(self):
+        protocol = CompositeProtocol(
+            base=_hf_base(), corrections=[_delta_t(), _delta_q()]
+        )
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        # Round-trip preserves base + every correction.
+        self.assertEqual(rebuilt.base.label, "base")
+        self.assertEqual([t.label for t in rebuilt.corrections], ["delta_T", "delta_Q"])
+
+    def test_explicit_form_evaluate_after_round_trip(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t()])
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        energies = {"base": -100.0, "delta_T__high": -100.5, "delta_T__low": -100.4}
+        self.assertAlmostEqual(rebuilt.evaluate(energies), -100.1, places=12)
+
+    def test_explicit_user_input_minimal(self):
+        raw = {
+            "base": {"method": "ccsd(t)-f12", "basis": "cc-pVTZ-f12"},
+            "corrections": [
+                {
+                    "label": "delta_T", "type": "delta",
+                    "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+                    "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                },
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(raw)
+        self.assertEqual(protocol.base.level.method, "ccsd(t)-f12")
+        self.assertEqual(protocol.corrections[0].label, "delta_T")
+
+    def test_explicit_user_input_with_string_levels(self):
+        raw = {
+            "base": "ccsd(t)-f12/cc-pVTZ-f12",
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": "ccsdt/cc-pVDZ", "low": "ccsd(t)/cc-pVDZ"},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(raw)
+        self.assertEqual(protocol.base.level.basis, "cc-pvtz-f12")
+        self.assertEqual(protocol.corrections[0].high.method, "ccsdt")
+
+    def test_user_input_missing_base_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input({"corrections": []})
+
+    def test_user_input_unknown_term_type_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input({
+                "base": "hf/cc-pVTZ",
+                "corrections": [{"label": "x", "type": "bogus_term"}],
+            })
+
+
+class TestBuildProtocolHelper(unittest.TestCase):
+    """``build_protocol`` is the public adapter from any user input form."""
+
+    def test_dict_form_routed_to_from_user_input(self):
+        protocol = build_protocol({
+            "base": "hf/cc-pVTZ",
+            "corrections": [],
+        })
+        self.assertIsInstance(protocol, CompositeProtocol)
+        self.assertEqual(protocol.base.level.method, "hf")
+
+    def test_already_a_protocol_returned_as_is(self):
+        original = CompositeProtocol(base=_hf_base(), corrections=[])
+        self.assertIs(build_protocol(original), original)
+
+    def test_invalid_type_rejected(self):
+        with self.assertRaises(InputError):
+            build_protocol(12345)
+
+
+class TestFromUserInputNoMutation(unittest.TestCase):
+    """Phase 5.5: ``from_user_input`` must not mutate caller-owned dicts.
+
+    Pre-5.5 the base-dict branch popped the ``label`` key off the caller's
+    input, breaking idempotent re-parse and polluting restart state.
+    """
+
+    def test_explicit_dict_not_mutated(self):
+        original = {
+            "base": {"method": "hf", "basis": "cc-pVTZ", "label": "base"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+                 "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+            "reference": "test DOI",
+        }
+        snapshot = copy.deepcopy(original)
+        CompositeProtocol.from_user_input(original)
+        self.assertEqual(original, snapshot, "from_user_input mutated its input dict")
+
+    def test_preset_with_overrides_dict_not_mutated(self):
+        raw = {"preset": "HEAT-345Q", "overrides": {"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}}}
+        snapshot = copy.deepcopy(raw)
+        CompositeProtocol.from_user_input(raw)
+        self.assertEqual(raw, snapshot)
+
+    def test_base_dict_with_label_key_not_mutated(self):
+        base_dict = {"method": "hf", "basis": "cc-pVTZ", "label": "my_base"}
+        recipe = {"base": base_dict, "corrections": []}
+        snapshot = copy.deepcopy(base_dict)
+        protocol = CompositeProtocol.from_user_input(recipe)
+        self.assertEqual(base_dict, snapshot)
+        self.assertEqual(protocol.base.label, "my_base")
+        self.assertEqual(protocol.base.level.method, "hf")
+
+    def test_build_protocol_not_mutating(self):
+        raw = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        snapshot = copy.deepcopy(raw)
+        build_protocol(raw)
+        self.assertEqual(raw, snapshot)
+
+
+class TestFromUserInputPresetMetadataPreservation(unittest.TestCase):
+    """Phase 5.5: serialised ``as_dict()`` output must round-trip preset_name
+    through ``from_user_input`` (in addition to ``from_dict``)."""
+
+    def test_from_user_input_reads_preset_name_from_as_dict_output(self):
+        proto1 = CompositeProtocol.from_user_input("HEAT-345Q")
+        serialised = proto1.as_dict()
+        self.assertEqual(serialised["preset_name"], "HEAT-345Q")
+        proto2 = CompositeProtocol.from_user_input(serialised)
+        self.assertEqual(proto2.preset_name, "HEAT-345Q")
+        self.assertEqual(proto2.reference, proto1.reference)
+
+    def test_from_user_input_reads_reference_from_as_dict_output(self):
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+            "reference": "DOI: 10.1/test",
+        }
+        proto1 = CompositeProtocol.from_user_input(recipe)
+        proto2 = CompositeProtocol.from_user_input(proto1.as_dict())
+        self.assertEqual(proto2.reference, "DOI: 10.1/test")
+
+    def test_build_protocol_path_also_preserves_preset_name(self):
+        proto1 = CompositeProtocol.from_user_input("FPA-min")
+        proto2 = build_protocol(proto1.as_dict())
+        self.assertEqual(proto2.preset_name, "FPA-min")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/protocol_test.py
+++ b/arc/level/protocol_test.py
@@ -22,6 +22,7 @@ from arc.level.protocol import (
     SinglePointTerm,
     Term,
     build_protocol,
+    excitation_rank,
 )
 
 
@@ -93,6 +94,86 @@ class TestDeltaTerm(unittest.TestCase):
             DeltaTerm(label="bad", high=self.high, low=None)
         with self.assertRaises(InputError):
             DeltaTerm(label="bad", high=None, low=self.low)
+
+
+class TestExcitationRank(unittest.TestCase):
+    """``excitation_rank`` parses the CC excitation rank off a method string."""
+
+    def test_plain_cc_methods(self):
+        self.assertEqual(excitation_rank('ccsd'), 2)
+        self.assertEqual(excitation_rank('ccsdt'), 3)
+        self.assertEqual(excitation_rank('ccsdtq'), 4)
+
+    def test_perturbative_top_counts_like_iterative(self):
+        self.assertEqual(excitation_rank('ccsd(t)'), 3)
+        self.assertEqual(excitation_rank('ccsdt(q)'), 4)
+        self.assertEqual(excitation_rank('ccsdtq(p)'), 5)
+
+    def test_case_insensitive(self):
+        self.assertEqual(excitation_rank('CCSD'), 2)
+        self.assertEqual(excitation_rank('CCSDT(Q)'), 4)
+
+    def test_f12_suffix_stripped(self):
+        self.assertEqual(excitation_rank('ccsd(t)-f12'), 3)
+        self.assertEqual(excitation_rank('ccsd-f12a'), 2)
+        self.assertEqual(excitation_rank('CCSD(T)-F12b'), 3)
+
+    def test_spin_restriction_prefixes(self):
+        self.assertEqual(excitation_rank('uccsd(t)'), 3)
+        self.assertEqual(excitation_rank('rccsd(t)'), 3)
+
+    def test_non_cc_methods_return_none(self):
+        for method in ('hf', 'mp2', 'b3lyp', 'wb97xd', 'cisd', 'cbs-qb3', ''):
+            self.assertIsNone(excitation_rank(method), method)
+
+
+class TestDeltaTermIsTriviallyZero(unittest.TestCase):
+    """``DeltaTerm.is_trivially_zero`` — the proactive δ≡0 decision."""
+
+    def setUp(self):
+        self.delta_t = DeltaTerm(label='delta_T',
+                                 high=Level(method='ccsdt', basis='cc-pVDZ'),
+                                 low=Level(method='ccsd(t)', basis='cc-pVDZ'))
+        self.delta_q = DeltaTerm(label='delta_Q',
+                                 high=Level(method='ccsdt(q)', basis='cc-pVDZ'),
+                                 low=Level(method='ccsdt', basis='cc-pVDZ'))
+
+    def test_h_atom_skips_delta_t(self):
+        self.assertTrue(self.delta_t.is_trivially_zero(1))
+
+    def test_he_skips_delta_t_and_delta_q(self):
+        self.assertTrue(self.delta_t.is_trivially_zero(2))
+        self.assertTrue(self.delta_q.is_trivially_zero(2))
+
+    def test_three_correlated_electrons_keep_delta_t(self):
+        # CCSD(T)'s perturbative triples are inexact for 3 correlated electrons.
+        self.assertFalse(self.delta_t.is_trivially_zero(3))
+
+    def test_strict_boundary_rank_equals_n_corr_not_skipped(self):
+        # Be all-electron: n_corr=4 vs δ[(Q)] rank 4 — 4 < 4 is False.
+        self.assertFalse(self.delta_q.is_trivially_zero(4))
+
+    def test_three_correlated_electrons_skip_delta_q(self):
+        # CCSDT is FCI for 3 electrons and quadruples cannot exist, so (Q) = 0.
+        self.assertTrue(self.delta_q.is_trivially_zero(3))
+
+    def test_perturbative_low_leg_at_boundary_not_skipped(self):
+        # CCSDTQ is FCI for 3 electrons but CCSD(T) is not — δ ≠ 0.
+        term = DeltaTerm(label='d',
+                         high=Level(method='ccsdtq', basis='cc-pVDZ'),
+                         low=Level(method='ccsd(t)', basis='cc-pVDZ'))
+        self.assertFalse(term.is_trivially_zero(3))
+
+    def test_non_cc_low_leg_never_skipped(self):
+        term = DeltaTerm(label='d',
+                         high=Level(method='ccsd', basis='cc-pVDZ'),
+                         low=Level(method='mp2', basis='cc-pVDZ'))
+        self.assertFalse(term.is_trivially_zero(1))
+
+    def test_polyatomic_counts_keep_all_deltas(self):
+        for n_corr in (8, 10, 50):
+            self.assertFalse(self.delta_t.is_trivially_zero(n_corr))
+            self.assertFalse(self.delta_q.is_trivially_zero(n_corr))
 
 
 class TestCBSExtrapolationTerm(unittest.TestCase):
@@ -221,7 +302,7 @@ class TestCBSExtrapolationTerm(unittest.TestCase):
         )
 
     def test_components_corr_rejected_until_component_parsing_exists(self):
-        """Phase 5.5: reject components != 'total'. parse_e_elect returns total
+        """Reject components != 'total'. parse_e_elect returns total
         energies, so extrapolating them while claiming 'corr' or 'hf' would
         silently produce a wrong answer."""
         with self.assertRaises(InputError):
@@ -244,7 +325,7 @@ class TestCBSExtrapolationTerm(unittest.TestCase):
                 components="bogus",
             )
 
-    # --- Phase 5.5: formula arity at construction ---------------------------- #
+    # --- formula arity at construction --------------------------------------- #
 
     def test_martin_3pt_with_2_levels_rejected_at_construction(self):
         """martin_3pt needs exactly 3 levels — rejected eagerly."""
@@ -315,21 +396,21 @@ class TestCompositeProtocolBasics(unittest.TestCase):
         }
         self.assertAlmostEqual(protocol.evaluate(energies), -100.15, places=12)
 
-    def test_evaluate_with_cbs_term(self):
+    def test_cbs_term_in_corrections_rejected(self):
+        """A cbs_extrapolation correction with components='total' extrapolates
+        absolute energies and would double-count the base — rejected at
+        construction with a pointer to CBS-as-base usage."""
         cbs_term = CBSExtrapolationTerm(
             label="cbs_corr",
             formula="helgaker_corr_2pt",
             levels=[Level(method="ccsd(t)", basis="cc-pVTZ"),
                     Level(method="ccsd(t)", basis="cc-pVQZ")],
         )
-        protocol = CompositeProtocol(base=_hf_base(), corrections=[cbs_term])
-        energies = {
-            "base": -100.0,
-            "cbs_corr__card_3": -0.30,
-            "cbs_corr__card_4": -0.31,
-        }
-        cbs_value = (27 * -0.30 - 64 * -0.31) / (27 - 64)
-        self.assertAlmostEqual(protocol.evaluate(energies), -100.0 + cbs_value, places=12)
+        with self.assertRaises(InputError) as ctx:
+            CompositeProtocol(base=_hf_base(), corrections=[cbs_term])
+        message = str(ctx.exception)
+        self.assertIn("base", message)
+        self.assertIn("HEAT", message)
 
     def test_iter_required_jobs_yields_every_sub_job(self):
         protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_q()])
@@ -345,9 +426,16 @@ class TestCompositeProtocolBasics(unittest.TestCase):
             self.assertIsInstance(level, Level)
             self.assertTrue(sub_label.startswith(term_label))
 
-    def test_base_is_a_single_point_term(self):
+    def test_delta_base_rejected(self):
+        """A DeltaTerm provides no absolute energy and cannot anchor a protocol."""
         with self.assertRaises(InputError):
             CompositeProtocol(base=_delta_t(), corrections=[])
+
+    def test_primary_base_accessors_for_single_point_base(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t()])
+        self.assertEqual(protocol.base_sub_labels, ["base"])
+        self.assertEqual(protocol.primary_base_sub_label, "base")
+        self.assertEqual(protocol.primary_base_level, protocol.base.level)
 
     def test_duplicate_term_labels_rejected(self):
         with self.assertRaises(InputError):
@@ -359,9 +447,9 @@ class TestCompositeProtocolBasics(unittest.TestCase):
             CompositeProtocol(base=_hf_base(), corrections=[clash])
 
     def test_sub_label_collision_across_terms_rejected(self):
-        """Phase 5.5: a SinglePointTerm whose label matches a DeltaTerm's
-        generated sub_label must be rejected at construction time. Without this
-        check, the scheduler's pending/completed maps would get silent overwrites."""
+        """A SinglePointTerm whose label matches a DeltaTerm's generated
+        sub_label must be rejected at construction time. Without this check,
+        the scheduler's pending/completed maps would get silent overwrites."""
         with self.assertRaises(InputError) as ctx:
             CompositeProtocol(
                 base=_hf_base(),
@@ -374,6 +462,110 @@ class TestCompositeProtocolBasics(unittest.TestCase):
                 ],
             )
         self.assertIn("delta_T__high", str(ctx.exception))
+
+
+def _cbs_base():
+    return CBSExtrapolationTerm(
+        label="base",
+        formula="helgaker_corr_2pt",
+        levels=[Level(method="ccsd(t)", basis="cc-pVTZ"),
+                Level(method="ccsd(t)", basis="cc-pVQZ")],
+    )
+
+
+class TestCompositeProtocolCBSBase(unittest.TestCase):
+    """CBS-as-base: the canonical FPA shape — base is the absolute CBS energy."""
+
+    def test_cbs_base_accepted(self):
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[])
+        self.assertIsInstance(protocol.base, CBSExtrapolationTerm)
+
+    def test_evaluate_reproduces_hand_computed_fpa(self):
+        """E_final = E_CBS(T,Q) + δT, checked against a hand-computed value."""
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[_delta_t()])
+        e_3, e_4 = -100.30, -100.31
+        energies = {
+            "base__card_3": e_3,
+            "base__card_4": e_4,
+            "delta_T__high": -100.5,
+            "delta_T__low": -100.4,
+        }
+        e_cbs = (27 * e_3 - 64 * e_4) / (27 - 64)
+        expected = e_cbs + (-100.5 - -100.4)
+        self.assertAlmostEqual(protocol.evaluate(energies), expected, places=10)
+
+    def test_base_sub_labels_deterministic_from_cardinals(self):
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[])
+        self.assertEqual(protocol.base_sub_labels, ["base__card_3", "base__card_4"])
+
+    def test_primary_base_is_largest_cardinal_leg(self):
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[])
+        self.assertEqual(protocol.primary_base_sub_label, "base__card_4")
+        self.assertEqual(protocol.primary_base_level.basis, "cc-pvqz")
+
+    def test_iter_required_jobs_includes_one_job_per_cardinal(self):
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[_delta_t()])
+        sub_labels = sorted(sl for _t, sl, _l in protocol.iter_required_jobs())
+        self.assertEqual(sub_labels, ["base__card_3", "base__card_4",
+                                      "delta_T__high", "delta_T__low"])
+
+    def test_round_trip_dict_preserves_sub_labels(self):
+        """Restart rehydration keys off sub_labels — they must survive
+        ``as_dict`` → ``from_dict`` byte-identically."""
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[_delta_t()])
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        self.assertIsInstance(rebuilt.base, CBSExtrapolationTerm)
+        self.assertEqual(
+            [(t, sl) for t, sl, _l in rebuilt.iter_required_jobs()],
+            [(t, sl) for t, sl, _l in protocol.iter_required_jobs()],
+        )
+
+    def test_round_trip_evaluate_identical(self):
+        protocol = CompositeProtocol(base=_cbs_base(), corrections=[_delta_t()])
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        energies = {
+            "base__card_3": -100.30, "base__card_4": -100.31,
+            "delta_T__high": -100.5, "delta_T__low": -100.4,
+        }
+        self.assertAlmostEqual(rebuilt.evaluate(energies),
+                               protocol.evaluate(energies), places=12)
+
+    def test_from_user_input_cbs_base_dict(self):
+        """A typed cbs_extrapolation base dict (no label) defaults to label 'base'."""
+        raw = {
+            "base": {
+                "type": "cbs_extrapolation",
+                "formula": "helgaker_corr_2pt",
+                "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                           {"method": "ccsd(t)", "basis": "cc-pVQZ"}],
+            },
+            "corrections": [],
+        }
+        protocol = CompositeProtocol.from_user_input(raw)
+        self.assertIsInstance(protocol.base, CBSExtrapolationTerm)
+        self.assertEqual(protocol.base_sub_labels, ["base__card_3", "base__card_4"])
+
+    def test_from_user_input_delta_base_rejected(self):
+        raw = {
+            "base": {"type": "delta", "label": "base",
+                     "high": "ccsdt/cc-pVDZ", "low": "ccsd(t)/cc-pVDZ"},
+            "corrections": [],
+        }
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input(raw)
+
+    def test_from_user_input_cbs_correction_rejected(self):
+        raw = {
+            "base": "ccsd(t)-f12/cc-pVTZ-f12",
+            "corrections": [
+                {"label": "cbs_corr", "type": "cbs_extrapolation",
+                 "formula": "helgaker_corr_2pt", "components": "total",
+                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            ],
+        }
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input(raw)
 
 
 # --------------------------------------------------------------------------- #
@@ -457,9 +649,9 @@ class TestBuildProtocolHelper(unittest.TestCase):
 
 
 class TestFromUserInputNoMutation(unittest.TestCase):
-    """Phase 5.5: ``from_user_input`` must not mutate caller-owned dicts.
+    """``from_user_input`` must not mutate caller-owned dicts.
 
-    Pre-5.5 the base-dict branch popped the ``label`` key off the caller's
+    Previously the base-dict branch popped the ``label`` key off the caller's
     input, breaking idempotent re-parse and polluting restart state.
     """
 
@@ -500,7 +692,7 @@ class TestFromUserInputNoMutation(unittest.TestCase):
 
 
 class TestFromUserInputPresetMetadataPreservation(unittest.TestCase):
-    """Phase 5.5: serialised ``as_dict()`` output must round-trip preset_name
+    """Serialised ``as_dict()`` output must round-trip preset_name
     through ``from_user_input`` (in addition to ``from_dict``)."""
 
     def test_from_user_input_reads_preset_name_from_as_dict_output(self):

--- a/arc/level/protocol_test.py
+++ b/arc/level/protocol_test.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.protocol`` — the data model behind ``sp_composite``.
+
+These tests cover only the pure data-model layer (no scheduler, no IO). They verify:
+* ``Term`` subclasses know which sub-jobs they need and how to combine results.
+* ``CompositeProtocol`` sums correctly and survives YAML round-trips.
+* Construction-time validation rejects malformed inputs with :class:`InputError`.
+"""
+
+import copy
+import unittest
+
+from arc.exceptions import InputError
+from arc.level import Level
+from arc.level.protocol import (
+    CBSExtrapolationTerm,
+    CompositeProtocol,
+    DeltaTerm,
+    SinglePointTerm,
+    Term,
+    build_protocol,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Term subclasses                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestSinglePointTerm(unittest.TestCase):
+    def test_required_levels_one_entry(self):
+        lvl = Level(method="ccsd(t)-f12", basis="cc-pVTZ-f12")
+        t = SinglePointTerm(label="base", level=lvl)
+        self.assertEqual(t.required_levels(), [("base", lvl)])
+
+    def test_evaluate_returns_input(self):
+        lvl = Level(method="hf", basis="cc-pVTZ")
+        t = SinglePointTerm(label="base", level=lvl)
+        self.assertEqual(t.evaluate({"base": -76.0}), -76.0)
+
+    def test_evaluate_missing_key_raises(self):
+        t = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        with self.assertRaises(KeyError):
+            t.evaluate({"other": -1.0})
+
+    def test_round_trip_dict(self):
+        original = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        as_dict = original.as_dict()
+        self.assertEqual(as_dict["type"], "single_point")
+        self.assertEqual(as_dict["label"], "base")
+        rebuilt = Term.from_dict(as_dict)
+        self.assertIsInstance(rebuilt, SinglePointTerm)
+        self.assertEqual(rebuilt.level.method, "hf")
+
+
+class TestDeltaTerm(unittest.TestCase):
+    def setUp(self):
+        self.high = Level(method="ccsdt", basis="cc-pVDZ")
+        self.low = Level(method="ccsd(t)", basis="cc-pVDZ")
+
+    def test_required_levels_returns_high_and_low(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        pairs = dict(t.required_levels())
+        self.assertEqual(set(pairs.keys()), {"delta_T__high", "delta_T__low"})
+        self.assertIs(pairs["delta_T__high"], self.high)
+        self.assertIs(pairs["delta_T__low"], self.low)
+
+    def test_evaluate_high_minus_low(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        result = t.evaluate({"delta_T__high": -100.0, "delta_T__low": -98.0})
+        self.assertEqual(result, -2.0)
+
+    def test_evaluate_independent_of_other_keys(self):
+        t = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        result = t.evaluate(
+            {"delta_T__high": -100.0, "delta_T__low": -98.0, "noise": 999.0}
+        )
+        self.assertEqual(result, -2.0)
+
+    def test_round_trip_dict(self):
+        original = DeltaTerm(label="delta_T", high=self.high, low=self.low)
+        rebuilt = Term.from_dict(original.as_dict())
+        self.assertIsInstance(rebuilt, DeltaTerm)
+        self.assertEqual(rebuilt.label, "delta_T")
+        self.assertEqual(rebuilt.high.method, "ccsdt")
+        self.assertEqual(rebuilt.low.method, "ccsd(t)")
+
+    def test_construction_requires_both_high_and_low(self):
+        with self.assertRaises(InputError):
+            DeltaTerm(label="bad", high=self.high, low=None)
+        with self.assertRaises(InputError):
+            DeltaTerm(label="bad", high=None, low=self.low)
+
+
+class TestCBSExtrapolationTerm(unittest.TestCase):
+    def setUp(self):
+        self.tz = Level(method="ccsd(t)", basis="cc-pVTZ")
+        self.qz = Level(method="ccsd(t)", basis="cc-pVQZ")
+        self.fz = Level(method="ccsd(t)", basis="cc-pV5Z")
+
+    def test_required_levels_uses_cardinal_in_sub_label(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        keys = set(k for k, _ in term.required_levels())
+        self.assertEqual(keys, {"cbs_corr__card_3", "cbs_corr__card_4"})
+
+    def test_evaluate_calls_builtin_formula(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        # Same formula as cbs_test::test_known_values:
+        # E_CBS = (27*(-0.30) - 64*(-0.31)) / (27 - 64)
+        result = term.evaluate({"cbs_corr__card_3": -0.30, "cbs_corr__card_4": -0.31})
+        expected = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_evaluate_user_formula(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_user",
+            formula="(X**3 * E_X - Y**3 * E_Y) / (X**3 - Y**3)",
+            levels=[self.tz, self.qz],
+        )
+        result = term.evaluate({"cbs_user__card_3": -0.30, "cbs_user__card_4": -0.31})
+        expected = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(result, expected, places=12)
+
+    def test_evaluate_user_formula_zero_division_reports_formula_and_inputs(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_user",
+            formula="E_X / (E_Y - E_X)",
+            levels=[self.tz, self.qz],
+        )
+        with self.assertRaises(InputError) as cm:
+            term.evaluate({"cbs_user__card_3": -0.30, "cbs_user__card_4": -0.30})
+        message = str(cm.exception)
+        self.assertIn("E_X / (E_Y - E_X)", message)
+        self.assertIn("{3: -0.3, 4: -0.3}", message)
+
+    def test_three_point_martin(self):
+        term = CBSExtrapolationTerm(
+            label="cbs_m", formula="martin_3pt", levels=[self.tz, self.qz, self.fz]
+        )
+        # Synthetic E(L) = -1 + 0.05/(L+0.5)^4 + 0.01/(L+0.5)^6
+        e3 = -1.0 + 0.05 / 3.5**4 + 0.01 / 3.5**6
+        e4 = -1.0 + 0.05 / 4.5**4 + 0.01 / 4.5**6
+        e5 = -1.0 + 0.05 / 5.5**4 + 0.01 / 5.5**6
+        result = term.evaluate(
+            {"cbs_m__card_3": e3, "cbs_m__card_4": e4, "cbs_m__card_5": e5}
+        )
+        self.assertAlmostEqual(result, -1.0, places=10)
+
+    def test_round_trip_dict(self):
+        original = CBSExtrapolationTerm(
+            label="cbs_corr", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        rebuilt = Term.from_dict(original.as_dict())
+        self.assertIsInstance(rebuilt, CBSExtrapolationTerm)
+        self.assertEqual(rebuilt.formula, "helgaker_corr_2pt")
+        self.assertEqual(len(rebuilt.levels), 2)
+
+    def test_validate_too_few_levels(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(label="x", formula="helgaker_corr_2pt", levels=[self.tz])
+
+    def test_validate_method_mismatch_across_levels(self):
+        mixed = Level(method="ccsdt", basis="cc-pVQZ")
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, mixed]
+            )
+
+    def test_validate_indistinct_cardinals(self):
+        another_tz = Level(method="ccsd(t)", basis="cc-pVTZ")
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, another_tz]
+            )
+
+    def test_validate_unknown_builtin_formula(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="not_a_real_formula_2pt", levels=[self.tz, self.qz]
+            )
+
+    def test_user_formula_accepted_at_construction(self):
+        term = CBSExtrapolationTerm(
+            label="x",
+            formula="E_X + E_Y",
+            levels=[self.tz, self.qz],
+        )
+        self.assertEqual(term.formula, "E_X + E_Y")
+
+    def test_user_formula_with_disallowed_node_rejected_at_construction(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x",
+                formula="(0).__class__",
+                levels=[self.tz, self.qz],
+            )
+
+    def test_components_default_total(self):
+        term = CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz]
+        )
+        self.assertEqual(term.components, "total")
+
+    def test_components_total_is_default_and_valid(self):
+        term = CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+        )
+        self.assertEqual(term.components, "total")
+
+    def test_components_total_explicit_accepted(self):
+        CBSExtrapolationTerm(
+            label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+            components="total",
+        )
+
+    def test_components_corr_rejected_until_component_parsing_exists(self):
+        """Phase 5.5: reject components != 'total'. parse_e_elect returns total
+        energies, so extrapolating them while claiming 'corr' or 'hf' would
+        silently produce a wrong answer."""
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+                components="corr",
+            )
+
+    def test_components_hf_rejected_until_component_parsing_exists(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_hf_2pt", levels=[self.tz, self.qz],
+                components="hf",
+            )
+
+    def test_components_bogus_rejected(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="x", formula="helgaker_corr_2pt", levels=[self.tz, self.qz],
+                components="bogus",
+            )
+
+    # --- Phase 5.5: formula arity at construction ---------------------------- #
+
+    def test_martin_3pt_with_2_levels_rejected_at_construction(self):
+        """martin_3pt needs exactly 3 levels — rejected eagerly."""
+        with self.assertRaises(InputError) as ctx:
+            CBSExtrapolationTerm(
+                label="m", formula="martin_3pt",
+                levels=[self.tz, self.qz],
+            )
+        self.assertIn("martin_3pt", str(ctx.exception))
+        self.assertIn("3", str(ctx.exception))
+
+    def test_helgaker_corr_2pt_with_3_levels_rejected_at_construction(self):
+        with self.assertRaises(InputError):
+            CBSExtrapolationTerm(
+                label="h", formula="helgaker_corr_2pt",
+                levels=[self.tz, self.qz, self.fz],
+            )
+
+    def test_user_formula_with_4_levels_rejected(self):
+        """User formulas expose only X/Y/Z; 4+ levels are rejected."""
+        fourth = Level(method="ccsd(t)", basis="cc-pV6Z")
+        with self.assertRaises(InputError) as ctx:
+            CBSExtrapolationTerm(
+                label="u", formula="E_X + E_Y + E_Z",
+                levels=[self.tz, self.qz, self.fz, fourth],
+            )
+        self.assertIn("3", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+#  CompositeProtocol                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _hf_base():
+    return SinglePointTerm(label="base", level=Level(method="ccsd(t)-f12", basis="cc-pVTZ-f12"))
+
+
+def _delta_t():
+    return DeltaTerm(
+        label="delta_T",
+        high=Level(method="ccsdt", basis="cc-pVDZ"),
+        low=Level(method="ccsd(t)", basis="cc-pVDZ"),
+    )
+
+
+def _delta_q():
+    return DeltaTerm(
+        label="delta_Q",
+        high=Level(method="ccsdt(q)", basis="cc-pVDZ"),
+        low=Level(method="ccsdt", basis="cc-pVDZ"),
+    )
+
+
+class TestCompositeProtocolBasics(unittest.TestCase):
+    def test_evaluate_two_term(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t()])
+        energies = {"base": -100.0, "delta_T__high": -100.5, "delta_T__low": -100.4}
+        # base + (high - low) = -100.0 + (-100.5 - -100.4) = -100.1
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.1, places=12)
+
+    def test_evaluate_three_term(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_q()])
+        energies = {
+            "base": -100.0,
+            "delta_T__high": -100.5, "delta_T__low": -100.4,    # δT = -0.1
+            "delta_Q__high": -100.55, "delta_Q__low": -100.5,   # δQ = -0.05
+        }
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.15, places=12)
+
+    def test_evaluate_with_cbs_term(self):
+        cbs_term = CBSExtrapolationTerm(
+            label="cbs_corr",
+            formula="helgaker_corr_2pt",
+            levels=[Level(method="ccsd(t)", basis="cc-pVTZ"),
+                    Level(method="ccsd(t)", basis="cc-pVQZ")],
+        )
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[cbs_term])
+        energies = {
+            "base": -100.0,
+            "cbs_corr__card_3": -0.30,
+            "cbs_corr__card_4": -0.31,
+        }
+        cbs_value = (27 * -0.30 - 64 * -0.31) / (27 - 64)
+        self.assertAlmostEqual(protocol.evaluate(energies), -100.0 + cbs_value, places=12)
+
+    def test_iter_required_jobs_yields_every_sub_job(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_q()])
+        triples = list(protocol.iter_required_jobs())
+        sub_labels = sorted(t[1] for t in triples)
+        self.assertEqual(
+            sub_labels,
+            sorted(["base", "delta_T__high", "delta_T__low",
+                    "delta_Q__high", "delta_Q__low"]),
+        )
+        # Each triple is (term_label, sub_label, Level).
+        for term_label, sub_label, level in triples:
+            self.assertIsInstance(level, Level)
+            self.assertTrue(sub_label.startswith(term_label))
+
+    def test_base_is_a_single_point_term(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_delta_t(), corrections=[])
+
+    def test_duplicate_term_labels_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_hf_base(), corrections=[_delta_t(), _delta_t()])
+
+    def test_label_collision_with_base_rejected(self):
+        clash = SinglePointTerm(label="base", level=Level(method="hf", basis="cc-pVTZ"))
+        with self.assertRaises(InputError):
+            CompositeProtocol(base=_hf_base(), corrections=[clash])
+
+    def test_sub_label_collision_across_terms_rejected(self):
+        """Phase 5.5: a SinglePointTerm whose label matches a DeltaTerm's
+        generated sub_label must be rejected at construction time. Without this
+        check, the scheduler's pending/completed maps would get silent overwrites."""
+        with self.assertRaises(InputError) as ctx:
+            CompositeProtocol(
+                base=_hf_base(),
+                corrections=[
+                    SinglePointTerm(
+                        label="delta_T__high",
+                        level=Level(method="hf", basis="cc-pVDZ"),
+                    ),
+                    _delta_t(),  # produces sub_labels delta_T__high, delta_T__low
+                ],
+            )
+        self.assertIn("delta_T__high", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+#  YAML / dict round-trip                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestCompositeProtocolFromDict(unittest.TestCase):
+    def test_explicit_form_round_trip(self):
+        protocol = CompositeProtocol(
+            base=_hf_base(), corrections=[_delta_t(), _delta_q()]
+        )
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        # Round-trip preserves base + every correction.
+        self.assertEqual(rebuilt.base.label, "base")
+        self.assertEqual([t.label for t in rebuilt.corrections], ["delta_T", "delta_Q"])
+
+    def test_explicit_form_evaluate_after_round_trip(self):
+        protocol = CompositeProtocol(base=_hf_base(), corrections=[_delta_t()])
+        rebuilt = CompositeProtocol.from_dict(protocol.as_dict())
+        energies = {"base": -100.0, "delta_T__high": -100.5, "delta_T__low": -100.4}
+        self.assertAlmostEqual(rebuilt.evaluate(energies), -100.1, places=12)
+
+    def test_explicit_user_input_minimal(self):
+        raw = {
+            "base": {"method": "ccsd(t)-f12", "basis": "cc-pVTZ-f12"},
+            "corrections": [
+                {
+                    "label": "delta_T", "type": "delta",
+                    "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+                    "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                },
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(raw)
+        self.assertEqual(protocol.base.level.method, "ccsd(t)-f12")
+        self.assertEqual(protocol.corrections[0].label, "delta_T")
+
+    def test_explicit_user_input_with_string_levels(self):
+        raw = {
+            "base": "ccsd(t)-f12/cc-pVTZ-f12",
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": "ccsdt/cc-pVDZ", "low": "ccsd(t)/cc-pVDZ"},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(raw)
+        self.assertEqual(protocol.base.level.basis, "cc-pvtz-f12")
+        self.assertEqual(protocol.corrections[0].high.method, "ccsdt")
+
+    def test_user_input_missing_base_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input({"corrections": []})
+
+    def test_user_input_unknown_term_type_rejected(self):
+        with self.assertRaises(InputError):
+            CompositeProtocol.from_user_input({
+                "base": "hf/cc-pVTZ",
+                "corrections": [{"label": "x", "type": "bogus_term"}],
+            })
+
+
+class TestBuildProtocolHelper(unittest.TestCase):
+    """``build_protocol`` is the public adapter from any user input form."""
+
+    def test_dict_form_routed_to_from_user_input(self):
+        protocol = build_protocol({
+            "base": "hf/cc-pVTZ",
+            "corrections": [],
+        })
+        self.assertIsInstance(protocol, CompositeProtocol)
+        self.assertEqual(protocol.base.level.method, "hf")
+
+    def test_already_a_protocol_returned_as_is(self):
+        original = CompositeProtocol(base=_hf_base(), corrections=[])
+        self.assertIs(build_protocol(original), original)
+
+    def test_invalid_type_rejected(self):
+        with self.assertRaises(InputError):
+            build_protocol(12345)
+
+
+class TestFromUserInputNoMutation(unittest.TestCase):
+    """Phase 5.5: ``from_user_input`` must not mutate caller-owned dicts.
+
+    Pre-5.5 the base-dict branch popped the ``label`` key off the caller's
+    input, breaking idempotent re-parse and polluting restart state.
+    """
+
+    def test_explicit_dict_not_mutated(self):
+        original = {
+            "base": {"method": "hf", "basis": "cc-pVTZ", "label": "base"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+                 "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+            "reference": "test DOI",
+        }
+        snapshot = copy.deepcopy(original)
+        CompositeProtocol.from_user_input(original)
+        self.assertEqual(original, snapshot, "from_user_input mutated its input dict")
+
+    def test_preset_with_overrides_dict_not_mutated(self):
+        raw = {"preset": "HEAT-345Q", "overrides": {"delta_T": {"high": {"method": "ccsdt", "basis": "cc-pVTZ"}}}}
+        snapshot = copy.deepcopy(raw)
+        CompositeProtocol.from_user_input(raw)
+        self.assertEqual(raw, snapshot)
+
+    def test_base_dict_with_label_key_not_mutated(self):
+        base_dict = {"method": "hf", "basis": "cc-pVTZ", "label": "my_base"}
+        recipe = {"base": base_dict, "corrections": []}
+        snapshot = copy.deepcopy(base_dict)
+        protocol = CompositeProtocol.from_user_input(recipe)
+        self.assertEqual(base_dict, snapshot)
+        self.assertEqual(protocol.base.label, "my_base")
+        self.assertEqual(protocol.base.level.method, "hf")
+
+    def test_build_protocol_not_mutating(self):
+        raw = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        snapshot = copy.deepcopy(raw)
+        build_protocol(raw)
+        self.assertEqual(raw, snapshot)
+
+
+class TestFromUserInputPresetMetadataPreservation(unittest.TestCase):
+    """Phase 5.5: serialised ``as_dict()`` output must round-trip preset_name
+    through ``from_user_input`` (in addition to ``from_dict``)."""
+
+    def test_from_user_input_reads_preset_name_from_as_dict_output(self):
+        proto1 = CompositeProtocol.from_user_input("HEAT-345Q")
+        serialised = proto1.as_dict()
+        self.assertEqual(serialised["preset_name"], "HEAT-345Q")
+        proto2 = CompositeProtocol.from_user_input(serialised)
+        self.assertEqual(proto2.preset_name, "HEAT-345Q")
+        self.assertEqual(proto2.reference, proto1.reference)
+
+    def test_from_user_input_reads_reference_from_as_dict_output(self):
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+            "reference": "DOI: 10.1/test",
+        }
+        proto1 = CompositeProtocol.from_user_input(recipe)
+        proto2 = CompositeProtocol.from_user_input(proto1.as_dict())
+        self.assertEqual(proto2.reference, "DOI: 10.1/test")
+
+    def test_build_protocol_path_also_preserves_preset_name(self):
+        proto1 = CompositeProtocol.from_user_input("FPA-min")
+        proto2 = build_protocol(proto1.as_dict())
+        self.assertEqual(proto2.preset_name, "FPA-min")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/reporting.py
+++ b/arc/level/reporting.py
@@ -1,0 +1,711 @@
+"""
+``arc.level.reporting`` — provenance artifacts for ``sp_composite`` runs.
+
+Two reporting layers are exposed:
+
+* :func:`format_log_event` — formats a single structured ``[sp_composite]`` log
+  line. The Phase 2 scheduler integration calls this at every state transition
+  (queue, sub-job complete, term evaluated, protocol finalized) so the ARC log
+  alone tells the full story end-to-end.
+
+* :func:`write_composite_notebook` — emits a single, project-level Jupyter
+  notebook at ``<project>/output/sp_composite.ipynb`` with one H2 section per
+  species or transition state whose ``sp_composite`` has finalized. The
+  notebook is **unexecuted on write**: ARC lays down cell sources but does NOT
+  populate outputs. The user opens it and "Run All"; every energy shown is
+  then produced by the user's own machine invoking ARC's real parsers on the
+  real QM output files — genuine independent verification rather than a
+  re-display of numbers the scheduler already computed.
+
+The notebook is self-contained per section: each section carries its own
+literal recipe dict and reconstructs its :class:`CompositeProtocol` via
+:meth:`CompositeProtocol.from_user_input`, so a user can move or share a run
+directory without losing the provenance context.
+
+Dependencies are limited to ``nbformat`` (already pulled in by ARC's
+``environment.yml`` via ``conda-forge::jupyter``). No pandas, no executed
+notebooks at write time.
+
+References
+----------
+
+* Allen, East, Császár — focal-point analysis review (cited in per-preset
+  markdown content produced by this module when a preset supplies it).
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT.
+"""
+
+import hashlib
+import os
+import pprint
+from dataclasses import dataclass, field
+from typing import Any
+
+import nbformat
+import yaml
+from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+
+from arc.constants import E_h_kJmol
+from arc.exceptions import InputError
+from arc.level.protocol import CompositeProtocol
+from arc.parser.parser import parse_e_elect
+
+
+# =========================================================================== #
+#  format_log_event                                                           #
+# =========================================================================== #
+
+
+def format_log_event(species_label: str, event: str, payload: Any) -> str:
+    """Format a single ``[sp_composite]`` log line.
+
+    Examples
+    --------
+    >>> format_log_event("H2O", "queued", "delta_T")
+    '[sp_composite] H2O — queued: delta_T'
+    >>> format_log_event("H2O", "complete", None)
+    '[sp_composite] H2O — complete'
+    """
+    prefix = f"[sp_composite] {species_label} — {event}"
+    if payload is None:
+        return prefix
+    if isinstance(payload, dict):
+        body = ", ".join(f"{k}={v}" for k, v in payload.items())
+    else:
+        body = str(payload)
+    return f"{prefix}: {body}"
+
+
+# =========================================================================== #
+#  SpeciesSection — scheduler → reporter handoff                              #
+# =========================================================================== #
+
+
+_VALID_KINDS = ("species", "ts")
+
+
+@dataclass
+class SpeciesSection:
+    """One stationary point's contribution to the provenance notebook.
+
+    Attributes
+    ----------
+    label : str
+        Species or TS label (matches the scheduler's ``label`` key).
+    kind : {'species', 'ts'}
+        Whether this stationary point is a well (``'species'``) or a transition
+        state (``'ts'``). Controls section ordering in the notebook (species
+        first, TS second).
+    preset_name : str or None
+        Name of the preset used (e.g. ``'HEAT-345Q'``), or ``None`` if the
+        user supplied an explicit recipe.
+    reference : str
+        Citation string, ideally including a DOI. Deduplicated across sections
+        in the notebook's References block.
+    recipe : dict
+        The literal explicit recipe dict (``{"base": ..., "corrections": [...]}``)
+        used to construct ``protocol``. Written into the notebook verbatim so
+        each section is reproducible in isolation.
+    protocol : CompositeProtocol
+        The composite protocol this section reports on. Used only to
+        enumerate sub-job sub-labels and term types at write time; the
+        notebook reconstructs its own protocol from ``recipe`` via
+        :meth:`CompositeProtocol.from_user_input` when executed.
+    sub_job_paths : dict[str, str]
+        Mapping ``sub_label`` → absolute path to the QM output file. Rendered
+        into the notebook as paths relative to the notebook directory when
+        possible, absolute when the path escapes the notebook's tree.
+    flags : list[str]
+        Human-readable warnings surfaced by the scheduler (e.g. "δT exceeds
+        10 kJ/mol, potential single-reference breakdown"). Rendered verbatim
+        in the section's interpretation markdown cell.
+    """
+
+    label: str
+    kind: str
+    preset_name: str | None
+    reference: str
+    recipe: dict[str, Any]
+    protocol: CompositeProtocol
+    sub_job_paths: dict[str, str]
+    flags: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_KINDS:
+            raise InputError(
+                f"SpeciesSection.kind must be one of {_VALID_KINDS}; got {self.kind!r}."
+            )
+        if not self.label:
+            raise InputError("SpeciesSection.label must be non-empty.")
+
+
+# =========================================================================== #
+#  write_composite_notebook                                                   #
+# =========================================================================== #
+
+
+# Pinned nbformat versioning so re-writes produce byte-identical files.
+_NBFORMAT = 4
+_NBFORMAT_MINOR = 5
+
+# Pinned kernelspec — matches the standard python3 kernel that ships with
+# ipykernel. Notebooks open with this kernel by default in Jupyter/VS Code/etc.
+_KERNELSPEC = {
+    "name": "python3",
+    "display_name": "Python 3",
+    "language": "python",
+}
+
+_LANGUAGE_INFO = {
+    "name": "python",
+    "mimetype": "text/x-python",
+    "file_extension": ".py",
+    "pygments_lexer": "ipython3",
+}
+
+
+def write_composite_notebook(
+    path: str,
+    project_name: str,
+    arc_version: str,
+    timestamp: str,
+    sections: list[SpeciesSection],
+    notebook_dir: str,
+) -> None:
+    """Write (or overwrite) the project-level composite-provenance notebook.
+
+    Parameters
+    ----------
+    path : str
+        Destination file path, typically ``<project>/output/sp_composite.ipynb``.
+        The parent directory must exist.
+    project_name : str
+        Project name, surfaced in the title banner.
+    arc_version : str
+        ARC version string, surfaced in the title banner.
+    timestamp : str
+        ISO-8601 generation timestamp. Accepted as a parameter (rather than
+        read from the clock) so reruns produce byte-identical output — useful
+        for snapshot testing and for idempotent regeneration across a run.
+    sections : list[SpeciesSection]
+        One section per species/TS that has finalized its composite. The
+        writer sorts species-first / TS-second with alphabetical ordering
+        within each group, independent of caller order.
+    notebook_dir : str
+        The directory that will host the notebook. Used to render absolute
+        ``sub_job_paths`` as relative paths when they fall under this
+        directory, so the notebook + outputs directory can be copied together.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If any ``SpeciesSection.kind`` is not in ``{'species', 'ts'}``.
+        (The dataclass also validates, but we re-check defensively.)
+    """
+    for s in sections:
+        if s.kind not in _VALID_KINDS:
+            raise InputError(
+                f"SpeciesSection.kind must be one of {_VALID_KINDS}; got {s.kind!r} "
+                f"on label {s.label!r}."
+            )
+
+    ordered = _sort_sections(sections)
+
+    cells: list[Any] = []
+
+    # --- Top-level shared cells ------------------------------------------- #
+    cells.append(_title_banner_cell(
+        project_name=project_name,
+        arc_version=arc_version,
+        timestamp=timestamp,
+        sections=ordered,
+    ))
+    cells.append(_toc_cell(ordered))
+    cells.append(_setup_cell())
+
+    # --- Per-section cells ------------------------------------------------ #
+    for section in ordered:
+        cells.extend(_section_cells(section, notebook_dir))
+
+    # --- Project summary + references ------------------------------------- #
+    cells.append(_project_summary_header_cell())
+    cells.append(_project_summary_code_cell(ordered))
+    cells.append(_references_cell(ordered))
+
+    nb = new_notebook(cells=cells, metadata={
+        "kernelspec": dict(_KERNELSPEC),
+        "language_info": dict(_LANGUAGE_INFO),
+    })
+    nb["nbformat"] = _NBFORMAT
+    nb["nbformat_minor"] = _NBFORMAT_MINOR
+
+    with open(path, "w", encoding="utf-8") as fh:
+        nbformat.write(nb, fh, version=_NBFORMAT)
+
+
+# --------------------------------------------------------------------------- #
+#  Section ordering                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _sort_sections(sections: list[SpeciesSection]) -> list[SpeciesSection]:
+    """Species first (alphabetical), then TS (alphabetical)."""
+    species = sorted((s for s in sections if s.kind == "species"), key=lambda s: s.label)
+    ts = sorted((s for s in sections if s.kind == "ts"), key=lambda s: s.label)
+    return species + ts
+
+
+# --------------------------------------------------------------------------- #
+#  Cell IDs (stable across re-writes given the same inputs)                   #
+# --------------------------------------------------------------------------- #
+
+
+def _cell_id(section_key: str, role: str) -> str:
+    """Return a stable 16-char hex cell ID for the given section + role."""
+    digest = hashlib.sha1(f"{section_key}|{role}".encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _md(source: str, cell_id: str):
+    cell = new_markdown_cell(source=source)
+    cell["id"] = cell_id
+    return cell
+
+
+def _code(source: str, cell_id: str):
+    cell = new_code_cell(source=source)
+    cell["id"] = cell_id
+    # Guarantee unexecuted: nbformat.v4 already sets outputs=[] and
+    # execution_count=None for new_code_cell, but enforce explicitly.
+    cell["outputs"] = []
+    cell["execution_count"] = None
+    return cell
+
+
+# --------------------------------------------------------------------------- #
+#  Top-level shared cells                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _title_banner_cell(project_name: str, arc_version: str, timestamp: str,
+                       sections: list[SpeciesSection]):
+    n_species = sum(1 for s in sections if s.kind == "species")
+    n_ts = sum(1 for s in sections if s.kind == "ts")
+    source = (
+        f"# `sp_composite` provenance — {project_name}\n\n"
+        f"**ARC version:** `{arc_version}`   \n"
+        f"**Generated:** `{timestamp}`   \n"
+        f"**Sections:** {n_species} species, {n_ts} transition state"
+        f"{'s' if n_ts != 1 else ''}   \n\n"
+        "This notebook independently verifies the composite electronic energies that "
+        "ARC computed for each stationary point. Each section defines its own recipe, "
+        "re-parses the QM output files via `arc.parser.parse_e_elect`, and re-evaluates "
+        "the `CompositeProtocol` on the spot — so the numbers you see are produced by "
+        "your machine running ARC's real parsers, not transcribed from the scheduler's "
+        "memory.\n\n"
+        "**To verify:** open this notebook in Jupyter or VS Code and run **Run All**. "
+        "The `FINAL e_elect(...)` printed in each section is the value to compare "
+        "against ARC's `output.yml`.\n"
+    )
+    return _md(source, _cell_id("shared", "title"))
+
+
+def _toc_cell(sections: list[SpeciesSection]):
+    lines = ["### Table of contents\n"]
+    for s in sections:
+        kind_label = "Species" if s.kind == "species" else "TS"
+        lines.append(f"- [{kind_label}: {s.label}](#{kind_label}:-{s.label})")
+    lines.append("- [Project summary](#Project-summary)")
+    lines.append("- [References](#References)")
+    return _md("\n".join(lines), _cell_id("shared", "toc"))
+
+
+_SETUP_SOURCE = '''\
+# Shared setup — imports + helpers used by every species/TS section below.
+import os as _os
+
+import arc.common as arc_common
+import arc.parser.parser as arc_parser
+from arc.constants import E_h_kJmol
+from arc.level.protocol import CompositeProtocol
+
+# Accumulates per-section results so the Project summary can aggregate them.
+_RESULTS = {}
+
+# Determine the project directory from this notebook's location at runtime.
+# Notebook lives at ``<project>/output/sp_composite.ipynb``, so the project
+# directory is the parent of the notebook's directory. Jupyter / VS Code run
+# kernels with the notebook file's directory as cwd, so ``os.getcwd()``
+# resolves to ``<project>/output/`` and its parent is what we need.
+_NB_PROJECT_DIRECTORY = _os.path.dirname(_os.path.abspath(_os.curdir))
+
+
+def _resolve_path(p):
+    """Rebase a stored absolute path on the current project directory.
+
+    When the project folder is moved (or this notebook is opened on a different
+    machine), the originally-stored absolute paths under
+    ``<project>/calcs/Species/...`` and ``<project>/calcs/TSs/...`` no longer
+    point anywhere. ``arc.common.globalize_path`` recognises those prefixes and
+    rewrites the leading project-directory portion to match the current
+    notebook location. No-op when the project hasn't moved.
+    """
+    return arc_common.globalize_path(p, _NB_PROJECT_DIRECTORY)
+
+
+def _format_breakdown(protocol, energies_kJmol):
+    """Render a fixed-width per-term breakdown table as a string."""
+    hdr = f"{'term':<20} {'type':<22} {'contribution (kJ/mol)':>24}"
+    rule = "-" * len(hdr)
+    lines = [hdr, rule]
+    for term in protocol.terms:
+        contribution = term.evaluate(energies_kJmol)
+        lines.append(
+            f"{term.label:<20} {type(term).__name__:<22} {contribution:>24.6f}"
+        )
+    lines.append(rule)
+    return "\\n".join(lines)
+'''
+
+
+def _setup_cell():
+    return _code(_SETUP_SOURCE, _cell_id("shared", "setup"))
+
+
+# --------------------------------------------------------------------------- #
+#  Per-section cells                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _section_cells(section: SpeciesSection, notebook_dir: str) -> list[Any]:
+    key = f"{section.kind}:{section.label}"
+    kind_label = "Species" if section.kind == "species" else "TS"
+    return [
+        _md(f"## {kind_label}: {section.label}\n", _cell_id(key, "header")),
+        _md(_protocol_summary_markdown(section), _cell_id(key, "summary")),
+        _code(_recipe_code(section), _cell_id(key, "recipe")),
+        _code(_paths_code(section, notebook_dir), _cell_id(key, "paths")),
+        _code(_parse_code(section), _cell_id(key, "parse")),
+        _code(_breakdown_code(section), _cell_id(key, "breakdown")),
+        _code(_final_code(section), _cell_id(key, "final")),
+        _md(_interpretation_markdown(section), _cell_id(key, "interpretation")),
+    ]
+
+
+def _protocol_summary_markdown(section: SpeciesSection) -> str:
+    protocol_name = section.preset_name or "explicit recipe"
+    n_sub_jobs = sum(1 for _ in section.protocol.iter_required_jobs())
+    n_corrections = len(section.protocol.corrections)
+    formula_latex = _composite_formula_latex(section.protocol)
+    return (
+        f"**Protocol:** `{protocol_name}`   \n"
+        f"**Reference:** {section.reference}   \n"
+        f"**Sub-jobs:** {n_sub_jobs} across 1 base + {n_corrections} correction(s)   \n\n"
+        f"**Composite formula:**\n\n"
+        f"$$ {formula_latex} $$\n"
+    )
+
+
+def _composite_formula_latex(protocol: CompositeProtocol) -> str:
+    parts = [r"E_{\mathrm{" + _latex_escape(protocol.base.label) + "}}"]
+    for term in protocol.corrections:
+        parts.append(r"\delta_{\mathrm{" + _latex_escape(term.label) + "}}")
+    return r"E_{\mathrm{final}} = " + " + ".join(parts)
+
+
+def _latex_escape(text: str) -> str:
+    return text.replace("_", r"\_")
+
+
+def _recipe_code(section: SpeciesSection) -> str:
+    # pprint with sort_dicts=False preserves author intent; width 78 stays < 80 cols.
+    recipe_repr = pprint.pformat(section.recipe, sort_dicts=False, width=78)
+    return (
+        f"recipe = {recipe_repr}\n"
+        "protocol = CompositeProtocol.from_user_input(recipe)\n"
+        f"protocol  # {section.label}"
+    )
+
+
+def _paths_code(section: SpeciesSection, notebook_dir: str) -> str:
+    """Render the per-section ``paths`` dict as a code-cell source.
+
+    Each value is wrapped in ``_resolve_path(...)`` (defined in the shared
+    setup cell, which calls ``arc.common.globalize_path``) so absolute paths
+    pointing under ``<project>/calcs/Species|TSs/`` get auto-rebased when the
+    project directory is moved or the notebook is opened on a different
+    machine. Paths that don't match those prefixes flow through unchanged.
+
+    The ``notebook_dir`` parameter is kept on the signature for API stability
+    (callers in the writer pass it positionally) but is no longer used to
+    pre-render relative paths — runtime rebase via ``_resolve_path`` is more
+    robust because it handles moves the relative-path approach can't (e.g.,
+    paths outside the project tree, paths whose relative offset to the
+    notebook changes when the project tree is restructured).
+    """
+    del notebook_dir  # no longer used; kept on the signature for API stability
+    entries = []
+    for sub_label, abs_path in sorted(section.sub_job_paths.items()):
+        entries.append(f"    {sub_label!r}: _resolve_path({abs_path!r}),")
+    return "paths = {\n" + "\n".join(entries) + "\n}"
+
+
+def _parse_code(section: SpeciesSection) -> str:
+    return (
+        "# Parse the electronic energy from each sub-job's QM output file.\n"
+        "# arc_parser.parse_e_elect dispatches on ESS and returns kJ/mol.\n"
+        "# Also verifies that `paths` covers every sub_label the protocol\n"
+        "# requires — a missing entry here would fail protocol.evaluate later\n"
+        "# with a less-helpful KeyError.\n"
+        "_required_sub_labels = {sl for _t, sl, _l in protocol.iter_required_jobs()}\n"
+        "_missing_paths = sorted(_required_sub_labels - set(paths.keys()))\n"
+        "assert not _missing_paths, "
+        "f'paths is missing required sub_labels: {_missing_paths}'\n"
+        "energies_kJmol = {\n"
+        "    sub_label: arc_parser.parse_e_elect(p)\n"
+        "    for sub_label, p in paths.items()\n"
+        "}\n"
+        "missing = [sl for sl, v in energies_kJmol.items() if v is None]\n"
+        "assert not missing, "
+        "f'parse_e_elect failed for: {missing}'\n"
+        "energies_kJmol"
+    )
+
+
+def _breakdown_code(section: SpeciesSection) -> str:
+    return (
+        "# Per-term breakdown: what each term contributes to the composite total.\n"
+        "print(_format_breakdown(protocol, energies_kJmol))"
+    )
+
+
+def _final_code(section: SpeciesSection) -> str:
+    # ``section.label`` flows into the generated Python source three times
+    # (the _RESULTS key, the kind string, and the FINAL print). Every use
+    # is rendered via ``!r`` so labels containing quotes, parens, braces,
+    # or backslashes cannot break the cell's syntax.
+    label_repr = repr(section.label)
+    return (
+        "e_total_kJmol = protocol.evaluate(energies_kJmol)\n"
+        f"_RESULTS[{label_repr}] = {{\n"
+        f"    'kind': {section.kind!r},\n"
+        f"    'protocol_name': {section.preset_name!r},\n"
+        "    'e_total_kJmol': e_total_kJmol,\n"
+        "    'n_sub_jobs': len(paths),\n"
+        "}\n"
+        f"_label_display = {label_repr}\n"
+        "print(f'FINAL e_elect({_label_display}) = "
+        "{e_total_kJmol:,.3f} kJ/mol "
+        "({e_total_kJmol / E_h_kJmol:.9f} Hartree)')"
+    )
+
+
+def _interpretation_markdown(section: SpeciesSection) -> str:
+    if not section.flags:
+        return "_No warnings flagged for this section._\n"
+    lines = ["**Warnings from the scheduler:**\n"]
+    for flag in section.flags:
+        lines.append(f"- {flag}")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+#  Tail cells (project summary + references)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _project_summary_header_cell():
+    return _md(
+        "## Project summary\n\n"
+        "Aggregate of the composite results across every species / TS in the project. "
+        "This cell reads from the `_RESULTS` dict populated by each section above, so "
+        "it must be run after the per-section cells.\n",
+        _cell_id("shared", "summary_header"),
+    )
+
+
+_SUMMARY_CODE = '''\
+# Tabular summary of every section's final e_elect.
+if not _RESULTS:
+    print("(no composite results to summarise — did you run the per-section cells?)")
+else:
+    hdr = f"{'label':<20} {'kind':<10} {'protocol':<18} {'e_elect (kJ/mol)':>22}"
+    rule = "-" * len(hdr)
+    print(hdr)
+    print(rule)
+    for label, r in _RESULTS.items():
+        proto = r['protocol_name'] or 'explicit'
+        print(
+            f"{label:<20} {r['kind']:<10} {proto:<18} "
+            f"{r['e_total_kJmol']:>22,.3f}"
+        )
+'''
+
+
+def _project_summary_code_cell(sections: list[SpeciesSection]):
+    return _code(_SUMMARY_CODE, _cell_id("shared", "summary_code"))
+
+
+def _references_cell(sections: list[SpeciesSection]):
+    # Deduplicate references while preserving order of first appearance.
+    seen = set()
+    ordered_refs: list[str] = []
+    for s in sections:
+        if s.reference and s.reference not in seen:
+            seen.add(s.reference)
+            ordered_refs.append(s.reference)
+    lines = ["## References\n"]
+    if not ordered_refs:
+        lines.append("_(No references supplied by any section.)_\n")
+    else:
+        for ref in ordered_refs:
+            lines.append(f"- {ref}")
+    return _md("\n".join(lines) + "\n", _cell_id("shared", "references"))
+
+
+# =========================================================================== #
+#  build_species_report_dict + write_species_report_yaml                      #
+# =========================================================================== #
+#
+# Per-species YAML report. Companion to the project-level provenance notebook
+# (which serves *independent verification* via Run-All); this writer produces
+# a consumable per-species summary that's readable in plain text and easy to
+# parse from downstream tooling. One file per stationary point, written by
+# the scheduler at composite finalization.
+
+
+def _composite_formula_text(protocol: CompositeProtocol) -> str:
+    """Plain-text version of the composite formula (no LaTeX).
+
+    The notebook uses LaTeX rendering; the YAML report is plain text — readers
+    of ``cat sp_composite_report.yml`` shouldn't see ``\\delta`` macros.
+    """
+    parts = [f"E_{protocol.base.label}"]
+    for term in protocol.corrections:
+        parts.append(term.label)
+    return "E_final = " + " + ".join(parts)
+
+
+def build_species_report_dict(
+    section: SpeciesSection,
+    e_elect_kj_per_mol: float,
+    timestamp: str,
+    arc_version: str,
+    arc_commit: str,
+) -> dict[str, Any]:
+    """Assemble the per-species sp_composite report as a plain dict.
+
+    All energy values are computed by re-parsing the QM output files referenced
+    in ``section.sub_job_paths`` via :func:`arc.parser.parser.parse_e_elect`
+    (returns kJ/mol), then handed to each :class:`Term` to compute its
+    contribution. The same evaluation path the notebook's "Run All" follows —
+    the values land identically because the protocol is deterministic.
+
+    The caller-supplied ``e_elect_kj_per_mol`` is the value the scheduler
+    recorded on the ``ARCSpecies`` (set during ``_finalize_composite``). We
+    don't recompute the total here; we surface what ARC actually used so any
+    downstream tooling reading this report is consistent with the run's
+    output.yml / restart.yml.
+
+    Parameters
+    ----------
+    section : SpeciesSection
+        The reporting handoff struct populated by the scheduler at
+        finalization. Carries protocol, recipe, sub-job paths, flags.
+    e_elect_kj_per_mol : float
+        The final electronic energy ARC recorded for this species (kJ/mol).
+    timestamp : str
+        ISO-8601 string. Caller supplies for determinism (tests pin it).
+    arc_version, arc_commit : str
+        Provenance identifiers.
+
+    Returns
+    -------
+    dict
+        A plain dict ready for ``yaml.safe_dump`` or
+        :func:`write_species_report_yaml`.
+    """
+    energies_kj = {sl: parse_e_elect(p) for sl, p in section.sub_job_paths.items()}
+
+    base_term = section.protocol.base
+    base_sub_label, base_level = base_term.required_levels()[0]
+    base_block = {
+        "sub_label": base_sub_label,
+        "level": base_level.simple(),
+        "energy_kj_per_mol": energies_kj[base_sub_label],
+        "energy_hartree": energies_kj[base_sub_label] / E_h_kJmol,
+        "path": section.sub_job_paths[base_sub_label],
+    }
+
+    terms_block: list[dict[str, Any]] = []
+    for term in section.protocol.corrections:
+        contribution_kj = term.evaluate(energies_kj)
+        sub_jobs: list[dict[str, Any]] = []
+        for sub_label, level in term.required_levels():
+            sub_jobs.append({
+                "sub_label": sub_label,
+                "level": level.simple(),
+                "energy_kj_per_mol": energies_kj[sub_label],
+                "energy_hartree": energies_kj[sub_label] / E_h_kJmol,
+                "path": section.sub_job_paths[sub_label],
+            })
+        terms_block.append({
+            "label": term.label,
+            "type": type(term).__name__,
+            "contribution_kj_per_mol": contribution_kj,
+            "contribution_hartree": contribution_kj / E_h_kJmol,
+            "sub_jobs": sub_jobs,
+        })
+
+    return {
+        "species": section.label,
+        "kind": section.kind,
+        "generated_at": timestamp,
+        "arc_version": arc_version,
+        "arc_commit": arc_commit,
+        "protocol": {
+            "preset": section.preset_name,
+            "reference": section.reference,
+            "formula": _composite_formula_text(section.protocol),
+        },
+        "units": {
+            "energy": "kJ/mol",
+            "energy_alt": "Hartree",
+        },
+        "base": base_block,
+        "terms": terms_block,
+        "final": {
+            "e_elect_kj_per_mol": e_elect_kj_per_mol,
+            "e_elect_hartree": e_elect_kj_per_mol / E_h_kJmol,
+            "e_elect_source": "sp_composite",
+        },
+        "flags": list(section.flags),
+    }
+
+
+def write_species_report_yaml(
+    path: str,
+    section: SpeciesSection,
+    e_elect_kj_per_mol: float,
+    timestamp: str,
+    arc_version: str,
+    arc_commit: str,
+) -> None:
+    """Build and write the per-species sp_composite YAML report.
+
+    Creates the parent directory if missing. Output is deterministic: keys are
+    written in insertion order (Python 3.7+ dicts), flow style is block (the
+    YAML default), and ``sort_keys=False`` preserves the schema's natural
+    reading order (species → protocol → units → base → terms → final → flags).
+    Two writes with the same inputs produce byte-identical files.
+    """
+    report = build_species_report_dict(
+        section=section,
+        e_elect_kj_per_mol=e_elect_kj_per_mol,
+        timestamp=timestamp,
+        arc_version=arc_version,
+        arc_commit=arc_commit,
+    )
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        yaml.safe_dump(report, fh, sort_keys=False, default_flow_style=False)

--- a/arc/level/reporting.py
+++ b/arc/level/reporting.py
@@ -1,0 +1,535 @@
+"""
+``arc.level.reporting`` — provenance artifacts for ``sp_composite`` runs.
+
+Two reporting layers are exposed:
+
+* :func:`format_log_event` — formats a single structured ``[sp_composite]`` log
+  line. The Phase 2 scheduler integration calls this at every state transition
+  (queue, sub-job complete, term evaluated, protocol finalized) so the ARC log
+  alone tells the full story end-to-end.
+
+* :func:`write_composite_notebook` — emits a single, project-level Jupyter
+  notebook at ``<project>/output/sp_composite.ipynb`` with one H2 section per
+  species or transition state whose ``sp_composite`` has finalized. The
+  notebook is **unexecuted on write**: ARC lays down cell sources but does NOT
+  populate outputs. The user opens it and "Run All"; every energy shown is
+  then produced by the user's own machine invoking ARC's real parsers on the
+  real QM output files — genuine independent verification rather than a
+  re-display of numbers the scheduler already computed.
+
+The notebook is self-contained per section: each section carries its own
+literal recipe dict and reconstructs its :class:`CompositeProtocol` via
+:meth:`CompositeProtocol.from_user_input`, so a user can move or share a run
+directory without losing the provenance context.
+
+Dependencies are limited to ``nbformat`` (already pulled in by ARC's
+``environment.yml`` via ``conda-forge::jupyter``). No pandas, no executed
+notebooks at write time.
+
+References
+----------
+
+* Allen, East, Császár — focal-point analysis review (cited in per-preset
+  markdown content produced by this module when a preset supplies it).
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1804498 — HEAT.
+"""
+
+import hashlib
+import os
+import pprint
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import nbformat
+from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+
+from arc.exceptions import InputError
+from arc.level.protocol import CompositeProtocol
+
+
+# =========================================================================== #
+#  format_log_event                                                           #
+# =========================================================================== #
+
+
+def format_log_event(species_label: str, event: str, payload: Any) -> str:
+    """Format a single ``[sp_composite]`` log line.
+
+    Examples
+    --------
+    >>> format_log_event("H2O", "queued", "delta_T")
+    '[sp_composite] H2O — queued: delta_T'
+    >>> format_log_event("H2O", "complete", None)
+    '[sp_composite] H2O — complete'
+    """
+    prefix = f"[sp_composite] {species_label} — {event}"
+    if payload is None:
+        return prefix
+    if isinstance(payload, dict):
+        body = ", ".join(f"{k}={v}" for k, v in payload.items())
+    else:
+        body = str(payload)
+    return f"{prefix}: {body}"
+
+
+# =========================================================================== #
+#  SpeciesSection — scheduler → reporter handoff                              #
+# =========================================================================== #
+
+
+_VALID_KINDS = ("species", "ts")
+
+
+@dataclass
+class SpeciesSection:
+    """One stationary point's contribution to the provenance notebook.
+
+    Attributes
+    ----------
+    label : str
+        Species or TS label (matches the scheduler's ``label`` key).
+    kind : {'species', 'ts'}
+        Whether this stationary point is a well (``'species'``) or a transition
+        state (``'ts'``). Controls section ordering in the notebook (species
+        first, TS second).
+    preset_name : str or None
+        Name of the preset used (e.g. ``'HEAT-345Q'``), or ``None`` if the
+        user supplied an explicit recipe.
+    reference : str
+        Citation string, ideally including a DOI. Deduplicated across sections
+        in the notebook's References block.
+    recipe : dict
+        The literal explicit recipe dict (``{"base": ..., "corrections": [...]}``)
+        used to construct ``protocol``. Written into the notebook verbatim so
+        each section is reproducible in isolation.
+    protocol : CompositeProtocol
+        The composite protocol this section reports on. Used only to
+        enumerate sub-job sub-labels and term types at write time; the
+        notebook reconstructs its own protocol from ``recipe`` via
+        :meth:`CompositeProtocol.from_user_input` when executed.
+    sub_job_paths : Dict[str, str]
+        Mapping ``sub_label`` → absolute path to the QM output file. Rendered
+        into the notebook as paths relative to the notebook directory when
+        possible, absolute when the path escapes the notebook's tree.
+    flags : List[str]
+        Human-readable warnings surfaced by the scheduler (e.g. "δT exceeds
+        10 kJ/mol, potential single-reference breakdown"). Rendered verbatim
+        in the section's interpretation markdown cell.
+    """
+
+    label: str
+    kind: str
+    preset_name: Optional[str]
+    reference: str
+    recipe: Dict[str, Any]
+    protocol: CompositeProtocol
+    sub_job_paths: Dict[str, str]
+    flags: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_KINDS:
+            raise InputError(
+                f"SpeciesSection.kind must be one of {_VALID_KINDS}; got {self.kind!r}."
+            )
+        if not self.label:
+            raise InputError("SpeciesSection.label must be non-empty.")
+
+
+# =========================================================================== #
+#  write_composite_notebook                                                   #
+# =========================================================================== #
+
+
+# Pinned nbformat versioning so re-writes produce byte-identical files.
+_NBFORMAT = 4
+_NBFORMAT_MINOR = 5
+
+# Pinned kernelspec — matches the standard python3 kernel that ships with
+# ipykernel. Notebooks open with this kernel by default in Jupyter/VS Code/etc.
+_KERNELSPEC = {
+    "name": "python3",
+    "display_name": "Python 3",
+    "language": "python",
+}
+
+_LANGUAGE_INFO = {
+    "name": "python",
+    "mimetype": "text/x-python",
+    "file_extension": ".py",
+    "pygments_lexer": "ipython3",
+}
+
+
+def write_composite_notebook(
+    path: str,
+    project_name: str,
+    arc_version: str,
+    timestamp: str,
+    sections: List[SpeciesSection],
+    notebook_dir: str,
+) -> None:
+    """Write (or overwrite) the project-level composite-provenance notebook.
+
+    Parameters
+    ----------
+    path : str
+        Destination file path, typically ``<project>/output/sp_composite.ipynb``.
+        The parent directory must exist.
+    project_name : str
+        Project name, surfaced in the title banner.
+    arc_version : str
+        ARC version string, surfaced in the title banner.
+    timestamp : str
+        ISO-8601 generation timestamp. Accepted as a parameter (rather than
+        read from the clock) so reruns produce byte-identical output — useful
+        for snapshot testing and for idempotent regeneration across a run.
+    sections : List[SpeciesSection]
+        One section per species/TS that has finalized its composite. The
+        writer sorts species-first / TS-second with alphabetical ordering
+        within each group, independent of caller order.
+    notebook_dir : str
+        The directory that will host the notebook. Used to render absolute
+        ``sub_job_paths`` as relative paths when they fall under this
+        directory, so the notebook + outputs directory can be copied together.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If any ``SpeciesSection.kind`` is not in ``{'species', 'ts'}``.
+        (The dataclass also validates, but we re-check defensively.)
+    """
+    for s in sections:
+        if s.kind not in _VALID_KINDS:
+            raise InputError(
+                f"SpeciesSection.kind must be one of {_VALID_KINDS}; got {s.kind!r} "
+                f"on label {s.label!r}."
+            )
+
+    ordered = _sort_sections(sections)
+
+    cells: List[Any] = []
+
+    # --- Top-level shared cells ------------------------------------------- #
+    cells.append(_title_banner_cell(
+        project_name=project_name,
+        arc_version=arc_version,
+        timestamp=timestamp,
+        sections=ordered,
+    ))
+    cells.append(_toc_cell(ordered))
+    cells.append(_setup_cell())
+
+    # --- Per-section cells ------------------------------------------------ #
+    for section in ordered:
+        cells.extend(_section_cells(section, notebook_dir))
+
+    # --- Project summary + references ------------------------------------- #
+    cells.append(_project_summary_header_cell())
+    cells.append(_project_summary_code_cell(ordered))
+    cells.append(_references_cell(ordered))
+
+    nb = new_notebook(cells=cells, metadata={
+        "kernelspec": dict(_KERNELSPEC),
+        "language_info": dict(_LANGUAGE_INFO),
+    })
+    nb["nbformat"] = _NBFORMAT
+    nb["nbformat_minor"] = _NBFORMAT_MINOR
+
+    with open(path, "w", encoding="utf-8") as fh:
+        nbformat.write(nb, fh, version=_NBFORMAT)
+
+
+# --------------------------------------------------------------------------- #
+#  Section ordering                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _sort_sections(sections: List[SpeciesSection]) -> List[SpeciesSection]:
+    """Species first (alphabetical), then TS (alphabetical)."""
+    species = sorted((s for s in sections if s.kind == "species"), key=lambda s: s.label)
+    ts = sorted((s for s in sections if s.kind == "ts"), key=lambda s: s.label)
+    return species + ts
+
+
+# --------------------------------------------------------------------------- #
+#  Cell IDs (stable across re-writes given the same inputs)                   #
+# --------------------------------------------------------------------------- #
+
+
+def _cell_id(section_key: str, role: str) -> str:
+    """Return a stable 16-char hex cell ID for the given section + role."""
+    digest = hashlib.sha1(f"{section_key}|{role}".encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _md(source: str, cell_id: str):
+    cell = new_markdown_cell(source=source)
+    cell["id"] = cell_id
+    return cell
+
+
+def _code(source: str, cell_id: str):
+    cell = new_code_cell(source=source)
+    cell["id"] = cell_id
+    # Guarantee unexecuted: nbformat.v4 already sets outputs=[] and
+    # execution_count=None for new_code_cell, but enforce explicitly.
+    cell["outputs"] = []
+    cell["execution_count"] = None
+    return cell
+
+
+# --------------------------------------------------------------------------- #
+#  Top-level shared cells                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _title_banner_cell(project_name: str, arc_version: str, timestamp: str,
+                       sections: List[SpeciesSection]):
+    n_species = sum(1 for s in sections if s.kind == "species")
+    n_ts = sum(1 for s in sections if s.kind == "ts")
+    source = (
+        f"# `sp_composite` provenance — {project_name}\n\n"
+        f"**ARC version:** `{arc_version}`   \n"
+        f"**Generated:** `{timestamp}`   \n"
+        f"**Sections:** {n_species} species, {n_ts} transition state"
+        f"{'s' if n_ts != 1 else ''}   \n\n"
+        "This notebook independently verifies the composite electronic energies that "
+        "ARC computed for each stationary point. Each section defines its own recipe, "
+        "re-parses the QM output files via `arc.parser.parse_e_elect`, and re-evaluates "
+        "the `CompositeProtocol` on the spot — so the numbers you see are produced by "
+        "your machine running ARC's real parsers, not transcribed from the scheduler's "
+        "memory.\n\n"
+        "**To verify:** open this notebook in Jupyter or VS Code and run **Run All**. "
+        "The `FINAL e_elect(...)` printed in each section is the value to compare "
+        "against ARC's `output.yml`.\n"
+    )
+    return _md(source, _cell_id("shared", "title"))
+
+
+def _toc_cell(sections: List[SpeciesSection]):
+    lines = ["### Table of contents\n"]
+    for s in sections:
+        kind_label = "Species" if s.kind == "species" else "TS"
+        lines.append(f"- [{kind_label}: {s.label}](#{kind_label}:-{s.label})")
+    lines.append("- [Project summary](#Project-summary)")
+    lines.append("- [References](#References)")
+    return _md("\n".join(lines), _cell_id("shared", "toc"))
+
+
+_SETUP_SOURCE = '''\
+# Shared setup — imports + helpers used by every species/TS section below.
+import arc.parser.parser as arc_parser
+from arc.constants import E_h_kJmol
+from arc.level.protocol import CompositeProtocol
+
+# Accumulates per-section results so the Project summary can aggregate them.
+_RESULTS = {}
+
+
+def _format_breakdown(protocol, energies_kJmol):
+    """Render a fixed-width per-term breakdown table as a string."""
+    hdr = f"{'term':<20} {'type':<22} {'contribution (kJ/mol)':>24}"
+    rule = "-" * len(hdr)
+    lines = [hdr, rule]
+    for term in protocol.terms:
+        contribution = term.evaluate(energies_kJmol)
+        lines.append(
+            f"{term.label:<20} {type(term).__name__:<22} {contribution:>24.6f}"
+        )
+    lines.append(rule)
+    return "\\n".join(lines)
+'''
+
+
+def _setup_cell():
+    return _code(_SETUP_SOURCE, _cell_id("shared", "setup"))
+
+
+# --------------------------------------------------------------------------- #
+#  Per-section cells                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _section_cells(section: SpeciesSection, notebook_dir: str) -> List[Any]:
+    key = f"{section.kind}:{section.label}"
+    kind_label = "Species" if section.kind == "species" else "TS"
+    return [
+        _md(f"## {kind_label}: {section.label}\n", _cell_id(key, "header")),
+        _md(_protocol_summary_markdown(section), _cell_id(key, "summary")),
+        _code(_recipe_code(section), _cell_id(key, "recipe")),
+        _code(_paths_code(section, notebook_dir), _cell_id(key, "paths")),
+        _code(_parse_code(section), _cell_id(key, "parse")),
+        _code(_breakdown_code(section), _cell_id(key, "breakdown")),
+        _code(_final_code(section), _cell_id(key, "final")),
+        _md(_interpretation_markdown(section), _cell_id(key, "interpretation")),
+    ]
+
+
+def _protocol_summary_markdown(section: SpeciesSection) -> str:
+    protocol_name = section.preset_name or "explicit recipe"
+    n_sub_jobs = sum(1 for _ in section.protocol.iter_required_jobs())
+    n_corrections = len(section.protocol.corrections)
+    formula_latex = _composite_formula_latex(section.protocol)
+    return (
+        f"**Protocol:** `{protocol_name}`   \n"
+        f"**Reference:** {section.reference}   \n"
+        f"**Sub-jobs:** {n_sub_jobs} across 1 base + {n_corrections} correction(s)   \n\n"
+        f"**Composite formula:**\n\n"
+        f"$$ {formula_latex} $$\n"
+    )
+
+
+def _composite_formula_latex(protocol: CompositeProtocol) -> str:
+    parts = [r"E_{\mathrm{" + _latex_escape(protocol.base.label) + "}}"]
+    for term in protocol.corrections:
+        parts.append(r"\delta_{\mathrm{" + _latex_escape(term.label) + "}}")
+    return r"E_{\mathrm{final}} = " + " + ".join(parts)
+
+
+def _latex_escape(text: str) -> str:
+    return text.replace("_", r"\_")
+
+
+def _recipe_code(section: SpeciesSection) -> str:
+    # pprint with sort_dicts=False preserves author intent; width 78 stays < 80 cols.
+    recipe_repr = pprint.pformat(section.recipe, sort_dicts=False, width=78)
+    return (
+        f"recipe = {recipe_repr}\n"
+        "protocol = CompositeProtocol.from_user_input(recipe)\n"
+        f"protocol  # {section.label}"
+    )
+
+
+def _paths_code(section: SpeciesSection, notebook_dir: str) -> str:
+    entries = []
+    for sub_label, abs_path in sorted(section.sub_job_paths.items()):
+        rendered = _render_path(abs_path, notebook_dir)
+        entries.append(f"    {sub_label!r}: {rendered!r},")
+    return "paths = {\n" + "\n".join(entries) + "\n}"
+
+
+def _render_path(abs_path: str, notebook_dir: str) -> str:
+    """Render ``abs_path`` relative to ``notebook_dir`` if under it, else absolute."""
+    try:
+        common = os.path.commonpath([os.path.abspath(abs_path),
+                                     os.path.abspath(notebook_dir)])
+    except ValueError:
+        return abs_path
+    if common == os.path.abspath(notebook_dir):
+        rel = os.path.relpath(abs_path, notebook_dir)
+        return rel if rel.startswith((".", os.sep)) else f"./{rel}"
+    return abs_path
+
+
+def _parse_code(section: SpeciesSection) -> str:
+    return (
+        "# Parse the electronic energy from each sub-job's QM output file.\n"
+        "# arc_parser.parse_e_elect dispatches on ESS and returns kJ/mol.\n"
+        "# Also verifies that `paths` covers every sub_label the protocol\n"
+        "# requires — a missing entry here would fail protocol.evaluate later\n"
+        "# with a less-helpful KeyError.\n"
+        "_required_sub_labels = {sl for _t, sl, _l in protocol.iter_required_jobs()}\n"
+        "_missing_paths = sorted(_required_sub_labels - set(paths.keys()))\n"
+        "assert not _missing_paths, "
+        "f'paths is missing required sub_labels: {_missing_paths}'\n"
+        "energies_kJmol = {\n"
+        "    sub_label: arc_parser.parse_e_elect(p)\n"
+        "    for sub_label, p in paths.items()\n"
+        "}\n"
+        "missing = [sl for sl, v in energies_kJmol.items() if v is None]\n"
+        "assert not missing, "
+        "f'parse_e_elect failed for: {missing}'\n"
+        "energies_kJmol"
+    )
+
+
+def _breakdown_code(section: SpeciesSection) -> str:
+    return (
+        "# Per-term breakdown: what each term contributes to the composite total.\n"
+        "print(_format_breakdown(protocol, energies_kJmol))"
+    )
+
+
+def _final_code(section: SpeciesSection) -> str:
+    # ``section.label`` flows into the generated Python source three times
+    # (the _RESULTS key, the kind string, and the FINAL print). Every use
+    # is rendered via ``!r`` so labels containing quotes, parens, braces,
+    # or backslashes cannot break the cell's syntax.
+    label_repr = repr(section.label)
+    return (
+        "e_total_kJmol = protocol.evaluate(energies_kJmol)\n"
+        f"_RESULTS[{label_repr}] = {{\n"
+        f"    'kind': {section.kind!r},\n"
+        f"    'protocol_name': {section.preset_name!r},\n"
+        "    'e_total_kJmol': e_total_kJmol,\n"
+        "    'n_sub_jobs': len(paths),\n"
+        "}\n"
+        f"_label_display = {label_repr}\n"
+        "print(f'FINAL e_elect({_label_display}) = "
+        "{e_total_kJmol:,.3f} kJ/mol "
+        "({e_total_kJmol / E_h_kJmol:.9f} Hartree)')"
+    )
+
+
+def _interpretation_markdown(section: SpeciesSection) -> str:
+    if not section.flags:
+        return "_No warnings flagged for this section._\n"
+    lines = ["**Warnings from the scheduler:**\n"]
+    for flag in section.flags:
+        lines.append(f"- {flag}")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+#  Tail cells (project summary + references)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _project_summary_header_cell():
+    return _md(
+        "## Project summary\n\n"
+        "Aggregate of the composite results across every species / TS in the project. "
+        "This cell reads from the `_RESULTS` dict populated by each section above, so "
+        "it must be run after the per-section cells.\n",
+        _cell_id("shared", "summary_header"),
+    )
+
+
+_SUMMARY_CODE = '''\
+# Tabular summary of every section's final e_elect.
+if not _RESULTS:
+    print("(no composite results to summarise — did you run the per-section cells?)")
+else:
+    hdr = f"{'label':<20} {'kind':<10} {'protocol':<18} {'e_elect (kJ/mol)':>22}"
+    rule = "-" * len(hdr)
+    print(hdr)
+    print(rule)
+    for label, r in _RESULTS.items():
+        proto = r['protocol_name'] or 'explicit'
+        print(
+            f"{label:<20} {r['kind']:<10} {proto:<18} "
+            f"{r['e_total_kJmol']:>22,.3f}"
+        )
+'''
+
+
+def _project_summary_code_cell(sections: List[SpeciesSection]):
+    return _code(_SUMMARY_CODE, _cell_id("shared", "summary_code"))
+
+
+def _references_cell(sections: List[SpeciesSection]):
+    # Deduplicate references while preserving order of first appearance.
+    seen = set()
+    ordered_refs: List[str] = []
+    for s in sections:
+        if s.reference and s.reference not in seen:
+            seen.add(s.reference)
+            ordered_refs.append(s.reference)
+    lines = ["## References\n"]
+    if not ordered_refs:
+        lines.append("_(No references supplied by any section.)_\n")
+    else:
+        for ref in ordered_refs:
+            lines.append(f"- {ref}")
+    return _md("\n".join(lines) + "\n", _cell_id("shared", "references"))

--- a/arc/level/reporting.py
+++ b/arc/level/reporting.py
@@ -4,7 +4,7 @@
 Two reporting layers are exposed:
 
 * :func:`format_log_event` — formats a single structured ``[sp_composite]`` log
-  line. The Phase 2 scheduler integration calls this at every state transition
+  line. The scheduler integration calls this at every state transition
   (queue, sub-job complete, term evaluated, protocol finalized) so the ARC log
   alone tells the full story end-to-end.
 
@@ -26,8 +26,7 @@ Dependencies are limited to ``nbformat`` (already pulled in by ARC's
 ``environment.yml`` via ``conda-forge::jupyter``). No pandas, no executed
 notebooks at write time.
 
-References
-----------
+References:
 
 * Allen, East, Császár — focal-point analysis review (cited in per-preset
   markdown content produced by this module when a preset supplies it).
@@ -57,14 +56,22 @@ from arc.parser.parser import parse_e_elect
 
 
 def format_log_event(species_label: str, event: str, payload: Any) -> str:
-    """Format a single ``[sp_composite]`` log line.
+    """
+    Format a single ``[sp_composite]`` log line.
 
-    Examples
-    --------
-    >>> format_log_event("H2O", "queued", "delta_T")
-    '[sp_composite] H2O — queued: delta_T'
-    >>> format_log_event("H2O", "complete", None)
-    '[sp_composite] H2O — complete'
+    Args:
+        species_label (str): Species or TS label.
+        event (str): Event name (e.g. ``'queued'``, ``'complete'``).
+        payload (Any): Event payload — ``None``, a dict, or any stringifiable value.
+
+    Returns:
+        str: The formatted log line.
+
+    Examples:
+        >>> format_log_event("H2O", "queued", "delta_T")
+        '[sp_composite] H2O — queued: delta_T'
+        >>> format_log_event("H2O", "complete", None)
+        '[sp_composite] H2O — complete'
     """
     prefix = f"[sp_composite] {species_label} — {event}"
     if payload is None:
@@ -86,39 +93,41 @@ _VALID_KINDS = ("species", "ts")
 
 @dataclass
 class SpeciesSection:
-    """One stationary point's contribution to the provenance notebook.
+    """
+    One stationary point's contribution to the provenance notebook.
 
-    Attributes
-    ----------
-    label : str
-        Species or TS label (matches the scheduler's ``label`` key).
-    kind : {'species', 'ts'}
-        Whether this stationary point is a well (``'species'``) or a transition
-        state (``'ts'``). Controls section ordering in the notebook (species
-        first, TS second).
-    preset_name : str or None
-        Name of the preset used (e.g. ``'HEAT-345Q'``), or ``None`` if the
-        user supplied an explicit recipe.
-    reference : str
-        Citation string, ideally including a DOI. Deduplicated across sections
-        in the notebook's References block.
-    recipe : dict
-        The literal explicit recipe dict (``{"base": ..., "corrections": [...]}``)
-        used to construct ``protocol``. Written into the notebook verbatim so
-        each section is reproducible in isolation.
-    protocol : CompositeProtocol
-        The composite protocol this section reports on. Used only to
-        enumerate sub-job sub-labels and term types at write time; the
-        notebook reconstructs its own protocol from ``recipe`` via
-        :meth:`CompositeProtocol.from_user_input` when executed.
-    sub_job_paths : dict[str, str]
-        Mapping ``sub_label`` → absolute path to the QM output file. Rendered
-        into the notebook as paths relative to the notebook directory when
-        possible, absolute when the path escapes the notebook's tree.
-    flags : list[str]
-        Human-readable warnings surfaced by the scheduler (e.g. "δT exceeds
-        10 kJ/mol, potential single-reference breakdown"). Rendered verbatim
-        in the section's interpretation markdown cell.
+    Attributes:
+        label (str): Species or TS label (matches the scheduler's ``label`` key).
+        kind (str): Whether this stationary point is a well (``'species'``) or a
+            transition state (``'ts'``). Controls section ordering in the
+            notebook (species first, TS second).
+        preset_name (str | None): Name of the preset used (e.g. ``'HEAT-345Q'``),
+            or ``None`` if the user supplied an explicit recipe.
+        reference (str): Citation string, ideally including a DOI. Deduplicated
+            across sections in the notebook's References block.
+        recipe (dict): The literal explicit recipe dict
+            (``{"base": ..., "corrections": [...]}``) used to construct
+            ``protocol``. Written into the notebook verbatim so each section is
+            reproducible in isolation.
+        protocol (CompositeProtocol): The composite protocol this section
+            reports on. Used only to enumerate sub-job sub-labels and term
+            types at write time; the notebook reconstructs its own protocol
+            from ``recipe`` via :meth:`CompositeProtocol.from_user_input`
+            when executed.
+        sub_job_paths (dict[str, str]): Mapping ``sub_label`` → absolute path to
+            the QM output file. Rendered into the notebook as absolute paths,
+            each wrapped in ``_resolve_path(...)`` so that
+            ``arc.common.globalize_path`` rebases project-tree paths at
+            notebook execution time if the project directory has moved.
+        flags (list[str]): Human-readable warnings surfaced by the scheduler
+            (e.g. "δT exceeds 10 kJ/mol, potential single-reference
+            breakdown"). Rendered verbatim in the section's interpretation
+            markdown cell.
+        skipped_terms (dict[str, str]): Mapping ``term_label`` → human-readable
+            reason for delta terms the scheduler skipped as trivially zero
+            (δ≡0 by the correlated-electron-count vs. excitation-rank test).
+            Skipped terms have no sub-job paths; they render with contribution
+            0.0 and the reason in both the notebook and the YAML report.
     """
 
     label: str
@@ -129,6 +138,7 @@ class SpeciesSection:
     protocol: CompositeProtocol
     sub_job_paths: dict[str, str]
     flags: list[str] = field(default_factory=list)
+    skipped_terms: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.kind not in _VALID_KINDS:
@@ -172,35 +182,32 @@ def write_composite_notebook(
     sections: list[SpeciesSection],
     notebook_dir: str,
 ) -> None:
-    """Write (or overwrite) the project-level composite-provenance notebook.
+    """
+    Write (or overwrite) the project-level composite-provenance notebook.
 
-    Parameters
-    ----------
-    path : str
-        Destination file path, typically ``<project>/output/sp_composite.ipynb``.
-        The parent directory must exist.
-    project_name : str
-        Project name, surfaced in the title banner.
-    arc_version : str
-        ARC version string, surfaced in the title banner.
-    timestamp : str
-        ISO-8601 generation timestamp. Accepted as a parameter (rather than
-        read from the clock) so reruns produce byte-identical output — useful
-        for snapshot testing and for idempotent regeneration across a run.
-    sections : list[SpeciesSection]
-        One section per species/TS that has finalized its composite. The
-        writer sorts species-first / TS-second with alphabetical ordering
-        within each group, independent of caller order.
-    notebook_dir : str
-        The directory that will host the notebook. Used to render absolute
-        ``sub_job_paths`` as relative paths when they fall under this
-        directory, so the notebook + outputs directory can be copied together.
+    Args:
+        path (str): Destination file path, typically
+            ``<project>/output/sp_composite.ipynb``. The parent directory must exist.
+        project_name (str): Project name, surfaced in the title banner.
+        arc_version (str): ARC version string, surfaced in the title banner.
+        timestamp (str): ISO-8601 generation timestamp. Accepted as a parameter
+            (rather than read from the clock) so reruns produce byte-identical
+            output — useful for snapshot testing and for idempotent
+            regeneration across a run.
+        sections (list[SpeciesSection]): One section per species/TS that has
+            finalized its composite. The writer sorts species-first / TS-second
+            with alphabetical ordering within each group, independent of caller
+            order.
+        notebook_dir (str): The directory that will host the notebook. Accepted
+            for caller compatibility but currently unused: ``sub_job_paths``
+            are rendered as absolute paths wrapped in ``_resolve_path(...)``,
+            which rebases them via ``arc.common.globalize_path`` at notebook
+            execution time — more robust than pre-rendered relative paths when
+            the project tree is moved or restructured.
 
-    Raises
-    ------
-    arc.exceptions.InputError
-        If any ``SpeciesSection.kind`` is not in ``{'species', 'ts'}``.
-        (The dataclass also validates, but we re-check defensively.)
+    Raises:
+        InputError: If any ``SpeciesSection.kind`` is not in ``{'species', 'ts'}``.
+            (The dataclass also validates, but we re-check defensively.)
     """
     for s in sections:
         if s.kind not in _VALID_KINDS:
@@ -225,7 +232,7 @@ def write_composite_notebook(
 
     # --- Per-section cells ------------------------------------------------ #
     for section in ordered:
-        cells.extend(_section_cells(section, notebook_dir))
+        cells.extend(_section_cells(section))
 
     # --- Project summary + references ------------------------------------- #
     cells.append(_project_summary_header_cell())
@@ -353,17 +360,36 @@ def _resolve_path(p):
     return arc_common.globalize_path(p, _NB_PROJECT_DIRECTORY)
 
 
-def _format_breakdown(protocol, energies_kJmol):
-    """Render a fixed-width per-term breakdown table as a string."""
+def _format_breakdown(protocol, energies_kJmol, skipped_terms=None):
+    """Render a fixed-width per-term breakdown table as a string.
+
+    Extrapolated terms get an extra footnote line spelling out which formula
+    was applied to which sub-job legs. Terms in ``skipped_terms`` (label →
+    reason) were skipped by the scheduler as trivially zero: they render with
+    contribution 0.0 and a footnote carrying the reason.
+    """
+    skipped_terms = skipped_terms or {}
     hdr = f"{'term':<20} {'type':<22} {'contribution (kJ/mol)':>24}"
     rule = "-" * len(hdr)
     lines = [hdr, rule]
     for term in protocol.terms:
-        contribution = term.evaluate(energies_kJmol)
+        contribution = (
+            0.0 if term.label in skipped_terms else term.evaluate(energies_kJmol)
+        )
         lines.append(
             f"{term.label:<20} {type(term).__name__:<22} {contribution:>24.6f}"
         )
     lines.append(rule)
+    for term in protocol.terms:
+        if term.label in skipped_terms:
+            lines.append(f"{term.label}: {skipped_terms[term.label]}")
+            continue
+        formula = getattr(term, "formula", None)
+        if formula is not None:
+            legs = [sub_label for sub_label, _level in term.required_levels()]
+            lines.append(
+                f"{term.label}: formula {formula!r} applied to legs {legs}"
+            )
     return "\\n".join(lines)
 '''
 
@@ -377,14 +403,14 @@ def _setup_cell():
 # --------------------------------------------------------------------------- #
 
 
-def _section_cells(section: SpeciesSection, notebook_dir: str) -> list[Any]:
+def _section_cells(section: SpeciesSection) -> list[Any]:
     key = f"{section.kind}:{section.label}"
     kind_label = "Species" if section.kind == "species" else "TS"
     return [
         _md(f"## {kind_label}: {section.label}\n", _cell_id(key, "header")),
         _md(_protocol_summary_markdown(section), _cell_id(key, "summary")),
         _code(_recipe_code(section), _cell_id(key, "recipe")),
-        _code(_paths_code(section, notebook_dir), _cell_id(key, "paths")),
+        _code(_paths_code(section), _cell_id(key, "paths")),
         _code(_parse_code(section), _cell_id(key, "parse")),
         _code(_breakdown_code(section), _cell_id(key, "breakdown")),
         _code(_final_code(section), _cell_id(key, "final")),
@@ -427,8 +453,9 @@ def _recipe_code(section: SpeciesSection) -> str:
     )
 
 
-def _paths_code(section: SpeciesSection, notebook_dir: str) -> str:
-    """Render the per-section ``paths`` dict as a code-cell source.
+def _paths_code(section: SpeciesSection) -> str:
+    """
+    Render the per-section ``paths`` dict as a code-cell source.
 
     Each value is wrapped in ``_resolve_path(...)`` (defined in the shared
     setup cell, which calls ``arc.common.globalize_path``) so absolute paths
@@ -436,18 +463,25 @@ def _paths_code(section: SpeciesSection, notebook_dir: str) -> str:
     project directory is moved or the notebook is opened on a different
     machine. Paths that don't match those prefixes flow through unchanged.
 
-    The ``notebook_dir`` parameter is kept on the signature for API stability
-    (callers in the writer pass it positionally) but is no longer used to
-    pre-render relative paths — runtime rebase via ``_resolve_path`` is more
-    robust because it handles moves the relative-path approach can't (e.g.,
-    paths outside the project tree, paths whose relative offset to the
-    notebook changes when the project tree is restructured).
+    The cell also declares the section's ``skipped_terms`` dict (term label →
+    reason) so the parse / breakdown / final cells can account for delta terms
+    the scheduler skipped as trivially zero (their legs were never run, so
+    there are no paths to parse).
+
+    Args:
+        section (SpeciesSection): The section whose ``sub_job_paths`` to render.
+
+    Returns:
+        str: Source for the section's paths-dict code cell.
     """
-    del notebook_dir  # no longer used; kept on the signature for API stability
     entries = []
     for sub_label, abs_path in sorted(section.sub_job_paths.items()):
         entries.append(f"    {sub_label!r}: _resolve_path({abs_path!r}),")
-    return "paths = {\n" + "\n".join(entries) + "\n}"
+    skipped = []
+    for term_label, reason in sorted(section.skipped_terms.items()):
+        skipped.append(f"    {term_label!r}: {reason!r},")
+    return ("paths = {\n" + "\n".join(entries) + "\n}\n"
+            "skipped_terms = {\n" + "\n".join(skipped) + "\n}")
 
 
 def _parse_code(section: SpeciesSection) -> str:
@@ -455,9 +489,11 @@ def _parse_code(section: SpeciesSection) -> str:
         "# Parse the electronic energy from each sub-job's QM output file.\n"
         "# arc_parser.parse_e_elect dispatches on ESS and returns kJ/mol.\n"
         "# Also verifies that `paths` covers every sub_label the protocol\n"
-        "# requires — a missing entry here would fail protocol.evaluate later\n"
-        "# with a less-helpful KeyError.\n"
-        "_required_sub_labels = {sl for _t, sl, _l in protocol.iter_required_jobs()}\n"
+        "# requires — a missing entry here would fail the term evaluation later\n"
+        "# with a less-helpful KeyError. Terms in `skipped_terms` contribute\n"
+        "# exactly 0.0 by construction (δ≡0); their legs were never run.\n"
+        "_required_sub_labels = {sl for t, sl, _l in protocol.iter_required_jobs()\n"
+        "                        if t not in skipped_terms}\n"
         "_missing_paths = sorted(_required_sub_labels - set(paths.keys()))\n"
         "assert not _missing_paths, "
         "f'paths is missing required sub_labels: {_missing_paths}'\n"
@@ -475,7 +511,7 @@ def _parse_code(section: SpeciesSection) -> str:
 def _breakdown_code(section: SpeciesSection) -> str:
     return (
         "# Per-term breakdown: what each term contributes to the composite total.\n"
-        "print(_format_breakdown(protocol, energies_kJmol))"
+        "print(_format_breakdown(protocol, energies_kJmol, skipped_terms))"
     )
 
 
@@ -486,7 +522,10 @@ def _final_code(section: SpeciesSection) -> str:
     # or backslashes cannot break the cell's syntax.
     label_repr = repr(section.label)
     return (
-        "e_total_kJmol = protocol.evaluate(energies_kJmol)\n"
+        "e_total_kJmol = sum(\n"
+        "    0.0 if term.label in skipped_terms else term.evaluate(energies_kJmol)\n"
+        "    for term in protocol.terms\n"
+        ")\n"
         f"_RESULTS[{label_repr}] = {{\n"
         f"    'kind': {section.kind!r},\n"
         f"    'protocol_name': {section.preset_name!r},\n"
@@ -593,7 +632,8 @@ def build_species_report_dict(
     arc_version: str,
     arc_commit: str,
 ) -> dict[str, Any]:
-    """Assemble the per-species sp_composite report as a plain dict.
+    """
+    Assemble the per-species sp_composite report as a plain dict.
 
     All energy values are computed by re-parsing the QM output files referenced
     in ``section.sub_job_paths`` via :func:`arc.parser.parser.parse_e_elect`
@@ -607,38 +647,37 @@ def build_species_report_dict(
     downstream tooling reading this report is consistent with the run's
     output.yml / restart.yml.
 
-    Parameters
-    ----------
-    section : SpeciesSection
-        The reporting handoff struct populated by the scheduler at
-        finalization. Carries protocol, recipe, sub-job paths, flags.
-    e_elect_kj_per_mol : float
-        The final electronic energy ARC recorded for this species (kJ/mol).
-    timestamp : str
-        ISO-8601 string. Caller supplies for determinism (tests pin it).
-    arc_version, arc_commit : str
-        Provenance identifiers.
+    Args:
+        section (SpeciesSection): The reporting handoff struct populated by the
+            scheduler at finalization. Carries protocol, recipe, sub-job paths, flags.
+        e_elect_kj_per_mol (float): The final electronic energy ARC recorded
+            for this species (kJ/mol).
+        timestamp (str): ISO-8601 string. Caller supplies for determinism
+            (tests pin it).
+        arc_version (str): Provenance identifier.
+        arc_commit (str): Provenance identifier.
 
-    Returns
-    -------
-    dict
-        A plain dict ready for ``yaml.safe_dump`` or
+    Returns:
+        dict: A plain dict ready for ``yaml.safe_dump`` or
         :func:`write_species_report_yaml`.
     """
     energies_kj = {sl: parse_e_elect(p) for sl, p in section.sub_job_paths.items()}
 
-    base_term = section.protocol.base
-    base_sub_label, base_level = base_term.required_levels()[0]
-    base_block = {
-        "sub_label": base_sub_label,
-        "level": base_level.simple(),
-        "energy_kj_per_mol": energies_kj[base_sub_label],
-        "energy_hartree": energies_kj[base_sub_label] / E_h_kJmol,
-        "path": section.sub_job_paths[base_sub_label],
-    }
-
-    terms_block: list[dict[str, Any]] = []
-    for term in section.protocol.corrections:
+    def _term_block(term: Any) -> dict[str, Any]:
+        """Render one term (base or correction) polymorphically: contribution,
+        per-leg sub-jobs, and — for extrapolated terms — which formula was
+        applied to those legs. Terms the scheduler skipped as trivially zero
+        render with contribution 0.0, the skip reason, and no sub-jobs."""
+        if term.label in section.skipped_terms:
+            return {
+                "label": term.label,
+                "type": type(term).__name__,
+                "contribution_kj_per_mol": 0.0,
+                "contribution_hartree": 0.0,
+                "skipped": True,
+                "skip_reason": section.skipped_terms[term.label],
+                "sub_jobs": [],
+            }
         contribution_kj = term.evaluate(energies_kj)
         sub_jobs: list[dict[str, Any]] = []
         for sub_label, level in term.required_levels():
@@ -649,13 +688,20 @@ def build_species_report_dict(
                 "energy_hartree": energies_kj[sub_label] / E_h_kJmol,
                 "path": section.sub_job_paths[sub_label],
             })
-        terms_block.append({
+        block: dict[str, Any] = {
             "label": term.label,
             "type": type(term).__name__,
             "contribution_kj_per_mol": contribution_kj,
             "contribution_hartree": contribution_kj / E_h_kJmol,
             "sub_jobs": sub_jobs,
-        })
+        }
+        formula = getattr(term, "formula", None)
+        if formula is not None:
+            block["formula"] = formula
+        return block
+
+    base_block = _term_block(section.protocol.base)
+    terms_block = [_term_block(term) for term in section.protocol.corrections]
 
     return {
         "species": section.label,
@@ -691,13 +737,24 @@ def write_species_report_yaml(
     arc_version: str,
     arc_commit: str,
 ) -> None:
-    """Build and write the per-species sp_composite YAML report.
+    """
+    Build and write the per-species sp_composite YAML report.
 
     Creates the parent directory if missing. Output is deterministic: keys are
     written in insertion order (Python 3.7+ dicts), flow style is block (the
     YAML default), and ``sort_keys=False`` preserves the schema's natural
     reading order (species → protocol → units → base → terms → final → flags).
     Two writes with the same inputs produce byte-identical files.
+
+    Args:
+        path (str): Destination file path.
+        section (SpeciesSection): The reporting handoff struct populated by the
+            scheduler at finalization.
+        e_elect_kj_per_mol (float): The final electronic energy ARC recorded
+            for this species (kJ/mol).
+        timestamp (str): ISO-8601 string. Caller supplies for determinism.
+        arc_version (str): Provenance identifier.
+        arc_commit (str): Provenance identifier.
     """
     report = build_species_report_dict(
         section=section,
@@ -707,5 +764,7 @@ def write_species_report_yaml(
         arc_commit=arc_commit,
     )
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Raw yaml.safe_dump (not arc.common.save_yaml_file) because the report
+    # schema requires sort_keys=False, which the common helper does not expose.
     with open(path, "w") as fh:
         yaml.safe_dump(report, fh, sort_keys=False, default_flow_style=False)

--- a/arc/level/reporting_test.py
+++ b/arc/level/reporting_test.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.reporting`` — project-level Jupyter notebook artifact
++ the structured ``[sp_composite]`` log-event helper.
+
+The notebook-emitter must deliver:
+
+* A single ``.ipynb`` per project with one clearly-formatted section per species/TS.
+* Deterministic output (byte-identical re-writes with the same timestamp).
+* Self-contained per-section code: every section writes its own recipe dict and
+  reconstructs its own :class:`CompositeProtocol`, then re-parses the sub-job
+  output files via :func:`arc.parser.parse_e_elect` — giving the user
+  *independent* verification of ARC's computed energy.
+* End-to-end executability: the test suite writes a notebook against real
+  fixture output files (in Gaussian format that ARC's real parser consumes),
+  runs it via :mod:`nbclient`, and asserts the final ``e_elect`` printed in the
+  final code cell matches the value computed outside the notebook.
+"""
+
+import os
+import tempfile
+import unittest
+
+import nbclient
+import nbformat
+
+from arc.constants import E_h_kJmol
+from arc.exceptions import InputError
+from arc.level.protocol import CompositeProtocol
+from arc.level.reporting import (
+    SpeciesSection,
+    format_log_event,
+    write_composite_notebook,
+)
+
+
+def _write_gaussian_fixture(path: str, e_hartree: float) -> None:
+    """Minimal Gaussian-format output file parseable by ``arc.parser.parse_e_elect``.
+
+    ``arc.parser.determine_ess`` detects 'gaussian' from a line containing that
+    substring, and ``extract_scf_done`` regexes out the energy from a
+    ``SCF Done: E(RHF) = <value> A.U.`` line.
+    """
+    with open(path, "w") as fh:
+        fh.write(" Gaussian 16: test fixture\n")
+        fh.write(f" SCF Done:  E(RHF) =  {e_hartree:.9f}     A.U. after    1 cycles\n")
+
+
+# --------------------------------------------------------------------------- #
+#  format_log_event                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestFormatLogEvent(unittest.TestCase):
+    def test_format_basic(self):
+        line = format_log_event("H2O", "queued", "delta_T")
+        self.assertEqual(line, "[sp_composite] H2O — queued: delta_T")
+
+    def test_format_with_dict_payload(self):
+        line = format_log_event("H2O", "energy", {"sub_label": "base", "value_kJmol": -200000.0})
+        self.assertIn("[sp_composite] H2O — energy:", line)
+        self.assertIn("base", line)
+        self.assertIn("-200000", line)
+
+    def test_format_with_None_payload(self):
+        line = format_log_event("H2O", "complete", None)
+        self.assertEqual(line, "[sp_composite] H2O — complete")
+
+
+# --------------------------------------------------------------------------- #
+#  SpeciesSection dataclass                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _make_two_term_section(label: str = "H2O", kind: str = "species",
+                           paths: dict = None, flags: list = None) -> SpeciesSection:
+    recipe = {
+        "base": {"method": "hf", "basis": "cc-pVTZ"},
+        "corrections": [
+            {"label": "delta_T", "type": "delta",
+             "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+             "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+        ],
+    }
+    return SpeciesSection(
+        label=label,
+        kind=kind,
+        preset_name=None,
+        reference="DOI: 10.0/test",
+        recipe=recipe,
+        protocol=CompositeProtocol.from_user_input(recipe),
+        sub_job_paths=paths or {"base": "/tmp/base.out",
+                                "delta_T__high": "/tmp/hi.out",
+                                "delta_T__low": "/tmp/lo.out"},
+        flags=flags or [],
+    )
+
+
+class TestSpeciesSection(unittest.TestCase):
+    def test_fields_accessible(self):
+        s = _make_two_term_section()
+        self.assertEqual(s.label, "H2O")
+        self.assertEqual(s.kind, "species")
+        self.assertIsNone(s.preset_name)
+        self.assertIn("DOI", s.reference)
+        self.assertIn("base", s.recipe)
+        self.assertIsInstance(s.protocol, CompositeProtocol)
+        self.assertIn("base", s.sub_job_paths)
+        self.assertEqual(s.flags, [])
+
+    def test_kind_species_valid(self):
+        _make_two_term_section(kind="species")  # must not raise
+
+    def test_kind_ts_valid(self):
+        _make_two_term_section(kind="ts")  # must not raise
+
+    def test_kind_unknown_rejected(self):
+        with self.assertRaises(InputError):
+            _make_two_term_section(kind="bogus")
+
+
+# --------------------------------------------------------------------------- #
+#  write_composite_notebook                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestWriteCompositeNotebook(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.nb_path = os.path.join(self.tmp, "sp_composite.ipynb")
+        self.base_path = os.path.join(self.tmp, "base.out")
+        self.hi_path = os.path.join(self.tmp, "delta_T__high.out")
+        self.lo_path = os.path.join(self.tmp, "delta_T__low.out")
+        _write_gaussian_fixture(self.base_path, -76.345678)
+        _write_gaussian_fixture(self.hi_path, -76.345600)
+        _write_gaussian_fixture(self.lo_path, -76.346500)
+        self.section = _make_two_term_section(
+            paths={"base": self.base_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+        self.kwargs = dict(
+            path=self.nb_path,
+            project_name="unittest_project",
+            arc_version="test",
+            timestamp="2026-04-22T14:01:33Z",
+            sections=[self.section],
+            notebook_dir=self.tmp,
+        )
+
+    def tearDown(self):
+        for p in (self.nb_path, self.base_path, self.hi_path, self.lo_path):
+            if os.path.exists(p):
+                os.unlink(p)
+        os.rmdir(self.tmp)
+
+    def _read(self):
+        return nbformat.read(self.nb_path, as_version=4)
+
+    def _cells(self):
+        return self._read().cells
+
+    # --- existence + validity ---------------------------------------------- #
+
+    def test_file_written(self):
+        write_composite_notebook(**self.kwargs)
+        self.assertTrue(os.path.exists(self.nb_path))
+
+    def test_valid_nbformat_validates(self):
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        nbformat.validate(nb)  # raises if invalid
+
+    def test_code_cells_unexecuted(self):
+        write_composite_notebook(**self.kwargs)
+        for cell in self._cells():
+            if cell.cell_type == "code":
+                self.assertEqual(cell.outputs, [])
+                self.assertIsNone(cell.execution_count)
+
+    def test_notebook_has_stable_metadata(self):
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        self.assertIn("kernelspec", nb.metadata)
+        self.assertEqual(nb.metadata.kernelspec.get("name"), "python3")
+
+    # --- section structure -------------------------------------------------- #
+
+    def test_one_h2_per_section_single(self):
+        write_composite_notebook(**self.kwargs)
+        h2s = [c for c in self._cells()
+               if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        # One H2 for the species + one for the project summary tail.
+        species_h2s = [c for c in h2s if "H2O" in c.source]
+        self.assertEqual(len(species_h2s), 1)
+
+    def test_one_h2_per_section_multiple(self):
+        s1 = _make_two_term_section(label="H2O", paths=self.section.sub_job_paths)
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        s3 = _make_two_term_section(label="TS1", kind="ts", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [s2, s1, s3]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        h2_titles = [c.source.splitlines()[0]
+                     for c in cells
+                     if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")
+                     and "Project summary" not in c.source
+                     and "References" not in c.source]
+        # Species first (alphabetical), then TS (alphabetical): H2O, OH, TS1.
+        self.assertEqual(len(h2_titles), 3)
+        self.assertIn("H2O", h2_titles[0])
+        self.assertIn("OH", h2_titles[1])
+        self.assertIn("TS1", h2_titles[2])
+
+    def test_ts_sections_come_after_species(self):
+        ts = _make_two_term_section(label="AATS", kind="ts", paths=self.section.sub_job_paths)
+        sp = _make_two_term_section(label="ZZspecies", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [ts, sp]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        # Find the section-header (H2) cell for each.
+        zz_idx = next(i for i, c in enumerate(cells)
+                      if c.cell_type == "markdown" and c.source.lstrip().startswith("## Species: ZZspecies"))
+        aa_idx = next(i for i, c in enumerate(cells)
+                      if c.cell_type == "markdown" and c.source.lstrip().startswith("## TS: AATS"))
+        self.assertLess(zz_idx, aa_idx)
+
+    def test_shared_setup_cell_only_once(self):
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        setup_cells = [c for c in cells
+                       if c.cell_type == "code"
+                       and "import arc.parser" in c.source
+                       and "CompositeProtocol" in c.source]
+        self.assertEqual(len(setup_cells), 1)
+
+    def test_toc_present(self):
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        toc_cells = [c for c in self._cells()
+                     if c.cell_type == "markdown"
+                     and ("table of contents" in c.source.lower() or "contents" in c.source.lower())]
+        self.assertGreaterEqual(len(toc_cells), 1)
+        # TOC should mention every section label.
+        toc_joined = "\n".join(c.source for c in toc_cells)
+        self.assertIn("H2O", toc_joined)
+        self.assertIn("OH", toc_joined)
+
+    def test_references_section_present(self):
+        write_composite_notebook(**self.kwargs)
+        ref_cells = [c for c in self._cells()
+                     if c.cell_type == "markdown" and "References" in c.source]
+        self.assertGreaterEqual(len(ref_cells), 1)
+
+    def test_references_deduplicated(self):
+        # Two sections citing the same DOI → one entry in the References block.
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)  # same DOI
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        ref_cell = next(c for c in self._cells()
+                        if c.cell_type == "markdown" and c.source.lstrip().startswith("## References"))
+        self.assertEqual(ref_cell.source.count("DOI: 10.0/test"), 1)
+
+    def test_section_contains_required_cell_sequence(self):
+        write_composite_notebook(**self.kwargs)
+        cells = self._cells()
+        # Locate the H2O section header.
+        hdr = next(i for i, c in enumerate(cells)
+                   if c.cell_type == "markdown" and "## Species: H2O" in c.source)
+        # The 7 cells immediately after the header are: protocol summary (md),
+        # recipe + build (code), paths map (code), parse + evaluate (code),
+        # breakdown (code), final print (code), interpretation (md).
+        seq = cells[hdr + 1 : hdr + 8]
+        self.assertEqual(seq[0].cell_type, "markdown")
+        self.assertIn("DOI: 10.0/test", seq[0].source)
+        self.assertEqual(seq[1].cell_type, "code")
+        self.assertIn("CompositeProtocol.from_user_input", seq[1].source)
+        self.assertEqual(seq[2].cell_type, "code")
+        self.assertIn("paths", seq[2].source)
+        self.assertEqual(seq[3].cell_type, "code")
+        self.assertIn("parse_e_elect", seq[3].source)
+        self.assertEqual(seq[4].cell_type, "code")  # term breakdown
+        self.assertEqual(seq[5].cell_type, "code")  # final print
+        self.assertIn("FINAL", seq[5].source)
+        self.assertEqual(seq[6].cell_type, "markdown")  # interpretation
+
+    def test_section_markdown_includes_formula(self):
+        write_composite_notebook(**self.kwargs)
+        md_cells = [c for c in self._cells() if c.cell_type == "markdown"]
+        has_formula = any("$" in c.source and "E_" in c.source for c in md_cells)
+        self.assertTrue(has_formula, "No LaTeX-style formula found in any markdown cell.")
+
+    # --- path rendering ----------------------------------------------------- #
+
+    def test_paths_rendered_relative_when_under_notebook_dir(self):
+        write_composite_notebook(**self.kwargs)
+        paths_cell = next(c for c in self._cells()
+                          if c.cell_type == "code" and "paths = " in c.source
+                          and "parse_e_elect" not in c.source)
+        # Relative paths should start with './' and not have the tmp absolute prefix.
+        self.assertNotIn(self.tmp, paths_cell.source)
+        self.assertIn("./base.out", paths_cell.source)
+
+    def test_paths_rendered_absolute_when_outside(self):
+        # A path outside the notebook dir must appear as absolute.
+        outside_dir = tempfile.mkdtemp()
+        outside_path = os.path.join(outside_dir, "far.out")
+        _write_gaussian_fixture(outside_path, -1.0)
+        section = _make_two_term_section(
+            paths={"base": outside_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+        kwargs = {**self.kwargs, "sections": [section]}
+        try:
+            write_composite_notebook(**kwargs)
+            paths_cell = next(c for c in self._cells()
+                              if c.cell_type == "code" and "paths = " in c.source
+                              and "parse_e_elect" not in c.source)
+            self.assertIn(outside_path, paths_cell.source)
+        finally:
+            os.unlink(outside_path)
+            os.rmdir(outside_dir)
+
+    # --- determinism -------------------------------------------------------- #
+
+    def test_deterministic_byte_identical_across_runs(self):
+        write_composite_notebook(**self.kwargs)
+        with open(self.nb_path, "rb") as fh:
+            first = fh.read()
+        os.unlink(self.nb_path)
+        write_composite_notebook(**self.kwargs)
+        with open(self.nb_path, "rb") as fh:
+            second = fh.read()
+        self.assertEqual(first, second)
+
+    def test_cell_ids_are_stable_across_runs(self):
+        write_composite_notebook(**self.kwargs)
+        ids1 = [c.get("id") for c in self._cells()]
+        os.unlink(self.nb_path)
+        write_composite_notebook(**self.kwargs)
+        ids2 = [c.get("id") for c in self._cells()]
+        self.assertEqual(ids1, ids2)
+
+    # --- incremental growth -------------------------------------------------- #
+
+    def test_incremental_growth_preserves_existing_sections(self):
+        # First write: one section.
+        write_composite_notebook(**self.kwargs)
+        one_section_cells = len(self._cells())
+        # Second write: same section + a new one. Must include both.
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs2 = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs2)
+        two_section_cells = len(self._cells())
+        self.assertGreater(two_section_cells, one_section_cells)
+        # Both species labels are present.
+        joined = "\n".join(c.source for c in self._cells())
+        self.assertIn("H2O", joined)
+        self.assertIn("OH", joined)
+
+    # --- end-to-end executability -------------------------------------------- #
+
+    def test_notebook_executes_and_recomputes_expected_final_value(self):
+        """The generated notebook, executed via nbclient, prints the expected final e_elect."""
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        # Ensure the kernel subprocess resolves `arc` from THIS worktree, not any
+        # other `arc` package that happens to be on the user's sys.path.
+        arc_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__)
+        )))  # .../ARC-wt3
+        prior_pp = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = arc_root + (os.pathsep + prior_pp if prior_pp else "")
+        try:
+            client = nbclient.NotebookClient(
+                nb, timeout=60, resources={"metadata": {"path": self.tmp}}
+            )
+            client.execute()
+        finally:
+            if prior_pp:
+                os.environ["PYTHONPATH"] = prior_pp
+            else:
+                os.environ.pop("PYTHONPATH", None)
+        expected_kjmol = (
+            -76.345678 + (-76.345600 - (-76.346500))
+        ) * E_h_kJmol
+        stdouts = [
+            out.get("text", "")
+            for cell in nb.cells
+            if cell.cell_type == "code"
+            for out in cell.get("outputs", [])
+            if out.get("output_type") == "stream" and out.get("name") == "stdout"
+        ]
+        all_text = "\n".join(stdouts)
+        self.assertIn("FINAL", all_text)
+        # Compare to 2 decimal places (the print format is :,.3f kJ/mol).
+        self.assertIn(f"{expected_kjmol:,.3f}", all_text)
+
+
+# --------------------------------------------------------------------------- #
+#  Import placement (module-level, per project guidelines)                    #
+# --------------------------------------------------------------------------- #
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/reporting_test.py
+++ b/arc/level/reporting_test.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.reporting`` — project-level Jupyter notebook artifact
++ the structured ``[sp_composite]`` log-event helper.
+
+The notebook-emitter must deliver:
+
+* A single ``.ipynb`` per project with one clearly-formatted section per species/TS.
+* Deterministic output (byte-identical re-writes with the same timestamp).
+* Self-contained per-section code: every section writes its own recipe dict and
+  reconstructs its own :class:`CompositeProtocol`, then re-parses the sub-job
+  output files via :func:`arc.parser.parse_e_elect` — giving the user
+  *independent* verification of ARC's computed energy.
+* End-to-end executability: the test suite writes a notebook against real
+  fixture output files (in Gaussian format that ARC's real parser consumes),
+  runs it via :mod:`nbclient`, and asserts the final ``e_elect`` printed in the
+  final code cell matches the value computed outside the notebook.
+"""
+
+import os
+import tempfile
+import unittest
+
+import nbclient
+import nbformat
+
+from arc.constants import E_h_kJmol
+from arc.exceptions import InputError
+from arc.level.protocol import CompositeProtocol
+from arc.level.reporting import (
+    SpeciesSection,
+    build_species_report_dict,
+    format_log_event,
+    write_composite_notebook,
+    write_species_report_yaml,
+)
+
+
+def _write_gaussian_fixture(path: str, e_hartree: float) -> None:
+    """Minimal Gaussian-format output file parseable by ``arc.parser.parse_e_elect``.
+
+    ``arc.parser.determine_ess`` detects 'gaussian' from a line containing that
+    substring, and ``extract_scf_done`` regexes out the energy from a
+    ``SCF Done: E(RHF) = <value> A.U.`` line.
+    """
+    with open(path, "w") as fh:
+        fh.write(" Gaussian 16: test fixture\n")
+        fh.write(f" SCF Done:  E(RHF) =  {e_hartree:.9f}     A.U. after    1 cycles\n")
+
+
+# --------------------------------------------------------------------------- #
+#  format_log_event                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestFormatLogEvent(unittest.TestCase):
+    def test_format_basic(self):
+        line = format_log_event("H2O", "queued", "delta_T")
+        self.assertEqual(line, "[sp_composite] H2O — queued: delta_T")
+
+    def test_format_with_dict_payload(self):
+        line = format_log_event("H2O", "energy", {"sub_label": "base", "value_kJmol": -200000.0})
+        self.assertIn("[sp_composite] H2O — energy:", line)
+        self.assertIn("base", line)
+        self.assertIn("-200000", line)
+
+    def test_format_with_None_payload(self):
+        line = format_log_event("H2O", "complete", None)
+        self.assertEqual(line, "[sp_composite] H2O — complete")
+
+
+# --------------------------------------------------------------------------- #
+#  SpeciesSection dataclass                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _make_two_term_section(label: str = "H2O", kind: str = "species",
+                           paths: dict = None, flags: list = None) -> SpeciesSection:
+    recipe = {
+        "base": {"method": "hf", "basis": "cc-pVTZ"},
+        "corrections": [
+            {"label": "delta_T", "type": "delta",
+             "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+             "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+        ],
+    }
+    return SpeciesSection(
+        label=label,
+        kind=kind,
+        preset_name=None,
+        reference="DOI: 10.0/test",
+        recipe=recipe,
+        protocol=CompositeProtocol.from_user_input(recipe),
+        sub_job_paths=paths or {"base": "/tmp/base.out",
+                                "delta_T__high": "/tmp/hi.out",
+                                "delta_T__low": "/tmp/lo.out"},
+        flags=flags or [],
+    )
+
+
+class TestSpeciesSection(unittest.TestCase):
+    def test_fields_accessible(self):
+        s = _make_two_term_section()
+        self.assertEqual(s.label, "H2O")
+        self.assertEqual(s.kind, "species")
+        self.assertIsNone(s.preset_name)
+        self.assertIn("DOI", s.reference)
+        self.assertIn("base", s.recipe)
+        self.assertIsInstance(s.protocol, CompositeProtocol)
+        self.assertIn("base", s.sub_job_paths)
+        self.assertEqual(s.flags, [])
+
+    def test_kind_species_valid(self):
+        _make_two_term_section(kind="species")  # must not raise
+
+    def test_kind_ts_valid(self):
+        _make_two_term_section(kind="ts")  # must not raise
+
+    def test_kind_unknown_rejected(self):
+        with self.assertRaises(InputError):
+            _make_two_term_section(kind="bogus")
+
+
+# --------------------------------------------------------------------------- #
+#  write_composite_notebook                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestWriteCompositeNotebook(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.nb_path = os.path.join(self.tmp, "sp_composite.ipynb")
+        self.base_path = os.path.join(self.tmp, "base.out")
+        self.hi_path = os.path.join(self.tmp, "delta_T__high.out")
+        self.lo_path = os.path.join(self.tmp, "delta_T__low.out")
+        _write_gaussian_fixture(self.base_path, -76.345678)
+        _write_gaussian_fixture(self.hi_path, -76.345600)
+        _write_gaussian_fixture(self.lo_path, -76.346500)
+        self.section = _make_two_term_section(
+            paths={"base": self.base_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+        self.kwargs = dict(
+            path=self.nb_path,
+            project_name="unittest_project",
+            arc_version="test",
+            timestamp="2026-04-22T14:01:33Z",
+            sections=[self.section],
+            notebook_dir=self.tmp,
+        )
+
+    def tearDown(self):
+        for p in (self.nb_path, self.base_path, self.hi_path, self.lo_path):
+            if os.path.exists(p):
+                os.unlink(p)
+        os.rmdir(self.tmp)
+
+    def _read(self):
+        return nbformat.read(self.nb_path, as_version=4)
+
+    def _cells(self):
+        return self._read().cells
+
+    # --- existence + validity ---------------------------------------------- #
+
+    def test_file_written(self):
+        write_composite_notebook(**self.kwargs)
+        self.assertTrue(os.path.exists(self.nb_path))
+
+    def test_valid_nbformat_validates(self):
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        nbformat.validate(nb)  # raises if invalid
+
+    def test_code_cells_unexecuted(self):
+        write_composite_notebook(**self.kwargs)
+        for cell in self._cells():
+            if cell.cell_type == "code":
+                self.assertEqual(cell.outputs, [])
+                self.assertIsNone(cell.execution_count)
+
+    def test_notebook_has_stable_metadata(self):
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        self.assertIn("kernelspec", nb.metadata)
+        self.assertEqual(nb.metadata.kernelspec.get("name"), "python3")
+
+    # --- section structure -------------------------------------------------- #
+
+    def test_one_h2_per_section_single(self):
+        write_composite_notebook(**self.kwargs)
+        h2s = [c for c in self._cells()
+               if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        # One H2 for the species + one for the project summary tail.
+        species_h2s = [c for c in h2s if "H2O" in c.source]
+        self.assertEqual(len(species_h2s), 1)
+
+    def test_one_h2_per_section_multiple(self):
+        s1 = _make_two_term_section(label="H2O", paths=self.section.sub_job_paths)
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        s3 = _make_two_term_section(label="TS1", kind="ts", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [s2, s1, s3]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        h2_titles = [c.source.splitlines()[0]
+                     for c in cells
+                     if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")
+                     and "Project summary" not in c.source
+                     and "References" not in c.source]
+        # Species first (alphabetical), then TS (alphabetical): H2O, OH, TS1.
+        self.assertEqual(len(h2_titles), 3)
+        self.assertIn("H2O", h2_titles[0])
+        self.assertIn("OH", h2_titles[1])
+        self.assertIn("TS1", h2_titles[2])
+
+    def test_ts_sections_come_after_species(self):
+        ts = _make_two_term_section(label="AATS", kind="ts", paths=self.section.sub_job_paths)
+        sp = _make_two_term_section(label="ZZspecies", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [ts, sp]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        # Find the section-header (H2) cell for each.
+        zz_idx = next(i for i, c in enumerate(cells)
+                      if c.cell_type == "markdown" and c.source.lstrip().startswith("## Species: ZZspecies"))
+        aa_idx = next(i for i, c in enumerate(cells)
+                      if c.cell_type == "markdown" and c.source.lstrip().startswith("## TS: AATS"))
+        self.assertLess(zz_idx, aa_idx)
+
+    def test_shared_setup_cell_only_once(self):
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        cells = self._cells()
+        setup_cells = [c for c in cells
+                       if c.cell_type == "code"
+                       and "import arc.parser" in c.source
+                       and "CompositeProtocol" in c.source]
+        self.assertEqual(len(setup_cells), 1)
+
+    def test_toc_present(self):
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        toc_cells = [c for c in self._cells()
+                     if c.cell_type == "markdown"
+                     and ("table of contents" in c.source.lower() or "contents" in c.source.lower())]
+        self.assertGreaterEqual(len(toc_cells), 1)
+        # TOC should mention every section label.
+        toc_joined = "\n".join(c.source for c in toc_cells)
+        self.assertIn("H2O", toc_joined)
+        self.assertIn("OH", toc_joined)
+
+    def test_references_section_present(self):
+        write_composite_notebook(**self.kwargs)
+        ref_cells = [c for c in self._cells()
+                     if c.cell_type == "markdown" and "References" in c.source]
+        self.assertGreaterEqual(len(ref_cells), 1)
+
+    def test_references_deduplicated(self):
+        # Two sections citing the same DOI → one entry in the References block.
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)  # same DOI
+        kwargs = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs)
+        ref_cell = next(c for c in self._cells()
+                        if c.cell_type == "markdown" and c.source.lstrip().startswith("## References"))
+        self.assertEqual(ref_cell.source.count("DOI: 10.0/test"), 1)
+
+    def test_section_contains_required_cell_sequence(self):
+        write_composite_notebook(**self.kwargs)
+        cells = self._cells()
+        # Locate the H2O section header.
+        hdr = next(i for i, c in enumerate(cells)
+                   if c.cell_type == "markdown" and "## Species: H2O" in c.source)
+        # The 7 cells immediately after the header are: protocol summary (md),
+        # recipe + build (code), paths map (code), parse + evaluate (code),
+        # breakdown (code), final print (code), interpretation (md).
+        seq = cells[hdr + 1 : hdr + 8]
+        self.assertEqual(seq[0].cell_type, "markdown")
+        self.assertIn("DOI: 10.0/test", seq[0].source)
+        self.assertEqual(seq[1].cell_type, "code")
+        self.assertIn("CompositeProtocol.from_user_input", seq[1].source)
+        self.assertEqual(seq[2].cell_type, "code")
+        self.assertIn("paths", seq[2].source)
+        self.assertEqual(seq[3].cell_type, "code")
+        self.assertIn("parse_e_elect", seq[3].source)
+        self.assertEqual(seq[4].cell_type, "code")  # term breakdown
+        self.assertEqual(seq[5].cell_type, "code")  # final print
+        self.assertIn("FINAL", seq[5].source)
+        self.assertEqual(seq[6].cell_type, "markdown")  # interpretation
+
+    def test_section_markdown_includes_formula(self):
+        write_composite_notebook(**self.kwargs)
+        md_cells = [c for c in self._cells() if c.cell_type == "markdown"]
+        has_formula = any("$" in c.source and "E_" in c.source for c in md_cells)
+        self.assertTrue(has_formula, "No LaTeX-style formula found in any markdown cell.")
+
+    # --- path rendering ----------------------------------------------------- #
+
+    def test_paths_kept_absolute_and_wrapped_in_resolve_path(self):
+        """Absolute paths survive into the paths-dict cell and each is wrapped
+        in ``_resolve_path(...)`` so they're rebased through
+        ``arc.common.globalize_path`` at notebook execution time. This makes
+        the notebook robust to the user moving the project directory or
+        running on a different machine — paths under ``<project>/calcs/Species/``
+        or ``<project>/calcs/TSs/`` get auto-rebased to the new project root."""
+        write_composite_notebook(**self.kwargs)
+        paths_cell = next(c for c in self._cells()
+                          if c.cell_type == "code" and "paths = " in c.source
+                          and "parse_e_elect" not in c.source)
+        # Each path value must be wrapped in _resolve_path(...).
+        self.assertIn("_resolve_path(", paths_cell.source)
+        # Paths are stored as absolute strings so globalize_path can recognise
+        # the project-directory prefix and rewrite it. The rewrite is a no-op
+        # if the project hasn't moved.
+        self.assertIn(self.base_path, paths_cell.source)
+        self.assertIn(self.hi_path, paths_cell.source)
+        self.assertIn(self.lo_path, paths_cell.source)
+
+    def test_paths_outside_project_survive_resolve_unchanged(self):
+        """Paths that don't match the ``/calcs/Species|TSs/`` pattern flow
+        through ``globalize_path`` unchanged (it only rebases project-tree
+        QM-output paths). They must still appear as absolutes wrapped in
+        ``_resolve_path(...)`` — the notebook can't pre-judge what's
+        inside vs outside the project."""
+        outside_dir = tempfile.mkdtemp()
+        outside_path = os.path.join(outside_dir, "far.out")
+        _write_gaussian_fixture(outside_path, -1.0)
+        section = _make_two_term_section(
+            paths={"base": outside_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+        kwargs = {**self.kwargs, "sections": [section]}
+        try:
+            write_composite_notebook(**kwargs)
+            paths_cell = next(c for c in self._cells()
+                              if c.cell_type == "code" and "paths = " in c.source
+                              and "parse_e_elect" not in c.source)
+            self.assertIn(outside_path, paths_cell.source)
+            self.assertIn("_resolve_path(", paths_cell.source)
+        finally:
+            os.unlink(outside_path)
+            os.rmdir(outside_dir)
+
+    def test_setup_cell_defines_resolve_path_and_imports_arc_common(self):
+        """The setup cell must define ``_resolve_path`` and import
+        ``arc.common`` so the per-section paths-dict cells can call
+        ``_resolve_path(...)`` on each absolute path."""
+        write_composite_notebook(**self.kwargs)
+        # Setup cell is the first code cell after the title/banner markdown.
+        setup_cells = [c for c in self._cells()
+                       if c.cell_type == "code" and "_resolve_path" in c.source]
+        self.assertGreaterEqual(len(setup_cells), 1,
+                                "Expected at least one code cell defining _resolve_path.")
+        setup_src = setup_cells[0].source
+        self.assertIn("arc.common", setup_src)
+        self.assertIn("globalize_path", setup_src)
+        self.assertIn("def _resolve_path", setup_src)
+
+    # --- determinism -------------------------------------------------------- #
+
+    def test_deterministic_byte_identical_across_runs(self):
+        write_composite_notebook(**self.kwargs)
+        with open(self.nb_path, "rb") as fh:
+            first = fh.read()
+        os.unlink(self.nb_path)
+        write_composite_notebook(**self.kwargs)
+        with open(self.nb_path, "rb") as fh:
+            second = fh.read()
+        self.assertEqual(first, second)
+
+    def test_cell_ids_are_stable_across_runs(self):
+        write_composite_notebook(**self.kwargs)
+        ids1 = [c.get("id") for c in self._cells()]
+        os.unlink(self.nb_path)
+        write_composite_notebook(**self.kwargs)
+        ids2 = [c.get("id") for c in self._cells()]
+        self.assertEqual(ids1, ids2)
+
+    # --- incremental growth -------------------------------------------------- #
+
+    def test_incremental_growth_preserves_existing_sections(self):
+        # First write: one section.
+        write_composite_notebook(**self.kwargs)
+        one_section_cells = len(self._cells())
+        # Second write: same section + a new one. Must include both.
+        s2 = _make_two_term_section(label="OH", paths=self.section.sub_job_paths)
+        kwargs2 = {**self.kwargs, "sections": [self.section, s2]}
+        write_composite_notebook(**kwargs2)
+        two_section_cells = len(self._cells())
+        self.assertGreater(two_section_cells, one_section_cells)
+        # Both species labels are present.
+        joined = "\n".join(c.source for c in self._cells())
+        self.assertIn("H2O", joined)
+        self.assertIn("OH", joined)
+
+    # --- end-to-end executability -------------------------------------------- #
+
+    def test_notebook_executes_and_recomputes_expected_final_value(self):
+        """The generated notebook, executed via nbclient, prints the expected final e_elect."""
+        write_composite_notebook(**self.kwargs)
+        nb = self._read()
+        # Ensure the kernel subprocess resolves `arc` from THIS worktree, not any
+        # other `arc` package that happens to be on the user's sys.path.
+        arc_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__)
+        )))  # .../ARC-wt3
+        prior_pp = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = arc_root + (os.pathsep + prior_pp if prior_pp else "")
+        try:
+            client = nbclient.NotebookClient(
+                nb, timeout=60, resources={"metadata": {"path": self.tmp}}
+            )
+            client.execute()
+        finally:
+            if prior_pp:
+                os.environ["PYTHONPATH"] = prior_pp
+            else:
+                os.environ.pop("PYTHONPATH", None)
+        expected_kjmol = (
+            -76.345678 + (-76.345600 - (-76.346500))
+        ) * E_h_kJmol
+        stdouts = [
+            out.get("text", "")
+            for cell in nb.cells
+            if cell.cell_type == "code"
+            for out in cell.get("outputs", [])
+            if out.get("output_type") == "stream" and out.get("name") == "stdout"
+        ]
+        all_text = "\n".join(stdouts)
+        self.assertIn("FINAL", all_text)
+        # Compare to 2 decimal places (the print format is :,.3f kJ/mol).
+        self.assertIn(f"{expected_kjmol:,.3f}", all_text)
+
+
+# --------------------------------------------------------------------------- #
+#  build_species_report_dict + write_species_report_yaml                      #
+# --------------------------------------------------------------------------- #
+
+
+import yaml  # noqa: E402  (import after the other module-level imports for grouping)
+
+
+class TestSpeciesReportDict(unittest.TestCase):
+    """``build_species_report_dict`` produces the consumable per-species summary.
+
+    The notebook (``sp_composite.ipynb``) is for *independent verification* via
+    Run-All; this YAML report is for *consumption* — readable in plain text,
+    parseable by tooling, one file per species with every term's contribution
+    spelled out next to the QM-output paths backing it.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.base_path = os.path.join(self.tmp, "base.out")
+        self.hi_path = os.path.join(self.tmp, "delta_T__high.out")
+        self.lo_path = os.path.join(self.tmp, "delta_T__low.out")
+        _write_gaussian_fixture(self.base_path, -76.345678)
+        _write_gaussian_fixture(self.hi_path, -76.346500)   # lower (more negative) → contribution = high - low < 0
+        _write_gaussian_fixture(self.lo_path, -76.345600)
+        self.section = _make_two_term_section(
+            paths={"base": self.base_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+
+    def tearDown(self):
+        # Tests create nested directories (e.g. Species/H2O/...) — use rmtree
+        # to clean them up wholesale rather than enumerating fixture files.
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_top_level_fields(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="2026-04-30T13:10:32Z",
+            arc_version="1.1.0",
+            arc_commit="74fc4fa5",
+        )
+        self.assertEqual(d["species"], "H2O")
+        self.assertEqual(d["kind"], "species")
+        self.assertEqual(d["generated_at"], "2026-04-30T13:10:32Z")
+        self.assertEqual(d["arc_version"], "1.1.0")
+        self.assertEqual(d["arc_commit"], "74fc4fa5")
+
+    def test_protocol_block(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="2026-04-30T13:10:32Z",
+            arc_version="1.1.0",
+            arc_commit="abc",
+        )
+        self.assertIsNone(d["protocol"]["preset"])  # explicit recipe in fixture
+        self.assertIn("DOI", d["protocol"]["reference"])
+        # Formula spells out the sum the protocol evaluates.
+        self.assertIn("E_base", d["protocol"]["formula"])
+        self.assertIn("delta_T", d["protocol"]["formula"])
+
+    def test_units_block(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        self.assertEqual(d["units"]["energy"], "kJ/mol")
+        self.assertEqual(d["units"]["energy_alt"], "Hartree")
+
+    def test_base_block(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        base = d["base"]
+        self.assertEqual(base["sub_label"], "base")
+        self.assertEqual(base["path"], self.base_path)
+        # Energy parsed via arc.parser; cross-check Hartree↔kJ/mol consistency.
+        self.assertAlmostEqual(
+            base["energy_kj_per_mol"] / E_h_kJmol,
+            base["energy_hartree"],
+            places=6,
+        )
+
+    def test_terms_block_has_one_entry_per_correction(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        self.assertEqual(len(d["terms"]), 1)  # fixture has exactly one correction
+        term = d["terms"][0]
+        self.assertEqual(term["label"], "delta_T")
+        self.assertEqual(term["type"], "DeltaTerm")
+        self.assertEqual(len(term["sub_jobs"]), 2)
+        self.assertEqual({sj["sub_label"] for sj in term["sub_jobs"]},
+                         {"delta_T__high", "delta_T__low"})
+        # Contribution = E[high] - E[low] = -76.346500 - (-76.345600) = -0.000900 Ha
+        # = -0.000900 × E_h_kJmol ≈ -2.363 kJ/mol
+        self.assertAlmostEqual(term["contribution_hartree"], -0.000900, places=6)
+        self.assertAlmostEqual(term["contribution_kj_per_mol"],
+                               -0.000900 * E_h_kJmol, places=3)
+
+    def test_final_block_uses_caller_supplied_e_elect(self):
+        d = build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.123,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        self.assertEqual(d["final"]["e_elect_kj_per_mol"], -200000.123)
+        self.assertAlmostEqual(d["final"]["e_elect_hartree"],
+                               -200000.123 / E_h_kJmol, places=6)
+        self.assertEqual(d["final"]["e_elect_source"], "sp_composite")
+
+    def test_flags_propagated(self):
+        section = _make_two_term_section(
+            paths={"base": self.base_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+            flags=["MRCC degenerate-system fallback for delta_Q__high"],
+        )
+        d = build_species_report_dict(
+            section=section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        self.assertEqual(len(d["flags"]), 1)
+        self.assertIn("MRCC", d["flags"][0])
+
+    def test_yaml_round_trips(self):
+        out = os.path.join(self.tmp, "sp_composite_report.yml")
+        write_species_report_yaml(
+            path=out,
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="2026-04-30T13:10:32Z",
+            arc_version="1.1.0",
+            arc_commit="74fc4fa5",
+        )
+        self.assertTrue(os.path.exists(out))
+        with open(out) as fh:
+            loaded = yaml.safe_load(fh)
+        self.assertEqual(loaded["species"], "H2O")
+        self.assertEqual(loaded["kind"], "species")
+        self.assertIn("base", loaded)
+        self.assertEqual(len(loaded["terms"]), 1)
+        self.assertEqual(loaded["terms"][0]["label"], "delta_T")
+
+    def test_yaml_writer_creates_parent_directory(self):
+        nested = os.path.join(self.tmp, "Species", "H2O", "sp_composite_report.yml")
+        write_species_report_yaml(
+            path=nested,
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        self.assertTrue(os.path.exists(nested))
+
+    def test_writer_is_deterministic(self):
+        """Two writes with the same inputs produce byte-identical files."""
+        out_a = os.path.join(self.tmp, "a.yml")
+        out_b = os.path.join(self.tmp, "b.yml")
+        for out in (out_a, out_b):
+            write_species_report_yaml(
+                path=out,
+                section=self.section,
+                e_elect_kj_per_mol=-200000.0,
+                timestamp="2026-04-30T13:10:32Z",
+                arc_version="1.1.0",
+                arc_commit="74fc4fa5",
+            )
+        with open(out_a, "rb") as fa, open(out_b, "rb") as fb:
+            self.assertEqual(fa.read(), fb.read())
+
+
+# --------------------------------------------------------------------------- #
+#  Import placement (module-level, per project guidelines)                    #
+# --------------------------------------------------------------------------- #
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/reporting_test.py
+++ b/arc/level/reporting_test.py
@@ -19,6 +19,7 @@ The notebook-emitter must deliver:
   final code cell matches the value computed outside the notebook.
 """
 
+import importlib.util
 import os
 import tempfile
 import unittest
@@ -399,20 +400,22 @@ class TestWriteCompositeNotebook(unittest.TestCase):
 
     # --- end-to-end executability -------------------------------------------- #
 
+    @unittest.skipUnless(importlib.util.find_spec("ipykernel") is not None,
+                         "ipykernel is required to execute the generated notebook")
     def test_notebook_executes_and_recomputes_expected_final_value(self):
         """The generated notebook, executed via nbclient, prints the expected final e_elect."""
         write_composite_notebook(**self.kwargs)
         nb = self._read()
-        # Ensure the kernel subprocess resolves `arc` from THIS worktree, not any
-        # other `arc` package that happens to be on the user's sys.path.
+        # Ensure the kernel subprocess resolves `arc` from THIS repository root,
+        # not any other `arc` package that happens to be on the user's sys.path.
         arc_root = os.path.dirname(os.path.dirname(os.path.dirname(
             os.path.abspath(__file__)
-        )))  # .../ARC-wt3
+        )))
         prior_pp = os.environ.get("PYTHONPATH", "")
         os.environ["PYTHONPATH"] = arc_root + (os.pathsep + prior_pp if prior_pp else "")
         try:
             client = nbclient.NotebookClient(
-                nb, timeout=60, resources={"metadata": {"path": self.tmp}}
+                nb, timeout=180, resources={"metadata": {"path": self.tmp}}
             )
             client.execute()
         finally:
@@ -521,14 +524,19 @@ class TestSpeciesReportDict(unittest.TestCase):
             arc_commit="c",
         )
         base = d["base"]
-        self.assertEqual(base["sub_label"], "base")
-        self.assertEqual(base["path"], self.base_path)
+        self.assertEqual(base["label"], "base")
+        self.assertEqual(base["type"], "SinglePointTerm")
+        self.assertEqual(len(base["sub_jobs"]), 1)
+        sub_job = base["sub_jobs"][0]
+        self.assertEqual(sub_job["sub_label"], "base")
+        self.assertEqual(sub_job["path"], self.base_path)
         # Energy parsed via arc.parser; cross-check Hartree↔kJ/mol consistency.
         self.assertAlmostEqual(
-            base["energy_kj_per_mol"] / E_h_kJmol,
-            base["energy_hartree"],
+            sub_job["energy_kj_per_mol"] / E_h_kJmol,
+            sub_job["energy_hartree"],
             places=6,
         )
+        self.assertAlmostEqual(base["contribution_hartree"], -76.345678, places=6)
 
     def test_terms_block_has_one_entry_per_correction(self):
         d = build_species_report_dict(
@@ -627,6 +635,231 @@ class TestSpeciesReportDict(unittest.TestCase):
             )
         with open(out_a, "rb") as fa, open(out_b, "rb") as fb:
             self.assertEqual(fa.read(), fb.read())
+
+
+def _make_cbs_base_section(paths: dict) -> SpeciesSection:
+    """A section whose base is a two-point CBS extrapolation (FPA shape)."""
+    recipe = {
+        "base": {"label": "base", "type": "cbs_extrapolation",
+                 "formula": "helgaker_corr_2pt",
+                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+        "corrections": [
+            {"label": "delta_T", "type": "delta",
+             "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+             "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+        ],
+    }
+    return SpeciesSection(
+        label="H2O",
+        kind="species",
+        preset_name=None,
+        reference="DOI: 10.0/test",
+        recipe=recipe,
+        protocol=CompositeProtocol.from_user_input(recipe),
+        sub_job_paths=paths,
+        flags=[],
+    )
+
+
+class TestSpeciesReportCBSBase(unittest.TestCase):
+    """The YAML report renders a multi-job CBS base polymorphically: which
+    formula was applied to which legs must be readable from the report."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.tz_path = os.path.join(self.tmp, "base__card_3.out")
+        self.qz_path = os.path.join(self.tmp, "base__card_4.out")
+        self.hi_path = os.path.join(self.tmp, "delta_T__high.out")
+        self.lo_path = os.path.join(self.tmp, "delta_T__low.out")
+        _write_gaussian_fixture(self.tz_path, -76.300000)
+        _write_gaussian_fixture(self.qz_path, -76.330000)
+        _write_gaussian_fixture(self.hi_path, -76.346500)
+        _write_gaussian_fixture(self.lo_path, -76.345600)
+        self.section = _make_cbs_base_section(
+            paths={"base__card_3": self.tz_path,
+                   "base__card_4": self.qz_path,
+                   "delta_T__high": self.hi_path,
+                   "delta_T__low": self.lo_path},
+        )
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _report(self):
+        return build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-200000.0,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+
+    def test_base_block_lists_one_sub_job_per_cardinal(self):
+        base = self._report()["base"]
+        self.assertEqual(base["type"], "CBSExtrapolationTerm")
+        self.assertEqual({sj["sub_label"] for sj in base["sub_jobs"]},
+                         {"base__card_3", "base__card_4"})
+
+    def test_base_block_names_the_formula(self):
+        base = self._report()["base"]
+        self.assertEqual(base["formula"], "helgaker_corr_2pt")
+
+    def test_base_contribution_is_extrapolated_energy(self):
+        base = self._report()["base"]
+        e_cbs = (27 * -76.30 - 64 * -76.33) / (27 - 64)
+        self.assertAlmostEqual(base["contribution_hartree"], e_cbs, places=6)
+
+    def test_correction_terms_unchanged(self):
+        d = self._report()
+        self.assertEqual(len(d["terms"]), 1)
+        self.assertEqual(d["terms"][0]["label"], "delta_T")
+
+    def test_notebook_renders_formula_and_legs(self):
+        """The provenance notebook must let a reader see which formula was
+        applied to which CBS legs: the recipe cell carries the formula, and the
+        breakdown helper footnotes formula → legs."""
+        nb_path = os.path.join(self.tmp, "sp_composite.ipynb")
+        write_composite_notebook(
+            path=nb_path,
+            project_name="p",
+            arc_version="v",
+            timestamp="2026-06-11T00:00:00Z",
+            sections=[self.section],
+            notebook_dir=self.tmp,
+        )
+        nb = nbformat.read(nb_path, as_version=4)
+        sources = [c.source for c in nb.cells]
+        self.assertTrue(any("helgaker_corr_2pt" in s for s in sources))
+        self.assertTrue(any("applied to legs" in s for s in sources))
+
+
+def _make_skipped_delta_section(paths: dict) -> SpeciesSection:
+    """A section whose only delta correction was skipped as trivially zero."""
+    recipe = {
+        "base": {"method": "hf", "basis": "cc-pVTZ"},
+        "corrections": [
+            {"label": "delta_T", "type": "delta",
+             "high": {"method": "ccsdt", "basis": "cc-pVDZ"},
+             "low": {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+        ],
+    }
+    return SpeciesSection(
+        label="H",
+        kind="species",
+        preset_name=None,
+        reference="DOI: 10.0/test",
+        recipe=recipe,
+        protocol=CompositeProtocol.from_user_input(recipe),
+        sub_job_paths=paths,
+        flags=[],
+        skipped_terms={"delta_T": "δ≡0 (n_corr=1 < rank=3) — skipped"},
+    )
+
+
+class TestSkippedTermRendering(unittest.TestCase):
+    """Terms skipped as trivially zero (δ≡0) render with contribution 0.0 and a
+    reason — in both the YAML report and the provenance notebook — and the
+    notebook stays executable without the skipped legs' output files."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.base_path = os.path.join(self.tmp, "base.out")
+        _write_gaussian_fixture(self.base_path, -0.499)
+        self.section = _make_skipped_delta_section(paths={"base": self.base_path})
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _report(self):
+        return build_species_report_dict(
+            section=self.section,
+            e_elect_kj_per_mol=-0.499 * E_h_kJmol,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+
+    def test_section_defaults_to_no_skipped_terms(self):
+        self.assertEqual(_make_two_term_section().skipped_terms, {})
+
+    def test_skipped_term_block_contribution_zero_with_reason(self):
+        term = self._report()["terms"][0]
+        self.assertEqual(term["label"], "delta_T")
+        self.assertEqual(term["contribution_kj_per_mol"], 0.0)
+        self.assertEqual(term["contribution_hartree"], 0.0)
+        self.assertTrue(term["skipped"])
+        self.assertIn("δ≡0", term["skip_reason"])
+        self.assertEqual(term["sub_jobs"], [])
+
+    def test_base_block_unaffected_by_skips(self):
+        base = self._report()["base"]
+        self.assertNotIn("skipped", base)
+        self.assertAlmostEqual(base["contribution_hartree"], -0.499, places=6)
+
+    def test_yaml_report_round_trips_skip_reason(self):
+        out = os.path.join(self.tmp, "report.yml")
+        write_species_report_yaml(
+            path=out,
+            section=self.section,
+            e_elect_kj_per_mol=-0.499 * E_h_kJmol,
+            timestamp="t",
+            arc_version="v",
+            arc_commit="c",
+        )
+        with open(out) as fh:
+            report = yaml.safe_load(fh)
+        self.assertIn("δ≡0", report["terms"][0]["skip_reason"])
+
+    def _write_notebook(self):
+        nb_path = os.path.join(self.tmp, "sp_composite.ipynb")
+        write_composite_notebook(
+            path=nb_path,
+            project_name="p",
+            arc_version="v",
+            timestamp="2026-06-11T00:00:00Z",
+            sections=[self.section],
+            notebook_dir=self.tmp,
+        )
+        return nbformat.read(nb_path, as_version=4)
+
+    def test_notebook_renders_skip_reason(self):
+        nb = self._write_notebook()
+        sources = [c.source for c in nb.cells]
+        self.assertTrue(any("skipped_terms" in s for s in sources))
+        self.assertTrue(any("δ≡0" in s for s in sources))
+
+    @unittest.skipUnless(importlib.util.find_spec("ipykernel") is not None,
+                         "ipykernel is required to execute the generated notebook")
+    def test_notebook_executes_with_skipped_term(self):
+        nb = self._write_notebook()
+        arc_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__)
+        )))
+        prior_pp = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = arc_root + (os.pathsep + prior_pp if prior_pp else "")
+        try:
+            client = nbclient.NotebookClient(
+                nb, timeout=180, resources={"metadata": {"path": self.tmp}}
+            )
+            client.execute()
+        finally:
+            if prior_pp:
+                os.environ["PYTHONPATH"] = prior_pp
+            else:
+                os.environ.pop("PYTHONPATH", None)
+        expected_kjmol = -0.499 * E_h_kJmol
+        stdouts = [
+            out.get("text", "")
+            for cell in nb.cells
+            if cell.cell_type == "code"
+            for out in cell.get("outputs", [])
+            if out.get("output_type") == "stream" and out.get("name") == "stdout"
+        ]
+        all_text = "\n".join(stdouts)
+        self.assertIn(f"{expected_kjmol:,.3f}", all_text)
 
 
 # --------------------------------------------------------------------------- #

--- a/arc/level/species_state.py
+++ b/arc/level/species_state.py
@@ -1,0 +1,114 @@
+"""
+``arc.level.species_state`` — per-species ``sp_composite`` state model.
+
+A species can be in one of three states with respect to ``sp_composite``:
+
+* ``"inherit"``  — no ``sp_composite`` key on the species; the project-wide
+  protocol (if any) applies.
+* ``"opt_out"``  — species wrote ``sp_composite: null``; the project-wide
+  protocol is explicitly bypassed and plain ``sp_level`` is used.
+* ``"explicit"`` — species wrote a preset name or a recipe dict; that species
+  uses the explicit protocol regardless of the project-wide one.
+
+These three must be distinguishable at parse time and must round-trip through
+``as_dict`` / ``from_dict`` / restart. That requires a sentinel that is NOT
+``None`` (since ``None`` is the valid explicit user input for ``"opt_out"``),
+hence :data:`INHERIT` below.
+
+The sentinel is used only at constructor time as a default argument value; on a
+constructed :class:`~arc.species.species.ARCSpecies` instance you'll see the
+explicit string state in ``sp_composite_state`` and either ``None`` (for
+``"inherit"`` / ``"opt_out"``) or a :class:`~arc.level.protocol.CompositeProtocol`
+(for ``"explicit"``) in ``sp_composite``.
+"""
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+from arc.exceptions import InputError
+
+if TYPE_CHECKING:
+    # Imported only for static type checkers. Avoids forcing
+    # ``arc.level.protocol`` (and its preset/cbs dependencies) to load just
+    # because a caller did ``from arc.level import INHERIT``.
+    from arc.level.protocol import CompositeProtocol
+
+
+SP_COMPOSITE_STATES: Tuple[str, ...] = ("inherit", "opt_out", "explicit")
+
+
+class _InheritSentinel:
+    """Singleton marker used as a ctor default for ``sp_composite``.
+
+    Distinct from :data:`None` so the constructor can tell "user passed nothing"
+    (→ inherit the project default) from "user passed ``None``" (→ opt out).
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "arc.level.INHERIT"
+
+    def __reduce__(self):
+        # Pickle as a stable reference so restart/roundtrip preserves identity.
+        return (_resolve_inherit, ())
+
+
+def _resolve_inherit():
+    """Unpickle helper; returns the module-level singleton."""
+    return INHERIT
+
+
+INHERIT = _InheritSentinel()
+
+
+def active_composite_for(
+    species_state: str,
+    species_protocol: Optional["CompositeProtocol"],
+    global_protocol: Optional["CompositeProtocol"],
+) -> Optional["CompositeProtocol"]:
+    """Return the composite protocol to apply to a single species, or ``None``.
+
+    Parameters
+    ----------
+    species_state : str
+        One of :data:`SP_COMPOSITE_STATES`.
+    species_protocol : CompositeProtocol or None
+        The species-local protocol. Must be non-``None`` iff
+        ``species_state == "explicit"``.
+    global_protocol : CompositeProtocol or None
+        The project-wide default protocol (or ``None`` if the project didn't
+        set one).
+
+    Returns
+    -------
+    CompositeProtocol or None
+        * ``species_protocol`` if ``species_state == "explicit"``.
+        * ``None`` if ``species_state == "opt_out"``.
+        * ``global_protocol`` (possibly ``None``) if ``species_state == "inherit"``.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``species_state`` is not a valid state, or if ``"explicit"`` is
+        paired with a ``None`` ``species_protocol``.
+    """
+    if species_state == "explicit":
+        if species_protocol is None:
+            raise InputError(
+                "active_composite_for: state 'explicit' requires a non-None "
+                "species_protocol; got None."
+            )
+        return species_protocol
+    if species_state == "opt_out":
+        return None
+    if species_state == "inherit":
+        return global_protocol
+    raise InputError(
+        f"active_composite_for: unknown species_state {species_state!r}; "
+        f"expected one of {SP_COMPOSITE_STATES}."
+    )

--- a/arc/level/species_state.py
+++ b/arc/level/species_state.py
@@ -1,0 +1,114 @@
+"""
+``arc.level.species_state`` — per-species ``sp_composite`` state model.
+
+A species can be in one of three states with respect to ``sp_composite``:
+
+* ``"inherit"``  — no ``sp_composite`` key on the species; the project-wide
+  protocol (if any) applies.
+* ``"opt_out"``  — species wrote ``sp_composite: null``; the project-wide
+  protocol is explicitly bypassed and plain ``sp_level`` is used.
+* ``"explicit"`` — species wrote a preset name or a recipe dict; that species
+  uses the explicit protocol regardless of the project-wide one.
+
+These three must be distinguishable at parse time and must round-trip through
+``as_dict`` / ``from_dict`` / restart. That requires a sentinel that is NOT
+``None`` (since ``None`` is the valid explicit user input for ``"opt_out"``),
+hence :data:`INHERIT` below.
+
+The sentinel is used only at constructor time as a default argument value; on a
+constructed :class:`~arc.species.species.ARCSpecies` instance you'll see the
+explicit string state in ``sp_composite_state`` and either ``None`` (for
+``"inherit"`` / ``"opt_out"``) or a :class:`~arc.level.protocol.CompositeProtocol`
+(for ``"explicit"``) in ``sp_composite``.
+"""
+
+from typing import TYPE_CHECKING
+
+from arc.exceptions import InputError
+
+if TYPE_CHECKING:
+    # Imported only for static type checkers. Avoids forcing
+    # ``arc.level.protocol`` (and its preset/cbs dependencies) to load just
+    # because a caller did ``from arc.level import INHERIT``.
+    from arc.level.protocol import CompositeProtocol
+
+
+SP_COMPOSITE_STATES: tuple[str, ...] = ("inherit", "opt_out", "explicit")
+
+
+class _InheritSentinel:
+    """Singleton marker used as a ctor default for ``sp_composite``.
+
+    Distinct from :data:`None` so the constructor can tell "user passed nothing"
+    (→ inherit the project default) from "user passed ``None``" (→ opt out).
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "arc.level.INHERIT"
+
+    def __reduce__(self):
+        # Pickle as a stable reference so restart/roundtrip preserves identity.
+        return (_resolve_inherit, ())
+
+
+def _resolve_inherit():
+    """Unpickle helper; returns the module-level singleton."""
+    return INHERIT
+
+
+INHERIT = _InheritSentinel()
+
+
+def active_composite_for(
+    species_state: str,
+    species_protocol: "CompositeProtocol | None",
+    global_protocol: "CompositeProtocol | None",
+) -> "CompositeProtocol | None":
+    """Return the composite protocol to apply to a single species, or ``None``.
+
+    Parameters
+    ----------
+    species_state : str
+        One of :data:`SP_COMPOSITE_STATES`.
+    species_protocol : CompositeProtocol or None
+        The species-local protocol. Must be non-``None`` iff
+        ``species_state == "explicit"``.
+    global_protocol : CompositeProtocol or None
+        The project-wide default protocol (or ``None`` if the project didn't
+        set one).
+
+    Returns
+    -------
+    CompositeProtocol or None
+        * ``species_protocol`` if ``species_state == "explicit"``.
+        * ``None`` if ``species_state == "opt_out"``.
+        * ``global_protocol`` (possibly ``None``) if ``species_state == "inherit"``.
+
+    Raises
+    ------
+    arc.exceptions.InputError
+        If ``species_state`` is not a valid state, or if ``"explicit"`` is
+        paired with a ``None`` ``species_protocol``.
+    """
+    if species_state == "explicit":
+        if species_protocol is None:
+            raise InputError(
+                "active_composite_for: state 'explicit' requires a non-None "
+                "species_protocol; got None."
+            )
+        return species_protocol
+    if species_state == "opt_out":
+        return None
+    if species_state == "inherit":
+        return global_protocol
+    raise InputError(
+        f"active_composite_for: unknown species_state {species_state!r}; "
+        f"expected one of {SP_COMPOSITE_STATES}."
+    )

--- a/arc/level/species_state.py
+++ b/arc/level/species_state.py
@@ -37,7 +37,8 @@ SP_COMPOSITE_STATES: tuple[str, ...] = ("inherit", "opt_out", "explicit")
 
 
 class _InheritSentinel:
-    """Singleton marker used as a ctor default for ``sp_composite``.
+    """
+    Singleton marker used as a ctor default for ``sp_composite``.
 
     Distinct from :data:`None` so the constructor can tell "user passed nothing"
     (→ inherit the project default) from "user passed ``None``" (→ opt out).
@@ -71,31 +72,25 @@ def active_composite_for(
     species_protocol: "CompositeProtocol | None",
     global_protocol: "CompositeProtocol | None",
 ) -> "CompositeProtocol | None":
-    """Return the composite protocol to apply to a single species, or ``None``.
+    """
+    Return the composite protocol to apply to a single species, or ``None``.
 
-    Parameters
-    ----------
-    species_state : str
-        One of :data:`SP_COMPOSITE_STATES`.
-    species_protocol : CompositeProtocol or None
-        The species-local protocol. Must be non-``None`` iff
-        ``species_state == "explicit"``.
-    global_protocol : CompositeProtocol or None
-        The project-wide default protocol (or ``None`` if the project didn't
-        set one).
+    Args:
+        species_state (str): One of :data:`SP_COMPOSITE_STATES`.
+        species_protocol (CompositeProtocol | None): The species-local protocol.
+            Must be non-``None`` iff ``species_state == "explicit"``.
+        global_protocol (CompositeProtocol | None): The project-wide default
+            protocol (or ``None`` if the project didn't set one).
 
-    Returns
-    -------
-    CompositeProtocol or None
-        * ``species_protocol`` if ``species_state == "explicit"``.
-        * ``None`` if ``species_state == "opt_out"``.
-        * ``global_protocol`` (possibly ``None``) if ``species_state == "inherit"``.
+    Returns:
+        CompositeProtocol | None:
+            * ``species_protocol`` if ``species_state == "explicit"``.
+            * ``None`` if ``species_state == "opt_out"``.
+            * ``global_protocol`` (possibly ``None``) if ``species_state == "inherit"``.
 
-    Raises
-    ------
-    arc.exceptions.InputError
-        If ``species_state`` is not a valid state, or if ``"explicit"`` is
-        paired with a ``None`` ``species_protocol``.
+    Raises:
+        InputError: If ``species_state`` is not a valid state, or if
+            ``"explicit"`` is paired with a ``None`` ``species_protocol``.
     """
     if species_state == "explicit":
         if species_protocol is None:

--- a/arc/level/species_state_test.py
+++ b/arc/level/species_state_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for ``arc.level.species_state`` — the three-state model that
+distinguishes, at the per-species level:
+
+* ``"inherit"``   — user did not set ``sp_composite`` for this species; fall back
+  to the project-wide protocol (if any).
+* ``"opt_out"``   — user wrote ``sp_composite: null`` for this species; explicitly
+  bypass the project-wide protocol and use plain ``sp_level``.
+* ``"explicit"``  — user provided a preset name or a recipe dict for this species.
+
+The ``INHERIT`` sentinel is the default argument value used to distinguish
+"user passed nothing" from "user passed ``None``" at constructor time.
+"""
+
+import unittest
+
+from arc.exceptions import InputError
+from arc.level.protocol import CompositeProtocol
+from arc.level.species_state import (
+    INHERIT,
+    SP_COMPOSITE_STATES,
+    active_composite_for,
+)
+
+
+def _dummy_protocol(label: str = "base") -> CompositeProtocol:
+    return CompositeProtocol.from_user_input({
+        "base": {"method": "hf", "basis": "cc-pVTZ"},
+        "corrections": [],
+    })
+
+
+class TestInheritSentinel(unittest.TestCase):
+    def test_sentinel_is_a_singleton(self):
+        from arc.level.species_state import INHERIT as a, INHERIT as b
+        self.assertIs(a, b)
+
+    def test_sentinel_is_not_none(self):
+        self.assertIsNot(INHERIT, None)
+
+    def test_sentinel_has_a_readable_repr(self):
+        self.assertIn("INHERIT", repr(INHERIT))
+
+    def test_sentinel_is_exported_from_package(self):
+        from arc.level import INHERIT as via_package
+        self.assertIs(via_package, INHERIT)
+
+
+class TestStatesConstant(unittest.TestCase):
+    def test_exact_membership(self):
+        self.assertEqual(set(SP_COMPOSITE_STATES), {"inherit", "opt_out", "explicit"})
+
+
+class TestActiveCompositeFor(unittest.TestCase):
+    def test_explicit_returns_species_protocol(self):
+        species_proto = _dummy_protocol()
+        global_proto = _dummy_protocol()
+        result = active_composite_for("explicit", species_proto, global_proto)
+        self.assertIs(result, species_proto)
+
+    def test_opt_out_returns_none_even_with_global(self):
+        global_proto = _dummy_protocol()
+        result = active_composite_for("opt_out", None, global_proto)
+        self.assertIsNone(result)
+
+    def test_inherit_returns_global(self):
+        global_proto = _dummy_protocol()
+        result = active_composite_for("inherit", None, global_proto)
+        self.assertIs(result, global_proto)
+
+    def test_inherit_with_no_global_returns_none(self):
+        result = active_composite_for("inherit", None, None)
+        self.assertIsNone(result)
+
+    def test_explicit_without_species_protocol_errors(self):
+        # An "explicit" state with no protocol is a construction bug, not a user error.
+        with self.assertRaises(InputError):
+            active_composite_for("explicit", None, None)
+
+    def test_unknown_state_rejected(self):
+        with self.assertRaises(InputError):
+            active_composite_for("bogus", None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arc/level/species_state_test.py
+++ b/arc/level/species_state_test.py
@@ -15,6 +15,7 @@ The ``INHERIT`` sentinel is the default argument value used to distinguish
 "user passed nothing" from "user passed ``None``" at constructor time.
 """
 
+import pickle
 import unittest
 
 from arc.exceptions import InputError
@@ -47,6 +48,9 @@ class TestInheritSentinel(unittest.TestCase):
     def test_sentinel_is_exported_from_package(self):
         from arc.level import INHERIT as via_package
         self.assertIs(via_package, INHERIT)
+
+    def test_sentinel_pickle_round_trip_preserves_identity(self):
+        self.assertIs(pickle.loads(pickle.dumps(INHERIT)), INHERIT)
 
 
 class TestStatesConstant(unittest.TestCase):

--- a/arc/main.py
+++ b/arc/main.py
@@ -32,6 +32,7 @@ from arc.common import (VERSION,
 from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 from arc.level import Level, assign_frequency_scale_factor
+from arc.level.protocol import CompositeProtocol
 from arc.job.factory import _registered_job_adapters
 from arc.job.ssh import SSHClient
 from arc.output import write_output_yml
@@ -256,6 +257,7 @@ class ARC(object):
                  reactions: Optional[List[ARCReaction]] = None,
                  running_jobs: Optional[dict] = None,
                  scan_level: Optional[Union[str, dict, Level]] = None,
+                 sp_composite: Optional[Union[str, dict, CompositeProtocol]] = None,
                  sp_level: Optional[Union[str, dict, Level]] = None,
                  species: Optional[List[ARCSpecies]] = None,
                  specific_job_type: str = '',
@@ -339,6 +341,7 @@ class ARC(object):
         self.opt_level = opt_level or None
         self.freq_level = freq_level or None
         self.sp_level = sp_level or None
+        self.sp_composite = sp_composite or None
         self.scan_level = scan_level or None
         self.ts_guess_level = ts_guess_level or None
         self.irc_level = irc_level or None
@@ -450,6 +453,12 @@ class ARC(object):
             restart_dict['compare_to_rmg'] = self.compare_to_rmg
         if self.composite_method is not None:
             restart_dict['composite_method'] = self.composite_method.as_dict()
+        if self.sp_composite is not None:
+            restart_dict['sp_composite'] = (
+                self.sp_composite.as_dict()
+                if isinstance(self.sp_composite, CompositeProtocol)
+                else self.sp_composite
+            )
         if not self.compute_rates:
             restart_dict['compute_rates'] = self.compute_rates
         if not self.compute_thermo:
@@ -582,6 +591,7 @@ class ARC(object):
                                    opt_level=self.opt_level,
                                    freq_level=self.freq_level,
                                    sp_level=self.sp_level,
+                                   sp_composite=self.sp_composite,
                                    scan_level=self.scan_level,
                                    ts_guess_level=self.ts_guess_level,
                                    irc_level=self.irc_level,
@@ -1004,6 +1014,34 @@ class ARC(object):
             self.ts_guess_level = Level(repr=self.ts_guess_level)
             logger.info(f'TS guesses:{default_flag} {self.ts_guess_level}')
 
+        if self.sp_composite is not None:
+            # Phase 2: parse the composite protocol, validate mutual exclusions,
+            # and backfill sp_level from the protocol's base level when omitted.
+            if self.composite_method is not None:
+                raise InputError(
+                    "sp_composite and composite_method are mutually exclusive. "
+                    "composite_method refers to Gaussian-style single-job composites "
+                    "(e.g. CBS-QB3, G4); sp_composite refers to multi-SP focal-point "
+                    "protocols. Pick one."
+                )
+            if self.adaptive_levels is not None:
+                raise InputError(
+                    "sp_composite is not supported together with adaptive_levels in "
+                    "this release. Drop one of them."
+                )
+            if not isinstance(self.sp_composite, CompositeProtocol):
+                self.sp_composite = CompositeProtocol.from_user_input(self.sp_composite)
+            logger.info(
+                f'sp_composite protocol resolved: base={self.sp_composite.base.level.simple()}, '
+                f'{len(self.sp_composite.corrections)} correction(s).'
+            )
+            if self.sp_level is None:
+                self.sp_level = self.sp_composite.base.level
+                logger.info(
+                    f'sp_level not set explicitly; derived from sp_composite.base.level: '
+                    f'{self.sp_level.simple()}'
+                )
+
         if self.composite_method is not None:
             self.composite_method = Level(repr=self.composite_method)
             if self.composite_method.method_type != "composite":
@@ -1200,27 +1238,40 @@ class ARC(object):
     def check_arkane_level_of_theory(self):
         """
         Check that the level of theory has AEC in Arkane.
+
+        When ``sp_composite`` is active, route the AEC lookup through the protocol's
+        ``base.level`` and skip the BAC lookup entirely with a single warning — BAC
+        corrections were derived for a single LoT and are not meaningful on top of
+        a composite that already applies δ-corrections. Per-species AEC/BAC variants
+        are not supported in this release; the lookup stays global.
         """
         explicitly_set = self.arkane_level_of_theory is not None
         if self.arkane_level_of_theory is None:
-            self.arkane_level_of_theory = self.composite_method if self.composite_method is not None \
-                else self.sp_level if self.sp_level is not None else None
+            if self.sp_composite is not None:
+                self.arkane_level_of_theory = self.sp_composite.base.level
+            elif self.composite_method is not None:
+                self.arkane_level_of_theory = self.composite_method
+            elif self.sp_level is not None:
+                self.arkane_level_of_theory = self.sp_level
         if self.arkane_level_of_theory is None:
             logger.warning('Could not determine a level of theory to be used for Arkane!')
         else:
             if explicitly_set:
                 source = ''
+            elif self.sp_composite is not None:
+                source = ' (from sp_composite.base.level)'
             elif self.composite_method is not None:
                 source = ' (from composite method)'
             else:
                 source = ' (from sp level)'
             logger.info(f'Arkane level of theory:{source} {self.arkane_level_of_theory}')
-            if self.bac_type is not None:
-                check_arkane_bacs(sp_level=self.arkane_level_of_theory, bac_type=self.bac_type,
-                                  raise_error=self.compute_thermo)
+            if self.sp_composite is not None:
+                logger.warning('BAC lookup is skipped because sp_composite is active.')
+                check_arkane_aec(sp_level=self.arkane_level_of_theory, raise_error=self.compute_thermo)
+            elif self.bac_type is not None:
+                check_arkane_bacs(sp_level=self.arkane_level_of_theory, bac_type=self.bac_type, raise_error=self.compute_thermo)
             else:
-                check_arkane_aec(sp_level=self.arkane_level_of_theory,
-                                 raise_error=self.compute_thermo)
+                check_arkane_aec(sp_level=self.arkane_level_of_theory, raise_error=self.compute_thermo)
 
     def backup_restart(self):
         """

--- a/arc/main.py
+++ b/arc/main.py
@@ -30,6 +30,7 @@ from arc.common import (VERSION,
 from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 from arc.level import Level, assign_frequency_scale_factor
+from arc.level.protocol import CompositeProtocol
 from arc.job.factory import _registered_job_adapters
 from arc.job.ssh import SSHClient
 from arc.output import write_output_yml
@@ -257,6 +258,7 @@ class ARC(object):
                  scan_level: str | dict | Level | None = None,
                  sp_level: str | dict | Level | None = None,
                  species: list[ARCSpecies] | None = None,
+                 sp_composite: str | dict | CompositeProtocol | None = None,
                  specific_job_type: str = '',
                  T_min: tuple[float, str] | None = None,
                  T_max: tuple[float, str] | None = None,
@@ -337,6 +339,7 @@ class ARC(object):
         self.opt_level = opt_level or None
         self.freq_level = freq_level or None
         self.sp_level = sp_level or None
+        self.sp_composite = sp_composite or None
         self.scan_level = scan_level or None
         self.ts_guess_level = ts_guess_level or None
         self.irc_level = irc_level or None
@@ -450,6 +453,12 @@ class ARC(object):
             restart_dict['compare_to_rmg'] = self.compare_to_rmg
         if self.composite_method is not None:
             restart_dict['composite_method'] = self.composite_method.as_dict()
+        if self.sp_composite is not None:
+            restart_dict['sp_composite'] = (
+                self.sp_composite.as_dict()
+                if isinstance(self.sp_composite, CompositeProtocol)
+                else self.sp_composite
+            )
         if not self.compute_rates:
             restart_dict['compute_rates'] = self.compute_rates
         if not self.compute_thermo:
@@ -582,6 +591,7 @@ class ARC(object):
                                    opt_level=self.opt_level,
                                    freq_level=self.freq_level,
                                    sp_level=self.sp_level,
+                                   sp_composite=self.sp_composite,
                                    scan_level=self.scan_level,
                                    ts_guess_level=self.ts_guess_level,
                                    irc_level=self.irc_level,
@@ -1004,6 +1014,34 @@ class ARC(object):
             self.ts_guess_level = Level(repr=self.ts_guess_level)
             logger.info(f'TS guesses:{default_flag} {self.ts_guess_level}')
 
+        if self.sp_composite is not None:
+            # Phase 2: parse the composite protocol, validate mutual exclusions,
+            # and backfill sp_level from the protocol's base level when omitted.
+            if self.composite_method is not None:
+                raise InputError(
+                    "sp_composite and composite_method are mutually exclusive. "
+                    "composite_method refers to Gaussian-style single-job composites "
+                    "(e.g. CBS-QB3, G4); sp_composite refers to multi-SP focal-point "
+                    "protocols. Pick one."
+                )
+            if self.adaptive_levels is not None:
+                raise InputError(
+                    "sp_composite is not supported together with adaptive_levels in "
+                    "this release. Drop one of them."
+                )
+            if not isinstance(self.sp_composite, CompositeProtocol):
+                self.sp_composite = CompositeProtocol.from_user_input(self.sp_composite)
+            logger.info(
+                f'sp_composite protocol resolved: base={self.sp_composite.base.level.simple()}, '
+                f'{len(self.sp_composite.corrections)} correction(s).'
+            )
+            if self.sp_level is None:
+                self.sp_level = self.sp_composite.base.level
+                logger.info(
+                    f'sp_level not set explicitly; derived from sp_composite.base.level: '
+                    f'{self.sp_level.simple()}'
+                )
+
         if self.composite_method is not None:
             self.composite_method = Level(repr=self.composite_method)
             if self.composite_method.method_type != "composite":
@@ -1200,27 +1238,40 @@ class ARC(object):
     def check_arkane_level_of_theory(self):
         """
         Check that the level of theory has AEC in Arkane.
+
+        When ``sp_composite`` is active, route the AEC lookup through the protocol's
+        ``base.level`` and skip the BAC lookup entirely with a single warning — BAC
+        corrections were derived for a single LoT and are not meaningful on top of
+        a composite that already applies δ-corrections. Per-species AEC/BAC variants
+        are not supported in this release; the lookup stays global.
         """
         explicitly_set = self.arkane_level_of_theory is not None
         if self.arkane_level_of_theory is None:
-            self.arkane_level_of_theory = self.composite_method if self.composite_method is not None \
-                else self.sp_level if self.sp_level is not None else None
+            if self.sp_composite is not None:
+                self.arkane_level_of_theory = self.sp_composite.base.level
+            elif self.composite_method is not None:
+                self.arkane_level_of_theory = self.composite_method
+            elif self.sp_level is not None:
+                self.arkane_level_of_theory = self.sp_level
         if self.arkane_level_of_theory is None:
             logger.warning('Could not determine a level of theory to be used for Arkane!')
         else:
             if explicitly_set:
                 source = ''
+            elif self.sp_composite is not None:
+                source = ' (from sp_composite.base.level)'
             elif self.composite_method is not None:
                 source = ' (from composite method)'
             else:
                 source = ' (from sp level)'
             logger.info(f'Arkane level of theory:{source} {self.arkane_level_of_theory}')
-            if self.bac_type is not None:
-                check_arkane_bacs(sp_level=self.arkane_level_of_theory, bac_type=self.bac_type,
-                                  raise_error=self.compute_thermo)
+            if self.sp_composite is not None:
+                logger.warning('BAC lookup is skipped because sp_composite is active.')
+                check_arkane_aec(sp_level=self.arkane_level_of_theory, raise_error=self.compute_thermo)
+            elif self.bac_type is not None:
+                check_arkane_bacs(sp_level=self.arkane_level_of_theory, bac_type=self.bac_type, raise_error=self.compute_thermo)
             else:
-                check_arkane_aec(sp_level=self.arkane_level_of_theory,
-                                 raise_error=self.compute_thermo)
+                check_arkane_aec(sp_level=self.arkane_level_of_theory, raise_error=self.compute_thermo)
 
     def backup_restart(self):
         """

--- a/arc/main.py
+++ b/arc/main.py
@@ -145,6 +145,8 @@ class ARC(object):
         output_multi_spc (dict, optional): Output dictionary with status and final QM file paths for the multi species. 
                                            Only used for restarting.
         running_jobs (dict, optional): A dictionary of jobs submitted in a precious ARC instance, used for restarting.
+        _zombie_kills (dict, optional): Restart-internal bookkeeping of zombie job kills per species
+                                        (written and consumed by the Scheduler via the restart file).
         ts_adapters (list, optional): Entries represent different TS adapters.
         report_e_elect (bool, optional): Whether to report electronic energy. Default is ``False``.
         skip_nmd (bool, optional): Whether to skip normal mode displacement check. Default is ``False``.
@@ -188,6 +190,8 @@ class ARC(object):
         execution_time (str): Overall execution time.
         lib_long_desc (str): A multiline description of levels of theory for the outputted RMG libraries.
         running_jobs (dict): A dictionary of jobs submitted in a precious ARC instance, used for restarting.
+        _zombie_kills (dict): Restart-internal bookkeeping of zombie job kills per species
+                              (written and consumed by the Scheduler via the restart file).
         T_min (tuple): The minimum temperature for kinetics computations, e.g., (500, 'K').
         T_max (tuple): The maximum temperature for kinetics computations, e.g., (3000, 'K').
         T_count (int): The number of temperature points between ``T_min`` and ``T_max``.
@@ -271,6 +275,7 @@ class ARC(object):
                  verbose=logging.INFO,
                  report_e_elect: bool | None = False,
                  skip_nmd: bool | None = False,
+                 _zombie_kills: dict | None = None,
                  ):
 
         if project is None:
@@ -287,6 +292,7 @@ class ARC(object):
         self.output_multi_spc = output_multi_spc
         self.standardize_output_paths()  # depends on self.project_directory
         self.running_jobs = running_jobs or dict()
+        self._zombie_kills = _zombie_kills or dict()
         for jobs in self.running_jobs.values():
             for job in jobs:
                 if 'xyz' in job.keys():
@@ -512,6 +518,8 @@ class ARC(object):
             restart_dict['reactions'] = [rxn.as_dict() for rxn in self.reactions]
         if self.running_jobs:
             restart_dict['running_jobs'] = self.running_jobs
+        if self._zombie_kills:
+            restart_dict['_zombie_kills'] = self._zombie_kills
         if self.scan_level is not None and len(self.scan_level.method) \
                 and str(self.scan_level).split()[0] != default_levels_of_theory['scan']:
             restart_dict['scan_level'] = self.scan_level.as_dict() \
@@ -1014,8 +1022,15 @@ class ARC(object):
             self.ts_guess_level = Level(repr=self.ts_guess_level)
             logger.info(f'TS guesses:{default_flag} {self.ts_guess_level}')
 
+        if self.adaptive_levels is not None or self.composite_method is not None:
+            explicit_spc_labels = [spc.label for spc in self.species if spc.sp_composite_state == 'explicit']
+            if explicit_spc_labels:
+                conflicting_arg = 'adaptive_levels' if self.adaptive_levels is not None else 'composite_method'
+                raise InputError(f'Species {explicit_spc_labels} define an explicit sp_composite protocol, '
+                                 f'which is not supported together with {conflicting_arg}. Drop one of them.')
+
         if self.sp_composite is not None:
-            # Phase 2: parse the composite protocol, validate mutual exclusions,
+            # Parse the composite protocol, validate mutual exclusions,
             # and backfill sp_level from the protocol's base level when omitted.
             if self.composite_method is not None:
                 raise InputError(
@@ -1032,15 +1047,28 @@ class ARC(object):
             if not isinstance(self.sp_composite, CompositeProtocol):
                 self.sp_composite = CompositeProtocol.from_user_input(self.sp_composite)
             logger.info(
-                f'sp_composite protocol resolved: base={self.sp_composite.base.level.simple()}, '
+                f'sp_composite protocol resolved: base={self.sp_composite.primary_base_level.simple()}, '
                 f'{len(self.sp_composite.corrections)} correction(s).'
             )
+            if self.bac_type is not None:
+                logger.warning('Setting bac_type to None: BAC corrections were derived for a single level of theory '
+                               'and are not applied on top of an sp_composite protocol.')
+                self.bac_type = None
             if self.sp_level is None:
-                self.sp_level = self.sp_composite.base.level
+                # For a CBS base this is the largest-cardinal leg of the extrapolation.
+                self.sp_level = self.sp_composite.primary_base_level
                 logger.info(
-                    f'sp_level not set explicitly; derived from sp_composite.base.level: '
-                    f'{self.sp_level.simple()}'
+                    f'sp_level not set explicitly; derived from the sp_composite base '
+                    f'(primary leg): {self.sp_level.simple()}'
                 )
+            elif Level(repr=self.sp_level).simple() != self.sp_composite.primary_base_level.simple():
+                opt_out_labels = [spc.label for spc in self.species if spc.sp_composite_state == 'opt_out']
+                composite_labels = [spc.label for spc in self.species if spc.sp_composite_state != 'opt_out']
+                logger.warning(f'Both sp_level ({Level(repr=self.sp_level).simple()}) and sp_composite '
+                               f'(base: {self.sp_composite.primary_base_level.simple()}) were specified. '
+                               f'The explicit sp_level only applies to species that opt out of sp_composite '
+                               f'({opt_out_labels or "none"}); all other species ({composite_labels or "none"}) '
+                               f'use the composite protocol, and the stated sp_level is ignored for them.')
 
         if self.composite_method is not None:
             self.composite_method = Level(repr=self.composite_method)
@@ -1198,6 +1226,10 @@ class ARC(object):
                 raise InputError(f'Got both level_of_theory and composite_method arguments. Choose the correct one:\n'
                                  f'level_of_theory: {self.level_of_theory}\n'
                                  f'composite_method: {self.composite_method}')
+            if self.sp_composite is not None:
+                raise InputError(f'Got both level_of_theory and sp_composite arguments. Choose the correct one:\n'
+                                 f'level_of_theory: {self.level_of_theory}\n'
+                                 f'sp_composite: {self.sp_composite}')
             if not isinstance(self.level_of_theory, str):
                 raise InputError(f'level_of_theory must be a string.\n'
                                  f'Got {self.level_of_theory} which is a {type(self.level_of_theory)}.')
@@ -1240,7 +1272,8 @@ class ARC(object):
         Check that the level of theory has AEC in Arkane.
 
         When ``sp_composite`` is active, route the AEC lookup through the protocol's
-        ``base.level`` and skip the BAC lookup entirely with a single warning — BAC
+        primary base level (the single base level, or the largest-cardinal CBS leg)
+        and skip the BAC lookup entirely with a single warning — BAC
         corrections were derived for a single LoT and are not meaningful on top of
         a composite that already applies δ-corrections. Per-species AEC/BAC variants
         are not supported in this release; the lookup stays global.
@@ -1248,7 +1281,7 @@ class ARC(object):
         explicitly_set = self.arkane_level_of_theory is not None
         if self.arkane_level_of_theory is None:
             if self.sp_composite is not None:
-                self.arkane_level_of_theory = self.sp_composite.base.level
+                self.arkane_level_of_theory = self.sp_composite.primary_base_level
             elif self.composite_method is not None:
                 self.arkane_level_of_theory = self.composite_method
             elif self.sp_level is not None:
@@ -1259,7 +1292,7 @@ class ARC(object):
             if explicitly_set:
                 source = ''
             elif self.sp_composite is not None:
-                source = ' (from sp_composite.base.level)'
+                source = ' (from the sp_composite base, primary leg)'
             elif self.composite_method is not None:
                 source = ' (from composite method)'
             else:
@@ -1294,19 +1327,34 @@ class ARC(object):
                 if 'paths' in spc_output:
                     for key, val in spc_output['paths'].items():
                         if key in ['geo', 'freq', 'sp', 'composite']:
-                            if val and not os.path.isfile(val):
-                                # try correcting relative paths
-                                if os.path.isfile(os.path.join(ARC_PATH, val)):
-                                    self.output[label]['paths'][key] = os.path.join(ARC_PATH, val)
-                                elif os.path.isfile(os.path.join(ARC_PATH, 'Projects', val)):
-                                    self.output[label]['paths'][key] = os.path.join(ARC_PATH, 'Projects', val)
-                                elif os.path.isfile(os.path.join(globalize_path(
-                                        string=val, project_directory=self.project_directory))):
-                                    self.output[label]['paths'][key] = globalize_path(
-                                        string=val, project_directory=self.project_directory)
+                            self.output[label]['paths'][key] = self.standardize_path(val)
+                        elif key == 'sp_composite' and isinstance(val, dict):
+                            for sub_label, sub_path in val.items():
+                                val[sub_label] = self.standardize_path(sub_path)
             logger.debug(f'output dictionary successfully parsed:\n{self.output}')
         elif self.output is None:
             self.output = dict()
+
+    def standardize_path(self, path: str | None) -> str | None:
+        """
+        Rebase a single output file path on the current project directory if it does not exist as given.
+
+        Args:
+            path (str, optional): The file path to check and possibly rebase.
+
+        Returns:
+            str | None: A corrected existing path if one was found, else the original value.
+        """
+        if path and not os.path.isfile(path):
+            # try correcting relative paths
+            if os.path.isfile(os.path.join(ARC_PATH, path)):
+                return os.path.join(ARC_PATH, path)
+            if os.path.isfile(os.path.join(ARC_PATH, 'Projects', path)):
+                return os.path.join(ARC_PATH, 'Projects', path)
+            globalized = globalize_path(string=path, project_directory=self.project_directory)
+            if os.path.isfile(globalized):
+                return globalized
+        return path
 
 
 def process_adaptive_levels(adaptive_levels: list | None) -> dict | None:

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -5,6 +5,7 @@
 This module contains unit tests for the arc.main module
 """
 
+import logging
 import os
 import shutil
 import unittest
@@ -13,6 +14,7 @@ from arc.common import ARC_PATH
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.main import ARC, process_adaptive_levels
 from arc.species.species import ARCSpecies
 
@@ -485,11 +487,145 @@ class TestARC(unittest.TestCase):
         Delete all project directories created during these unit tests
         """
         projects = ['arc_project_for_testing_delete_after_usage_test_from_dict',
-                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong']
+                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong',
+                    'test_sp_composite']
         for project in projects:
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestARCSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for project-level ``sp_composite`` YAML plumbing.
+    """
+
+    @classmethod
+    def tearDownClass(cls):
+        for project in ['test_sp_composite_preset',
+                        'test_sp_composite_explicit',
+                        'test_sp_composite_preset_override',
+                        'test_sp_composite_mutex_composite',
+                        'test_sp_composite_mutex_adaptive',
+                        'test_sp_composite_fallback',
+                        'test_sp_composite_preserves_sp_level',
+                        'test_sp_composite_aec_bac']:
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
+            if os.path.isdir(project_directory):
+                shutil.rmtree(project_directory, ignore_errors=True)
+
+    def test_preset_string_parsed(self):
+        arc = ARC(project='test_sp_composite_preset', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+
+    def test_explicit_dict_parsed(self):
+        # compute_thermo=False avoids the Arkane AEC lookup that would otherwise
+        # reject hf/cc-pVTZ for lacking a database entry — we're testing parsing.
+        recipe = {
+            'base': {'method': 'hf', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        arc = ARC(project='test_sp_composite_explicit', sp_composite=recipe,
+                  compute_thermo=False, freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+        self.assertEqual(arc.sp_composite.base.level.method, 'hf')
+
+    def test_preset_with_overrides_parsed(self):
+        arc = ARC(project='test_sp_composite_preset_override',
+                  sp_composite={'preset': 'HEAT-345Q',
+                                'overrides': {'delta_T': {'high': {'method': 'ccsdt',
+                                                                   'basis': 'cc-pVTZ'}}}},
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        delta_t = next(t for t in arc.sp_composite.corrections if t.label == 'delta_T')
+        self.assertEqual(delta_t.high.basis, 'cc-pvtz')
+
+    def test_mutex_with_composite_method(self):
+        # Mutual-exclusion check fires during ARC.__init__ → process_level_of_theory.
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_composite',
+                sp_composite='HEAT-345Q', composite_method='CBS-QB3',
+                freq_scale_factor=1)
+
+    def test_mutex_with_adaptive_levels(self):
+        adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'}}
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_adaptive',
+                sp_composite='HEAT-345Q', adaptive_levels=adaptive,
+                freq_scale_factor=1)
+
+    def test_fallback_sp_level_from_base(self):
+        """When sp_composite is set and sp_level is omitted, sp_level is derived from base.level."""
+        arc = ARC(project='test_sp_composite_fallback', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_level, Level)
+        self.assertEqual(arc.sp_level.method, arc.sp_composite.base.level.method)
+        self.assertEqual(arc.sp_level.basis, arc.sp_composite.base.level.basis)
+
+    def test_user_supplied_sp_level_preserved(self):
+        """An explicit sp_level coexists with sp_composite and is not overridden."""
+        arc = ARC(project='test_sp_composite_preserves_sp_level',
+                  sp_composite='HEAT-345Q',
+                  sp_level='wb97xd/def2-tzvp',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertEqual(arc.sp_level.method, 'wb97xd')
+        self.assertEqual(arc.sp_level.basis, 'def2-tzvp')
+
+    def test_per_species_aec_limitation_documented(self):
+        """
+        Known limitation: when species carry their own sp_composite overrides,
+        the project-level AEC lookup still uses the *global* ``sp_composite.base.level``
+        (not per-species base levels). The user should set ``arkane_level_of_theory``
+        explicitly if they need a different AEC target. This test locks that
+        behavior so it's an intentional contract, not accidental.
+        """
+        global_recipe = 'HEAT-345Q'
+        local_recipe = {
+            'base': {'method': 'mp2', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        arc = ARC(project='test_sp_composite_per_species_aec_limit',
+                  sp_composite=global_recipe,
+                  species=[spc],
+                  freq_scale_factor=1)
+        arc.arkane_level_of_theory = None
+        arc.check_arkane_level_of_theory()
+        # arkane_level_of_theory resolved to the GLOBAL protocol's base level
+        # (ccsd(t)-f12 from HEAT-345Q), not the species-level mp2.
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
+        self.assertEqual(arc.arkane_level_of_theory.method, 'ccsd(t)-f12')
+        # Clean up the project directory created by ARC init.
+        project_dir = os.path.join(ARC_PATH, 'Projects',
+                                   'test_sp_composite_per_species_aec_limit')
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+
+    def test_aec_defaults_to_base_and_bac_skipped_with_warning(self):
+        """
+        When sp_composite is active: AEC lookup uses base.level; BAC is skipped with
+        a logger warning. ARC logs to the ``'arc'`` named logger.
+        """
+        arc = ARC(project='test_sp_composite_aec_bac',
+                  sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        # ARC.__init__ already ran check_arkane_level_of_theory once; clear the
+        # resolved value so the second call exercises the full branching.
+        arc.arkane_level_of_theory = None
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            arc.check_arkane_level_of_theory()
+        joined = '\n'.join(cm.output)
+        self.assertIn('sp_composite', joined)
+        self.assertIn('BAC', joined)
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
 
 
 if __name__ == '__main__':

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -5,6 +5,7 @@
 This module contains unit tests for the arc.main module
 """
 
+import logging
 import os
 import shutil
 import unittest
@@ -13,6 +14,7 @@ from arc.common import ARC_PATH
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.main import ARC, process_adaptive_levels
 from arc.species.species import ARCSpecies
 
@@ -93,7 +95,9 @@ class TestARC(unittest.TestCase):
                                           'xtb': ['local'],
                                           'xtb_gsm': ['local'],
                                           },
-                         'freq_level': {'basis': '6-311+g(3df,2p)',
+                         'freq_level': {'args': {'block': {},
+                                                 'keyword': {'general': 'scf=(NDamp=30)'}},
+                                        'basis': '6-311+g(3df,2p)',
                                         'method': 'b3lyp',
                                         'method_type': 'dft',
                                         'software': 'gaussian'},
@@ -516,11 +520,145 @@ class TestARC(unittest.TestCase):
         Delete all project directories created during these unit tests
         """
         projects = ['arc_project_for_testing_delete_after_usage_test_from_dict',
-                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong']
+                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong',
+                    'test_sp_composite']
         for project in projects:
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestARCSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for project-level ``sp_composite`` YAML plumbing.
+    """
+
+    @classmethod
+    def tearDownClass(cls):
+        for project in ['test_sp_composite_preset',
+                        'test_sp_composite_explicit',
+                        'test_sp_composite_preset_override',
+                        'test_sp_composite_mutex_composite',
+                        'test_sp_composite_mutex_adaptive',
+                        'test_sp_composite_fallback',
+                        'test_sp_composite_preserves_sp_level',
+                        'test_sp_composite_aec_bac']:
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
+            if os.path.isdir(project_directory):
+                shutil.rmtree(project_directory, ignore_errors=True)
+
+    def test_preset_string_parsed(self):
+        arc = ARC(project='test_sp_composite_preset', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+
+    def test_explicit_dict_parsed(self):
+        # compute_thermo=False avoids the Arkane AEC lookup that would otherwise
+        # reject hf/cc-pVTZ for lacking a database entry — we're testing parsing.
+        recipe = {
+            'base': {'method': 'hf', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        arc = ARC(project='test_sp_composite_explicit', sp_composite=recipe,
+                  compute_thermo=False, freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+        self.assertEqual(arc.sp_composite.base.level.method, 'hf')
+
+    def test_preset_with_overrides_parsed(self):
+        arc = ARC(project='test_sp_composite_preset_override',
+                  sp_composite={'preset': 'HEAT-345Q',
+                                'overrides': {'delta_T': {'high': {'method': 'ccsdt',
+                                                                   'basis': 'cc-pVTZ'}}}},
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        delta_t = next(t for t in arc.sp_composite.corrections if t.label == 'delta_T')
+        self.assertEqual(delta_t.high.basis, 'cc-pvtz')
+
+    def test_mutex_with_composite_method(self):
+        # Mutual-exclusion check fires during ARC.__init__ → process_level_of_theory.
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_composite',
+                sp_composite='HEAT-345Q', composite_method='CBS-QB3',
+                freq_scale_factor=1)
+
+    def test_mutex_with_adaptive_levels(self):
+        adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'}}
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_adaptive',
+                sp_composite='HEAT-345Q', adaptive_levels=adaptive,
+                freq_scale_factor=1)
+
+    def test_fallback_sp_level_from_base(self):
+        """When sp_composite is set and sp_level is omitted, sp_level is derived from base.level."""
+        arc = ARC(project='test_sp_composite_fallback', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_level, Level)
+        self.assertEqual(arc.sp_level.method, arc.sp_composite.base.level.method)
+        self.assertEqual(arc.sp_level.basis, arc.sp_composite.base.level.basis)
+
+    def test_user_supplied_sp_level_preserved(self):
+        """An explicit sp_level coexists with sp_composite and is not overridden."""
+        arc = ARC(project='test_sp_composite_preserves_sp_level',
+                  sp_composite='HEAT-345Q',
+                  sp_level='wb97xd/def2-tzvp',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertEqual(arc.sp_level.method, 'wb97xd')
+        self.assertEqual(arc.sp_level.basis, 'def2-tzvp')
+
+    def test_per_species_aec_limitation_documented(self):
+        """
+        Known limitation: when species carry their own sp_composite overrides,
+        the project-level AEC lookup still uses the *global* ``sp_composite.base.level``
+        (not per-species base levels). The user should set ``arkane_level_of_theory``
+        explicitly if they need a different AEC target. This test locks that
+        behavior so it's an intentional contract, not accidental.
+        """
+        global_recipe = 'HEAT-345Q'
+        local_recipe = {
+            'base': {'method': 'mp2', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        arc = ARC(project='test_sp_composite_per_species_aec_limit',
+                  sp_composite=global_recipe,
+                  species=[spc],
+                  freq_scale_factor=1)
+        arc.arkane_level_of_theory = None
+        arc.check_arkane_level_of_theory()
+        # arkane_level_of_theory resolved to the GLOBAL protocol's base level
+        # (ccsd(t)-f12 from HEAT-345Q), not the species-level mp2.
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
+        self.assertEqual(arc.arkane_level_of_theory.method, 'ccsd(t)-f12')
+        # Clean up the project directory created by ARC init.
+        project_dir = os.path.join(ARC_PATH, 'Projects',
+                                   'test_sp_composite_per_species_aec_limit')
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+
+    def test_aec_defaults_to_base_and_bac_skipped_with_warning(self):
+        """
+        When sp_composite is active: AEC lookup uses base.level; BAC is skipped with
+        a logger warning. ARC logs to the ``'arc'`` named logger.
+        """
+        arc = ARC(project='test_sp_composite_aec_bac',
+                  sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        # ARC.__init__ already ran check_arkane_level_of_theory once; clear the
+        # resolved value so the second call exercises the full branching.
+        arc.arkane_level_of_theory = None
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            arc.check_arkane_level_of_theory()
+        joined = '\n'.join(cm.output)
+        self.assertIn('sp_composite', joined)
+        self.assertIn('BAC', joined)
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
 
 
 if __name__ == '__main__':

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -530,8 +530,15 @@ class TestARC(unittest.TestCase):
 
 class TestARCSpComposite(unittest.TestCase):
     """
-    Phase 2 tests for project-level ``sp_composite`` YAML plumbing.
+    Tests for project-level ``sp_composite`` YAML plumbing.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
 
     @classmethod
     def tearDownClass(cls):
@@ -540,15 +547,25 @@ class TestARCSpComposite(unittest.TestCase):
                         'test_sp_composite_preset_override',
                         'test_sp_composite_mutex_composite',
                         'test_sp_composite_mutex_adaptive',
+                        'test_sp_composite_mutex_lot',
                         'test_sp_composite_fallback',
+                        'test_sp_composite_fallback_cbs',
                         'test_sp_composite_preserves_sp_level',
-                        'test_sp_composite_aec_bac']:
-            project_directory = os.path.join(ARC_PATH, 'Projects', project)
+                        'test_sp_composite_sp_level_warn',
+                        'test_sp_composite_per_species_aec_limit',
+                        'test_sp_composite_aec_bac',
+                        'test_sp_composite_bac_none',
+                        'test_sp_composite_spc_mutex_adaptive',
+                        'test_sp_composite_spc_mutex_composite',
+                        'test_sp_composite_zombie',
+                        'test_sp_composite_paths',
+                        'test_sp_composite_roundtrip']:
+            project_directory = os.path.join(ARC_PATH, 'Projects', f'{project}_{cls.worker}')
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
 
     def test_preset_string_parsed(self):
-        arc = ARC(project='test_sp_composite_preset', sp_composite='HEAT-345Q',
+        arc = ARC(project=f'test_sp_composite_preset_{self.worker}', sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_composite, CompositeProtocol)
@@ -560,14 +577,14 @@ class TestARCSpComposite(unittest.TestCase):
             'base': {'method': 'hf', 'basis': 'cc-pVTZ'},
             'corrections': [],
         }
-        arc = ARC(project='test_sp_composite_explicit', sp_composite=recipe,
+        arc = ARC(project=f'test_sp_composite_explicit_{self.worker}', sp_composite=recipe,
                   compute_thermo=False, freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_composite, CompositeProtocol)
         self.assertEqual(arc.sp_composite.base.level.method, 'hf')
 
     def test_preset_with_overrides_parsed(self):
-        arc = ARC(project='test_sp_composite_preset_override',
+        arc = ARC(project=f'test_sp_composite_preset_override_{self.worker}',
                   sp_composite={'preset': 'HEAT-345Q',
                                 'overrides': {'delta_T': {'high': {'method': 'ccsdt',
                                                                    'basis': 'cc-pVTZ'}}}},
@@ -579,36 +596,137 @@ class TestARCSpComposite(unittest.TestCase):
     def test_mutex_with_composite_method(self):
         # Mutual-exclusion check fires during ARC.__init__ → process_level_of_theory.
         with self.assertRaises(InputError):
-            ARC(project='test_sp_composite_mutex_composite',
+            ARC(project=f'test_sp_composite_mutex_composite_{self.worker}',
                 sp_composite='HEAT-345Q', composite_method='CBS-QB3',
                 freq_scale_factor=1)
 
     def test_mutex_with_adaptive_levels(self):
         adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
-                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'}}
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'},
+                    (6, 'inf'): {('opt', 'freq'): 'b3lyp/6-31g(d,p)',
+                                 'sp': 'wb97xd/6-311+g(2d,2p)'}}
         with self.assertRaises(InputError):
-            ARC(project='test_sp_composite_mutex_adaptive',
+            ARC(project=f'test_sp_composite_mutex_adaptive_{self.worker}',
                 sp_composite='HEAT-345Q', adaptive_levels=adaptive,
                 freq_scale_factor=1)
 
+    def test_mutex_with_level_of_theory(self):
+        """level_of_theory and sp_composite are mutually exclusive."""
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_mutex_lot_{self.worker}',
+                sp_composite='HEAT-345Q',
+                level_of_theory='ccsd(t)/cc-pvtz//b3lyp/6-31g(d,p)',
+                freq_scale_factor=1)
+
+    def test_species_explicit_protocol_mutex_with_adaptive_levels(self):
+        """A per-species explicit sp_composite protocol is rejected when adaptive_levels is set."""
+        spc = ARCSpecies(label='H2', smiles='[H][H]',
+                         sp_composite={'base': {'method': 'mp2', 'basis': 'cc-pVTZ'}, 'corrections': []})
+        adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'},
+                    (6, 'inf'): {('opt', 'freq'): 'b3lyp/6-31g(d,p)',
+                                 'sp': 'wb97xd/6-311+g(2d,2p)'}}
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_spc_mutex_adaptive_{self.worker}',
+                species=[spc], adaptive_levels=adaptive, freq_scale_factor=1)
+
+    def test_species_explicit_protocol_mutex_with_composite_method(self):
+        """A per-species explicit sp_composite protocol is rejected when composite_method is set."""
+        spc = ARCSpecies(label='H2', smiles='[H][H]',
+                         sp_composite={'base': {'method': 'mp2', 'basis': 'cc-pVTZ'}, 'corrections': []})
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_spc_mutex_composite_{self.worker}',
+                species=[spc], composite_method='CBS-QB3', freq_scale_factor=1)
+
     def test_fallback_sp_level_from_base(self):
         """When sp_composite is set and sp_level is omitted, sp_level is derived from base.level."""
-        arc = ARC(project='test_sp_composite_fallback', sp_composite='HEAT-345Q',
+        arc = ARC(project=f'test_sp_composite_fallback_{self.worker}', sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_level, Level)
         self.assertEqual(arc.sp_level.method, arc.sp_composite.base.level.method)
         self.assertEqual(arc.sp_level.basis, arc.sp_composite.base.level.basis)
 
+    def test_fallback_sp_level_from_cbs_base(self):
+        """A CBS base has no single level; sp_level defaults to the
+        largest-cardinal leg of the extrapolation."""
+        arc = ARC(project=f'test_sp_composite_fallback_cbs_{self.worker}', sp_composite='FPA-min',
+                  compute_thermo=False, freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_level, Level)
+        self.assertEqual(arc.sp_level.method, 'ccsd(t)')
+        self.assertEqual(arc.sp_level.basis, 'cc-pvqz')
+        self.assertEqual(arc.sp_level.simple(),
+                         arc.sp_composite.primary_base_level.simple())
+
     def test_user_supplied_sp_level_preserved(self):
         """An explicit sp_level coexists with sp_composite and is not overridden."""
-        arc = ARC(project='test_sp_composite_preserves_sp_level',
+        arc = ARC(project=f'test_sp_composite_preserves_sp_level_{self.worker}',
                   sp_composite='HEAT-345Q',
                   sp_level='wb97xd/def2-tzvp',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertEqual(arc.sp_level.method, 'wb97xd')
         self.assertEqual(arc.sp_level.basis, 'def2-tzvp')
+
+    def test_user_supplied_sp_level_with_sp_composite_warns(self):
+        """A user sp_level alongside sp_composite triggers a warning naming opt-out species."""
+        spc_in = ARCSpecies(label='H2', smiles='[H][H]')
+        spc_out = ARCSpecies(label='O2', smiles='[O][O]', sp_composite=None)
+        arc = ARC(project=f'test_sp_composite_sp_level_warn_{self.worker}',
+                  sp_composite='HEAT-345Q',
+                  sp_level='wb97xd/def2-tzvp',
+                  species=[spc_in, spc_out],
+                  freq_scale_factor=1)
+        # ARC.__init__ resets the log handlers, so re-run set_levels_of_theory to capture the warning.
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            arc.set_levels_of_theory()
+        joined = '\n'.join(cm.output)
+        self.assertIn('sp_level', joined)
+        self.assertIn('O2', joined)
+        self.assertIn('H2', joined)
+
+    def test_bac_type_forced_to_none(self):
+        """When sp_composite is active, bac_type is forced to None so BACs never reach processing."""
+        arc = ARC(project=f'test_sp_composite_bac_none_{self.worker}',
+                  sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        self.assertIsNone(arc.bac_type)
+
+    def test_zombie_kills_restart_roundtrip(self):
+        """A restart dict carrying _zombie_kills constructs ARC and reaches the scheduler-bound restart state."""
+        input_dict = {'project': f'test_sp_composite_zombie_{self.worker}',
+                      '_zombie_kills': {'H2': ['sp']},
+                      'freq_scale_factor': 1}
+        arc = ARC(**input_dict)
+        self.assertEqual(arc._zombie_kills, {'H2': ['sp']})
+        self.assertEqual(arc.restart_dict['_zombie_kills'], {'H2': ['sp']})
+
+    def test_standardize_output_paths_rebases_sp_composite(self):
+        """Stale absolute paths in output[label]['paths']['sp_composite'] are rebased on the project directory."""
+        project = f'test_sp_composite_paths_{self.worker}'
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
+        rel = os.path.join('calcs', 'Species', 'H2', 'sp_a', 'output.out')
+        real_path = os.path.join(project_directory, rel)
+        os.makedirs(os.path.dirname(real_path), exist_ok=True)
+        with open(real_path, 'w') as f:
+            f.write('test')
+        stale = os.path.join('/old_machine', 'runs', rel)
+        output = {'H2': {'paths': {'sp': stale, 'sp_composite': {'sp_a': stale}}}}
+        arc = ARC(project=project, project_directory=project_directory, output=output,
+                  freq_scale_factor=1)
+        self.assertEqual(arc.output['H2']['paths']['sp'], real_path)
+        self.assertEqual(arc.output['H2']['paths']['sp_composite']['sp_a'], real_path)
+
+    def test_sp_composite_restart_roundtrip(self):
+        """sp_composite survives an as_dict() → ARC(**dict) round trip."""
+        arc1 = ARC(project=f'test_sp_composite_roundtrip_{self.worker}', sp_composite='HEAT-345Q',
+                   freq_scale_factor=1)
+        arc2 = ARC(**arc1.as_dict())
+        self.assertIsInstance(arc2.sp_composite, CompositeProtocol)
+        self.assertEqual(arc2.sp_composite.preset_name, arc1.sp_composite.preset_name)
+        self.assertEqual([term.label for term in arc2.sp_composite.corrections],
+                         [term.label for term in arc1.sp_composite.corrections])
 
     def test_per_species_aec_limitation_documented(self):
         """
@@ -624,7 +742,7 @@ class TestARCSpComposite(unittest.TestCase):
             'corrections': [],
         }
         spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
-        arc = ARC(project='test_sp_composite_per_species_aec_limit',
+        arc = ARC(project=f'test_sp_composite_per_species_aec_limit_{self.worker}',
                   sp_composite=global_recipe,
                   species=[spc],
                   freq_scale_factor=1)
@@ -635,18 +753,13 @@ class TestARCSpComposite(unittest.TestCase):
         self.assertEqual(arc.arkane_level_of_theory.method,
                          arc.sp_composite.base.level.method)
         self.assertEqual(arc.arkane_level_of_theory.method, 'ccsd(t)-f12')
-        # Clean up the project directory created by ARC init.
-        project_dir = os.path.join(ARC_PATH, 'Projects',
-                                   'test_sp_composite_per_species_aec_limit')
-        if os.path.isdir(project_dir):
-            shutil.rmtree(project_dir, ignore_errors=True)
 
     def test_aec_defaults_to_base_and_bac_skipped_with_warning(self):
         """
         When sp_composite is active: AEC lookup uses base.level; BAC is skipped with
         a logger warning. ARC logs to the ``'arc'`` named logger.
         """
-        arc = ARC(project='test_sp_composite_aec_bac',
+        arc = ARC(project=f'test_sp_composite_aec_bac_{self.worker}',
                   sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         # ARC.__init__ already ran check_arkane_level_of_theory once; clear the

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -5,6 +5,7 @@
 This module contains unit tests for the arc.main module
 """
 
+import logging
 import os
 import shutil
 import unittest
@@ -13,6 +14,7 @@ from arc.common import ARC_PATH
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.main import ARC, process_adaptive_levels
 from arc.species.species import ARCSpecies
 
@@ -95,7 +97,9 @@ class TestARC(unittest.TestCase):
                                           'xtb': ['local'],
                                           'xtb_gsm': ['local'],
                                           },
-                         'freq_level': {'basis': '6-311+g(3df,2p)',
+                         'freq_level': {'args': {'block': {},
+                                                 'keyword': {'general': 'scf=(NDamp=30)'}},
+                                        'basis': '6-311+g(3df,2p)',
                                         'method': 'b3lyp',
                                         'method_type': 'dft',
                                         'software': 'gaussian'},
@@ -518,11 +522,145 @@ class TestARC(unittest.TestCase):
         Delete all project directories created during these unit tests
         """
         projects = ['arc_project_for_testing_delete_after_usage_test_from_dict',
-                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong']
+                    'arc_model_chemistry_test', 'arc_test', 'test', 'unit_test_specific_job', 'wrong',
+                    'test_sp_composite']
         for project in projects:
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestARCSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for project-level ``sp_composite`` YAML plumbing.
+    """
+
+    @classmethod
+    def tearDownClass(cls):
+        for project in ['test_sp_composite_preset',
+                        'test_sp_composite_explicit',
+                        'test_sp_composite_preset_override',
+                        'test_sp_composite_mutex_composite',
+                        'test_sp_composite_mutex_adaptive',
+                        'test_sp_composite_fallback',
+                        'test_sp_composite_preserves_sp_level',
+                        'test_sp_composite_aec_bac']:
+            project_directory = os.path.join(ARC_PATH, 'Projects', project)
+            if os.path.isdir(project_directory):
+                shutil.rmtree(project_directory, ignore_errors=True)
+
+    def test_preset_string_parsed(self):
+        arc = ARC(project='test_sp_composite_preset', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+
+    def test_explicit_dict_parsed(self):
+        # compute_thermo=False avoids the Arkane AEC lookup that would otherwise
+        # reject hf/cc-pVTZ for lacking a database entry — we're testing parsing.
+        recipe = {
+            'base': {'method': 'hf', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        arc = ARC(project='test_sp_composite_explicit', sp_composite=recipe,
+                  compute_thermo=False, freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_composite, CompositeProtocol)
+        self.assertEqual(arc.sp_composite.base.level.method, 'hf')
+
+    def test_preset_with_overrides_parsed(self):
+        arc = ARC(project='test_sp_composite_preset_override',
+                  sp_composite={'preset': 'HEAT-345Q',
+                                'overrides': {'delta_T': {'high': {'method': 'ccsdt',
+                                                                   'basis': 'cc-pVTZ'}}}},
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        delta_t = next(t for t in arc.sp_composite.corrections if t.label == 'delta_T')
+        self.assertEqual(delta_t.high.basis, 'cc-pvtz')
+
+    def test_mutex_with_composite_method(self):
+        # Mutual-exclusion check fires during ARC.__init__ → process_level_of_theory.
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_composite',
+                sp_composite='HEAT-345Q', composite_method='CBS-QB3',
+                freq_scale_factor=1)
+
+    def test_mutex_with_adaptive_levels(self):
+        adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'}}
+        with self.assertRaises(InputError):
+            ARC(project='test_sp_composite_mutex_adaptive',
+                sp_composite='HEAT-345Q', adaptive_levels=adaptive,
+                freq_scale_factor=1)
+
+    def test_fallback_sp_level_from_base(self):
+        """When sp_composite is set and sp_level is omitted, sp_level is derived from base.level."""
+        arc = ARC(project='test_sp_composite_fallback', sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_level, Level)
+        self.assertEqual(arc.sp_level.method, arc.sp_composite.base.level.method)
+        self.assertEqual(arc.sp_level.basis, arc.sp_composite.base.level.basis)
+
+    def test_user_supplied_sp_level_preserved(self):
+        """An explicit sp_level coexists with sp_composite and is not overridden."""
+        arc = ARC(project='test_sp_composite_preserves_sp_level',
+                  sp_composite='HEAT-345Q',
+                  sp_level='wb97xd/def2-tzvp',
+                  freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertEqual(arc.sp_level.method, 'wb97xd')
+        self.assertEqual(arc.sp_level.basis, 'def2-tzvp')
+
+    def test_per_species_aec_limitation_documented(self):
+        """
+        Known limitation: when species carry their own sp_composite overrides,
+        the project-level AEC lookup still uses the *global* ``sp_composite.base.level``
+        (not per-species base levels). The user should set ``arkane_level_of_theory``
+        explicitly if they need a different AEC target. This test locks that
+        behavior so it's an intentional contract, not accidental.
+        """
+        global_recipe = 'HEAT-345Q'
+        local_recipe = {
+            'base': {'method': 'mp2', 'basis': 'cc-pVTZ'},
+            'corrections': [],
+        }
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        arc = ARC(project='test_sp_composite_per_species_aec_limit',
+                  sp_composite=global_recipe,
+                  species=[spc],
+                  freq_scale_factor=1)
+        arc.arkane_level_of_theory = None
+        arc.check_arkane_level_of_theory()
+        # arkane_level_of_theory resolved to the GLOBAL protocol's base level
+        # (ccsd(t)-f12 from HEAT-345Q), not the species-level mp2.
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
+        self.assertEqual(arc.arkane_level_of_theory.method, 'ccsd(t)-f12')
+        # Clean up the project directory created by ARC init.
+        project_dir = os.path.join(ARC_PATH, 'Projects',
+                                   'test_sp_composite_per_species_aec_limit')
+        if os.path.isdir(project_dir):
+            shutil.rmtree(project_dir, ignore_errors=True)
+
+    def test_aec_defaults_to_base_and_bac_skipped_with_warning(self):
+        """
+        When sp_composite is active: AEC lookup uses base.level; BAC is skipped with
+        a logger warning. ARC logs to the ``'arc'`` named logger.
+        """
+        arc = ARC(project='test_sp_composite_aec_bac',
+                  sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        # ARC.__init__ already ran check_arkane_level_of_theory once; clear the
+        # resolved value so the second call exercises the full branching.
+        arc.arkane_level_of_theory = None
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            arc.check_arkane_level_of_theory()
+        joined = '\n'.join(cm.output)
+        self.assertIn('sp_composite', joined)
+        self.assertIn('BAC', joined)
+        self.assertEqual(arc.arkane_level_of_theory.method,
+                         arc.sp_composite.base.level.method)
 
 
 if __name__ == '__main__':

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -532,8 +532,15 @@ class TestARC(unittest.TestCase):
 
 class TestARCSpComposite(unittest.TestCase):
     """
-    Phase 2 tests for project-level ``sp_composite`` YAML plumbing.
+    Tests for project-level ``sp_composite`` YAML plumbing.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
 
     @classmethod
     def tearDownClass(cls):
@@ -542,15 +549,25 @@ class TestARCSpComposite(unittest.TestCase):
                         'test_sp_composite_preset_override',
                         'test_sp_composite_mutex_composite',
                         'test_sp_composite_mutex_adaptive',
+                        'test_sp_composite_mutex_lot',
                         'test_sp_composite_fallback',
+                        'test_sp_composite_fallback_cbs',
                         'test_sp_composite_preserves_sp_level',
-                        'test_sp_composite_aec_bac']:
-            project_directory = os.path.join(ARC_PATH, 'Projects', project)
+                        'test_sp_composite_sp_level_warn',
+                        'test_sp_composite_per_species_aec_limit',
+                        'test_sp_composite_aec_bac',
+                        'test_sp_composite_bac_none',
+                        'test_sp_composite_spc_mutex_adaptive',
+                        'test_sp_composite_spc_mutex_composite',
+                        'test_sp_composite_zombie',
+                        'test_sp_composite_paths',
+                        'test_sp_composite_roundtrip']:
+            project_directory = os.path.join(ARC_PATH, 'Projects', f'{project}_{cls.worker}')
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
 
     def test_preset_string_parsed(self):
-        arc = ARC(project='test_sp_composite_preset', sp_composite='HEAT-345Q',
+        arc = ARC(project=f'test_sp_composite_preset_{self.worker}', sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_composite, CompositeProtocol)
@@ -562,14 +579,14 @@ class TestARCSpComposite(unittest.TestCase):
             'base': {'method': 'hf', 'basis': 'cc-pVTZ'},
             'corrections': [],
         }
-        arc = ARC(project='test_sp_composite_explicit', sp_composite=recipe,
+        arc = ARC(project=f'test_sp_composite_explicit_{self.worker}', sp_composite=recipe,
                   compute_thermo=False, freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_composite, CompositeProtocol)
         self.assertEqual(arc.sp_composite.base.level.method, 'hf')
 
     def test_preset_with_overrides_parsed(self):
-        arc = ARC(project='test_sp_composite_preset_override',
+        arc = ARC(project=f'test_sp_composite_preset_override_{self.worker}',
                   sp_composite={'preset': 'HEAT-345Q',
                                 'overrides': {'delta_T': {'high': {'method': 'ccsdt',
                                                                    'basis': 'cc-pVTZ'}}}},
@@ -581,36 +598,137 @@ class TestARCSpComposite(unittest.TestCase):
     def test_mutex_with_composite_method(self):
         # Mutual-exclusion check fires during ARC.__init__ → process_level_of_theory.
         with self.assertRaises(InputError):
-            ARC(project='test_sp_composite_mutex_composite',
+            ARC(project=f'test_sp_composite_mutex_composite_{self.worker}',
                 sp_composite='HEAT-345Q', composite_method='CBS-QB3',
                 freq_scale_factor=1)
 
     def test_mutex_with_adaptive_levels(self):
         adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
-                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'}}
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'},
+                    (6, 'inf'): {('opt', 'freq'): 'b3lyp/6-31g(d,p)',
+                                 'sp': 'wb97xd/6-311+g(2d,2p)'}}
         with self.assertRaises(InputError):
-            ARC(project='test_sp_composite_mutex_adaptive',
+            ARC(project=f'test_sp_composite_mutex_adaptive_{self.worker}',
                 sp_composite='HEAT-345Q', adaptive_levels=adaptive,
                 freq_scale_factor=1)
 
+    def test_mutex_with_level_of_theory(self):
+        """level_of_theory and sp_composite are mutually exclusive."""
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_mutex_lot_{self.worker}',
+                sp_composite='HEAT-345Q',
+                level_of_theory='ccsd(t)/cc-pvtz//b3lyp/6-31g(d,p)',
+                freq_scale_factor=1)
+
+    def test_species_explicit_protocol_mutex_with_adaptive_levels(self):
+        """A per-species explicit sp_composite protocol is rejected when adaptive_levels is set."""
+        spc = ARCSpecies(label='H2', smiles='[H][H]',
+                         sp_composite={'base': {'method': 'mp2', 'basis': 'cc-pVTZ'}, 'corrections': []})
+        adaptive = {(1, 5): {('opt', 'freq'): 'wb97xd/6-311+g(2d,2p)',
+                             'sp': 'ccsd(t)-f12/cc-pvdz-f12'},
+                    (6, 'inf'): {('opt', 'freq'): 'b3lyp/6-31g(d,p)',
+                                 'sp': 'wb97xd/6-311+g(2d,2p)'}}
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_spc_mutex_adaptive_{self.worker}',
+                species=[spc], adaptive_levels=adaptive, freq_scale_factor=1)
+
+    def test_species_explicit_protocol_mutex_with_composite_method(self):
+        """A per-species explicit sp_composite protocol is rejected when composite_method is set."""
+        spc = ARCSpecies(label='H2', smiles='[H][H]',
+                         sp_composite={'base': {'method': 'mp2', 'basis': 'cc-pVTZ'}, 'corrections': []})
+        with self.assertRaises(InputError):
+            ARC(project=f'test_sp_composite_spc_mutex_composite_{self.worker}',
+                species=[spc], composite_method='CBS-QB3', freq_scale_factor=1)
+
     def test_fallback_sp_level_from_base(self):
         """When sp_composite is set and sp_level is omitted, sp_level is derived from base.level."""
-        arc = ARC(project='test_sp_composite_fallback', sp_composite='HEAT-345Q',
+        arc = ARC(project=f'test_sp_composite_fallback_{self.worker}', sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertIsInstance(arc.sp_level, Level)
         self.assertEqual(arc.sp_level.method, arc.sp_composite.base.level.method)
         self.assertEqual(arc.sp_level.basis, arc.sp_composite.base.level.basis)
 
+    def test_fallback_sp_level_from_cbs_base(self):
+        """A CBS base has no single level; sp_level defaults to the
+        largest-cardinal leg of the extrapolation."""
+        arc = ARC(project=f'test_sp_composite_fallback_cbs_{self.worker}', sp_composite='FPA-min',
+                  compute_thermo=False, freq_scale_factor=1)
+        arc.process_level_of_theory()
+        self.assertIsInstance(arc.sp_level, Level)
+        self.assertEqual(arc.sp_level.method, 'ccsd(t)')
+        self.assertEqual(arc.sp_level.basis, 'cc-pvqz')
+        self.assertEqual(arc.sp_level.simple(),
+                         arc.sp_composite.primary_base_level.simple())
+
     def test_user_supplied_sp_level_preserved(self):
         """An explicit sp_level coexists with sp_composite and is not overridden."""
-        arc = ARC(project='test_sp_composite_preserves_sp_level',
+        arc = ARC(project=f'test_sp_composite_preserves_sp_level_{self.worker}',
                   sp_composite='HEAT-345Q',
                   sp_level='wb97xd/def2-tzvp',
                   freq_scale_factor=1)
         arc.process_level_of_theory()
         self.assertEqual(arc.sp_level.method, 'wb97xd')
         self.assertEqual(arc.sp_level.basis, 'def2-tzvp')
+
+    def test_user_supplied_sp_level_with_sp_composite_warns(self):
+        """A user sp_level alongside sp_composite triggers a warning naming opt-out species."""
+        spc_in = ARCSpecies(label='H2', smiles='[H][H]')
+        spc_out = ARCSpecies(label='O2', smiles='[O][O]', sp_composite=None)
+        arc = ARC(project=f'test_sp_composite_sp_level_warn_{self.worker}',
+                  sp_composite='HEAT-345Q',
+                  sp_level='wb97xd/def2-tzvp',
+                  species=[spc_in, spc_out],
+                  freq_scale_factor=1)
+        # ARC.__init__ resets the log handlers, so re-run set_levels_of_theory to capture the warning.
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            arc.set_levels_of_theory()
+        joined = '\n'.join(cm.output)
+        self.assertIn('sp_level', joined)
+        self.assertIn('O2', joined)
+        self.assertIn('H2', joined)
+
+    def test_bac_type_forced_to_none(self):
+        """When sp_composite is active, bac_type is forced to None so BACs never reach processing."""
+        arc = ARC(project=f'test_sp_composite_bac_none_{self.worker}',
+                  sp_composite='HEAT-345Q',
+                  freq_scale_factor=1)
+        self.assertIsNone(arc.bac_type)
+
+    def test_zombie_kills_restart_roundtrip(self):
+        """A restart dict carrying _zombie_kills constructs ARC and reaches the scheduler-bound restart state."""
+        input_dict = {'project': f'test_sp_composite_zombie_{self.worker}',
+                      '_zombie_kills': {'H2': ['sp']},
+                      'freq_scale_factor': 1}
+        arc = ARC(**input_dict)
+        self.assertEqual(arc._zombie_kills, {'H2': ['sp']})
+        self.assertEqual(arc.restart_dict['_zombie_kills'], {'H2': ['sp']})
+
+    def test_standardize_output_paths_rebases_sp_composite(self):
+        """Stale absolute paths in output[label]['paths']['sp_composite'] are rebased on the project directory."""
+        project = f'test_sp_composite_paths_{self.worker}'
+        project_directory = os.path.join(ARC_PATH, 'Projects', project)
+        rel = os.path.join('calcs', 'Species', 'H2', 'sp_a', 'output.out')
+        real_path = os.path.join(project_directory, rel)
+        os.makedirs(os.path.dirname(real_path), exist_ok=True)
+        with open(real_path, 'w') as f:
+            f.write('test')
+        stale = os.path.join('/old_machine', 'runs', rel)
+        output = {'H2': {'paths': {'sp': stale, 'sp_composite': {'sp_a': stale}}}}
+        arc = ARC(project=project, project_directory=project_directory, output=output,
+                  freq_scale_factor=1)
+        self.assertEqual(arc.output['H2']['paths']['sp'], real_path)
+        self.assertEqual(arc.output['H2']['paths']['sp_composite']['sp_a'], real_path)
+
+    def test_sp_composite_restart_roundtrip(self):
+        """sp_composite survives an as_dict() → ARC(**dict) round trip."""
+        arc1 = ARC(project=f'test_sp_composite_roundtrip_{self.worker}', sp_composite='HEAT-345Q',
+                   freq_scale_factor=1)
+        arc2 = ARC(**arc1.as_dict())
+        self.assertIsInstance(arc2.sp_composite, CompositeProtocol)
+        self.assertEqual(arc2.sp_composite.preset_name, arc1.sp_composite.preset_name)
+        self.assertEqual([term.label for term in arc2.sp_composite.corrections],
+                         [term.label for term in arc1.sp_composite.corrections])
 
     def test_per_species_aec_limitation_documented(self):
         """
@@ -626,7 +744,7 @@ class TestARCSpComposite(unittest.TestCase):
             'corrections': [],
         }
         spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
-        arc = ARC(project='test_sp_composite_per_species_aec_limit',
+        arc = ARC(project=f'test_sp_composite_per_species_aec_limit_{self.worker}',
                   sp_composite=global_recipe,
                   species=[spc],
                   freq_scale_factor=1)
@@ -637,18 +755,13 @@ class TestARCSpComposite(unittest.TestCase):
         self.assertEqual(arc.arkane_level_of_theory.method,
                          arc.sp_composite.base.level.method)
         self.assertEqual(arc.arkane_level_of_theory.method, 'ccsd(t)-f12')
-        # Clean up the project directory created by ARC init.
-        project_dir = os.path.join(ARC_PATH, 'Projects',
-                                   'test_sp_composite_per_species_aec_limit')
-        if os.path.isdir(project_dir):
-            shutil.rmtree(project_dir, ignore_errors=True)
 
     def test_aec_defaults_to_base_and_bac_skipped_with_warning(self):
         """
         When sp_composite is active: AEC lookup uses base.level; BAC is skipped with
         a logger warning. ARC logs to the ``'arc'`` named logger.
         """
-        arc = ARC(project='test_sp_composite_aec_bac',
+        arc = ARC(project=f'test_sp_composite_aec_bac_{self.worker}',
                   sp_composite='HEAT-345Q',
                   freq_scale_factor=1)
         # ARC.__init__ already ran check_arkane_level_of_theory once; clear the

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -17,14 +17,15 @@ from arc.exceptions import AtomTypeError, ConformerError, InputError, SpeciesErr
 from arc.family import ReactionFamily
 from arc.molecule import Molecule
 from arc.molecule.resonance import generate_resonance_structures_safely
-from arc.species import ARCSpecies
-from arc.species.conformers import determine_chirality
 from arc.species.converter import compare_confs, sort_xyz_using_indices, xyz_from_data
 from arc.species.vectors import calculate_dihedral_angle, get_delta_angle
 
+# ``ARCSpecies`` and ``determine_chirality`` are imported locally in their
+# call-sites to break a circular import via arc.species → arc.plotter → here.
 if TYPE_CHECKING:
     from arc.molecule.molecule import Atom
     from arc.reaction import ARCReaction
+    from arc.species import ARCSpecies
 
 RESERVED_FINGERPRINT_KEYS = ['self', 'chirality', 'label']
 
@@ -137,7 +138,7 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
     return atom_map
 
 
-def get_arc_species(spc: ARCSpecies | Molecule) -> ARCSpecies:
+def get_arc_species(spc: "ARCSpecies | Molecule") -> "ARCSpecies":
     """
     Convert an object to an ARCSpecies object.
 
@@ -147,6 +148,7 @@ def get_arc_species(spc: ARCSpecies | Molecule) -> ARCSpecies:
     Returns:
         ARCSpecies: The corresponding ARCSpecies object.
     """
+    from arc.species import ARCSpecies
     if isinstance(spc, ARCSpecies):
         return spc
     if isinstance(spc, Molecule):
@@ -250,6 +252,7 @@ def fingerprint(spc: ARCSpecies,
         dict[int, dict[str, list[int]]]: Keys are indices of heavy atoms, values are dicts. keys are element symbols,
                                          values are indices of adjacent atoms corresponding to this element.
     """
+    from arc.species.conformers import determine_chirality
     fingerprint_dict = dict()
     chirality_dict = determine_chirality(conformers=[{'xyz': spc.get_xyz()}],
                                          label=spc.label,
@@ -1165,7 +1168,7 @@ def make_bond_changes(rxn: ARCReaction, r_cuts: list[ARCSpecies], r_label_dict: 
                         r_cut.mol = r_cut_mol_copy
 
 
-def update_xyz(species: list[ARCSpecies]) -> list[ARCSpecies]:
+def update_xyz(species: "list[ARCSpecies]") -> "list[ARCSpecies]":
     """
     A helper function, updates the xyz values of each species after cutting. This is important, since the
     scission sometimes scrambles the Molecule object, and updating the xyz makes up for that.
@@ -1176,6 +1179,7 @@ def update_xyz(species: list[ARCSpecies]) -> list[ARCSpecies]:
     Returns:
         list[ARCSpecies]: A newly generated copies of the ARCSpecies, with updated xyz.
     """
+    from arc.species import ARCSpecies
     new = list()
     for spc in species:
         new_spc = ARCSpecies(label="copy", mol=spc.mol.copy(deep=True))
@@ -1497,6 +1501,7 @@ def copy_species_list_for_mapping(species: list["ARCSpecies"]) -> list["ARCSpeci
     Returns:
         list[ARCSpecies]: The copied species list.
     """
+    from arc.species import ARCSpecies
     copies = list()
     for spc in species:
         new_spc = ARCSpecies(label=spc.label, mol=spc.mol.copy(deep=True), xyz=spc.get_xyz(), keep_mol=True)
@@ -1525,6 +1530,7 @@ def find_all_breaking_bonds(rxn: "ARCReaction",
             broken bond (1-indexed), representing the atom indices to be cut.
             Returns ``None`` if ``rxn.family`` is not set or ``rxn.product_dicts`` is empty.
     """
+    from arc.species import ARCSpecies
     if rxn.family is None:
         return None
     family = ReactionFamily(label=rxn.family)

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -18,14 +18,15 @@ from arc.exceptions import AtomTypeError, ConformerError, InputError, SpeciesErr
 from arc.family import ReactionFamily
 from arc.molecule import Molecule
 from arc.molecule.resonance import generate_resonance_structures_safely
-from arc.species import ARCSpecies
-from arc.species.conformers import determine_chirality
 from arc.species.converter import compare_confs, sort_xyz_using_indices, xyz_from_data
 from arc.species.vectors import apply_rodrigues_rotation, calculate_dihedral_angle, get_delta_angle
 
+# ``ARCSpecies`` and ``determine_chirality`` are imported locally in their
+# call-sites to break a circular import via arc.species → arc.plotter → here.
 if TYPE_CHECKING:
     from arc.molecule.molecule import Atom
     from arc.reaction import ARCReaction
+    from arc.species import ARCSpecies
 
 RESERVED_FINGERPRINT_KEYS = ['self', 'chirality', 'label']
 
@@ -138,7 +139,7 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
     return atom_map
 
 
-def get_arc_species(spc: ARCSpecies | Molecule) -> ARCSpecies:
+def get_arc_species(spc: "ARCSpecies | Molecule") -> "ARCSpecies":
     """
     Convert an object to an ARCSpecies object.
 
@@ -148,6 +149,7 @@ def get_arc_species(spc: ARCSpecies | Molecule) -> ARCSpecies:
     Returns:
         ARCSpecies: The corresponding ARCSpecies object.
     """
+    from arc.species import ARCSpecies
     if isinstance(spc, ARCSpecies):
         return spc
     if isinstance(spc, Molecule):
@@ -251,6 +253,7 @@ def fingerprint(spc: ARCSpecies,
         dict[int, dict[str, list[int]]]: Keys are indices of heavy atoms, values are dicts. keys are element symbols,
                                          values are indices of adjacent atoms corresponding to this element.
     """
+    from arc.species.conformers import determine_chirality
     fingerprint_dict = dict()
     chirality_dict = determine_chirality(conformers=[{'xyz': spc.get_xyz()}],
                                          label=spc.label,
@@ -1292,7 +1295,7 @@ def make_bond_changes(rxn: ARCReaction, r_cuts: list[ARCSpecies], r_label_dict: 
                         r_cut.mol = r_cut_mol_copy
 
 
-def update_xyz(species: list[ARCSpecies]) -> list[ARCSpecies]:
+def update_xyz(species: "list[ARCSpecies]") -> "list[ARCSpecies]":
     """
     A helper function, updates the xyz values of each species after cutting. This is important, since the
     scission sometimes scrambles the Molecule object, and updating the xyz makes up for that.
@@ -1303,6 +1306,7 @@ def update_xyz(species: list[ARCSpecies]) -> list[ARCSpecies]:
     Returns:
         list[ARCSpecies]: A newly generated copies of the ARCSpecies, with updated xyz.
     """
+    from arc.species import ARCSpecies
     new = list()
     for spc in species:
         new_spc = ARCSpecies(label="copy", mol=spc.mol.copy(deep=True))
@@ -1625,6 +1629,7 @@ def copy_species_list_for_mapping(species: list["ARCSpecies"]) -> list["ARCSpeci
     Returns:
         list[ARCSpecies]: The copied species list.
     """
+    from arc.species import ARCSpecies
     copies = list()
     for spc in species:
         new_spc = ARCSpecies(label=spc.label, mol=spc.mol.copy(deep=True), xyz=spc.get_xyz(), keep_mol=True)
@@ -1653,6 +1658,7 @@ def find_all_breaking_bonds(rxn: "ARCReaction",
             broken bond (1-indexed), representing the atom indices to be cut.
             Returns ``None`` if ``rxn.family`` is not set or ``rxn.product_dicts`` is empty.
     """
+    from arc.species import ARCSpecies
     if rxn.family is None:
         return None
     family = ReactionFamily(label=rxn.family)

--- a/arc/molecule/molecule.py
+++ b/arc/molecule/molecule.py
@@ -1935,7 +1935,7 @@ class Molecule(Graph):
         try:
             return translator.to_inchi(self, backend=backend)
         except:
-            logger.exception(f"Error for molecule \n{self.to_adjacency_list()}")
+            logger.debug(f"Identifier generation failed for molecule\n{self.to_adjacency_list()}", exc_info=True)
             raise
 
     def to_augmented_inchi(self, backend='rdkit-first'):
@@ -1952,7 +1952,7 @@ class Molecule(Graph):
         try:
             return translator.to_inchi(self, backend=backend, aug_level=2)
         except:
-            logger.exception(f"Error for molecule \n{self.to_adjacency_list()}")
+            logger.debug(f"Identifier generation failed for molecule\n{self.to_adjacency_list()}", exc_info=True)
             raise
 
     def to_inchi_key(self, backend='rdkit-first'):
@@ -1972,7 +1972,7 @@ class Molecule(Graph):
         try:
             return translator.to_inchi_key(self, backend=backend)
         except:
-            logger.exception(f"Error for molecule \n{self.to_adjacency_list()}")
+            logger.debug(f"Identifier generation failed for molecule\n{self.to_adjacency_list()}", exc_info=True)
             raise
 
     def to_augmented_inchi_key(self, backend='rdkit-first'):
@@ -1990,7 +1990,7 @@ class Molecule(Graph):
         try:
             return translator.to_inchi_key(self, backend=backend, aug_level=2)
         except:
-            logger.exception(f"Error for molecule \n{self.to_adjacency_list()}")
+            logger.debug(f"Identifier generation failed for molecule\n{self.to_adjacency_list()}", exc_info=True)
             raise
 
     def to_smarts(self):

--- a/arc/molecule/translator.py
+++ b/arc/molecule/translator.py
@@ -553,7 +553,11 @@ def _write(mol, identifier_type, backend):
             logger.warning(f"Unexpected error from backend '{option}': {e}")
             continue
 
-    logger.error(f"Unable to generate identifier '{identifier_type}' for this molecule:\n{mol.to_adjacency_list()}")
+    logger.debug(
+        f"Unable to generate identifier '{identifier_type}' for this molecule "
+        f"(structure may be fragmented or carry anomalous formal charges):\n"
+        f"{mol.to_adjacency_list()}"
+    )
     raise ValueError(f"Unable to generate identifier type '{identifier_type}' with backend(s): {backend}")
 
 

--- a/arc/molecule/translator_test.py
+++ b/arc/molecule/translator_test.py
@@ -706,5 +706,42 @@ class ParsingTest(unittest.TestCase):
         self.assertTrue('InChIKey is a write-only format' in str(cm.exception))
 
 
+class IdentifierFailureLoggingTest(unittest.TestCase):
+    """When neither backend can canonicalize a molecule into InChI / InChIKey
+    (e.g. malformed resonance structures from RMG perception), the translator
+    and the four Molecule wrappers must raise ValueError but emit nothing at
+    WARNING level or above. The caller (resonance dedup, etc.) routinely
+    swallows the ValueError; the previous WARNING + ERROR-with-traceback pair
+    was log spam."""
+
+    def _assert_wrapper_logs_below_warning(self, wrapper_name, translator_func_name):
+        """Patch the underlying translator function to raise, call the
+        Molecule wrapper, and verify the wrapper re-raises while emitting only
+        DEBUG-level (not WARNING/ERROR) log records."""
+        from arc.molecule import translator as t
+        mol = Molecule().from_smiles('C')
+        with patch.object(t, translator_func_name,
+                          side_effect=ValueError('mocked-out backend')):
+            with self.assertLogs('arc', level='DEBUG') as cm:
+                with self.assertRaises(ValueError):
+                    getattr(mol, wrapper_name)()
+        for record in cm.records:
+            self.assertLess(record.levelno, 30,  # WARNING == 30
+                            f"Unexpected {record.levelname} log line from "
+                            f"{wrapper_name}: {record.getMessage()}")
+
+    def test_to_inchi_wrapper_logs_only_at_debug_on_failure(self):
+        self._assert_wrapper_logs_below_warning('to_inchi', 'to_inchi')
+
+    def test_to_inchi_key_wrapper_logs_only_at_debug_on_failure(self):
+        self._assert_wrapper_logs_below_warning('to_inchi_key', 'to_inchi_key')
+
+    def test_to_augmented_inchi_wrapper_logs_only_at_debug_on_failure(self):
+        self._assert_wrapper_logs_below_warning('to_augmented_inchi', 'to_inchi')
+
+    def test_to_augmented_inchi_key_wrapper_logs_only_at_debug_on_failure(self):
+        self._assert_wrapper_logs_below_warning('to_augmented_inchi_key', 'to_inchi_key')
+
+
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/output.py
+++ b/arc/output.py
@@ -24,6 +24,7 @@ from arc.statmech.arkane import (
     AEC_SECTION_START, AEC_SECTION_END,
     MBAC_SECTION_START, MBAC_SECTION_END,
     PBAC_SECTION_START, PBAC_SECTION_END,
+    filter_real_stderr_lines,
     find_best_across_files, get_qm_corrections_files,
 )
 
@@ -339,8 +340,9 @@ def _get_energy_corrections(arkane_level_of_theory, bac_type: str | None) -> tup
                 'fi"',
             ]
             _, stderr = execute_command(command=commands, executable='/bin/bash')
-            if stderr:
-                logger.warning(f'get_qm_corrections.py stderr: {stderr}')
+            real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+            if real_stderr:
+                logger.warning(f'get_qm_corrections.py stderr: {real_stderr}')
 
             result = read_yaml_file(tmp_out) or {}
             return result.get('aec'), result.get('bac')
@@ -412,8 +414,9 @@ def _compute_point_groups(species_dict: dict, project_directory: str) -> dict[st
             'fi"',
         ]
         _, stderr = execute_command(command=commands, executable='/bin/bash')
-        if stderr:
-            logger.warning(f'get_point_groups.py stderr: {stderr}')
+        real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+        if real_stderr:
+            logger.warning(f'get_point_groups.py stderr: {real_stderr}')
 
         result = read_yaml_file(tmp_out) or {}
         return {str(k): (str(v) if v is not None else None) for k, v in result.items()}

--- a/arc/output.py
+++ b/arc/output.py
@@ -25,6 +25,7 @@ from arc.statmech.arkane import (
     AEC_SECTION_START, AEC_SECTION_END,
     MBAC_SECTION_START, MBAC_SECTION_END,
     PBAC_SECTION_START, PBAC_SECTION_END,
+    filter_real_stderr_lines,
     find_best_across_files, get_qm_corrections_files,
 )
 
@@ -328,8 +329,9 @@ def _get_energy_corrections(arkane_level_of_theory, bac_type: str | None) -> tup
 
             command = rmg_env_command(py_args=[script_path, tmp_in, tmp_out])
             _, stderr = execute_command(command=command, shell=True, executable='/bin/bash')
-            if stderr:
-                logger.warning(f'get_qm_corrections.py stderr: {stderr}')
+            real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+            if real_stderr:
+                logger.warning(f'get_qm_corrections.py stderr: {real_stderr}')
 
             result = read_yaml_file(tmp_out) or {}
             return result.get('aec'), result.get('bac')
@@ -389,8 +391,9 @@ def _compute_point_groups(species_dict: dict, project_directory: str) -> dict[st
 
         command = rmg_env_command(py_args=[script_path, tmp_in, tmp_out])
         _, stderr = execute_command(command=command, shell=True, executable='/bin/bash')
-        if stderr:
-            logger.warning(f'get_point_groups.py stderr: {stderr}')
+        real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+        if real_stderr:
+            logger.warning(f'get_point_groups.py stderr: {real_stderr}')
 
         result = read_yaml_file(tmp_out) or {}
         return {str(k): (str(v) if v is not None else None) for k, v in result.items()}

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -10,6 +10,7 @@ from arc.common import ARC_PATH, get_logger, read_yaml_file, save_yaml_file
 from arc.imports import settings
 from arc.level import Level
 from arc.job.local import execute_command
+from arc.statmech.arkane import filter_real_stderr_lines
 from arc.statmech.factory import statmech_factory
 
 
@@ -298,8 +299,9 @@ def compare_thermo(species_for_thermo_lib: list,
                 'fi"',
                 ]
     stdout, stderr = execute_command(command=commands, no_fail=True)
-    if len(stderr):
-        logger.error(f'Error while running RMG thermo script: {stderr}')
+    real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+    if real_stderr:
+        logger.error(f'Error while running RMG thermo script: {real_stderr}')
     species_list = read_yaml_file(path=species_thermo_path)
     for original_spc, rmg_spc in zip(species_for_thermo_lib, species_list):
         h298, s298, comment = rmg_spc.get('h298', None), rmg_spc.get('s298', None), rmg_spc.get('comment', None)

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -30,6 +30,42 @@ def resolve_neb_level(ts_adapters: list) -> Level | None:
     return None
 
 
+def classify_species_for_thermo(species_dict: dict,
+                                output_dict: dict,
+                                ) -> tuple[list, list, list]:
+    """
+    Sort project species into buckets for thermo computation.
+
+    Transition states and IRC endpoint species are skipped: TSs are not real thermo
+    targets, and IRC endpoints are spawned only to verify TS connectivity (created
+    with ``compute_thermo=False`` and a non-None ``irc_label`` pointing back at the
+    parent TS). Including them would produce spurious "did not converge" errors.
+
+    Args:
+        species_dict (dict): Keys are species labels, values are ``ARCSpecies`` objects.
+        output_dict (dict): Keys are species labels, values are output sub-dicts that
+                            include a ``'convergence'`` flag.
+
+    Returns:
+        tuple[list, list, list]:
+            - converged: Species that should receive a full thermo treatment.
+            - e0_only: Species that should receive ``E0`` only.
+            - unconverged: Species that were intended to receive thermo but did not converge.
+    """
+    converged, e0_only, unconverged = list(), list(), list()
+    for spc in species_dict.values():
+        if spc.is_ts or spc.irc_label is not None:
+            continue
+        if (spc.compute_thermo or spc.e0_only) and output_dict[spc.label]['convergence']:
+            if spc.e0_only:
+                e0_only.append(spc)
+            else:
+                converged.append(spc)
+        else:
+            unconverged.append(spc)
+    return converged, e0_only, unconverged
+
+
 def process_arc_project(thermo_adapter: str,
                         kinetics_adapter: str,
                         project: str,
@@ -153,16 +189,8 @@ def process_arc_project(thermo_adapter: str,
 
     # 2. Thermo
     if compute_thermo:
-        for spc in species_dict.values():
-            if spc.is_ts:
-                continue
-            if (spc.compute_thermo or spc.e0_only) and output_dict[spc.label]['convergence']:
-                if spc.e0_only:
-                    converged_e0_only_species.append(spc)
-                else:
-                    converged_species.append(spc)
-            else:
-                unconverged_species.append(spc)
+        converged_species, converged_e0_only_species, unconverged_species = \
+            classify_species_for_thermo(species_dict=species_dict, output_dict=output_dict)
     if unconverged_species:
         logger.info('\n\n')
         logger.error(f'The following species did not converge:\n{", ".join([spc.label for spc in unconverged_species])}.\n'

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -11,6 +11,7 @@ from arc.imports import settings
 from arc.level import Level
 from arc.job.env_run import rmg_env_command
 from arc.job.local import execute_command
+from arc.statmech.arkane import filter_real_stderr_lines
 from arc.statmech.factory import statmech_factory
 
 
@@ -289,8 +290,9 @@ def compare_thermo(species_for_thermo_lib: list,
     command = rmg_env_command(py_args=[THERMO_SCRIPT_PATH, species_thermo_path],
                               env_vars={'RMG_DB_PATH': rmg_db_path, 'RMG_DATABASE': rmg_db_path})
     stdout, stderr = execute_command(command=command, shell=True, no_fail=True, executable='/bin/bash')
-    if len(stderr):
-        logger.error(f'Error while running RMG thermo script: {stderr}')
+    real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+    if real_stderr:
+        logger.error(f'Error while running RMG thermo script: {real_stderr}')
     species_list = read_yaml_file(path=species_thermo_path)
     for original_spc, rmg_spc in zip(species_for_thermo_lib, species_list):
         h298, s298, comment = rmg_spc.get('h298', None), rmg_spc.get('s298', None), rmg_spc.get('comment', None)

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -31,6 +31,42 @@ def resolve_neb_level(ts_adapters: list) -> Level | None:
     return None
 
 
+def classify_species_for_thermo(species_dict: dict,
+                                output_dict: dict,
+                                ) -> tuple[list, list, list]:
+    """
+    Sort project species into buckets for thermo computation.
+
+    Transition states and IRC endpoint species are skipped: TSs are not real thermo
+    targets, and IRC endpoints are spawned only to verify TS connectivity (created
+    with ``compute_thermo=False`` and a non-None ``irc_label`` pointing back at the
+    parent TS). Including them would produce spurious "did not converge" errors.
+
+    Args:
+        species_dict (dict): Keys are species labels, values are ``ARCSpecies`` objects.
+        output_dict (dict): Keys are species labels, values are output sub-dicts that
+                            include a ``'convergence'`` flag.
+
+    Returns:
+        tuple[list, list, list]:
+            - converged: Species that should receive a full thermo treatment.
+            - e0_only: Species that should receive ``E0`` only.
+            - unconverged: Species that were intended to receive thermo but did not converge.
+    """
+    converged, e0_only, unconverged = list(), list(), list()
+    for spc in species_dict.values():
+        if spc.is_ts or spc.irc_label is not None:
+            continue
+        if (spc.compute_thermo or spc.e0_only) and output_dict[spc.label]['convergence']:
+            if spc.e0_only:
+                e0_only.append(spc)
+            else:
+                converged.append(spc)
+        else:
+            unconverged.append(spc)
+    return converged, e0_only, unconverged
+
+
 def process_arc_project(thermo_adapter: str,
                         kinetics_adapter: str,
                         project: str,
@@ -154,16 +190,8 @@ def process_arc_project(thermo_adapter: str,
 
     # 2. Thermo
     if compute_thermo:
-        for spc in species_dict.values():
-            if spc.is_ts:
-                continue
-            if (spc.compute_thermo or spc.e0_only) and output_dict[spc.label]['convergence']:
-                if spc.e0_only:
-                    converged_e0_only_species.append(spc)
-                else:
-                    converged_species.append(spc)
-            else:
-                unconverged_species.append(spc)
+        converged_species, converged_e0_only_species, unconverged_species = \
+            classify_species_for_thermo(species_dict=species_dict, output_dict=output_dict)
     if unconverged_species:
         logger.info('\n\n')
         logger.error(f'The following species did not converge:\n{", ".join([spc.label for spc in unconverged_species])}.\n'

--- a/arc/processor_test.py
+++ b/arc/processor_test.py
@@ -42,6 +42,38 @@ class TestProcessor(unittest.TestCase):
                                                           'CH4_BDE_1_2_A': self.ch4_bde_1_2_a})
         self.assertEqual(bde_report, {(1, 2): 50})
 
+    def test_classify_species_for_thermo_skips_irc_endpoints(self):
+        """IRC endpoint species and TSs must be skipped, not flagged as unconverged."""
+        ch4 = ARCSpecies(label='CH4', smiles='C')
+        nh3 = ARCSpecies(label='NH3', smiles='N')  # converged but compute_thermo unset → unconverged bucket
+        nh3.compute_thermo = False
+        ts1 = ARCSpecies(label='TS1', smiles='[CH3]', is_ts=True)
+        irc_fwd = ARCSpecies(label='IRC_TS1_1', smiles='C', compute_thermo=False, irc_label='TS1')
+        irc_rev = ARCSpecies(label='IRC_TS1_2', smiles='C', compute_thermo=False, irc_label='TS1')
+        species_dict = {'CH4': ch4, 'NH3': nh3, 'TS1': ts1,
+                        'IRC_TS1_1': irc_fwd, 'IRC_TS1_2': irc_rev}
+        # IRC labels intentionally absent from output_dict — the helper must not look them up.
+        output_dict = {'CH4': {'convergence': True}, 'NH3': {'convergence': True},
+                       'TS1': {'convergence': True}}
+        converged, e0_only, unconverged = processor.classify_species_for_thermo(
+            species_dict=species_dict, output_dict=output_dict)
+        self.assertEqual([s.label for s in converged], ['CH4'])
+        self.assertEqual(e0_only, [])
+        self.assertEqual([s.label for s in unconverged], ['NH3'])
+
+    def test_classify_species_for_thermo_e0_only_and_unconverged(self):
+        """e0_only species route to e0 bucket; species with compute_thermo but no convergence go unconverged."""
+        e0_spc = ARCSpecies(label='E0_only_spc', smiles='C')
+        e0_spc.e0_only = True
+        unconv = ARCSpecies(label='Unconv', smiles='N')
+        species_dict = {'E0_only_spc': e0_spc, 'Unconv': unconv}
+        output_dict = {'E0_only_spc': {'convergence': True}, 'Unconv': {'convergence': False}}
+        converged, e0_only, unconverged = processor.classify_species_for_thermo(
+            species_dict=species_dict, output_dict=output_dict)
+        self.assertEqual(converged, [])
+        self.assertEqual([s.label for s in e0_only], ['E0_only_spc'])
+        self.assertEqual([s.label for s in unconverged], ['Unconv'])
+
     def test_compare_rates(self):
         """Test the compare_rates() method"""
         rxn_1 = ARCReaction(r_species=[self.ch4, self.h],

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -11,7 +11,7 @@ import shutil
 import time
 
 import numpy as np
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import arc.parser.parser as parser
 from arc import plotter
@@ -46,7 +46,10 @@ from arc.job.trsh import (scan_quality_check,
                           trsh_negative_freq,
                           trsh_scan_job,
                           )
-from arc.level import Level
+from arc.constants import E_h_kJmol
+from arc.level import Level, active_composite_for
+from arc.level.protocol import CompositeProtocol
+from arc.level.reporting import SpeciesSection, format_log_event, write_composite_notebook
 from arc.species.species import (ARCSpecies,
                                  are_coords_compliant_with_graph,
                                  determine_rotor_symmetry,
@@ -239,6 +242,7 @@ class Scheduler(object):
                  opt_level: Optional[Level] = None,
                  freq_level: Optional[Level] = None,
                  sp_level: Optional[Level] = None,
+                 sp_composite: Optional['CompositeProtocol'] = None,
                  scan_level: Optional[Level] = None,
                  ts_guess_level: Optional[Level] = None,
                  irc_level: Optional[Level] = None,
@@ -315,6 +319,21 @@ class Scheduler(object):
         self.report_time = time.time()  # init time for reporting status every 1 hr
         self.servers = list()
         self.composite_method = composite_method
+        # Phase 3 composite-orchestration state.
+        # self.sp_composite holds the project-wide CompositeProtocol (or None). Per-species
+        # protocols live on each ARCSpecies via sp_composite_state/sp_composite and are
+        # resolved through arc.level.active_composite_for().
+        self.sp_composite = sp_composite
+        # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
+        # rebuilt on restart from output[label]['paths']['sp_composite'].
+        self._sp_composite_pending: Dict[str, Dict[str, Level]] = dict()
+        # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
+        # notebook writer consumes the full values list on every regeneration.
+        self._sp_composite_sections: Dict[str, SpeciesSection] = dict()
+        # Rehydrate composite state from the persistent output dict so restart
+        # re-queues only the missing sub-jobs. Safe to call even when no species
+        # has an active composite — it's a no-op in that case.
+        self._rehydrate_composite_state()
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
         self.ts_guess_level = ts_guess_level
@@ -1378,6 +1397,384 @@ class Scheduler(object):
             self.run_job(label=label, xyz=self.species_dict[label].get_xyz(generate=False),
                          level_of_theory=self.freq_level, job_type='freq')
 
+    # ------------------------------------------------------------------------ #
+    #  sp_composite orchestration (Phase 3)                                    #
+    # ------------------------------------------------------------------------ #
+    #
+    # Design:
+    #
+    # * ``_composite_for(label)`` resolves the *active* protocol for a species by
+    #   delegating to ``arc.level.active_composite_for`` (species state beats global).
+    # * Pending sub-jobs are tracked in ``self._sp_composite_pending[label]`` as a
+    #   ``{sub_label: Level}`` dict. Completion is tracked in
+    #   ``self.output[label]['paths']['sp_composite']`` — the persistent store, so
+    #   restart works without needing any additional serialization.
+    # * Sub-jobs are matched to their ``sub_label`` by ``Level`` equality
+    #   (``Level.__eq__``). Multiple ``sub_label``s can legitimately share one
+    #   ``Level`` (e.g. HEAT's δ_T-low and δ_Q-low both use ccsd(t)/cc-pVDZ); in
+    #   that case a single sp job is spawned and its output path is mapped to
+    #   every matching ``sub_label``. Tests cover this case.
+    # * When the last pending sub_label's path is recorded, ``_finalize_composite``
+    #   parses every output file via ``parser.parse_e_elect`` (returns kJ/mol),
+    #   calls ``protocol.evaluate`` (unit-agnostic sum), writes ``species.e_elect``,
+    #   sets ``species.e_elect_source='sp_composite'``, flips the output flag, and
+    #   regenerates the project notebook with the *cumulative* section list.
+
+    def _composite_for(self, label: str) -> Optional[CompositeProtocol]:
+        """Return the composite protocol to apply to this species, or ``None``.
+
+        Resolves species-explicit → opt-out (None) → global inheritance via the
+        shared helper in :mod:`arc.level`.
+        """
+        species = self.species_dict.get(label)
+        if species is None:
+            return None
+        return active_composite_for(
+            species_state=getattr(species, "sp_composite_state", "inherit"),
+            species_protocol=getattr(species, "sp_composite", None),
+            global_protocol=self.sp_composite,
+        )
+
+    def _validate_composite_completed(self, label: str) -> List[str]:
+        """Drop sub_label entries whose recorded output file is missing or
+        unparseable.
+
+        Mutates ``output[label]['paths']['sp_composite']`` in place — bad
+        entries are removed so :meth:`_seed_composite_pending` treats them as
+        pending on the next walk. Returns the list of invalidated sub_labels
+        (possibly empty) for tests/logging.
+        """
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+        if not completed:
+            return []
+        invalidated: List[str] = []
+        for sub_label in list(completed.keys()):
+            path = completed[sub_label]
+            if not path or not os.path.isfile(path):
+                reason = "file missing on disk"
+            else:
+                # parse_e_elect can raise on malformed/partial outputs (e.g. an
+                # ESS adapter parser hitting an unexpected line). Treat any
+                # exception as "unparseable" rather than letting it bubble out
+                # of restart rehydration and crash the scheduler.
+                try:
+                    value = parser.parse_e_elect(path)
+                except Exception as exc:
+                    reason = f"parse_e_elect raised: {exc!r}"
+                else:
+                    if value is None:
+                        reason = "parse_e_elect returned None"
+                    else:
+                        continue
+            del completed[sub_label]
+            invalidated.append(sub_label)
+            logger.warning(format_log_event(
+                label, "sub-job output invalidated — will be requeued",
+                {"sub_label": sub_label, "path": path, "reason": reason},
+            ))
+        return invalidated
+
+    def _seed_composite_pending(self, label: str) -> None:
+        """Populate ``_sp_composite_pending[label]`` from the protocol minus what's
+        already recorded as completed in the output dict (restart-friendly).
+
+        Runs :meth:`_validate_composite_completed` first so any corrupted
+        previously-recorded output is pushed back into pending automatically.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        self._validate_composite_completed(label)
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+        pending: Dict[str, Level] = {}
+        for _term_label, sub_label, level in protocol.iter_required_jobs():
+            if sub_label not in completed:
+                pending[sub_label] = level
+        self._sp_composite_pending[label] = pending
+        logger.info(format_log_event(
+            label,
+            "protocol resolved",
+            {
+                "total_sub_jobs": sum(1 for _ in protocol.iter_required_jobs()),
+                "pending": len(pending),
+                "already_completed": len(completed),
+            },
+        ))
+
+    def _record_composite_completion(
+        self,
+        label: str,
+        level: Level,
+        sp_path: str,
+    ) -> List[str]:
+        """Map a completed sp job's ``(level, path)`` to its ``sub_label``(s).
+
+        Returns the list of sub_labels that were resolved by this completion.
+        Multiple sub_labels may share one Level — all of them are moved from
+        pending to completed and point at the same output file.
+        """
+        pending = self._sp_composite_pending.setdefault(label, {})
+        completed_paths = self.output[label]['paths']['sp_composite']
+        matched = [sl for sl, lvl in pending.items() if lvl == level]
+        for sl in matched:
+            completed_paths[sl] = sp_path
+            del pending[sl]
+            logger.info(format_log_event(
+                label,
+                "sub-job completed",
+                {"sub_label": sl, "level": level.simple(), "path": sp_path},
+            ))
+        return matched
+
+    def _spawn_composite_pending(self, label: str) -> None:
+        """Spawn one sp job per *unique* pending ``Level``.
+
+        Pending sub_labels that share a Level with an existing pending sub_label
+        are de-duplicated here: only one sp job runs, and its eventual output
+        path maps to every matching sub_label at completion time.
+        """
+        pending = self._sp_composite_pending.get(label, {})
+        if not pending:
+            return
+        unique_levels: List[Tuple[Level, List[str]]] = []
+        for sub_label, lvl in pending.items():
+            for existing_lvl, sub_labels in unique_levels:
+                if existing_lvl == lvl:
+                    sub_labels.append(sub_label)
+                    break
+            else:
+                unique_levels.append((lvl, [sub_label]))
+        for lvl, sub_labels in unique_levels:
+            # If an sp job at this Level is already queued/running (e.g. after a
+            # restart re-queue), skip.
+            existing = self.job_dict.get(label, {}).get('sp', {})
+            if any(j.level == lvl for j in existing.values()):
+                continue
+            logger.info(format_log_event(
+                label,
+                "sub-job queued",
+                {"sub_labels": sub_labels, "level": lvl.simple()},
+            ))
+            self.run_job(
+                label=label,
+                xyz=self.species_dict[label].get_xyz(generate=False),
+                level_of_theory=lvl,
+                job_type='sp',
+            )
+
+    def _finalize_composite(self, label: str) -> None:
+        """Parse every sub-job energy, evaluate the protocol, set species.e_elect,
+        emit logs, flip the output flag, and regenerate the project notebook."""
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        completed = self.output[label]['paths']['sp_composite']
+        energies_kJmol: Dict[str, float] = {}
+        # Each missing entry carries enough context (sub_label + reason +
+        # optional path/exception) so the warning payload tells the operator
+        # exactly which sub-job to re-run, without crashing the scheduler.
+        missing: List[Dict[str, str]] = []
+        for _term_label, sub_label, _level in protocol.iter_required_jobs():
+            path = completed.get(sub_label)
+            if not path:
+                missing.append({"sub_label": sub_label, "reason": "missing path"})
+                continue
+            try:
+                value = parser.parse_e_elect(path)
+            except Exception as exc:
+                missing.append({
+                    "sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect raised",
+                    "exception": repr(exc),
+                })
+                continue
+            if value is None:
+                missing.append({
+                    "sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect returned None",
+                })
+                continue
+            energies_kJmol[sub_label] = value
+        if missing:
+            logger.warning(format_log_event(
+                label, "finalize aborted — missing or unparseable sub-jobs",
+                {"missing": missing},
+            ))
+            return
+        e_total_kJmol = protocol.evaluate(energies_kJmol)
+        self.species_dict[label].e_elect = e_total_kJmol
+        self.species_dict[label].e_elect_source = "sp_composite"
+        self.output[label]['job_types']['sp_composite'] = True
+        self.output[label]['job_types']['sp'] = True
+        logger.info(format_log_event(
+            label, "all sub-jobs complete",
+            {"count": len(energies_kJmol)},
+        ))
+        # Per-term breakdown: one [sp_composite] … term evaluated event per term,
+        # in protocol order. Exposes the individual contribution that landed in
+        # the final total — enough to reconstruct the math from the log alone.
+        for term in protocol.terms:
+            contribution = term.evaluate(energies_kJmol)
+            term_sub_labels = [sl for sl, _lvl in term.required_levels()]
+            payload = {
+                "term": term.label,
+                "type": type(term).__name__,
+                "sub_labels": term_sub_labels,
+                "kJ_per_mol": f"{contribution:.3f}",
+                "Hartree": f"{contribution / E_h_kJmol:.9f}",
+            }
+            formula_attr = getattr(term, "formula", None)
+            if formula_attr is not None:
+                payload["formula"] = formula_attr
+            logger.info(format_log_event(label, "term evaluated", payload))
+        logger.info(format_log_event(
+            label, "FINAL e_elect",
+            {
+                "kJ_per_mol": f"{e_total_kJmol:.3f}",
+                "Hartree": f"{e_total_kJmol / E_h_kJmol:.9f}",
+            },
+        ))
+        self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+        if self.report_e_elect:
+            self.save_e_elect(label)
+        self._regenerate_composite_notebook()
+        if species_has_freq(self.output[label], self.species_dict[label].yml_path):
+            self.check_rxn_e0_by_spc(label)
+        self.save_restart_dict()
+
+    def _build_species_section(
+        self,
+        label: str,
+        protocol: CompositeProtocol,
+    ) -> SpeciesSection:
+        """Assemble a :class:`SpeciesSection` for the provenance notebook.
+
+        ``recipe`` is ``protocol.as_dict()`` — a self-contained explicit recipe
+        that the notebook can round-trip through
+        :meth:`CompositeProtocol.from_user_input`. ``preset_name`` and
+        ``reference`` come from the protocol itself when available; otherwise
+        they fall back to explicit-recipe defaults.
+        """
+        species = self.species_dict[label]
+        preset_name = getattr(protocol, "preset_name", None)
+        reference = getattr(protocol, "reference", None)
+        flags: List[str] = []
+        if not reference:
+            reference = (
+                "Explicit sp_composite recipe — no formal reference supplied by "
+                "the user. The full recipe is encoded in this cell and is "
+                "sufficient to reproduce the protocol."
+            )
+            if preset_name is None:
+                flags.append("No formal reference supplied; recipe is explicit-only.")
+        return SpeciesSection(
+            label=label,
+            kind="ts" if getattr(species, "is_ts", False) else "species",
+            preset_name=preset_name,
+            reference=reference,
+            recipe=protocol.as_dict(),
+            protocol=protocol,
+            sub_job_paths=dict(self.output[label]['paths']['sp_composite']),
+            flags=flags,
+        )
+
+    def _regenerate_composite_notebook(self) -> None:
+        """Rewrite ``<project>/output/sp_composite.ipynb`` from the cumulative
+        :class:`SpeciesSection` list. Stateless writer; idempotent."""
+        if not self._sp_composite_sections:
+            return
+        output_dir = os.path.join(self.project_directory, "output")
+        os.makedirs(output_dir, exist_ok=True)
+        nb_path = os.path.join(output_dir, "sp_composite.ipynb")
+        write_composite_notebook(
+            path=nb_path,
+            project_name=self.project,
+            arc_version="",  # Phase 4 may surface this; not critical for provenance.
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            sections=list(self._sp_composite_sections.values()),
+            notebook_dir=output_dir,
+        )
+        logger.info(format_log_event(
+            "project", "provenance notebook regenerated",
+            {"path": nb_path, "sections": len(self._sp_composite_sections)},
+        ))
+
+    def _post_sp_actions_composite(
+        self,
+        label: str,
+        sp_path: str,
+        level: Optional[Level],
+    ) -> None:
+        """Composite branch of :meth:`post_sp_actions`.
+
+        Seeds pending on first entry, records this sp job's completion against
+        any matching pending sub_labels, spawns remaining sub-jobs, and finalizes
+        when all pending are resolved.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        if label not in self._sp_composite_pending:
+            self._seed_composite_pending(label)
+        effective_level = level or self.sp_level
+        matched = self._record_composite_completion(label, effective_level, sp_path)
+        if not matched:
+            logger.warning(format_log_event(
+                label, "sp completion matched no pending sub_label — ignoring",
+                {"level": str(effective_level), "path": sp_path},
+            ))
+            return
+        if self._sp_composite_pending[label]:
+            self._spawn_composite_pending(label)
+        else:
+            self._finalize_composite(label)
+
+    def _rehydrate_composite_state(self) -> None:
+        """On scheduler init/restart, seed pending for every species with an active
+        composite, rebuild the SpeciesSection for species that already finalized,
+        then kick-start any pending sub-jobs so a restart with no other events
+        still makes progress."""
+        for label, species in self.species_dict.items():
+            protocol = self._composite_for(label)
+            if protocol is None:
+                continue
+            self._seed_composite_pending(label)
+            if self.output.get(label, {}).get('job_types', {}).get('sp_composite'):
+                self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+        # Kick-start after every species has been seeded — ``_spawn_composite_pending``
+        # will dedupe against sp jobs restored by ``restore_running_jobs``, and will
+        # only touch species whose pending dict is non-empty AND that have already
+        # made some composite progress (i.e., have at least one recorded sub-job
+        # output, implying opt + base-SP have run). Species mid-opt won't have
+        # pending seeded with anything they couldn't spawn a geometry for.
+        self._kickstart_composite_queues()
+
+    def _kickstart_composite_queues(self) -> None:
+        """Actively spawn pending sub-jobs for species with prior composite
+        progress, so a restart with no other events still moves forward.
+
+        Conservative: only kicks species whose ``output[...]['paths']['sp_composite']``
+        already contains at least one completed sub_label. Species mid-opt (no
+        composite progress yet) follow the normal opt → spawn_post_opt_jobs path.
+        """
+        for label in list(self._sp_composite_pending.keys()):
+            pending = self._sp_composite_pending[label]
+            if not pending:
+                continue
+            completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+            if not completed:
+                # No prior progress — let the normal opt/SP flow get this species
+                # to the composite branch; don't spawn SPs against a species that
+                # may not have an optimized geometry yet.
+                continue
+            logger.info(format_log_event(
+                label, "restart kick-start",
+                {"queuing_sub_labels": sorted(pending.keys())},
+            ))
+            self._spawn_composite_pending(label)
+
     def run_sp_job(self,
                    label: str,
                    level: Optional[Level] = None,
@@ -1392,7 +1789,11 @@ class Scheduler(object):
             level (Level): An alternative level of theory to run at. If ``None``, self.sp_level will be used.
             conformer (int): The conformer number.
         """
-        level = level or self.sp_level
+        # Phase 3: for species with an active sp_composite, the SP runs at the
+        # protocol's base.level (unless the caller passed an explicit ``level``).
+        if level is None:
+            _active_protocol = self._composite_for(label)
+            level = _active_protocol.base.level if _active_protocol is not None else self.sp_level
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
                          xyz=self.species_dict[label].conformers[conformer],
@@ -1401,6 +1802,7 @@ class Scheduler(object):
                          conformer=conformer)
             return
         if level == self.opt_level and not self.composite_method \
+                and self._composite_for(label) is None \
                 and not (level.software == 'xtb' and self.species_dict[label].is_ts) \
                 and 'paths' in self.output[label] and 'geo' in self.output[label]['paths'] \
                 and self.output[label]['paths']['geo']:
@@ -2829,6 +3231,13 @@ class Scheduler(object):
             sp_path (str): The path to 'output.out' for the single point job.
             level (Level, optional): The level of theory used for the sp job.
         """
+        # Phase 3: when sp_composite is active for this species, route through
+        # the composite branch. The legacy path below does not run for composite
+        # species — e_elect is set by ``_finalize_composite`` after all sub-jobs
+        # complete, not from any single intermediate SP.
+        if self._composite_for(label) is not None:
+            self._post_sp_actions_composite(label, sp_path, level)
+            return
         original_sp_path = self.output[label]['paths']['sp'] if 'sp' in self.output[label]['paths'] else None
         self.output[label]['paths']['sp'] = sp_path
         if self.sp_level is not None and 'ccsd' in self.sp_level.method:
@@ -3935,6 +4344,10 @@ class Scheduler(object):
                     for key in path_keys:
                         if key not in self.output[species.label]['paths']:
                             self.output[species.label]['paths'][key] = ''
+                    # Phase 3: sp_composite tracks sub_label → output-file path.
+                    # Dict-valued rather than string — each composite has many sub-jobs.
+                    if 'sp_composite' not in self.output[species.label]['paths']:
+                        self.output[species.label]['paths']['sp_composite'] = dict()
                     if species.is_ts:
                         if 'irc' not in self.output[species.label]['paths']:
                             self.output[species.label]['paths']['irc'] = list()
@@ -3942,7 +4355,7 @@ class Scheduler(object):
                             self.output[species.label]['paths']['neb'] = ''
                     if 'job_types' not in self.output[species.label]:
                         self.output[species.label]['job_types'] = dict()
-                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'onedmin']:
+                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'sp_composite', 'onedmin']:
                         if job_type in ['rotors', 'bde']:
                             # rotors could be invalidated due to many reasons,
                             # also could be falsely identified in a species that has no torsional modes.

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -4451,7 +4451,7 @@ class Scheduler(object):
                     if irc_label in self.output:
                         del self.output[irc_label]
                     if irc_label in self.species_dict:
-                        self.species_list = [spc for spc in self.species_list if spc.label != irc_label]
+                        self.species_list[:] = [spc for spc in self.species_list if spc.label != irc_label]
                         del self.species_dict[irc_label]
                     if irc_label in self.unique_species_labels:
                         self.unique_species_labels.remove(irc_label)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -43,6 +43,7 @@ from arc.job.local import check_running_jobs_ids
 from arc.job.pipe.pipe_coordinator import PipeCoordinator
 from arc.job.pipe.pipe_planner import PipePlanner
 from arc.job.ssh import SSHClient
+from arc.job.zombie import is_zombie as _is_zombie_job
 from arc.job.trsh import (scan_quality_check,
                           trsh_conformer_isomorphism,
                           trsh_ess_job,
@@ -338,6 +339,13 @@ class Scheduler(object):
         # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
         # rebuilt on restart from output[label]['paths']['sp_composite'].
         self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
+        # Per-(species, job_type) cap on zombie-job kills (one resubmit per
+        # job_type per species). Persisted in the restart YAML.
+        self._zombie_kills: dict[str, set[str]] = dict()
+        if self.restart_dict is not None and '_zombie_kills' in self.restart_dict:
+            self._zombie_kills = {
+                label: set(types) for label, types in self.restart_dict['_zombie_kills'].items()
+            }
         # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
         # notebook writer consumes the full values list on every regeneration.
         self._sp_composite_sections: dict[str, SpeciesSection] = dict()
@@ -647,6 +655,7 @@ class Scheduler(object):
                 self.get_completed_incore_jobs()  # updates ``self.completed_incore_jobs``
                 if label not in self.running_jobs.keys():
                     continue
+                self.check_for_zombie_jobs(label)
                 job_list = self.running_jobs[label]
                 for job_name in job_list:
                     if 'conf' in job_name:
@@ -1109,6 +1118,80 @@ class Scheduler(object):
                 level.software = 'terachem'
             job_adapter = level.software
         return job_adapter.lower()
+
+    def resolve_job_by_name(self, label: str, job_name: str) -> JobAdapter | None:
+        """Find a ``JobAdapter`` in ``self.job_dict[label]`` by its ``job_name``.
+
+        ``job_dict`` is keyed ``[label][job_type][job_name → JobAdapter]`` for most
+        job_types, but ``conf_opt`` / ``conf_sp`` / ``tsg`` use integer keys whose
+        values carry the actual ``job_name`` on the ``JobAdapter`` object.
+
+        Args:
+            label (str): The species label.
+            job_name (str): The ``job_name`` to find.
+
+        Returns:
+            JobAdapter | None: The matching job, or ``None`` if no job with this
+            ``job_name`` exists for the species.
+        """
+        if label not in self.job_dict:
+            return None
+        for jobs in self.job_dict[label].values():
+            if not isinstance(jobs, dict):
+                continue
+            if job_name in jobs:
+                return jobs[job_name]
+            for j in jobs.values():
+                if getattr(j, 'job_name', None) == job_name:
+                    return j
+        return None
+
+    def check_for_zombie_jobs(self, label: str) -> None:
+        """Detect zombie jobs for a species (queue reports running but no
+        output traffic after the grace period), kill and resubmit them.
+
+        The cap of one resubmission per (species, job_type) prevents loops
+        when the underlying issue is in our submission, not the cluster.
+
+        Args:
+            label (str): The species label whose running jobs should be checked.
+
+        Returns:
+            None: Side-effects only. Mutates ``self.running_jobs[label]`` (drops
+            zombie ``job_name``\\ s) and ``self._zombie_kills[label]`` (records the
+            killed ``job_type``), and resubmits via ``self._run_a_job``.
+        """
+        if label not in self.running_jobs or label not in self.job_dict:
+            return
+        for job_name in list(self.running_jobs.get(label, [])):
+            job = self.resolve_job_by_name(label, job_name)
+            if job is None or not _is_zombie_job(job, self.server_job_ids):
+                continue
+            job_type = job.job_type
+            if job_type in self._zombie_kills.get(label, set()):
+                logger.warning(
+                    f'Job {job_name} for {label} ({job_type}) appears to be a '
+                    f'zombie a second time after one resubmission — leaving '
+                    f'for manual intervention.'
+                )
+                continue
+            elapsed_min = int((datetime.datetime.now() - job.initial_time).total_seconds() // 60)
+            logger.warning(
+                f'Job {job_name} for {label} ({job_type}) shows no output '
+                f'activity after {elapsed_min} min and the queue still reports '
+                f'it as running. Treating as a zombie: killing and resubmitting.'
+            )
+            try:
+                job.delete()
+            except Exception as exc:
+                logger.warning(
+                    f'Failed to delete zombie job {job_name} for {label}: '
+                    f'{type(exc).__name__}: {exc}. Continuing with resubmission.'
+                )
+            self._zombie_kills.setdefault(label, set()).add(job_type)
+            if job_name in self.running_jobs[label]:
+                self.running_jobs[label].remove(job_name)
+            self._run_a_job(job=job, label=label)
 
     def end_job(self, job: JobAdapter,
                 label: str,
@@ -4462,6 +4545,9 @@ class Scheduler(object):
             self.restart_dict['output'] = self.output
             self.restart_dict['output_multi_spc'] = self.output_multi_spc
             self.restart_dict['species'] = [spc.as_dict() for spc in self.species_dict.values()]
+            self.restart_dict['_zombie_kills'] = {
+                label: sorted(types) for label, types in self._zombie_kills.items()
+            }
             self.restart_dict['running_jobs'] = dict()
             for spc in self.species_dict.values():
                 if spc.label in self.running_jobs:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -49,7 +49,15 @@ from arc.job.trsh import (scan_quality_check,
                           trsh_negative_freq,
                           trsh_scan_job,
                           )
-from arc.level import Level
+from arc.constants import E_h_kJmol
+from arc.level import Level, active_composite_for
+from arc.level.protocol import CompositeProtocol
+from arc.level.reporting import (
+    SpeciesSection,
+    format_log_event,
+    write_composite_notebook,
+    write_species_report_yaml,
+)
 from arc.species.species import (ARCSpecies,
                                  are_coords_compliant_with_graph,
                                  check_label,
@@ -243,6 +251,7 @@ class Scheduler(object):
                  opt_level: Level | None = None,
                  freq_level: Level | None = None,
                  sp_level: Level | None = None,
+                 sp_composite: CompositeProtocol | None = None,
                  scan_level: Level | None = None,
                  ts_guess_level: Level | None = None,
                  irc_level: Level | None = None,
@@ -321,6 +330,21 @@ class Scheduler(object):
         self._last_status_payload: dict | None = None
         self.servers = list()
         self.composite_method = composite_method
+        # Phase 3 composite-orchestration state.
+        # self.sp_composite holds the project-wide CompositeProtocol (or None). Per-species
+        # protocols live on each ARCSpecies via sp_composite_state/sp_composite and are
+        # resolved through arc.level.active_composite_for().
+        self.sp_composite = sp_composite
+        # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
+        # rebuilt on restart from output[label]['paths']['sp_composite'].
+        self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
+        # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
+        # notebook writer consumes the full values list on every regeneration.
+        self._sp_composite_sections: dict[str, SpeciesSection] = dict()
+        # Rehydrate composite state from the persistent output dict so restart
+        # re-queues only the missing sub-jobs. Safe to call even when no species
+        # has an active composite — it's a no-op in that case.
+        self._rehydrate_composite_state()
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
         self.ts_guess_level = ts_guess_level
@@ -1004,6 +1028,20 @@ class Scheduler(object):
                           )
         label = label or reactions[0].ts_species.label
         label = species[0].multi_species if run_multi_species else label
+        # Narrow ``label`` from ``str | list[str]`` to ``str`` for the rest of
+        # this method. The two preceding lines already enforce the invariant —
+        # a list-valued ``label`` arg only reaches this point when
+        # ``run_multi_species`` was True (set iff every species in the list has
+        # ``multi_species`` populated), in which case we just reassigned
+        # ``label`` to the (single) ``species[0].multi_species`` string. Stating
+        # the invariant explicitly satisfies static analyzers (``self.job_dict[label]``
+        # downstream would TypeError on an unhashable list) and catches a real
+        # bug if the multi-species dispatch ever leaks a list through.
+        assert isinstance(label, str), (
+            f"run_job: expected ``label`` to be str by this point, got "
+            f"{type(label).__name__} ({label!r}). This indicates the "
+            f"multi-species dispatch above didn't collapse a list label."
+        )
         if label not in self.job_dict.keys():
             self.job_dict[label] = dict()
         if conformer is None and tsg is None:
@@ -1407,6 +1445,480 @@ class Scheduler(object):
             self.run_job(label=label, xyz=self.species_dict[label].get_xyz(generate=False),
                          level_of_theory=self.freq_level, job_type='freq')
 
+    # ------------------------------------------------------------------------ #
+    #  sp_composite orchestration (Phase 3)                                    #
+    # ------------------------------------------------------------------------ #
+    #
+    # Design:
+    #
+    # * ``_composite_for(label)`` resolves the *active* protocol for a species by
+    #   delegating to ``arc.level.active_composite_for`` (species state beats global).
+    # * Pending sub-jobs are tracked in ``self._sp_composite_pending[label]`` as a
+    #   ``{sub_label: Level}`` dict. Completion is tracked in
+    #   ``self.output[label]['paths']['sp_composite']`` — the persistent store, so
+    #   restart works without needing any additional serialization.
+    # * Sub-jobs are matched to their ``sub_label`` by ``Level`` equality
+    #   (``Level.__eq__``). Multiple ``sub_label``s can legitimately share one
+    #   ``Level`` (e.g. HEAT's δ_T-low and δ_Q-low both use ccsd(t)/cc-pVDZ); in
+    #   that case a single sp job is spawned and its output path is mapped to
+    #   every matching ``sub_label``. Tests cover this case.
+    # * When the last pending sub_label's path is recorded, ``_finalize_composite``
+    #   parses every output file via ``parser.parse_e_elect`` (returns kJ/mol),
+    #   calls ``protocol.evaluate`` (unit-agnostic sum), writes ``species.e_elect``,
+    #   sets ``species.e_elect_source='sp_composite'``, flips the output flag, and
+    #   regenerates the project notebook with the *cumulative* section list.
+
+    def _composite_for(self, label: str) -> CompositeProtocol | None:
+        """Return the composite protocol to apply to this species, or ``None``.
+
+        Resolves species-explicit → opt-out (None) → global inheritance via the
+        shared helper in :mod:`arc.level`.
+        """
+        species = self.species_dict.get(label)
+        if species is None:
+            return None
+        return active_composite_for(
+            species_state=getattr(species, "sp_composite_state", "inherit"),
+            species_protocol=getattr(species, "sp_composite", None),
+            global_protocol=self.sp_composite,
+        )
+
+    def _validate_composite_completed(self, label: str) -> list[str]:
+        """Drop sub_label entries whose recorded output file is missing or
+        unparseable.
+
+        Mutates ``output[label]['paths']['sp_composite']`` in place — bad
+        entries are removed so :meth:`_seed_composite_pending` treats them as
+        pending on the next walk. Returns the list of invalidated sub_labels
+        (possibly empty) for tests/logging.
+        """
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+        if not completed:
+            return []
+        invalidated: list[str] = []
+        for sub_label in list(completed.keys()):
+            path = completed[sub_label]
+            if not path or not os.path.isfile(path):
+                reason = "file missing on disk"
+            else:
+                # parse_e_elect can raise on malformed/partial outputs (e.g. an
+                # ESS adapter parser hitting an unexpected line). Treat any
+                # exception as "unparseable" rather than letting it bubble out
+                # of restart rehydration and crash the scheduler.
+                try:
+                    value = parser.parse_e_elect(path)
+                except Exception as exc:
+                    reason = f"parse_e_elect raised: {exc!r}"
+                else:
+                    if value is None:
+                        reason = "parse_e_elect returned None"
+                    else:
+                        continue
+            del completed[sub_label]
+            invalidated.append(sub_label)
+            logger.warning(format_log_event(
+                label, "sub-job output invalidated — will be requeued",
+                {"sub_label": sub_label, "path": path, "reason": reason},
+            ))
+        return invalidated
+
+    def _seed_composite_pending(self, label: str) -> None:
+        """Populate ``_sp_composite_pending[label]`` from the protocol minus what's
+        already recorded as completed in the output dict (restart-friendly).
+
+        Runs :meth:`_validate_composite_completed` first so any corrupted
+        previously-recorded output is pushed back into pending automatically.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        self._validate_composite_completed(label)
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+        pending: dict[str, Level] = {}
+        for _term_label, sub_label, level in protocol.iter_required_jobs():
+            if sub_label not in completed:
+                pending[sub_label] = level
+        self._sp_composite_pending[label] = pending
+        logger.info(format_log_event(
+            label,
+            "protocol resolved",
+            {
+                "total_sub_jobs": sum(1 for _ in protocol.iter_required_jobs()),
+                "pending": len(pending),
+                "already_completed": len(completed),
+            },
+        ))
+
+    def _record_composite_completion(self,
+                                     label: str,
+                                     level: Level,
+                                     sp_path: str,
+                                     ) -> list[str]:
+        """
+        Map a completed sp job's ``(level, path)`` to its ``sub_label``(s).
+
+        Returns the list of sub_labels that were resolved by this completion.
+        Multiple sub_labels may share one Level — all of them are moved from
+        pending to completed and point at the same output file.
+        """
+        pending = self._sp_composite_pending.setdefault(label, {})
+        completed_paths = self.output[label]['paths']['sp_composite']
+        matched = [sl for sl, lvl in pending.items() if lvl == level]
+        for sl in matched:
+            completed_paths[sl] = sp_path
+            del pending[sl]
+            logger.info(format_log_event(
+                label,
+                "sub-job completed",
+                {"sub_label": sl, "level": level.simple(), "path": sp_path},
+            ))
+        return matched
+
+    def _spawn_composite_pending(self, label: str) -> None:
+        """Spawn one sp job per *unique* pending ``Level``.
+
+        Pending sub_labels that share a Level with an existing pending sub_label
+        are de-duplicated here: only one sp job runs, and its eventual output
+        path maps to every matching sub_label at completion time.
+
+        Species whose geometry cannot be retrieved (``get_xyz(generate=False)``
+        returns ``None``, e.g. on a corrupted mid-opt restart) are skipped with
+        a warning rather than submitting sp jobs with no geometry.
+        """
+        pending = self._sp_composite_pending.get(label, {})
+        if not pending:
+            return
+        xyz = self.species_dict[label].get_xyz(generate=False)
+        if xyz is None:
+            logger.warning(format_log_event(
+                label, "no geometry available — skipping sub-job spawn",
+                {"pending_sub_labels": sorted(pending.keys())},
+            ))
+            return
+        unique_levels: list[tuple[Level, list[str]]] = []
+        for sub_label, lvl in pending.items():
+            for existing_lvl, sub_labels in unique_levels:
+                if existing_lvl == lvl:
+                    sub_labels.append(sub_label)
+                    break
+            else:
+                unique_levels.append((lvl, [sub_label]))
+        for lvl, sub_labels in unique_levels:
+            # If an sp job at this Level is already queued/running (e.g. after a
+            # restart re-queue), skip.
+            existing = self.job_dict.get(label, {}).get('sp', {})
+            if any(j.level == lvl for j in existing.values()):
+                continue
+            logger.info(format_log_event(label,
+                                         "sub-job queued",
+                                         {"sub_labels": sub_labels, "level": lvl.simple()}))
+            self.run_job(label=label,
+                         xyz=xyz,
+                         level_of_theory=lvl,
+                         job_type='sp')
+
+    def _finalize_composite(self, label: str) -> None:
+        """Parse every sub-job energy, evaluate the protocol, set species.e_elect,
+        emit logs, flip the output flag, and regenerate the project notebook."""
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        completed = self.output[label]['paths']['sp_composite']
+        energies_kJmol: dict[str, float] = {}
+        # Each missing entry carries enough context (sub_label + reason +
+        # optional path/exception) so the warning payload tells the operator
+        # exactly which sub-job to re-run, without crashing the scheduler.
+        missing: list[dict[str, str]] = []
+        for _term_label, sub_label, _level in protocol.iter_required_jobs():
+            path = completed.get(sub_label)
+            if not path:
+                missing.append({"sub_label": sub_label, "reason": "missing path"})
+                continue
+            try:
+                value = parser.parse_e_elect(path)
+            except Exception as exc:
+                missing.append({"sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect raised",
+                    "exception": repr(exc)})
+                continue
+            if value is None:
+                missing.append({"sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect returned None"})
+                continue
+            energies_kJmol[sub_label] = value
+        if missing:
+            logger.warning(format_log_event(label, "finalize aborted — missing or unparseable sub-jobs",
+                {"missing": missing}))
+            return
+        e_total_kJmol = protocol.evaluate(energies_kJmol)
+        self.species_dict[label].e_elect = e_total_kJmol
+        self.species_dict[label].e_elect_source = "sp_composite"
+        self.output[label]['job_types']['sp_composite'] = True
+        self.output[label]['job_types']['sp'] = True
+        logger.info(format_log_event(label, "all sub-jobs complete", {"count": len(energies_kJmol)}))
+        # Per-term breakdown: one [sp_composite] … term evaluated event per term,
+        # in protocol order. Exposes the individual contribution that landed in
+        # the final total — enough to reconstruct the math from the log alone.
+        for term in protocol.terms:
+            contribution = term.evaluate(energies_kJmol)
+            term_sub_labels = [sl for sl, _lvl in term.required_levels()]
+            payload = {"term": term.label,
+                       "type": type(term).__name__,
+                       "sub_labels": term_sub_labels,
+                       "kJ_per_mol": f"{contribution:.3f}",
+                       "Hartree": f"{contribution / E_h_kJmol:.9f}"}
+            formula_attr = getattr(term, "formula", None)
+            if formula_attr is not None:
+                payload["formula"] = formula_attr
+            logger.info(format_log_event(label, "term evaluated", payload))
+        logger.info(format_log_event(label, "FINAL e_elect",
+                                     {"kJ_per_mol": f"{e_total_kJmol:.3f}",
+                                      "Hartree": f"{e_total_kJmol / E_h_kJmol:.9f}"}))
+        self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+        if self.report_e_elect:
+            self.save_e_elect(label)
+        self._regenerate_composite_notebook()
+        self._write_species_report(label)
+        if species_has_freq(self.output[label], self.species_dict[label].yml_path):
+            self.check_rxn_e0_by_spc(label)
+        self.save_restart_dict()
+
+    def _build_species_section(self,
+                               label: str,
+                               protocol: CompositeProtocol,
+                               ) -> SpeciesSection:
+        """
+        Assemble a :class:`SpeciesSection` for the provenance notebook.
+
+        ``recipe`` is ``protocol.as_dict()`` — a self-contained explicit recipe
+        that the notebook can round-trip through
+        :meth:`CompositeProtocol.from_user_input`. ``preset_name`` and
+        ``reference`` come from the protocol itself when available; otherwise
+        they fall back to explicit-recipe defaults.
+        """
+        species = self.species_dict[label]
+        preset_name = getattr(protocol, "preset_name", None)
+        reference = getattr(protocol, "reference", None)
+        flags: list[str] = []
+        if not reference:
+            reference = ("Explicit sp_composite recipe — no formal reference supplied by "
+                         "the user. The full recipe is encoded in this cell and is "
+                         "sufficient to reproduce the protocol.")
+            if preset_name is None:
+                flags.append("No formal reference supplied; recipe is explicit-only.")
+        return SpeciesSection(
+            label=label,
+            kind="ts" if getattr(species, "is_ts", False) else "species",
+            preset_name=preset_name,
+            reference=reference,
+            recipe=protocol.as_dict(),
+            protocol=protocol,
+            sub_job_paths=dict(self.output[label]['paths']['sp_composite']),
+            flags=flags,
+        )
+
+    def _regenerate_composite_notebook(self) -> None:
+        """Rewrite ``<project>/output/sp_composite.ipynb`` from the cumulative
+        :class:`SpeciesSection` list. Stateless writer; idempotent."""
+        if not self._sp_composite_sections:
+            return
+        output_dir = os.path.join(self.project_directory, "output")
+        os.makedirs(output_dir, exist_ok=True)
+        nb_path = os.path.join(output_dir, "sp_composite.ipynb")
+        write_composite_notebook(
+            path=nb_path,
+            project_name=self.project,
+            arc_version="",  # Phase 4 may surface this; not critical for provenance.
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            sections=list(self._sp_composite_sections.values()),
+            notebook_dir=output_dir,
+        )
+        logger.info(format_log_event("project", "provenance notebook regenerated",
+                                     {"path": nb_path, "sections": len(self._sp_composite_sections)}))
+
+    def _write_species_report(self, label: str) -> None:
+        """
+        Write the per-species sp_composite YAML summary.
+
+        One file per stationary point at
+        ``<project>/output/Species/<label>/sp_composite_report.yml``
+        (or ``output/TSs/<label>/...`` for transition states). Companion to
+        the project-level provenance notebook: notebook is for *Run-All
+        verification*, this YAML is for *cat / parse consumption*.
+        """
+        section = self._sp_composite_sections.get(label)
+        if section is None:
+            return
+        species = self.species_dict[label]
+        e_elect = species.e_elect
+        if e_elect is None:
+            logger.debug(format_log_event(
+                label, "skipping species report — e_elect not set", None,
+            ))
+            return
+        subdir = "TSs" if section.kind == "ts" else "Species"
+        report_path = os.path.join(
+            self.project_directory, "output", subdir, label,
+            "sp_composite_report.yml",
+        )
+        write_species_report_yaml(
+            path=report_path,
+            section=section,
+            e_elect_kj_per_mol=e_elect,
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            arc_version="",  # surfaced via Phase 4 if needed
+            arc_commit="",   # surfaced via Phase 4 if needed
+        )
+        logger.info(format_log_event(label, "species report written", {"path": report_path}))
+
+    def _post_sp_actions_composite(self,
+                                   label: str,
+                                   sp_path: str,
+                                   level: Level | None,
+                                   ) -> None:
+        """
+        Composite branch of :meth:`post_sp_actions`.
+
+        Seeds pending on first entry, records this sp job's completion against
+        any matching pending sub_labels, spawns remaining sub-jobs, and finalizes
+        when all pending are resolved.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        if label not in self._sp_composite_pending:
+            self._seed_composite_pending(label)
+        effective_level = level or self.sp_level
+        matched = self._record_composite_completion(label, effective_level, sp_path)
+        if not matched:
+            logger.warning(format_log_event(label, "sp completion matched no pending sub_label — ignoring",
+                {"level": str(effective_level), "path": sp_path}))
+            return
+        if self._sp_composite_pending[label]:
+            self._spawn_composite_pending(label)
+        else:
+            self._finalize_composite(label)
+
+    def _mrcc_degenerate_short_circuit(self, label: str, job) -> bool:
+        """If a composite δ-term high-leg sub-job errored with the
+        ``MRCCDegenerateSystem`` keyword, substitute the sister low-leg's
+        recorded path and advance the composite. Returns ``True`` when the
+        short-circuit was applied so the caller can skip ``troubleshoot_ess``.
+
+        Why this exists: for systems too small to accommodate the requested
+        CC excitation rank (atomic H, H2 at CCSDT(Q), etc.) MRCC's xmrcc
+        bails — there's no determinant space to iterate. The two legs of
+        the δ term are mathematically degenerate (all CC ranks reduce to
+        HF), so δ = 0 is the correct physical answer. The trsh ladder
+        cannot fix this; it must be handled at the protocol level.
+
+        Conservative on safety:
+        * Only fires when keywords contain ``'MRCCDegenerateSystem'``.
+        * Only fires when the species has an active composite.
+        * Only fires for ``__high`` sub-labels with a recorded ``__low``
+          sister in ``output[label]['paths']['sp_composite']``. Low-leg
+          failures and high-leg failures without a completed sister fall
+          through so the caller's normal trsh path runs.
+        """
+        keywords = (job.job_status[1] or {}).get('keywords') or []
+        if 'MRCCDegenerateSystem' not in keywords:
+            return False
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return False
+        # Identify which pending sub_label this errored job corresponds to.
+        pending = self._sp_composite_pending.get(label, {})
+        failed_sub_label = next(
+            (sl for sl, lvl in pending.items() if lvl == job.level),
+            None,
+        )
+        if failed_sub_label is None or not failed_sub_label.endswith('__high'):
+            logger.warning(format_log_event(
+                label,
+                "MRCCDegenerateSystem on a non-high sub-job — falling through to trsh",
+                {"sub_label": failed_sub_label, "level": str(job.level)},
+            ))
+            return False
+        sister_low = failed_sub_label[: -len('__high')] + '__low'
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+        sister_path = completed.get(sister_low)
+        if not sister_path:
+            logger.warning(format_log_event(
+                label,
+                "MRCCDegenerateSystem high-leg failed but low-leg not yet recorded — deferring",
+                {"failed": failed_sub_label, "sister": sister_low},
+            ))
+            return False
+        logger.warning(format_log_event(
+            label,
+            "MRCC degenerate-system fallback: substituting low-leg energy for high-leg",
+            {"failed": failed_sub_label, "sister": sister_low,
+             "reason": "Method exceeds determinant space; δ = 0 by symmetry."},
+        ))
+        # Substitute by re-using the low-leg's path. _record_composite_completion
+        # writes the path into output and clears the pending entry — same as a
+        # normal completion, but pointing both legs at the same file so they
+        # parse to the same energy and the δ evaluates to zero.
+        completed_paths = self.output[label]['paths']['sp_composite']
+        completed_paths[failed_sub_label] = sister_path
+        del pending[failed_sub_label]
+        if pending:
+            self._spawn_composite_pending(label)
+        else:
+            self._finalize_composite(label)
+        return True
+
+    def _rehydrate_composite_state(self) -> None:
+        """On scheduler init/restart, seed pending for every species with an active
+        composite, rebuild the SpeciesSection for species that already finalized,
+        then kick-start any pending sub-jobs so a restart with no other events
+        still makes progress."""
+        for label, species in self.species_dict.items():
+            protocol = self._composite_for(label)
+            if protocol is None:
+                continue
+            self._seed_composite_pending(label)
+            if self.output.get(label, {}).get('job_types', {}).get('sp_composite'):
+                self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+                # Re-emit the per-species report so a restart fills in reports
+                # missing on disk (and refreshes any whose protocol metadata
+                # changed across versions). Cheap; one yaml.safe_dump per
+                # finalized species.
+                self._write_species_report(label)
+        # Kick-start after every species has been seeded — ``_spawn_composite_pending``
+        # will dedupe against sp jobs restored by ``restore_running_jobs``, and will
+        # only touch species whose pending dict is non-empty AND that have already
+        # made some composite progress (i.e., have at least one recorded sub-job
+        # output, implying opt + base-SP have run). Species mid-opt won't have
+        # pending seeded with anything they couldn't spawn a geometry for.
+        self._kickstart_composite_queues()
+
+    def _kickstart_composite_queues(self) -> None:
+        """Actively spawn pending sub-jobs for species with prior composite
+        progress, so a restart with no other events still moves forward.
+
+        Conservative: only kicks species whose ``output[...]['paths']['sp_composite']``
+        already contains at least one completed sub_label. Species mid-opt (no
+        composite progress yet) follow the normal opt → spawn_post_opt_jobs path.
+        """
+        for label in list(self._sp_composite_pending.keys()):
+            pending = self._sp_composite_pending[label]
+            if not pending:
+                continue
+            completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+            if not completed:
+                # No prior progress — let the normal opt/SP flow get this species
+                # to the composite branch; don't spawn SPs against a species that
+                # may not have an optimized geometry yet.
+                continue
+            logger.info(format_log_event(
+                label, "restart kick-start",
+                {"queuing_sub_labels": sorted(pending.keys())},
+            ))
+            self._spawn_composite_pending(label)
+
     def run_sp_job(self,
                    label: str,
                    level: Level | None = None,
@@ -1421,7 +1933,11 @@ class Scheduler(object):
             level (Level): An alternative level of theory to run at. If ``None``, self.sp_level will be used.
             conformer (int): The conformer number.
         """
-        level = level or self.sp_level
+        # Phase 3: for species with an active sp_composite, the SP runs at the
+        # protocol's base.level (unless the caller passed an explicit ``level``).
+        if level is None:
+            _active_protocol = self._composite_for(label)
+            level = _active_protocol.base.level if _active_protocol is not None else self.sp_level
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
                          xyz=self.species_dict[label].conformers[conformer],
@@ -1430,6 +1946,7 @@ class Scheduler(object):
                          conformer=conformer)
             return
         if level == self.opt_level and not self.composite_method \
+                and self._composite_for(label) is None \
                 and not (level.software == 'xtb' and self.species_dict[label].is_ts) \
                 and 'paths' in self.output[label] and 'geo' in self.output[label]['paths'] \
                 and self.output[label]['paths']['geo']:
@@ -2847,6 +3364,13 @@ class Scheduler(object):
             if self.species_dict[label].number_of_atoms == 1:
                 # save the geometry from the sp job for monoatomic species for which no opt/freq jobs will be spawned
                 self.output[label]['paths']['geo'] = job.local_path_to_output_file
+        elif self._mrcc_degenerate_short_circuit(label=label, job=job):
+            # MRCC bailed for a degenerate small-system δ-term high leg
+            # (atomic H, H2, etc., where the requested CC excitation rank
+            # exceeds the determinant space). The trsh ladder cannot help —
+            # cause is intrinsic. Helper substituted the low-leg energy and
+            # advanced the composite; nothing further to do here.
+            self.save_restart_dict()
         else:
             self.troubleshoot_ess(label=label,
                                   job=job,
@@ -2866,6 +3390,13 @@ class Scheduler(object):
             sp_path (str): The path to 'output.out' for the single point job.
             level (Level, optional): The level of theory used for the sp job.
         """
+        # Phase 3: when sp_composite is active for this species, route through
+        # the composite branch. The legacy path below does not run for composite
+        # species — e_elect is set by ``_finalize_composite`` after all sub-jobs
+        # complete, not from any single intermediate SP.
+        if self._composite_for(label) is not None:
+            self._post_sp_actions_composite(label, sp_path, level)
+            return
         original_sp_path = self.output[label]['paths']['sp'] if 'sp' in self.output[label]['paths'] else None
         self.output[label]['paths']['sp'] = sp_path
         if self.sp_level is not None and 'ccsd' in self.sp_level.method:
@@ -3767,22 +4298,49 @@ class Scheduler(object):
             label (str): The species label.
         """
         logger.debug(f'Deleting all jobs for species {label}')
+
+        def _safe_delete(job, display_name):
+            """Best-effort job delete: log failure (e.g. queue rejected qdel)
+            and continue. This loop is cleanup before troubleshooting / restart;
+            an orphan remote job will exit on its own and must not abort the
+            whole scheduler. Without this guard, a single failed delete
+            propagates a RuntimeError up through delete_all_species_jobs →
+            troubleshoot_negative_freq → schedule_jobs → __init__ and the
+            entire project dies."""
+            logger.info(f'Deleted job {display_name}')
+            try:
+                job.delete()
+            except Exception as exc:
+                logger.warning(
+                    f'Failed to delete job {display_name} for species '
+                    f'{label}: {type(exc).__name__}: {exc}. Continuing — '
+                    f'the orphan job (if any) will exit on its own.'
+                )
+
         for value in self.job_dict[label].values():
             if value in ['conf_opt', 'tsg']:
                 for job_name, job in self.job_dict[label][value].items():
                     if label in self.running_jobs.keys() and job_name in self.running_jobs[label] \
                             and job.execution_type != 'incore':
-                        logger.info(f'Deleted job {value}{job_name}')
-                        job.delete()
+                        _safe_delete(job, f'{value}{job_name}')
             for job_name, job in value.items():
                 if label in self.running_jobs.keys() and job_name in self.running_jobs[label] \
                         and job.execution_type != 'incore':
-                    logger.info(f'Deleted job {job_name}')
-                    job.delete()
+                    _safe_delete(job, job_name)
         self.running_jobs[label] = list()
-        self.output[label]['paths'] = {key: '' if key != 'irc' else list() for key in self.output[label]['paths'].keys()}
+        # Reset paths for this species. Most keys reset to ''; container-valued
+        # keys keep their type so the rest of the pipeline (composite tracking,
+        # IRC trajectory list) doesn't crash on a string where it expects a
+        # dict / list. Phase 3 added 'sp_composite' as a dict[sub_label → path];
+        # without the carve-out below it would collapse to '' here and the next
+        # composite sub-job completion would TypeError on item assignment.
+        _path_empty = {'irc': list, 'sp_composite': dict}
+        self.output[label]['paths'] = {
+            key: _path_empty.get(key, str)()
+            for key in self.output[label]['paths'].keys()
+        }
         for job_type in self.output[label]['job_types']:
-            # rotors and bde are initialised to True (see initialize_output_dict) because
+            # rotors and bde are initialized to True (see initialize_output_dict) because
             # species with no torsional modes / no BDE targets should not be blocked from
             # convergence.  Preserve that default when resetting job state.
             if job_type in ['rotors', 'bde']:
@@ -3794,6 +4352,8 @@ class Scheduler(object):
         self._pending_pipe_freq.discard(label)
         self._pending_pipe_irc.discard((label, 'forward'))
         self._pending_pipe_irc.discard((label, 'reverse'))
+        self._sp_composite_pending.pop(label, None)
+        self._sp_composite_sections.pop(label, None)
         # Clean up any IRC species spawned from this TS.
         if label in self.species_dict and self.species_dict[label].is_ts:
             irc_labels_str = self.species_dict[label].irc_label
@@ -4064,6 +4624,7 @@ class Scheduler(object):
                     for key in path_keys:
                         if key not in self.output[species.label]['paths']:
                             self.output[species.label]['paths'][key] = ''
+                    self._ensure_sp_composite_paths_invariant(species.label)
                     if species.is_ts:
                         if 'irc' not in self.output[species.label]['paths']:
                             self.output[species.label]['paths']['irc'] = list()
@@ -4071,7 +4632,7 @@ class Scheduler(object):
                             self.output[species.label]['paths']['neb'] = ''
                     if 'job_types' not in self.output[species.label]:
                         self.output[species.label]['job_types'] = dict()
-                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'onedmin']:
+                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'sp_composite', 'onedmin']:
                         if job_type in ['rotors', 'bde']:
                             # rotors could be invalidated due to many reasons,
                             # also could be falsely identified in a species that has no torsional modes.
@@ -4085,6 +4646,42 @@ class Scheduler(object):
                                 self.output[species.label][key] = None
                             else:
                                 self.output[species.label][key] = ''
+        # Always-on invariant — runs even when the gated init above was
+        # skipped because output[] was rehydrated from a stale restart.yml.
+        # Older ARC versions could persist paths['sp_composite'] as a scalar
+        # string (the same shape as paths['sp']); the composite code mutates
+        # this in place as a dict[sub_label → path] and would otherwise crash
+        # with ``TypeError: 'str' object does not support item assignment``.
+        for species in self.species_list:
+            if label is None or species.label == label:
+                if species.label in self.output:
+                    self._ensure_sp_composite_paths_invariant(species.label)
+
+    def _ensure_sp_composite_paths_invariant(self, label: str) -> None:
+        """Coerce ``output[label]['paths']['sp_composite']`` to a dict.
+
+        Phase 3 stores sub-job results as ``{sub_label: path}`` here. A non-
+        dict value (typically a leftover scalar string from an older ARC
+        version's restart.yml) is reset to ``{}`` and a single-line warning
+        is logged so the user can audit. Empty/absent values are reset
+        silently because they are not evidence of corruption — just absence.
+        """
+        species_output = self.output.get(label)
+        if not isinstance(species_output, dict):
+            return
+        paths = species_output.setdefault('paths', {})
+        existing = paths.get('sp_composite')
+        if isinstance(existing, dict):
+            return
+        if existing not in (None, ''):
+            logger.warning(
+                f"output['{label}']['paths']['sp_composite'] was a "
+                f"{type(existing).__name__} ({existing!r}); coercing to "
+                f"dict() — likely a stale restart.yml from an older ARC "
+                f"version. The composite will re-run any sub-jobs that "
+                f"were previously recorded against this scalar."
+            )
+        paths['sp_composite'] = dict()
 
     def _does_output_dict_contain_info(self):
         """

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -3851,7 +3851,7 @@ class Scheduler(object):
             else:
                 for job_type, spawn_job_type in self.job_types.items():
                     if spawn_job_type and not self.output[label]['job_types'][job_type] \
-                            and not ((self.species_dict[label].is_ts and job_type in ['scan', 'conf_opt'])
+                            and not ((self.species_dict[label].is_ts and job_type in ['scan', 'rotors', 'conf_opt'])
                                      or (self.species_dict[label].number_of_atoms == 1
                                          and job_type in ['conf_opt', 'opt', 'fine', 'freq', 'rotors', 'bde'])
                                      or job_type == 'bde' and self.species_dict[label].bdes is None

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -17,7 +17,9 @@ import arc.parser.parser as parser
 from arc import plotter
 from arc.checks.common import get_i_from_job_name, is_conformer_job, sum_time_delta
 from arc.checks.ts import check_imaginary_frequencies, check_ts, check_irc_species_and_rxn
-from arc.common import (extremum_list,
+from arc.common import (NUMBER_BY_SYMBOL,
+                        VERSION,
+                        extremum_list,
                         get_angle_in_180_range,
                         get_logger,
                         get_number_with_ordinal_indicator,
@@ -52,7 +54,7 @@ from arc.job.trsh import (scan_quality_check,
                           )
 from arc.constants import E_h_kJmol
 from arc.level import Level, active_composite_for
-from arc.level.protocol import CompositeProtocol
+from arc.level.protocol import CompositeProtocol, DeltaTerm, excitation_rank
 from arc.level.reporting import (
     SpeciesSection,
     format_log_event,
@@ -84,6 +86,51 @@ LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ, default_job_settings, \
     settings['LOWEST_MAJOR_TS_FREQ'], settings['HIGHEST_MAJOR_TS_FREQ'], settings['default_job_settings'], \
     settings['default_job_types'], settings['ts_adapters'], settings['max_ess_trsh'], settings['max_rotor_trsh'], \
     settings['rotor_scan_resolution'], settings['servers']
+
+ZOMBIE_RECHECK_SECONDS = 900
+
+# Frozen-core orbital count per atom by the standard chemical-core convention:
+# each atom freezes the doubly-occupied orbitals of the previous noble gas
+# (none for H/He, the He core for Li–Ne, the Ne core for Na–Ar, ...).
+# Entries are (max_atomic_number, n_core_orbitals), ascending.
+_FROZEN_CORE_ORBITALS_BY_MAX_Z = ((2, 0), (10, 1), (18, 5), (36, 9), (54, 18), (86, 27), (118, 43))
+
+
+def count_frozen_core_orbitals(symbols: tuple) -> int:
+    """
+    Count a species' frozen-core orbitals under the standard chemical-core convention.
+
+    Args:
+        symbols (tuple): Element symbols, e.g. ``('C', 'H', 'H', 'H', 'H')``.
+
+    Returns:
+        int: The total number of frozen-core orbitals across all atoms.
+    """
+    n_core = 0
+    for symbol in symbols:
+        z = NUMBER_BY_SYMBOL[symbol]
+        for max_z, core_orbitals in _FROZEN_CORE_ORBITALS_BY_MAX_Z:
+            if z <= max_z:
+                n_core += core_orbitals
+                break
+    return n_core
+
+
+def count_correlated_electrons(symbols: tuple, charge: int = 0) -> int:
+    """
+    Count a species' correlated electrons under the frozen-core convention.
+
+    ``n_corr = n_electrons − 2 × n_frozen_core_orbitals``.
+
+    Args:
+        symbols (tuple): Element symbols.
+        charge (int): The net molecular charge.
+
+    Returns:
+        int: The number of correlated electrons.
+    """
+    n_electrons = sum(NUMBER_BY_SYMBOL[symbol] for symbol in symbols) - charge
+    return n_electrons - 2 * count_frozen_core_orbitals(symbols)
 
 
 class Scheduler(object):
@@ -123,6 +170,7 @@ class Scheduler(object):
                                       'freq': <path to freq output file>,
                                       'sp': <path to sp output file>,
                                       'composite': <path to composite output file>,
+                                      'sp_composite': {sub_label: <path to sub-job output file>},
                                       'irc': [list of two IRC paths],
                                      },
                             'conformers': <comments>,
@@ -138,6 +186,10 @@ class Scheduler(object):
 
     Note:
         The rotor scan dicts are located under Species.rotors_dict
+
+    Note:
+        For species with an active sp_composite protocol, 'paths'->'sp' holds the protocol's
+        base ESS log and does NOT imply the sp phase is complete; see _sync_composite_sp_path.
 
     Args:
         project (str): The project's name. Used for naming the working directory.
@@ -196,6 +248,8 @@ class Scheduler(object):
         running_jobs (dict): A dictionary of currently running jobs (a subset of `job_dict`).
                              Keys are species/TS label, values are lists of job names (e.g. 'conformer3', 'opt_a123').
         server_job_ids (list): A list of relevant job IDs currently running on the server.
+        server_job_states (dict): Normalized queue states ('running'/'pending'/'held'/'exiting'/'unknown')
+                                  keyed by server job ID (str). Populated alongside ``server_job_ids``.
         output (dict): Output dictionary with status per job type and final QM file paths for all species.
         output_multi_spc (dict): Output dictionary with status per job type of multi-species clusters.
         ess_settings (dict): A dictionary of available ESS and a corresponding server list.
@@ -290,6 +344,7 @@ class Scheduler(object):
         self.max_job_time = max_job_time or default_job_settings.get('job_time_limit_hrs', 120)
         self.job_dict = dict()
         self.server_job_ids = list()
+        self.server_job_states = dict()
         self.completed_incore_jobs = list()
         self.running_jobs = dict()
         self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
@@ -331,7 +386,7 @@ class Scheduler(object):
         self._last_status_payload: dict | None = None
         self.servers = list()
         self.composite_method = composite_method
-        # Phase 3 composite-orchestration state.
+        # Composite-orchestration state.
         # self.sp_composite holds the project-wide CompositeProtocol (or None). Per-species
         # protocols live on each ARCSpecies via sp_composite_state/sp_composite and are
         # resolved through arc.level.active_composite_for().
@@ -339,20 +394,32 @@ class Scheduler(object):
         # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
         # rebuilt on restart from output[label]['paths']['sp_composite'].
         self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
-        # Per-(species, job_type) cap on zombie-job kills (one resubmit per
-        # job_type per species). Persisted in the restart YAML.
+        # Per-species δ terms skipped as trivially zero, keyed by label →
+        # {term_label: reason}. Transient; deterministically re-derived from
+        # species + protocol on every seed (restart-safe by construction).
+        self._sp_composite_skipped: dict[str, dict[str, str]] = dict()
+        # Per-(species, job_name) cap on zombie-job kills (one resubmit credit
+        # per job). Persisted in the restart YAML. Old-format restart entries
+        # (job_type strings such as 'sp') are loaded as-is but are inert:
+        # membership is checked by job_name only, so they cap nothing.
         self._zombie_kills: dict[str, set[str]] = dict()
         if self.restart_dict is not None and '_zombie_kills' in self.restart_dict:
             self._zombie_kills = {
-                label: set(types) for label, types in self.restart_dict['_zombie_kills'].items()
+                label: set(names) for label, names in self.restart_dict['_zombie_kills'].items()
             }
+        # Job names whose one-shot zombie warnings ('manual intervention' for
+        # capped jobs, 'held' for held jobs) already fired. Not persisted.
+        self._zombie_warned: set[str] = set()
+        # Per-job zombie-check throttle: job_name → last-check monotonic
+        # timestamp. Not persisted across restarts.
+        self._zombie_last_check: dict[str, float] = dict()
+        # First time each job was observed in a RUNNING queue state, keyed by
+        # job_name; the zombie grace clock starts here. In-memory only: a
+        # restart re-observes and conservatively restarts the clock.
+        self._zombie_running_since: dict[str, datetime.datetime] = dict()
         # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
         # notebook writer consumes the full values list on every regeneration.
         self._sp_composite_sections: dict[str, SpeciesSection] = dict()
-        # Rehydrate composite state from the persistent output dict so restart
-        # re-queues only the missing sub-jobs. Safe to call even when no species
-        # has an active composite — it's a no-op in that case.
-        self._rehydrate_composite_state()
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
         self.ts_guess_level = ts_guess_level
@@ -364,6 +431,12 @@ class Scheduler(object):
         self.orbitals_level = orbitals_level
         self.unique_species_labels = list()
         self.save_restart = False
+        # Rehydrate composite state from the persistent output dict so restart
+        # re-queues only the missing sub-jobs. Safe to call even when no species
+        # has an active composite — it's a no-op in that case. Must run after
+        # every attribute that run_job and save_restart_dict read (notably
+        # self.save_restart) is assigned, since the kick-start path submits jobs.
+        self._rehydrate_composite_state()
 
         if len(self.rxn_list):
             if self.adaptive_levels is not None:
@@ -471,8 +544,11 @@ class Scheduler(object):
                 if self.output[species.label]['convergence']:
                     continue
                 if species.is_monoatomic():
+                    # paths['sp'] also blocks the respawn: for an sp_composite species it holds the
+                    # completed base log, and the pending sub-jobs respawn via _kickstart_composite_queues.
                     if not self.output[species.label]['job_types']['sp'] \
                             and not self.output[species.label]['job_types']['composite'] \
+                            and not self.output[species.label]['paths']['sp'] \
                             and 'sp' not in list(self.job_dict[species.label].keys()) \
                             and 'composite' not in list(self.job_dict[species.label].keys()):
                         # No need to run opt/freq jobs for a monoatomic species, only run sp (or composite if relevant)
@@ -1042,15 +1118,15 @@ class Scheduler(object):
         # a list-valued ``label`` arg only reaches this point when
         # ``run_multi_species`` was True (set iff every species in the list has
         # ``multi_species`` populated), in which case we just reassigned
-        # ``label`` to the (single) ``species[0].multi_species`` string. Stating
-        # the invariant explicitly satisfies static analyzers (``self.job_dict[label]``
-        # downstream would TypeError on an unhashable list) and catches a real
-        # bug if the multi-species dispatch ever leaks a list through.
-        assert isinstance(label, str), (
-            f"run_job: expected ``label`` to be str by this point, got "
-            f"{type(label).__name__} ({label!r}). This indicates the "
-            f"multi-species dispatch above didn't collapse a list label."
-        )
+        # ``label`` to the (single) ``species[0].multi_species`` string.
+        # Raising explicitly (rather than asserting, which is stripped under
+        # ``python -O``) catches a real bug if the multi-species dispatch ever
+        # leaks a list through (``self.job_dict[label]`` downstream would
+        # TypeError on an unhashable list).
+        if not isinstance(label, str):
+            raise TypeError(f"run_job: expected ``label`` to be str by this point, got "
+                            f"{type(label).__name__} ({label!r}). This indicates the "
+                            f"multi-species dispatch above didn't collapse a list label.")
         if label not in self.job_dict.keys():
             self.job_dict[label] = dict()
         if conformer is None and tsg is None:
@@ -1124,7 +1200,10 @@ class Scheduler(object):
 
         ``job_dict`` is keyed ``[label][job_type][job_name → JobAdapter]`` for most
         job_types, but ``conf_opt`` / ``conf_sp`` / ``tsg`` use integer keys whose
-        values carry the actual ``job_name`` on the ``JobAdapter`` object.
+        values carry the actual ``job_name`` on the ``JobAdapter`` object. The
+        synthetic ``running_jobs`` names of those jobs ('conf_opt_<n>',
+        'conf_sp_<n>', 'tsg<n>') are resolved via their trailing index after the
+        real-job_name match fails.
 
         Args:
             label (str): The species label.
@@ -1144,14 +1223,32 @@ class Scheduler(object):
             for j in jobs.values():
                 if getattr(j, 'job_name', None) == job_name:
                     return j
+        try:
+            i = get_i_from_job_name(job_name)
+        except ValueError:
+            i = None
+        if i is not None:
+            for job_type in ('conf_opt', 'conf_sp', 'tsg'):
+                if job_name.startswith(job_type):
+                    jobs = self.job_dict[label].get(job_type)
+                    if isinstance(jobs, dict) and i in jobs:
+                        return jobs[i]
         return None
 
     def check_for_zombie_jobs(self, label: str) -> None:
-        """Detect zombie jobs for a species (queue reports running but no
+        """Detect zombie jobs for a species (queue reports RUNNING but no
         output traffic after the grace period), kill and resubmit them.
 
-        The cap of one resubmission per (species, job_type) prevents loops
+        A job is killable only while its queue state is 'running' (or absent
+        from ``self.server_job_states``, e.g. local jobs without state info);
+        'pending' is never killable regardless of age, and 'held' logs a
+        warning at most once. The grace clock starts at the first time the job
+        was observed running (``self._zombie_running_since``).
+
+        The cap of one resubmission per (species, job_name) prevents loops
         when the underlying issue is in our submission, not the cluster.
+        Capped jobs skip the (potentially remote) zombie stat entirely, and
+        each job is re-checked at most once per ``ZOMBIE_RECHECK_SECONDS``.
 
         Args:
             label (str): The species label whose running jobs should be checked.
@@ -1159,27 +1256,47 @@ class Scheduler(object):
         Returns:
             None: Side-effects only. Mutates ``self.running_jobs[label]`` (drops
             zombie ``job_name``\\ s) and ``self._zombie_kills[label]`` (records the
-            killed ``job_type``), and resubmits via ``self._run_a_job``.
+            killed ``job_name``), and resubmits via ``self._run_a_job``.
         """
         if label not in self.running_jobs or label not in self.job_dict:
             return
         for job_name in list(self.running_jobs.get(label, [])):
             job = self.resolve_job_by_name(label, job_name)
-            if job is None or not _is_zombie_job(job, self.server_job_ids):
+            if job is None:
                 continue
-            job_type = job.job_type
-            if job_type in self._zombie_kills.get(label, set()):
-                logger.warning(
-                    f'Job {job_name} for {label} ({job_type}) appears to be a '
-                    f'zombie a second time after one resubmission — leaving '
-                    f'for manual intervention.'
-                )
+            if job_name in self._zombie_kills.get(label, set()):
+                if job_name not in self._zombie_warned:
+                    self._zombie_warned.add(job_name)
+                    logger.warning(
+                        f'Job {job_name} for {label} ({job.job_type}) was already '
+                        f'resubmitted once after a zombie kill — skipping further '
+                        f'zombie checks for it, leaving for manual intervention.'
+                    )
                 continue
-            elapsed_min = int((datetime.datetime.now() - job.initial_time).total_seconds() // 60)
+            state = self.server_job_states.get(str(job.job_id),
+                                               self.server_job_states.get(job.job_id, 'running'))
+            if state == 'held':
+                held_key = f'{job_name}_held'
+                if held_key not in self._zombie_warned:
+                    self._zombie_warned.add(held_key)
+                    logger.warning(f'Job {job_name} for {label} ({job.job_type}) is held on the '
+                                   f'queue; not treating as a zombie, leaving for manual intervention.')
+                continue
+            if state != 'running':
+                continue
+            running_since = self._zombie_running_since.setdefault(job_name, datetime.datetime.now())
+            now = time.monotonic()
+            last_checked = self._zombie_last_check.get(job_name)
+            if last_checked is not None and now - last_checked < ZOMBIE_RECHECK_SECONDS:
+                continue
+            self._zombie_last_check[job_name] = now
+            if not _is_zombie_job(job, self.server_job_ids, running_since=running_since):
+                continue
+            elapsed_min = int((datetime.datetime.now() - running_since).total_seconds() // 60)
             logger.warning(
-                f'Job {job_name} for {label} ({job_type}) shows no output '
-                f'activity after {elapsed_min} min and the queue still reports '
-                f'it as running. Treating as a zombie: killing and resubmitting.'
+                f'Job {job_name} for {label} ({job.job_type}) shows no output '
+                f'activity after {elapsed_min} min of running and the queue still '
+                f'reports it as running. Treating as a zombie: killing and resubmitting.'
             )
             try:
                 job.delete()
@@ -1188,7 +1305,8 @@ class Scheduler(object):
                     f'Failed to delete zombie job {job_name} for {label}: '
                     f'{type(exc).__name__}: {exc}. Continuing with resubmission.'
                 )
-            self._zombie_kills.setdefault(label, set()).add(job_type)
+            self._zombie_kills.setdefault(label, set()).add(job_name)
+            self._zombie_running_since.pop(job_name, None)
             if job_name in self.running_jobs[label]:
                 self.running_jobs[label].remove(job_name)
             self._run_a_job(job=job, label=label)
@@ -1529,7 +1647,7 @@ class Scheduler(object):
                          level_of_theory=self.freq_level, job_type='freq')
 
     # ------------------------------------------------------------------------ #
-    #  sp_composite orchestration (Phase 3)                                    #
+    #  sp_composite orchestration                                              #
     # ------------------------------------------------------------------------ #
     #
     # Design:
@@ -1550,6 +1668,8 @@ class Scheduler(object):
     #   calls ``protocol.evaluate`` (unit-agnostic sum), writes ``species.e_elect``,
     #   sets ``species.e_elect_source='sp_composite'``, flips the output flag, and
     #   regenerates the project notebook with the *cumulative* section list.
+    # * ``output[label]['paths']['sp']`` mirrors the recorded base leg's log via
+    #   ``_sync_composite_sp_path`` (see its docstring for the invariant).
 
     def _composite_for(self, label: str) -> CompositeProtocol | None:
         """Return the composite protocol to apply to this species, or ``None``.
@@ -1565,6 +1685,67 @@ class Scheduler(object):
             species_protocol=getattr(species, "sp_composite", None),
             global_protocol=self.sp_composite,
         )
+
+    def _species_n_correlated(self, label: str) -> int | None:
+        """
+        Determine a species' correlated electron count (frozen-core convention).
+
+        Element symbols are taken from the species' geometry when available,
+        falling back to its 2D graph. Returns ``None`` when neither is
+        available (or an element is unrecognized) — callers must then treat
+        every delta term as potentially non-zero.
+
+        Args:
+            label (str): The species label.
+
+        Returns:
+            int | None: The correlated electron count, or ``None`` if unknown.
+        """
+        species = self.species_dict.get(label)
+        if species is None:
+            return None
+        xyz = species.get_xyz(generate=False)
+        symbols = tuple(xyz['symbols']) if xyz is not None and xyz.get('symbols') else None
+        if symbols is None and species.mol is not None:
+            symbols = tuple(atom.element.symbol for atom in species.mol.atoms)
+        if not symbols:
+            return None
+        try:
+            return count_correlated_electrons(symbols=symbols, charge=species.charge or 0)
+        except KeyError:
+            return None
+
+    def _composite_skipped_terms(self,
+                                 label: str,
+                                 protocol: CompositeProtocol,
+                                 ) -> dict[str, str]:
+        """
+        Decide, per delta term, whether its correction is trivially zero for this species.
+
+        A δ[high − low] correction is identically zero when the species'
+        correlated electron count is too small for the legs' coupled-cluster
+        excitation ranks to differ from full CI (see
+        :meth:`DeltaTerm.is_trivially_zero`) — e.g. atomic H or He through a
+        HEAT-style δ_T / δ_Q. Such terms are never queued; finalize counts
+        their contribution as exactly 0.0. The decision is deterministic from
+        species + protocol, so re-deriving it on restart is safe.
+
+        Args:
+            label (str): The species label.
+            protocol (CompositeProtocol): The species' active composite protocol.
+
+        Returns:
+            dict[str, str]: Mapping ``term_label`` → human-readable skip reason.
+        """
+        n_corr = self._species_n_correlated(label)
+        if n_corr is None:
+            return dict()
+        skipped: dict[str, str] = dict()
+        for term in protocol.corrections:
+            if isinstance(term, DeltaTerm) and term.is_trivially_zero(n_corr):
+                rank = excitation_rank(term.high.method)
+                skipped[term.label] = f'δ≡0 (n_corr={n_corr} < rank={rank}) — skipped'
+        return skipped
 
     def _validate_composite_completed(self, label: str) -> list[str]:
         """Drop sub_label entries whose recorded output file is missing or
@@ -1611,17 +1792,29 @@ class Scheduler(object):
 
         Runs :meth:`_validate_composite_completed` first so any corrupted
         previously-recorded output is pushed back into pending automatically.
+        Delta terms decided trivially zero for this species (δ≡0 by the
+        correlated-electron-count vs. excitation-rank test) are recorded in
+        ``_sp_composite_skipped[label]`` and neither of their legs is queued.
         """
         protocol = self._composite_for(label)
         if protocol is None:
             return
         self._validate_composite_completed(label)
+        skipped = self._composite_skipped_terms(label, protocol)
+        self._sp_composite_skipped[label] = skipped
+        for term_label, reason in skipped.items():
+            logger.info(format_log_event(
+                label, "term skipped", {"term": term_label, "reason": reason},
+            ))
         completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
         pending: dict[str, Level] = {}
-        for _term_label, sub_label, level in protocol.iter_required_jobs():
+        for term_label, sub_label, level in protocol.iter_required_jobs():
+            if term_label in skipped:
+                continue
             if sub_label not in completed:
                 pending[sub_label] = level
         self._sp_composite_pending[label] = pending
+        self._sync_composite_sp_path(label, protocol)
         logger.info(format_log_event(
             label,
             "protocol resolved",
@@ -1629,6 +1822,7 @@ class Scheduler(object):
                 "total_sub_jobs": sum(1 for _ in protocol.iter_required_jobs()),
                 "pending": len(pending),
                 "already_completed": len(completed),
+                "skipped_terms": sorted(skipped.keys()),
             },
         ))
 
@@ -1655,7 +1849,38 @@ class Scheduler(object):
                 "sub-job completed",
                 {"sub_label": sl, "level": level.simple(), "path": sp_path},
             ))
+        protocol = self._composite_for(label)
+        if protocol is not None:
+            self._sync_composite_sp_path(label, protocol)
         return matched
+
+    def _sync_composite_sp_path(self,
+                                label: str,
+                                protocol: CompositeProtocol,
+                                ) -> None:
+        """
+        Keep ``output[label]['paths']['sp']`` consistent with the recorded composite base leg.
+
+        Invariant: for a species with an active sp_composite protocol, ``paths['sp']`` is the
+        geometry-consistent base ESS log — the ``protocol.primary_base_sub_label`` leg (the
+        largest-cardinal leg for a CBS base) — or ``''`` if that leg has not been recorded
+        (or was invalidated). It exists for path-existence and freq-fallback consumers only
+        (Arkane species files, restart respawn guards); the AUTHORITATIVE energy is the
+        composite result stored in ``species.e_elect`` with ``e_elect_source='sp_composite'``.
+        ``paths['sp']`` being set does NOT mean the composite sp phase is complete — completion
+        is judged solely by all protocol sub-jobs being recorded and validated in
+        ``paths['sp_composite']`` (see ``_sp_composite_pending`` /
+        ``_validate_composite_completed``).
+
+        Args:
+            label (str): The species label.
+            protocol (CompositeProtocol): The species' active composite protocol.
+
+        Returns:
+            None
+        """
+        completed = self.output[label]['paths']['sp_composite']
+        self.output[label]['paths']['sp'] = completed.get(protocol.primary_base_sub_label, '')
 
     def _spawn_composite_pending(self, label: str) -> None:
         """Spawn one sp job per *unique* pending ``Level``.
@@ -1702,17 +1927,24 @@ class Scheduler(object):
 
     def _finalize_composite(self, label: str) -> None:
         """Parse every sub-job energy, evaluate the protocol, set species.e_elect,
-        emit logs, flip the output flag, and regenerate the project notebook."""
+        emit logs, flip the output flag, and regenerate the project notebook.
+        Delta terms recorded as skipped (δ≡0) contribute exactly 0.0."""
         protocol = self._composite_for(label)
         if protocol is None:
             return
+        skipped = self._sp_composite_skipped.get(label)
+        if skipped is None:
+            skipped = self._composite_skipped_terms(label, protocol)
+            self._sp_composite_skipped[label] = skipped
         completed = self.output[label]['paths']['sp_composite']
         energies_kJmol: dict[str, float] = {}
         # Each missing entry carries enough context (sub_label + reason +
         # optional path/exception) so the warning payload tells the operator
         # exactly which sub-job to re-run, without crashing the scheduler.
         missing: list[dict[str, str]] = []
-        for _term_label, sub_label, _level in protocol.iter_required_jobs():
+        for term_label, sub_label, _level in protocol.iter_required_jobs():
+            if term_label in skipped:
+                continue
             path = completed.get(sub_label)
             if not path:
                 missing.append({"sub_label": sub_label, "reason": "missing path"})
@@ -1735,7 +1967,8 @@ class Scheduler(object):
             logger.warning(format_log_event(label, "finalize aborted — missing or unparseable sub-jobs",
                 {"missing": missing}))
             return
-        e_total_kJmol = protocol.evaluate(energies_kJmol)
+        e_total_kJmol = sum(0.0 if term.label in skipped else term.evaluate(energies_kJmol)
+                            for term in protocol.terms)
         self.species_dict[label].e_elect = e_total_kJmol
         self.species_dict[label].e_elect_source = "sp_composite"
         self.output[label]['job_types']['sp_composite'] = True
@@ -1745,6 +1978,16 @@ class Scheduler(object):
         # in protocol order. Exposes the individual contribution that landed in
         # the final total — enough to reconstruct the math from the log alone.
         for term in protocol.terms:
+            if term.label in skipped:
+                logger.info(format_log_event(label, "term evaluated", {
+                    "term": term.label,
+                    "type": type(term).__name__,
+                    "sub_labels": [],
+                    "kJ_per_mol": "0.000",
+                    "Hartree": "0.000000000",
+                    "skipped": skipped[term.label],
+                }))
+                continue
             contribution = term.evaluate(energies_kJmol)
             term_sub_labels = [sl for sl, _lvl in term.required_levels()]
             payload = {"term": term.label,
@@ -1779,11 +2022,17 @@ class Scheduler(object):
         that the notebook can round-trip through
         :meth:`CompositeProtocol.from_user_input`. ``preset_name`` and
         ``reference`` come from the protocol itself when available; otherwise
-        they fall back to explicit-recipe defaults.
+        they fall back to explicit-recipe defaults. δ terms skipped as
+        trivially zero are forwarded so the notebook and the YAML report
+        render them with contribution 0.0 and the reason.
         """
         species = self.species_dict[label]
         preset_name = getattr(protocol, "preset_name", None)
         reference = getattr(protocol, "reference", None)
+        skipped = self._sp_composite_skipped.get(label)
+        if skipped is None:
+            skipped = self._composite_skipped_terms(label, protocol)
+            self._sp_composite_skipped[label] = skipped
         flags: list[str] = []
         if not reference:
             reference = ("Explicit sp_composite recipe — no formal reference supplied by "
@@ -1800,6 +2049,7 @@ class Scheduler(object):
             protocol=protocol,
             sub_job_paths=dict(self.output[label]['paths']['sp_composite']),
             flags=flags,
+            skipped_terms=dict(skipped),
         )
 
     def _regenerate_composite_notebook(self) -> None:
@@ -1813,7 +2063,7 @@ class Scheduler(object):
         write_composite_notebook(
             path=nb_path,
             project_name=self.project,
-            arc_version="",  # Phase 4 may surface this; not critical for provenance.
+            arc_version=VERSION,
             timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
             sections=list(self._sp_composite_sections.values()),
             notebook_dir=output_dir,
@@ -1851,8 +2101,8 @@ class Scheduler(object):
             section=section,
             e_elect_kj_per_mol=e_elect,
             timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
-            arc_version="",  # surfaced via Phase 4 if needed
-            arc_commit="",   # surfaced via Phase 4 if needed
+            arc_version=VERSION,
+            arc_commit="",
         )
         logger.info(format_log_event(label, "species report written", {"path": report_path}))
 
@@ -1884,75 +2134,6 @@ class Scheduler(object):
         else:
             self._finalize_composite(label)
 
-    def _mrcc_degenerate_short_circuit(self, label: str, job) -> bool:
-        """If a composite δ-term high-leg sub-job errored with the
-        ``MRCCDegenerateSystem`` keyword, substitute the sister low-leg's
-        recorded path and advance the composite. Returns ``True`` when the
-        short-circuit was applied so the caller can skip ``troubleshoot_ess``.
-
-        Why this exists: for systems too small to accommodate the requested
-        CC excitation rank (atomic H, H2 at CCSDT(Q), etc.) MRCC's xmrcc
-        bails — there's no determinant space to iterate. The two legs of
-        the δ term are mathematically degenerate (all CC ranks reduce to
-        HF), so δ = 0 is the correct physical answer. The trsh ladder
-        cannot fix this; it must be handled at the protocol level.
-
-        Conservative on safety:
-        * Only fires when keywords contain ``'MRCCDegenerateSystem'``.
-        * Only fires when the species has an active composite.
-        * Only fires for ``__high`` sub-labels with a recorded ``__low``
-          sister in ``output[label]['paths']['sp_composite']``. Low-leg
-          failures and high-leg failures without a completed sister fall
-          through so the caller's normal trsh path runs.
-        """
-        keywords = (job.job_status[1] or {}).get('keywords') or []
-        if 'MRCCDegenerateSystem' not in keywords:
-            return False
-        protocol = self._composite_for(label)
-        if protocol is None:
-            return False
-        # Identify which pending sub_label this errored job corresponds to.
-        pending = self._sp_composite_pending.get(label, {})
-        failed_sub_label = next(
-            (sl for sl, lvl in pending.items() if lvl == job.level),
-            None,
-        )
-        if failed_sub_label is None or not failed_sub_label.endswith('__high'):
-            logger.warning(format_log_event(
-                label,
-                "MRCCDegenerateSystem on a non-high sub-job — falling through to trsh",
-                {"sub_label": failed_sub_label, "level": str(job.level)},
-            ))
-            return False
-        sister_low = failed_sub_label[: -len('__high')] + '__low'
-        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
-        sister_path = completed.get(sister_low)
-        if not sister_path:
-            logger.warning(format_log_event(
-                label,
-                "MRCCDegenerateSystem high-leg failed but low-leg not yet recorded — deferring",
-                {"failed": failed_sub_label, "sister": sister_low},
-            ))
-            return False
-        logger.warning(format_log_event(
-            label,
-            "MRCC degenerate-system fallback: substituting low-leg energy for high-leg",
-            {"failed": failed_sub_label, "sister": sister_low,
-             "reason": "Method exceeds determinant space; δ = 0 by symmetry."},
-        ))
-        # Substitute by re-using the low-leg's path. _record_composite_completion
-        # writes the path into output and clears the pending entry — same as a
-        # normal completion, but pointing both legs at the same file so they
-        # parse to the same energy and the δ evaluates to zero.
-        completed_paths = self.output[label]['paths']['sp_composite']
-        completed_paths[failed_sub_label] = sister_path
-        del pending[failed_sub_label]
-        if pending:
-            self._spawn_composite_pending(label)
-        else:
-            self._finalize_composite(label)
-        return True
-
     def _rehydrate_composite_state(self) -> None:
         """On scheduler init/restart, seed pending for every species with an active
         composite, rebuild the SpeciesSection for species that already finalized,
@@ -1964,6 +2145,20 @@ class Scheduler(object):
                 continue
             self._seed_composite_pending(label)
             if self.output.get(label, {}).get('job_types', {}).get('sp_composite'):
+                # _seed_composite_pending may have stripped missing/unparseable
+                # paths via _validate_composite_completed; re-writing the report
+                # from a stripped dict would KeyError. Skip until the requeued
+                # sub-jobs complete and re-finalize the species.
+                completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+                skipped = self._sp_composite_skipped.get(label, {})
+                missing = [sub_label for term_label, sub_label, _level in protocol.iter_required_jobs()
+                           if term_label not in skipped and sub_label not in completed]
+                if missing:
+                    logger.warning(format_log_event(
+                        label, "finalized species is missing sub-job paths — skipping report re-write",
+                        {"missing": missing},
+                    ))
+                    continue
                 self._sp_composite_sections[label] = self._build_species_section(label, protocol)
                 # Re-emit the per-species report so a restart fills in reports
                 # missing on disk (and refreshes any whose protocol metadata
@@ -2016,11 +2211,13 @@ class Scheduler(object):
             level (Level): An alternative level of theory to run at. If ``None``, self.sp_level will be used.
             conformer (int): The conformer number.
         """
-        # Phase 3: for species with an active sp_composite, the SP runs at the
-        # protocol's base.level (unless the caller passed an explicit ``level``).
+        # For species with an active sp_composite, the SP runs at the protocol's
+        # primary base level — the single base level, or the largest-cardinal
+        # CBS leg (unless the caller passed an explicit ``level``). The remaining
+        # base legs and corrections are spawned by _post_sp_actions_composite.
         if level is None:
             _active_protocol = self._composite_for(label)
-            level = _active_protocol.base.level if _active_protocol is not None else self.sp_level
+            level = _active_protocol.primary_base_level if _active_protocol is not None else self.sp_level
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
                          xyz=self.species_dict[label].conformers[conformer],
@@ -3447,13 +3644,6 @@ class Scheduler(object):
             if self.species_dict[label].number_of_atoms == 1:
                 # save the geometry from the sp job for monoatomic species for which no opt/freq jobs will be spawned
                 self.output[label]['paths']['geo'] = job.local_path_to_output_file
-        elif self._mrcc_degenerate_short_circuit(label=label, job=job):
-            # MRCC bailed for a degenerate small-system δ-term high leg
-            # (atomic H, H2, etc., where the requested CC excitation rank
-            # exceeds the determinant space). The trsh ladder cannot help —
-            # cause is intrinsic. Helper substituted the low-leg energy and
-            # advanced the composite; nothing further to do here.
-            self.save_restart_dict()
         else:
             self.troubleshoot_ess(label=label,
                                   job=job,
@@ -3473,7 +3663,7 @@ class Scheduler(object):
             sp_path (str): The path to 'output.out' for the single point job.
             level (Level, optional): The level of theory used for the sp job.
         """
-        # Phase 3: when sp_composite is active for this species, route through
+        # When sp_composite is active for this species, route through
         # the composite branch. The legacy path below does not run for composite
         # species — e_elect is set by ``_finalize_composite`` after all sub-jobs
         # complete, not from any single intermediate SP.
@@ -3905,15 +4095,21 @@ class Scheduler(object):
         """
         Check job status on a specific server or on all active servers, get a list of relevant running job IDs.
 
+        Also retains a job_id → normalized queue state map in ``self.server_job_states``
+        (local jobs carry no state info and are absent from the map).
+
         Args:
             specific_server (str, optional): The server to check. If ``None``, check all active servers.
         """
         self.server_job_ids = list()
+        self.server_job_states = dict()
         for server in self.servers:
             if specific_server is None or server == specific_server:
                 if server != 'local':
                     with SSHClient(server) as ssh:
-                        self.server_job_ids.extend(ssh.check_running_jobs_ids())
+                        job_states = ssh.check_running_jobs_ids_and_states()
+                    self.server_job_ids.extend(job_states.keys())
+                    self.server_job_states.update({str(job_id): state for job_id, state in job_states.items()})
                 else:
                     self.server_job_ids.extend(check_running_jobs_ids())
 
@@ -4390,9 +4586,9 @@ class Scheduler(object):
             propagates a RuntimeError up through delete_all_species_jobs →
             troubleshoot_negative_freq → schedule_jobs → __init__ and the
             entire project dies."""
-            logger.info(f'Deleted job {display_name}')
             try:
                 job.delete()
+                logger.info(f'Deleted job {display_name}')
             except Exception as exc:
                 logger.warning(
                     f'Failed to delete job {display_name} for species '
@@ -4414,7 +4610,7 @@ class Scheduler(object):
         # Reset paths for this species. Most keys reset to ''; container-valued
         # keys keep their type so the rest of the pipeline (composite tracking,
         # IRC trajectory list) doesn't crash on a string where it expects a
-        # dict / list. Phase 3 added 'sp_composite' as a dict[sub_label → path];
+        # dict / list. 'sp_composite' is a dict[sub_label → path];
         # without the carve-out below it would collapse to '' here and the next
         # composite sub-job completion would TypeError on item assignment.
         _path_empty = {'irc': list, 'sp_composite': dict}
@@ -4436,6 +4632,7 @@ class Scheduler(object):
         self._pending_pipe_irc.discard((label, 'forward'))
         self._pending_pipe_irc.discard((label, 'reverse'))
         self._sp_composite_pending.pop(label, None)
+        self._sp_composite_skipped.pop(label, None)
         self._sp_composite_sections.pop(label, None)
         # Clean up any IRC species spawned from this TS.
         if label in self.species_dict and self.species_dict[label].is_ts:
@@ -4746,7 +4943,8 @@ class Scheduler(object):
     def _ensure_sp_composite_paths_invariant(self, label: str) -> None:
         """Coerce ``output[label]['paths']['sp_composite']`` to a dict.
 
-        Phase 3 stores sub-job results as ``{sub_label: path}`` here. A non-
+        The composite orchestration stores sub-job results as
+        ``{sub_label: path}`` here. A non-
         dict value (typically a leftover scalar string from an older ARC
         version's restart.yml) is reset to ``{}`` and a single-line warning
         is logged so the user can audit. Empty/absent values are reset
@@ -4901,6 +5099,11 @@ def species_has_sp(species_output_dict: dict,
     """
     Checks whether a species has a valid converged single-point energy using it's output dict.
 
+    For a species computed with an sp_composite protocol (non-empty ``paths['sp_composite']``),
+    the sp phase is complete only once all protocol sub-jobs were recorded and the protocol was
+    evaluated — flagged by ``job_types['sp_composite']``. ``paths['sp']`` (the geometry-consistent
+    base log) is deliberately ignored here, see Scheduler._sync_composite_sp_path.
+
     Args:
         species_output_dict (dict): The species output dict (i.e., Scheduler.output[label]).
         yml_path (str): THe species Arkane YAML file path.
@@ -4910,6 +5113,8 @@ def species_has_sp(species_output_dict: dict,
     """
     if yml_path is not None:
         return True
+    if species_output_dict['paths'].get('sp_composite'):
+        return bool(species_output_dict.get('job_types', {}).get('sp_composite'))
     if species_output_dict['paths']['sp'] or species_output_dict['paths']['composite']:
         return True
     return False

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -45,6 +45,7 @@ from arc.job.local import check_running_jobs_ids
 from arc.job.pipe.pipe_coordinator import PipeCoordinator
 from arc.job.pipe.pipe_planner import PipePlanner
 from arc.job.ssh import SSHClient
+from arc.job.zombie import is_zombie as _is_zombie_job
 from arc.job.trsh import (scan_quality_check,
                           trsh_conformer_isomorphism,
                           trsh_ess_job,
@@ -367,6 +368,13 @@ class Scheduler(object):
         # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
         # rebuilt on restart from output[label]['paths']['sp_composite'].
         self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
+        # Per-(species, job_type) cap on zombie-job kills (one resubmit per
+        # job_type per species). Persisted in the restart YAML.
+        self._zombie_kills: dict[str, set[str]] = dict()
+        if self.restart_dict is not None and '_zombie_kills' in self.restart_dict:
+            self._zombie_kills = {
+                label: set(types) for label, types in self.restart_dict['_zombie_kills'].items()
+            }
         # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
         # notebook writer consumes the full values list on every regeneration.
         self._sp_composite_sections: dict[str, SpeciesSection] = dict()
@@ -698,6 +706,7 @@ class Scheduler(object):
                 self.get_completed_incore_jobs()  # updates ``self.completed_incore_jobs``
                 if label not in self.running_jobs.keys():
                     continue
+                self.check_for_zombie_jobs(label)
                 job_list = self.running_jobs[label]
                 for job_name in job_list:
                     if 'conf' in job_name:
@@ -1184,6 +1193,80 @@ class Scheduler(object):
                 level.software = 'terachem'
             job_adapter = level.software
         return job_adapter.lower()
+
+    def resolve_job_by_name(self, label: str, job_name: str) -> JobAdapter | None:
+        """Find a ``JobAdapter`` in ``self.job_dict[label]`` by its ``job_name``.
+
+        ``job_dict`` is keyed ``[label][job_type][job_name → JobAdapter]`` for most
+        job_types, but ``conf_opt`` / ``conf_sp`` / ``tsg`` use integer keys whose
+        values carry the actual ``job_name`` on the ``JobAdapter`` object.
+
+        Args:
+            label (str): The species label.
+            job_name (str): The ``job_name`` to find.
+
+        Returns:
+            JobAdapter | None: The matching job, or ``None`` if no job with this
+            ``job_name`` exists for the species.
+        """
+        if label not in self.job_dict:
+            return None
+        for jobs in self.job_dict[label].values():
+            if not isinstance(jobs, dict):
+                continue
+            if job_name in jobs:
+                return jobs[job_name]
+            for j in jobs.values():
+                if getattr(j, 'job_name', None) == job_name:
+                    return j
+        return None
+
+    def check_for_zombie_jobs(self, label: str) -> None:
+        """Detect zombie jobs for a species (queue reports running but no
+        output traffic after the grace period), kill and resubmit them.
+
+        The cap of one resubmission per (species, job_type) prevents loops
+        when the underlying issue is in our submission, not the cluster.
+
+        Args:
+            label (str): The species label whose running jobs should be checked.
+
+        Returns:
+            None: Side-effects only. Mutates ``self.running_jobs[label]`` (drops
+            zombie ``job_name``\\ s) and ``self._zombie_kills[label]`` (records the
+            killed ``job_type``), and resubmits via ``self._run_a_job``.
+        """
+        if label not in self.running_jobs or label not in self.job_dict:
+            return
+        for job_name in list(self.running_jobs.get(label, [])):
+            job = self.resolve_job_by_name(label, job_name)
+            if job is None or not _is_zombie_job(job, self.server_job_ids):
+                continue
+            job_type = job.job_type
+            if job_type in self._zombie_kills.get(label, set()):
+                logger.warning(
+                    f'Job {job_name} for {label} ({job_type}) appears to be a '
+                    f'zombie a second time after one resubmission — leaving '
+                    f'for manual intervention.'
+                )
+                continue
+            elapsed_min = int((datetime.datetime.now() - job.initial_time).total_seconds() // 60)
+            logger.warning(
+                f'Job {job_name} for {label} ({job_type}) shows no output '
+                f'activity after {elapsed_min} min and the queue still reports '
+                f'it as running. Treating as a zombie: killing and resubmitting.'
+            )
+            try:
+                job.delete()
+            except Exception as exc:
+                logger.warning(
+                    f'Failed to delete zombie job {job_name} for {label}: '
+                    f'{type(exc).__name__}: {exc}. Continuing with resubmission.'
+                )
+            self._zombie_kills.setdefault(label, set()).add(job_type)
+            if job_name in self.running_jobs[label]:
+                self.running_jobs[label].remove(job_name)
+            self._run_a_job(job=job, label=label)
 
     def end_job(self, job: JobAdapter,
                 label: str,
@@ -4681,6 +4764,9 @@ class Scheduler(object):
             self.restart_dict['output'] = self.output
             self.restart_dict['output_multi_spc'] = self.output_multi_spc
             self.restart_dict['species'] = [spc.as_dict() for spc in self.species_dict.values()]
+            self.restart_dict['_zombie_kills'] = {
+                label: sorted(types) for label, types in self._zombie_kills.items()
+            }
             self.restart_dict['running_jobs'] = dict()
             for spc in self.species_dict.values():
                 if spc.label in self.running_jobs:

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -51,7 +51,15 @@ from arc.job.trsh import (scan_quality_check,
                           trsh_negative_freq,
                           trsh_scan_job,
                           )
-from arc.level import Level
+from arc.constants import E_h_kJmol
+from arc.level import Level, active_composite_for
+from arc.level.protocol import CompositeProtocol
+from arc.level.reporting import (
+    SpeciesSection,
+    format_log_event,
+    write_composite_notebook,
+    write_species_report_yaml,
+)
 from arc.species.species import (ARCSpecies,
                                  are_coords_compliant_with_graph,
                                  check_label,
@@ -272,6 +280,7 @@ class Scheduler(object):
                  opt_level: Level | None = None,
                  freq_level: Level | None = None,
                  sp_level: Level | None = None,
+                 sp_composite: CompositeProtocol | None = None,
                  scan_level: Level | None = None,
                  ts_guess_level: Level | None = None,
                  irc_level: Level | None = None,
@@ -350,6 +359,21 @@ class Scheduler(object):
         self._last_status_payload: dict | None = None
         self.servers = list()
         self.composite_method = composite_method
+        # Phase 3 composite-orchestration state.
+        # self.sp_composite holds the project-wide CompositeProtocol (or None). Per-species
+        # protocols live on each ARCSpecies via sp_composite_state/sp_composite and are
+        # resolved through arc.level.active_composite_for().
+        self.sp_composite = sp_composite
+        # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
+        # rebuilt on restart from output[label]['paths']['sp_composite'].
+        self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
+        # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
+        # notebook writer consumes the full values list on every regeneration.
+        self._sp_composite_sections: dict[str, SpeciesSection] = dict()
+        # Rehydrate composite state from the persistent output dict so restart
+        # re-queues only the missing sub-jobs. Safe to call even when no species
+        # has an active composite — it's a no-op in that case.
+        self._rehydrate_composite_state()
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
         self.ts_guess_level = ts_guess_level
@@ -1079,6 +1103,20 @@ class Scheduler(object):
                           )
         label = label or reactions[0].ts_species.label
         label = species[0].multi_species if run_multi_species else label
+        # Narrow ``label`` from ``str | list[str]`` to ``str`` for the rest of
+        # this method. The two preceding lines already enforce the invariant —
+        # a list-valued ``label`` arg only reaches this point when
+        # ``run_multi_species`` was True (set iff every species in the list has
+        # ``multi_species`` populated), in which case we just reassigned
+        # ``label`` to the (single) ``species[0].multi_species`` string. Stating
+        # the invariant explicitly satisfies static analyzers (``self.job_dict[label]``
+        # downstream would TypeError on an unhashable list) and catches a real
+        # bug if the multi-species dispatch ever leaks a list through.
+        assert isinstance(label, str), (
+            f"run_job: expected ``label`` to be str by this point, got "
+            f"{type(label).__name__} ({label!r}). This indicates the "
+            f"multi-species dispatch above didn't collapse a list label."
+        )
         if label not in self.job_dict.keys():
             self.job_dict[label] = dict()
         if conformer is None and tsg is None:
@@ -1489,6 +1527,480 @@ class Scheduler(object):
             self.run_job(label=label, xyz=self.species_dict[label].get_xyz(generate=False),
                          level_of_theory=self.freq_level, job_type='freq')
 
+    # ------------------------------------------------------------------------ #
+    #  sp_composite orchestration (Phase 3)                                    #
+    # ------------------------------------------------------------------------ #
+    #
+    # Design:
+    #
+    # * ``_composite_for(label)`` resolves the *active* protocol for a species by
+    #   delegating to ``arc.level.active_composite_for`` (species state beats global).
+    # * Pending sub-jobs are tracked in ``self._sp_composite_pending[label]`` as a
+    #   ``{sub_label: Level}`` dict. Completion is tracked in
+    #   ``self.output[label]['paths']['sp_composite']`` — the persistent store, so
+    #   restart works without needing any additional serialization.
+    # * Sub-jobs are matched to their ``sub_label`` by ``Level`` equality
+    #   (``Level.__eq__``). Multiple ``sub_label``s can legitimately share one
+    #   ``Level`` (e.g. HEAT's δ_T-low and δ_Q-low both use ccsd(t)/cc-pVDZ); in
+    #   that case a single sp job is spawned and its output path is mapped to
+    #   every matching ``sub_label``. Tests cover this case.
+    # * When the last pending sub_label's path is recorded, ``_finalize_composite``
+    #   parses every output file via ``parser.parse_e_elect`` (returns kJ/mol),
+    #   calls ``protocol.evaluate`` (unit-agnostic sum), writes ``species.e_elect``,
+    #   sets ``species.e_elect_source='sp_composite'``, flips the output flag, and
+    #   regenerates the project notebook with the *cumulative* section list.
+
+    def _composite_for(self, label: str) -> CompositeProtocol | None:
+        """Return the composite protocol to apply to this species, or ``None``.
+
+        Resolves species-explicit → opt-out (None) → global inheritance via the
+        shared helper in :mod:`arc.level`.
+        """
+        species = self.species_dict.get(label)
+        if species is None:
+            return None
+        return active_composite_for(
+            species_state=getattr(species, "sp_composite_state", "inherit"),
+            species_protocol=getattr(species, "sp_composite", None),
+            global_protocol=self.sp_composite,
+        )
+
+    def _validate_composite_completed(self, label: str) -> list[str]:
+        """Drop sub_label entries whose recorded output file is missing or
+        unparseable.
+
+        Mutates ``output[label]['paths']['sp_composite']`` in place — bad
+        entries are removed so :meth:`_seed_composite_pending` treats them as
+        pending on the next walk. Returns the list of invalidated sub_labels
+        (possibly empty) for tests/logging.
+        """
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+        if not completed:
+            return []
+        invalidated: list[str] = []
+        for sub_label in list(completed.keys()):
+            path = completed[sub_label]
+            if not path or not os.path.isfile(path):
+                reason = "file missing on disk"
+            else:
+                # parse_e_elect can raise on malformed/partial outputs (e.g. an
+                # ESS adapter parser hitting an unexpected line). Treat any
+                # exception as "unparseable" rather than letting it bubble out
+                # of restart rehydration and crash the scheduler.
+                try:
+                    value = parser.parse_e_elect(path)
+                except Exception as exc:
+                    reason = f"parse_e_elect raised: {exc!r}"
+                else:
+                    if value is None:
+                        reason = "parse_e_elect returned None"
+                    else:
+                        continue
+            del completed[sub_label]
+            invalidated.append(sub_label)
+            logger.warning(format_log_event(
+                label, "sub-job output invalidated — will be requeued",
+                {"sub_label": sub_label, "path": path, "reason": reason},
+            ))
+        return invalidated
+
+    def _seed_composite_pending(self, label: str) -> None:
+        """Populate ``_sp_composite_pending[label]`` from the protocol minus what's
+        already recorded as completed in the output dict (restart-friendly).
+
+        Runs :meth:`_validate_composite_completed` first so any corrupted
+        previously-recorded output is pushed back into pending automatically.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        self._validate_composite_completed(label)
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+        pending: dict[str, Level] = {}
+        for _term_label, sub_label, level in protocol.iter_required_jobs():
+            if sub_label not in completed:
+                pending[sub_label] = level
+        self._sp_composite_pending[label] = pending
+        logger.info(format_log_event(
+            label,
+            "protocol resolved",
+            {
+                "total_sub_jobs": sum(1 for _ in protocol.iter_required_jobs()),
+                "pending": len(pending),
+                "already_completed": len(completed),
+            },
+        ))
+
+    def _record_composite_completion(self,
+                                     label: str,
+                                     level: Level,
+                                     sp_path: str,
+                                     ) -> list[str]:
+        """
+        Map a completed sp job's ``(level, path)`` to its ``sub_label``(s).
+
+        Returns the list of sub_labels that were resolved by this completion.
+        Multiple sub_labels may share one Level — all of them are moved from
+        pending to completed and point at the same output file.
+        """
+        pending = self._sp_composite_pending.setdefault(label, {})
+        completed_paths = self.output[label]['paths']['sp_composite']
+        matched = [sl for sl, lvl in pending.items() if lvl == level]
+        for sl in matched:
+            completed_paths[sl] = sp_path
+            del pending[sl]
+            logger.info(format_log_event(
+                label,
+                "sub-job completed",
+                {"sub_label": sl, "level": level.simple(), "path": sp_path},
+            ))
+        return matched
+
+    def _spawn_composite_pending(self, label: str) -> None:
+        """Spawn one sp job per *unique* pending ``Level``.
+
+        Pending sub_labels that share a Level with an existing pending sub_label
+        are de-duplicated here: only one sp job runs, and its eventual output
+        path maps to every matching sub_label at completion time.
+
+        Species whose geometry cannot be retrieved (``get_xyz(generate=False)``
+        returns ``None``, e.g. on a corrupted mid-opt restart) are skipped with
+        a warning rather than submitting sp jobs with no geometry.
+        """
+        pending = self._sp_composite_pending.get(label, {})
+        if not pending:
+            return
+        xyz = self.species_dict[label].get_xyz(generate=False)
+        if xyz is None:
+            logger.warning(format_log_event(
+                label, "no geometry available — skipping sub-job spawn",
+                {"pending_sub_labels": sorted(pending.keys())},
+            ))
+            return
+        unique_levels: list[tuple[Level, list[str]]] = []
+        for sub_label, lvl in pending.items():
+            for existing_lvl, sub_labels in unique_levels:
+                if existing_lvl == lvl:
+                    sub_labels.append(sub_label)
+                    break
+            else:
+                unique_levels.append((lvl, [sub_label]))
+        for lvl, sub_labels in unique_levels:
+            # If an sp job at this Level is already queued/running (e.g. after a
+            # restart re-queue), skip.
+            existing = self.job_dict.get(label, {}).get('sp', {})
+            if any(j.level == lvl for j in existing.values()):
+                continue
+            logger.info(format_log_event(label,
+                                         "sub-job queued",
+                                         {"sub_labels": sub_labels, "level": lvl.simple()}))
+            self.run_job(label=label,
+                         xyz=xyz,
+                         level_of_theory=lvl,
+                         job_type='sp')
+
+    def _finalize_composite(self, label: str) -> None:
+        """Parse every sub-job energy, evaluate the protocol, set species.e_elect,
+        emit logs, flip the output flag, and regenerate the project notebook."""
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        completed = self.output[label]['paths']['sp_composite']
+        energies_kJmol: dict[str, float] = {}
+        # Each missing entry carries enough context (sub_label + reason +
+        # optional path/exception) so the warning payload tells the operator
+        # exactly which sub-job to re-run, without crashing the scheduler.
+        missing: list[dict[str, str]] = []
+        for _term_label, sub_label, _level in protocol.iter_required_jobs():
+            path = completed.get(sub_label)
+            if not path:
+                missing.append({"sub_label": sub_label, "reason": "missing path"})
+                continue
+            try:
+                value = parser.parse_e_elect(path)
+            except Exception as exc:
+                missing.append({"sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect raised",
+                    "exception": repr(exc)})
+                continue
+            if value is None:
+                missing.append({"sub_label": sub_label,
+                    "path": path,
+                    "reason": "parse_e_elect returned None"})
+                continue
+            energies_kJmol[sub_label] = value
+        if missing:
+            logger.warning(format_log_event(label, "finalize aborted — missing or unparseable sub-jobs",
+                {"missing": missing}))
+            return
+        e_total_kJmol = protocol.evaluate(energies_kJmol)
+        self.species_dict[label].e_elect = e_total_kJmol
+        self.species_dict[label].e_elect_source = "sp_composite"
+        self.output[label]['job_types']['sp_composite'] = True
+        self.output[label]['job_types']['sp'] = True
+        logger.info(format_log_event(label, "all sub-jobs complete", {"count": len(energies_kJmol)}))
+        # Per-term breakdown: one [sp_composite] … term evaluated event per term,
+        # in protocol order. Exposes the individual contribution that landed in
+        # the final total — enough to reconstruct the math from the log alone.
+        for term in protocol.terms:
+            contribution = term.evaluate(energies_kJmol)
+            term_sub_labels = [sl for sl, _lvl in term.required_levels()]
+            payload = {"term": term.label,
+                       "type": type(term).__name__,
+                       "sub_labels": term_sub_labels,
+                       "kJ_per_mol": f"{contribution:.3f}",
+                       "Hartree": f"{contribution / E_h_kJmol:.9f}"}
+            formula_attr = getattr(term, "formula", None)
+            if formula_attr is not None:
+                payload["formula"] = formula_attr
+            logger.info(format_log_event(label, "term evaluated", payload))
+        logger.info(format_log_event(label, "FINAL e_elect",
+                                     {"kJ_per_mol": f"{e_total_kJmol:.3f}",
+                                      "Hartree": f"{e_total_kJmol / E_h_kJmol:.9f}"}))
+        self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+        if self.report_e_elect:
+            self.save_e_elect(label)
+        self._regenerate_composite_notebook()
+        self._write_species_report(label)
+        if species_has_freq(self.output[label], self.species_dict[label].yml_path):
+            self.check_rxn_e0_by_spc(label)
+        self.save_restart_dict()
+
+    def _build_species_section(self,
+                               label: str,
+                               protocol: CompositeProtocol,
+                               ) -> SpeciesSection:
+        """
+        Assemble a :class:`SpeciesSection` for the provenance notebook.
+
+        ``recipe`` is ``protocol.as_dict()`` — a self-contained explicit recipe
+        that the notebook can round-trip through
+        :meth:`CompositeProtocol.from_user_input`. ``preset_name`` and
+        ``reference`` come from the protocol itself when available; otherwise
+        they fall back to explicit-recipe defaults.
+        """
+        species = self.species_dict[label]
+        preset_name = getattr(protocol, "preset_name", None)
+        reference = getattr(protocol, "reference", None)
+        flags: list[str] = []
+        if not reference:
+            reference = ("Explicit sp_composite recipe — no formal reference supplied by "
+                         "the user. The full recipe is encoded in this cell and is "
+                         "sufficient to reproduce the protocol.")
+            if preset_name is None:
+                flags.append("No formal reference supplied; recipe is explicit-only.")
+        return SpeciesSection(
+            label=label,
+            kind="ts" if getattr(species, "is_ts", False) else "species",
+            preset_name=preset_name,
+            reference=reference,
+            recipe=protocol.as_dict(),
+            protocol=protocol,
+            sub_job_paths=dict(self.output[label]['paths']['sp_composite']),
+            flags=flags,
+        )
+
+    def _regenerate_composite_notebook(self) -> None:
+        """Rewrite ``<project>/output/sp_composite.ipynb`` from the cumulative
+        :class:`SpeciesSection` list. Stateless writer; idempotent."""
+        if not self._sp_composite_sections:
+            return
+        output_dir = os.path.join(self.project_directory, "output")
+        os.makedirs(output_dir, exist_ok=True)
+        nb_path = os.path.join(output_dir, "sp_composite.ipynb")
+        write_composite_notebook(
+            path=nb_path,
+            project_name=self.project,
+            arc_version="",  # Phase 4 may surface this; not critical for provenance.
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            sections=list(self._sp_composite_sections.values()),
+            notebook_dir=output_dir,
+        )
+        logger.info(format_log_event("project", "provenance notebook regenerated",
+                                     {"path": nb_path, "sections": len(self._sp_composite_sections)}))
+
+    def _write_species_report(self, label: str) -> None:
+        """
+        Write the per-species sp_composite YAML summary.
+
+        One file per stationary point at
+        ``<project>/output/Species/<label>/sp_composite_report.yml``
+        (or ``output/TSs/<label>/...`` for transition states). Companion to
+        the project-level provenance notebook: notebook is for *Run-All
+        verification*, this YAML is for *cat / parse consumption*.
+        """
+        section = self._sp_composite_sections.get(label)
+        if section is None:
+            return
+        species = self.species_dict[label]
+        e_elect = species.e_elect
+        if e_elect is None:
+            logger.debug(format_log_event(
+                label, "skipping species report — e_elect not set", None,
+            ))
+            return
+        subdir = "TSs" if section.kind == "ts" else "Species"
+        report_path = os.path.join(
+            self.project_directory, "output", subdir, label,
+            "sp_composite_report.yml",
+        )
+        write_species_report_yaml(
+            path=report_path,
+            section=section,
+            e_elect_kj_per_mol=e_elect,
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            arc_version="",  # surfaced via Phase 4 if needed
+            arc_commit="",   # surfaced via Phase 4 if needed
+        )
+        logger.info(format_log_event(label, "species report written", {"path": report_path}))
+
+    def _post_sp_actions_composite(self,
+                                   label: str,
+                                   sp_path: str,
+                                   level: Level | None,
+                                   ) -> None:
+        """
+        Composite branch of :meth:`post_sp_actions`.
+
+        Seeds pending on first entry, records this sp job's completion against
+        any matching pending sub_labels, spawns remaining sub-jobs, and finalizes
+        when all pending are resolved.
+        """
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return
+        if label not in self._sp_composite_pending:
+            self._seed_composite_pending(label)
+        effective_level = level or self.sp_level
+        matched = self._record_composite_completion(label, effective_level, sp_path)
+        if not matched:
+            logger.warning(format_log_event(label, "sp completion matched no pending sub_label — ignoring",
+                {"level": str(effective_level), "path": sp_path}))
+            return
+        if self._sp_composite_pending[label]:
+            self._spawn_composite_pending(label)
+        else:
+            self._finalize_composite(label)
+
+    def _mrcc_degenerate_short_circuit(self, label: str, job) -> bool:
+        """If a composite δ-term high-leg sub-job errored with the
+        ``MRCCDegenerateSystem`` keyword, substitute the sister low-leg's
+        recorded path and advance the composite. Returns ``True`` when the
+        short-circuit was applied so the caller can skip ``troubleshoot_ess``.
+
+        Why this exists: for systems too small to accommodate the requested
+        CC excitation rank (atomic H, H2 at CCSDT(Q), etc.) MRCC's xmrcc
+        bails — there's no determinant space to iterate. The two legs of
+        the δ term are mathematically degenerate (all CC ranks reduce to
+        HF), so δ = 0 is the correct physical answer. The trsh ladder
+        cannot fix this; it must be handled at the protocol level.
+
+        Conservative on safety:
+        * Only fires when keywords contain ``'MRCCDegenerateSystem'``.
+        * Only fires when the species has an active composite.
+        * Only fires for ``__high`` sub-labels with a recorded ``__low``
+          sister in ``output[label]['paths']['sp_composite']``. Low-leg
+          failures and high-leg failures without a completed sister fall
+          through so the caller's normal trsh path runs.
+        """
+        keywords = (job.job_status[1] or {}).get('keywords') or []
+        if 'MRCCDegenerateSystem' not in keywords:
+            return False
+        protocol = self._composite_for(label)
+        if protocol is None:
+            return False
+        # Identify which pending sub_label this errored job corresponds to.
+        pending = self._sp_composite_pending.get(label, {})
+        failed_sub_label = next(
+            (sl for sl, lvl in pending.items() if lvl == job.level),
+            None,
+        )
+        if failed_sub_label is None or not failed_sub_label.endswith('__high'):
+            logger.warning(format_log_event(
+                label,
+                "MRCCDegenerateSystem on a non-high sub-job — falling through to trsh",
+                {"sub_label": failed_sub_label, "level": str(job.level)},
+            ))
+            return False
+        sister_low = failed_sub_label[: -len('__high')] + '__low'
+        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+        sister_path = completed.get(sister_low)
+        if not sister_path:
+            logger.warning(format_log_event(
+                label,
+                "MRCCDegenerateSystem high-leg failed but low-leg not yet recorded — deferring",
+                {"failed": failed_sub_label, "sister": sister_low},
+            ))
+            return False
+        logger.warning(format_log_event(
+            label,
+            "MRCC degenerate-system fallback: substituting low-leg energy for high-leg",
+            {"failed": failed_sub_label, "sister": sister_low,
+             "reason": "Method exceeds determinant space; δ = 0 by symmetry."},
+        ))
+        # Substitute by re-using the low-leg's path. _record_composite_completion
+        # writes the path into output and clears the pending entry — same as a
+        # normal completion, but pointing both legs at the same file so they
+        # parse to the same energy and the δ evaluates to zero.
+        completed_paths = self.output[label]['paths']['sp_composite']
+        completed_paths[failed_sub_label] = sister_path
+        del pending[failed_sub_label]
+        if pending:
+            self._spawn_composite_pending(label)
+        else:
+            self._finalize_composite(label)
+        return True
+
+    def _rehydrate_composite_state(self) -> None:
+        """On scheduler init/restart, seed pending for every species with an active
+        composite, rebuild the SpeciesSection for species that already finalized,
+        then kick-start any pending sub-jobs so a restart with no other events
+        still makes progress."""
+        for label, species in self.species_dict.items():
+            protocol = self._composite_for(label)
+            if protocol is None:
+                continue
+            self._seed_composite_pending(label)
+            if self.output.get(label, {}).get('job_types', {}).get('sp_composite'):
+                self._sp_composite_sections[label] = self._build_species_section(label, protocol)
+                # Re-emit the per-species report so a restart fills in reports
+                # missing on disk (and refreshes any whose protocol metadata
+                # changed across versions). Cheap; one yaml.safe_dump per
+                # finalized species.
+                self._write_species_report(label)
+        # Kick-start after every species has been seeded — ``_spawn_composite_pending``
+        # will dedupe against sp jobs restored by ``restore_running_jobs``, and will
+        # only touch species whose pending dict is non-empty AND that have already
+        # made some composite progress (i.e., have at least one recorded sub-job
+        # output, implying opt + base-SP have run). Species mid-opt won't have
+        # pending seeded with anything they couldn't spawn a geometry for.
+        self._kickstart_composite_queues()
+
+    def _kickstart_composite_queues(self) -> None:
+        """Actively spawn pending sub-jobs for species with prior composite
+        progress, so a restart with no other events still moves forward.
+
+        Conservative: only kicks species whose ``output[...]['paths']['sp_composite']``
+        already contains at least one completed sub_label. Species mid-opt (no
+        composite progress yet) follow the normal opt → spawn_post_opt_jobs path.
+        """
+        for label in list(self._sp_composite_pending.keys()):
+            pending = self._sp_composite_pending[label]
+            if not pending:
+                continue
+            completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {})
+            if not completed:
+                # No prior progress — let the normal opt/SP flow get this species
+                # to the composite branch; don't spawn SPs against a species that
+                # may not have an optimized geometry yet.
+                continue
+            logger.info(format_log_event(
+                label, "restart kick-start",
+                {"queuing_sub_labels": sorted(pending.keys())},
+            ))
+            self._spawn_composite_pending(label)
+
     def run_sp_job(self,
                    label: str,
                    level: Level | None = None,
@@ -1503,7 +2015,11 @@ class Scheduler(object):
             level (Level): An alternative level of theory to run at. If ``None``, self.sp_level will be used.
             conformer (int): The conformer number.
         """
-        level = level or self.sp_level
+        # Phase 3: for species with an active sp_composite, the SP runs at the
+        # protocol's base.level (unless the caller passed an explicit ``level``).
+        if level is None:
+            _active_protocol = self._composite_for(label)
+            level = _active_protocol.base.level if _active_protocol is not None else self.sp_level
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
                          xyz=self.species_dict[label].conformers[conformer],
@@ -1512,6 +2028,7 @@ class Scheduler(object):
                          conformer=conformer)
             return
         if level == self.opt_level and not self.composite_method \
+                and self._composite_for(label) is None \
                 and not (level.software == 'xtb' and self.species_dict[label].is_ts) \
                 and 'paths' in self.output[label] and 'geo' in self.output[label]['paths'] \
                 and self.output[label]['paths']['geo']:
@@ -3031,6 +3548,13 @@ class Scheduler(object):
             if self.species_dict[label].number_of_atoms == 1:
                 # save the geometry from the sp job for monoatomic species for which no opt/freq jobs will be spawned
                 self.output[label]['paths']['geo'] = job.local_path_to_output_file
+        elif self._mrcc_degenerate_short_circuit(label=label, job=job):
+            # MRCC bailed for a degenerate small-system δ-term high leg
+            # (atomic H, H2, etc., where the requested CC excitation rank
+            # exceeds the determinant space). The trsh ladder cannot help —
+            # cause is intrinsic. Helper substituted the low-leg energy and
+            # advanced the composite; nothing further to do here.
+            self.save_restart_dict()
         else:
             self.troubleshoot_ess(label=label,
                                   job=job,
@@ -3050,6 +3574,13 @@ class Scheduler(object):
             sp_path (str): The path to 'output.out' for the single point job.
             level (Level, optional): The level of theory used for the sp job.
         """
+        # Phase 3: when sp_composite is active for this species, route through
+        # the composite branch. The legacy path below does not run for composite
+        # species — e_elect is set by ``_finalize_composite`` after all sub-jobs
+        # complete, not from any single intermediate SP.
+        if self._composite_for(label) is not None:
+            self._post_sp_actions_composite(label, sp_path, level)
+            return
         original_sp_path = self.output[label]['paths']['sp'] if 'sp' in self.output[label]['paths'] else None
         self.output[label]['paths']['sp'] = sp_path
         if self.sp_level is not None and 'ccsd' in self.sp_level.method:
@@ -3986,22 +4517,49 @@ class Scheduler(object):
             label (str): The species label.
         """
         logger.debug(f'Deleting all jobs for species {label}')
+
+        def _safe_delete(job, display_name):
+            """Best-effort job delete: log failure (e.g. queue rejected qdel)
+            and continue. This loop is cleanup before troubleshooting / restart;
+            an orphan remote job will exit on its own and must not abort the
+            whole scheduler. Without this guard, a single failed delete
+            propagates a RuntimeError up through delete_all_species_jobs →
+            troubleshoot_negative_freq → schedule_jobs → __init__ and the
+            entire project dies."""
+            logger.info(f'Deleted job {display_name}')
+            try:
+                job.delete()
+            except Exception as exc:
+                logger.warning(
+                    f'Failed to delete job {display_name} for species '
+                    f'{label}: {type(exc).__name__}: {exc}. Continuing — '
+                    f'the orphan job (if any) will exit on its own.'
+                )
+
         for value in self.job_dict[label].values():
             if value in ['conf_opt', 'tsg']:
                 for job_name, job in self.job_dict[label][value].items():
                     if label in self.running_jobs.keys() and job_name in self.running_jobs[label] \
                             and job.execution_type != 'incore':
-                        logger.info(f'Deleted job {value}{job_name}')
-                        job.delete()
+                        _safe_delete(job, f'{value}{job_name}')
             for job_name, job in value.items():
                 if label in self.running_jobs.keys() and job_name in self.running_jobs[label] \
                         and job.execution_type != 'incore':
-                    logger.info(f'Deleted job {job_name}')
-                    job.delete()
+                    _safe_delete(job, job_name)
         self.running_jobs[label] = list()
-        self.output[label]['paths'] = {key: '' if key != 'irc' else list() for key in self.output[label]['paths'].keys()}
+        # Reset paths for this species. Most keys reset to ''; container-valued
+        # keys keep their type so the rest of the pipeline (composite tracking,
+        # IRC trajectory list) doesn't crash on a string where it expects a
+        # dict / list. Phase 3 added 'sp_composite' as a dict[sub_label → path];
+        # without the carve-out below it would collapse to '' here and the next
+        # composite sub-job completion would TypeError on item assignment.
+        _path_empty = {'irc': list, 'sp_composite': dict}
+        self.output[label]['paths'] = {
+            key: _path_empty.get(key, str)()
+            for key in self.output[label]['paths'].keys()
+        }
         for job_type in self.output[label]['job_types']:
-            # rotors and bde are initialised to True (see initialize_output_dict) because
+            # rotors and bde are initialized to True (see initialize_output_dict) because
             # species with no torsional modes / no BDE targets should not be blocked from
             # convergence.  Preserve that default when resetting job state.
             if job_type in ['rotors', 'bde']:
@@ -4013,6 +4571,8 @@ class Scheduler(object):
         self._pending_pipe_freq.discard(label)
         self._pending_pipe_irc.discard((label, 'forward'))
         self._pending_pipe_irc.discard((label, 'reverse'))
+        self._sp_composite_pending.pop(label, None)
+        self._sp_composite_sections.pop(label, None)
         # Clean up any IRC species spawned from this TS.
         if label in self.species_dict and self.species_dict[label].is_ts:
             irc_labels_str = self.species_dict[label].irc_label
@@ -4283,6 +4843,7 @@ class Scheduler(object):
                     for key in path_keys:
                         if key not in self.output[species.label]['paths']:
                             self.output[species.label]['paths'][key] = ''
+                    self._ensure_sp_composite_paths_invariant(species.label)
                     if species.is_ts:
                         if 'irc' not in self.output[species.label]['paths']:
                             self.output[species.label]['paths']['irc'] = list()
@@ -4290,7 +4851,7 @@ class Scheduler(object):
                             self.output[species.label]['paths']['neb'] = ''
                     if 'job_types' not in self.output[species.label]:
                         self.output[species.label]['job_types'] = dict()
-                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'onedmin']:
+                    for job_type in list(set(self.job_types.keys())) + ['opt', 'freq', 'sp', 'composite', 'sp_composite', 'onedmin']:
                         if job_type in ['rotors', 'bde']:
                             # rotors could be invalidated due to many reasons,
                             # also could be falsely identified in a species that has no torsional modes.
@@ -4304,6 +4865,42 @@ class Scheduler(object):
                                 self.output[species.label][key] = None
                             else:
                                 self.output[species.label][key] = ''
+        # Always-on invariant — runs even when the gated init above was
+        # skipped because output[] was rehydrated from a stale restart.yml.
+        # Older ARC versions could persist paths['sp_composite'] as a scalar
+        # string (the same shape as paths['sp']); the composite code mutates
+        # this in place as a dict[sub_label → path] and would otherwise crash
+        # with ``TypeError: 'str' object does not support item assignment``.
+        for species in self.species_list:
+            if label is None or species.label == label:
+                if species.label in self.output:
+                    self._ensure_sp_composite_paths_invariant(species.label)
+
+    def _ensure_sp_composite_paths_invariant(self, label: str) -> None:
+        """Coerce ``output[label]['paths']['sp_composite']`` to a dict.
+
+        Phase 3 stores sub-job results as ``{sub_label: path}`` here. A non-
+        dict value (typically a leftover scalar string from an older ARC
+        version's restart.yml) is reset to ``{}`` and a single-line warning
+        is logged so the user can audit. Empty/absent values are reset
+        silently because they are not evidence of corruption — just absence.
+        """
+        species_output = self.output.get(label)
+        if not isinstance(species_output, dict):
+            return
+        paths = species_output.setdefault('paths', {})
+        existing = paths.get('sp_composite')
+        if isinstance(existing, dict):
+            return
+        if existing not in (None, ''):
+            logger.warning(
+                f"output['{label}']['paths']['sp_composite'] was a "
+                f"{type(existing).__name__} ({existing!r}); coercing to "
+                f"dict() — likely a stale restart.yml from an older ARC "
+                f"version. The composite will re-run any sub-jobs that "
+                f"were previously recorded against this scalar."
+            )
+        paths['sp_composite'] = dict()
 
     def _does_output_dict_contain_info(self):
         """

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -4670,7 +4670,7 @@ class Scheduler(object):
                     if irc_label in self.output:
                         del self.output[irc_label]
                     if irc_label in self.species_dict:
-                        self.species_list = [spc for spc in self.species_list if spc.label != irc_label]
+                        self.species_list[:] = [spc for spc in self.species_list if spc.label != irc_label]
                         del self.species_dict[irc_label]
                     if irc_label in self.unique_species_labels:
                         self.unique_species_labels.remove(irc_label)

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -4035,7 +4035,7 @@ class Scheduler(object):
             else:
                 for job_type, spawn_job_type in self.job_types.items():
                     if spawn_job_type and not self.output[label]['job_types'][job_type] \
-                            and not ((self.species_dict[label].is_ts and job_type in ['scan', 'conf_opt'])
+                            and not ((self.species_dict[label].is_ts and job_type in ['scan', 'rotors', 'conf_opt'])
                                      or (self.species_dict[label].number_of_atoms == 1
                                          and job_type in ['conf_opt', 'opt', 'fine', 'freq', 'rotors', 'bde'])
                                      or job_type == 'bde' and self.species_dict[label].bdes is None

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -19,7 +19,9 @@ import arc.parser.parser as parser
 from arc import plotter
 from arc.checks.common import get_i_from_job_name, is_conformer_job, sum_time_delta
 from arc.checks.ts import check_imaginary_frequencies, check_ts, check_irc_species_and_rxn
-from arc.common import (extremum_list,
+from arc.common import (NUMBER_BY_SYMBOL,
+                        VERSION,
+                        extremum_list,
                         get_angle_in_180_range,
                         get_logger,
                         get_number_with_ordinal_indicator,
@@ -54,7 +56,7 @@ from arc.job.trsh import (scan_quality_check,
                           )
 from arc.constants import E_h_kJmol
 from arc.level import Level, active_composite_for
-from arc.level.protocol import CompositeProtocol
+from arc.level.protocol import CompositeProtocol, DeltaTerm, excitation_rank
 from arc.level.reporting import (
     SpeciesSection,
     format_log_event,
@@ -88,6 +90,51 @@ LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ, default_job_settings, \
     settings['rotor_scan_resolution'], settings['servers']
 
 WRONG_FREQ_MESSAGE = 'wrong number of negative frequencies; '
+
+ZOMBIE_RECHECK_SECONDS = 900
+
+# Frozen-core orbital count per atom by the standard chemical-core convention:
+# each atom freezes the doubly-occupied orbitals of the previous noble gas
+# (none for H/He, the He core for Li–Ne, the Ne core for Na–Ar, ...).
+# Entries are (max_atomic_number, n_core_orbitals), ascending.
+_FROZEN_CORE_ORBITALS_BY_MAX_Z = ((2, 0), (10, 1), (18, 5), (36, 9), (54, 18), (86, 27), (118, 43))
+
+
+def count_frozen_core_orbitals(symbols: tuple) -> int:
+    """
+    Count a species' frozen-core orbitals under the standard chemical-core convention.
+
+    Args:
+        symbols (tuple): Element symbols, e.g. ``('C', 'H', 'H', 'H', 'H')``.
+
+    Returns:
+        int: The total number of frozen-core orbitals across all atoms.
+    """
+    n_core = 0
+    for symbol in symbols:
+        z = NUMBER_BY_SYMBOL[symbol]
+        for max_z, core_orbitals in _FROZEN_CORE_ORBITALS_BY_MAX_Z:
+            if z <= max_z:
+                n_core += core_orbitals
+                break
+    return n_core
+
+
+def count_correlated_electrons(symbols: tuple, charge: int = 0) -> int:
+    """
+    Count a species' correlated electrons under the frozen-core convention.
+
+    ``n_corr = n_electrons − 2 × n_frozen_core_orbitals``.
+
+    Args:
+        symbols (tuple): Element symbols.
+        charge (int): The net molecular charge.
+
+    Returns:
+        int: The number of correlated electrons.
+    """
+    n_electrons = sum(NUMBER_BY_SYMBOL[symbol] for symbol in symbols) - charge
+    return n_electrons - 2 * count_frozen_core_orbitals(symbols)
 
 
 def tsg_method_matches_adapter(method: str | None, job_adapter: str | None) -> bool:
@@ -152,6 +199,7 @@ class Scheduler(object):
                                       'freq': <path to freq output file>,
                                       'sp': <path to sp output file>,
                                       'composite': <path to composite output file>,
+                                      'sp_composite': {sub_label: <path to sub-job output file>},
                                       'irc': [list of two IRC paths],
                                      },
                             'conformers': <comments>,
@@ -167,6 +215,10 @@ class Scheduler(object):
 
     Note:
         The rotor scan dicts are located under Species.rotors_dict
+
+    Note:
+        For species with an active sp_composite protocol, 'paths'->'sp' holds the protocol's
+        base ESS log and does NOT imply the sp phase is complete; see _sync_composite_sp_path.
 
     Args:
         project (str): The project's name. Used for naming the working directory.
@@ -225,6 +277,8 @@ class Scheduler(object):
         running_jobs (dict): A dictionary of currently running jobs (a subset of `job_dict`).
                              Keys are species/TS label, values are lists of job names (e.g. 'conformer3', 'opt_a123').
         server_job_ids (list): A list of relevant job IDs currently running on the server.
+        server_job_states (dict): Normalized queue states ('running'/'pending'/'held'/'exiting'/'unknown')
+                                  keyed by server job ID (str). Populated alongside ``server_job_ids``.
         output (dict): Output dictionary with status per job type and final QM file paths for all species.
         output_multi_spc (dict): Output dictionary with status per job type of multi-species clusters.
         ess_settings (dict): A dictionary of available ESS and a corresponding server list.
@@ -319,6 +373,7 @@ class Scheduler(object):
         self.max_job_time = max_job_time or default_job_settings.get('job_time_limit_hrs', 120)
         self.job_dict = dict()
         self.server_job_ids = list()
+        self.server_job_states = dict()
         self.completed_incore_jobs = list()
         self.running_jobs = dict()
         self.allow_nonisomorphic_2d = allow_nonisomorphic_2d
@@ -360,7 +415,7 @@ class Scheduler(object):
         self._last_status_payload: dict | None = None
         self.servers = list()
         self.composite_method = composite_method
-        # Phase 3 composite-orchestration state.
+        # Composite-orchestration state.
         # self.sp_composite holds the project-wide CompositeProtocol (or None). Per-species
         # protocols live on each ARCSpecies via sp_composite_state/sp_composite and are
         # resolved through arc.level.active_composite_for().
@@ -368,20 +423,32 @@ class Scheduler(object):
         # Per-species pending sub-jobs keyed by label → {sub_label: Level}. Transient;
         # rebuilt on restart from output[label]['paths']['sp_composite'].
         self._sp_composite_pending: dict[str, dict[str, Level]] = dict()
-        # Per-(species, job_type) cap on zombie-job kills (one resubmit per
-        # job_type per species). Persisted in the restart YAML.
+        # Per-species δ terms skipped as trivially zero, keyed by label →
+        # {term_label: reason}. Transient; deterministically re-derived from
+        # species + protocol on every seed (restart-safe by construction).
+        self._sp_composite_skipped: dict[str, dict[str, str]] = dict()
+        # Per-(species, job_name) cap on zombie-job kills (one resubmit credit
+        # per job). Persisted in the restart YAML. Old-format restart entries
+        # (job_type strings such as 'sp') are loaded as-is but are inert:
+        # membership is checked by job_name only, so they cap nothing.
         self._zombie_kills: dict[str, set[str]] = dict()
         if self.restart_dict is not None and '_zombie_kills' in self.restart_dict:
             self._zombie_kills = {
-                label: set(types) for label, types in self.restart_dict['_zombie_kills'].items()
+                label: set(names) for label, names in self.restart_dict['_zombie_kills'].items()
             }
+        # Job names whose one-shot zombie warnings ('manual intervention' for
+        # capped jobs, 'held' for held jobs) already fired. Not persisted.
+        self._zombie_warned: set[str] = set()
+        # Per-job zombie-check throttle: job_name → last-check monotonic
+        # timestamp. Not persisted across restarts.
+        self._zombie_last_check: dict[str, float] = dict()
+        # First time each job was observed in a RUNNING queue state, keyed by
+        # job_name; the zombie grace clock starts here. In-memory only: a
+        # restart re-observes and conservatively restarts the clock.
+        self._zombie_running_since: dict[str, datetime.datetime] = dict()
         # Cumulative finalized SpeciesSection objects (label → SpeciesSection). The
         # notebook writer consumes the full values list on every regeneration.
         self._sp_composite_sections: dict[str, SpeciesSection] = dict()
-        # Rehydrate composite state from the persistent output dict so restart
-        # re-queues only the missing sub-jobs. Safe to call even when no species
-        # has an active composite — it's a no-op in that case.
-        self._rehydrate_composite_state()
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
         self.ts_guess_level = ts_guess_level
@@ -393,6 +460,12 @@ class Scheduler(object):
         self.orbitals_level = orbitals_level
         self.unique_species_labels = list()
         self.save_restart = False
+        # Rehydrate composite state from the persistent output dict so restart
+        # re-queues only the missing sub-jobs. Safe to call even when no species
+        # has an active composite — it's a no-op in that case. Must run after
+        # every attribute that run_job and save_restart_dict read (notably
+        # self.save_restart) is assigned, since the kick-start path submits jobs.
+        self._rehydrate_composite_state()
 
         if len(self.rxn_list):
             if self.adaptive_levels is not None:
@@ -499,8 +572,11 @@ class Scheduler(object):
                 if self.output[species.label]['convergence']:
                     continue
                 if species.is_monoatomic():
+                    # paths['sp'] also blocks the respawn: for an sp_composite species it holds the
+                    # completed base log, and the pending sub-jobs respawn via _kickstart_composite_queues.
                     if not self.output[species.label]['job_types']['sp'] \
                             and not self.output[species.label]['job_types']['composite'] \
+                            and not self.output[species.label]['paths']['sp'] \
                             and 'sp' not in list(self.job_dict[species.label].keys()) \
                             and 'composite' not in list(self.job_dict[species.label].keys()):
                         # No need to run opt/freq jobs for a monoatomic species, only run sp (or composite if relevant)
@@ -1117,15 +1193,15 @@ class Scheduler(object):
         # a list-valued ``label`` arg only reaches this point when
         # ``run_multi_species`` was True (set iff every species in the list has
         # ``multi_species`` populated), in which case we just reassigned
-        # ``label`` to the (single) ``species[0].multi_species`` string. Stating
-        # the invariant explicitly satisfies static analyzers (``self.job_dict[label]``
-        # downstream would TypeError on an unhashable list) and catches a real
-        # bug if the multi-species dispatch ever leaks a list through.
-        assert isinstance(label, str), (
-            f"run_job: expected ``label`` to be str by this point, got "
-            f"{type(label).__name__} ({label!r}). This indicates the "
-            f"multi-species dispatch above didn't collapse a list label."
-        )
+        # ``label`` to the (single) ``species[0].multi_species`` string.
+        # Raising explicitly (rather than asserting, which is stripped under
+        # ``python -O``) catches a real bug if the multi-species dispatch ever
+        # leaks a list through (``self.job_dict[label]`` downstream would
+        # TypeError on an unhashable list).
+        if not isinstance(label, str):
+            raise TypeError(f"run_job: expected ``label`` to be str by this point, got "
+                            f"{type(label).__name__} ({label!r}). This indicates the "
+                            f"multi-species dispatch above didn't collapse a list label.")
         if label not in self.job_dict.keys():
             self.job_dict[label] = dict()
         if conformer is None and tsg is None:
@@ -1199,7 +1275,10 @@ class Scheduler(object):
 
         ``job_dict`` is keyed ``[label][job_type][job_name → JobAdapter]`` for most
         job_types, but ``conf_opt`` / ``conf_sp`` / ``tsg`` use integer keys whose
-        values carry the actual ``job_name`` on the ``JobAdapter`` object.
+        values carry the actual ``job_name`` on the ``JobAdapter`` object. The
+        synthetic ``running_jobs`` names of those jobs ('conf_opt_<n>',
+        'conf_sp_<n>', 'tsg<n>') are resolved via their trailing index after the
+        real-job_name match fails.
 
         Args:
             label (str): The species label.
@@ -1219,14 +1298,32 @@ class Scheduler(object):
             for j in jobs.values():
                 if getattr(j, 'job_name', None) == job_name:
                     return j
+        try:
+            i = get_i_from_job_name(job_name)
+        except ValueError:
+            i = None
+        if i is not None:
+            for job_type in ('conf_opt', 'conf_sp', 'tsg'):
+                if job_name.startswith(job_type):
+                    jobs = self.job_dict[label].get(job_type)
+                    if isinstance(jobs, dict) and i in jobs:
+                        return jobs[i]
         return None
 
     def check_for_zombie_jobs(self, label: str) -> None:
-        """Detect zombie jobs for a species (queue reports running but no
+        """Detect zombie jobs for a species (queue reports RUNNING but no
         output traffic after the grace period), kill and resubmit them.
 
-        The cap of one resubmission per (species, job_type) prevents loops
+        A job is killable only while its queue state is 'running' (or absent
+        from ``self.server_job_states``, e.g. local jobs without state info);
+        'pending' is never killable regardless of age, and 'held' logs a
+        warning at most once. The grace clock starts at the first time the job
+        was observed running (``self._zombie_running_since``).
+
+        The cap of one resubmission per (species, job_name) prevents loops
         when the underlying issue is in our submission, not the cluster.
+        Capped jobs skip the (potentially remote) zombie stat entirely, and
+        each job is re-checked at most once per ``ZOMBIE_RECHECK_SECONDS``.
 
         Args:
             label (str): The species label whose running jobs should be checked.
@@ -1234,27 +1331,47 @@ class Scheduler(object):
         Returns:
             None: Side-effects only. Mutates ``self.running_jobs[label]`` (drops
             zombie ``job_name``\\ s) and ``self._zombie_kills[label]`` (records the
-            killed ``job_type``), and resubmits via ``self._run_a_job``.
+            killed ``job_name``), and resubmits via ``self._run_a_job``.
         """
         if label not in self.running_jobs or label not in self.job_dict:
             return
         for job_name in list(self.running_jobs.get(label, [])):
             job = self.resolve_job_by_name(label, job_name)
-            if job is None or not _is_zombie_job(job, self.server_job_ids):
+            if job is None:
                 continue
-            job_type = job.job_type
-            if job_type in self._zombie_kills.get(label, set()):
-                logger.warning(
-                    f'Job {job_name} for {label} ({job_type}) appears to be a '
-                    f'zombie a second time after one resubmission — leaving '
-                    f'for manual intervention.'
-                )
+            if job_name in self._zombie_kills.get(label, set()):
+                if job_name not in self._zombie_warned:
+                    self._zombie_warned.add(job_name)
+                    logger.warning(
+                        f'Job {job_name} for {label} ({job.job_type}) was already '
+                        f'resubmitted once after a zombie kill — skipping further '
+                        f'zombie checks for it, leaving for manual intervention.'
+                    )
                 continue
-            elapsed_min = int((datetime.datetime.now() - job.initial_time).total_seconds() // 60)
+            state = self.server_job_states.get(str(job.job_id),
+                                               self.server_job_states.get(job.job_id, 'running'))
+            if state == 'held':
+                held_key = f'{job_name}_held'
+                if held_key not in self._zombie_warned:
+                    self._zombie_warned.add(held_key)
+                    logger.warning(f'Job {job_name} for {label} ({job.job_type}) is held on the '
+                                   f'queue; not treating as a zombie, leaving for manual intervention.')
+                continue
+            if state != 'running':
+                continue
+            running_since = self._zombie_running_since.setdefault(job_name, datetime.datetime.now())
+            now = time.monotonic()
+            last_checked = self._zombie_last_check.get(job_name)
+            if last_checked is not None and now - last_checked < ZOMBIE_RECHECK_SECONDS:
+                continue
+            self._zombie_last_check[job_name] = now
+            if not _is_zombie_job(job, self.server_job_ids, running_since=running_since):
+                continue
+            elapsed_min = int((datetime.datetime.now() - running_since).total_seconds() // 60)
             logger.warning(
-                f'Job {job_name} for {label} ({job_type}) shows no output '
-                f'activity after {elapsed_min} min and the queue still reports '
-                f'it as running. Treating as a zombie: killing and resubmitting.'
+                f'Job {job_name} for {label} ({job.job_type}) shows no output '
+                f'activity after {elapsed_min} min of running and the queue still '
+                f'reports it as running. Treating as a zombie: killing and resubmitting.'
             )
             try:
                 job.delete()
@@ -1263,7 +1380,8 @@ class Scheduler(object):
                     f'Failed to delete zombie job {job_name} for {label}: '
                     f'{type(exc).__name__}: {exc}. Continuing with resubmission.'
                 )
-            self._zombie_kills.setdefault(label, set()).add(job_type)
+            self._zombie_kills.setdefault(label, set()).add(job_name)
+            self._zombie_running_since.pop(job_name, None)
             if job_name in self.running_jobs[label]:
                 self.running_jobs[label].remove(job_name)
             self._run_a_job(job=job, label=label)
@@ -1611,7 +1729,7 @@ class Scheduler(object):
                          level_of_theory=self.freq_level, job_type='freq')
 
     # ------------------------------------------------------------------------ #
-    #  sp_composite orchestration (Phase 3)                                    #
+    #  sp_composite orchestration                                              #
     # ------------------------------------------------------------------------ #
     #
     # Design:
@@ -1632,6 +1750,8 @@ class Scheduler(object):
     #   calls ``protocol.evaluate`` (unit-agnostic sum), writes ``species.e_elect``,
     #   sets ``species.e_elect_source='sp_composite'``, flips the output flag, and
     #   regenerates the project notebook with the *cumulative* section list.
+    # * ``output[label]['paths']['sp']`` mirrors the recorded base leg's log via
+    #   ``_sync_composite_sp_path`` (see its docstring for the invariant).
 
     def _composite_for(self, label: str) -> CompositeProtocol | None:
         """Return the composite protocol to apply to this species, or ``None``.
@@ -1647,6 +1767,67 @@ class Scheduler(object):
             species_protocol=getattr(species, "sp_composite", None),
             global_protocol=self.sp_composite,
         )
+
+    def _species_n_correlated(self, label: str) -> int | None:
+        """
+        Determine a species' correlated electron count (frozen-core convention).
+
+        Element symbols are taken from the species' geometry when available,
+        falling back to its 2D graph. Returns ``None`` when neither is
+        available (or an element is unrecognized) — callers must then treat
+        every delta term as potentially non-zero.
+
+        Args:
+            label (str): The species label.
+
+        Returns:
+            int | None: The correlated electron count, or ``None`` if unknown.
+        """
+        species = self.species_dict.get(label)
+        if species is None:
+            return None
+        xyz = species.get_xyz(generate=False)
+        symbols = tuple(xyz['symbols']) if xyz is not None and xyz.get('symbols') else None
+        if symbols is None and species.mol is not None:
+            symbols = tuple(atom.element.symbol for atom in species.mol.atoms)
+        if not symbols:
+            return None
+        try:
+            return count_correlated_electrons(symbols=symbols, charge=species.charge or 0)
+        except KeyError:
+            return None
+
+    def _composite_skipped_terms(self,
+                                 label: str,
+                                 protocol: CompositeProtocol,
+                                 ) -> dict[str, str]:
+        """
+        Decide, per delta term, whether its correction is trivially zero for this species.
+
+        A δ[high − low] correction is identically zero when the species'
+        correlated electron count is too small for the legs' coupled-cluster
+        excitation ranks to differ from full CI (see
+        :meth:`DeltaTerm.is_trivially_zero`) — e.g. atomic H or He through a
+        HEAT-style δ_T / δ_Q. Such terms are never queued; finalize counts
+        their contribution as exactly 0.0. The decision is deterministic from
+        species + protocol, so re-deriving it on restart is safe.
+
+        Args:
+            label (str): The species label.
+            protocol (CompositeProtocol): The species' active composite protocol.
+
+        Returns:
+            dict[str, str]: Mapping ``term_label`` → human-readable skip reason.
+        """
+        n_corr = self._species_n_correlated(label)
+        if n_corr is None:
+            return dict()
+        skipped: dict[str, str] = dict()
+        for term in protocol.corrections:
+            if isinstance(term, DeltaTerm) and term.is_trivially_zero(n_corr):
+                rank = excitation_rank(term.high.method)
+                skipped[term.label] = f'δ≡0 (n_corr={n_corr} < rank={rank}) — skipped'
+        return skipped
 
     def _validate_composite_completed(self, label: str) -> list[str]:
         """Drop sub_label entries whose recorded output file is missing or
@@ -1693,17 +1874,29 @@ class Scheduler(object):
 
         Runs :meth:`_validate_composite_completed` first so any corrupted
         previously-recorded output is pushed back into pending automatically.
+        Delta terms decided trivially zero for this species (δ≡0 by the
+        correlated-electron-count vs. excitation-rank test) are recorded in
+        ``_sp_composite_skipped[label]`` and neither of their legs is queued.
         """
         protocol = self._composite_for(label)
         if protocol is None:
             return
         self._validate_composite_completed(label)
+        skipped = self._composite_skipped_terms(label, protocol)
+        self._sp_composite_skipped[label] = skipped
+        for term_label, reason in skipped.items():
+            logger.info(format_log_event(
+                label, "term skipped", {"term": term_label, "reason": reason},
+            ))
         completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
         pending: dict[str, Level] = {}
-        for _term_label, sub_label, level in protocol.iter_required_jobs():
+        for term_label, sub_label, level in protocol.iter_required_jobs():
+            if term_label in skipped:
+                continue
             if sub_label not in completed:
                 pending[sub_label] = level
         self._sp_composite_pending[label] = pending
+        self._sync_composite_sp_path(label, protocol)
         logger.info(format_log_event(
             label,
             "protocol resolved",
@@ -1711,6 +1904,7 @@ class Scheduler(object):
                 "total_sub_jobs": sum(1 for _ in protocol.iter_required_jobs()),
                 "pending": len(pending),
                 "already_completed": len(completed),
+                "skipped_terms": sorted(skipped.keys()),
             },
         ))
 
@@ -1737,7 +1931,38 @@ class Scheduler(object):
                 "sub-job completed",
                 {"sub_label": sl, "level": level.simple(), "path": sp_path},
             ))
+        protocol = self._composite_for(label)
+        if protocol is not None:
+            self._sync_composite_sp_path(label, protocol)
         return matched
+
+    def _sync_composite_sp_path(self,
+                                label: str,
+                                protocol: CompositeProtocol,
+                                ) -> None:
+        """
+        Keep ``output[label]['paths']['sp']`` consistent with the recorded composite base leg.
+
+        Invariant: for a species with an active sp_composite protocol, ``paths['sp']`` is the
+        geometry-consistent base ESS log — the ``protocol.primary_base_sub_label`` leg (the
+        largest-cardinal leg for a CBS base) — or ``''`` if that leg has not been recorded
+        (or was invalidated). It exists for path-existence and freq-fallback consumers only
+        (Arkane species files, restart respawn guards); the AUTHORITATIVE energy is the
+        composite result stored in ``species.e_elect`` with ``e_elect_source='sp_composite'``.
+        ``paths['sp']`` being set does NOT mean the composite sp phase is complete — completion
+        is judged solely by all protocol sub-jobs being recorded and validated in
+        ``paths['sp_composite']`` (see ``_sp_composite_pending`` /
+        ``_validate_composite_completed``).
+
+        Args:
+            label (str): The species label.
+            protocol (CompositeProtocol): The species' active composite protocol.
+
+        Returns:
+            None
+        """
+        completed = self.output[label]['paths']['sp_composite']
+        self.output[label]['paths']['sp'] = completed.get(protocol.primary_base_sub_label, '')
 
     def _spawn_composite_pending(self, label: str) -> None:
         """Spawn one sp job per *unique* pending ``Level``.
@@ -1784,17 +2009,24 @@ class Scheduler(object):
 
     def _finalize_composite(self, label: str) -> None:
         """Parse every sub-job energy, evaluate the protocol, set species.e_elect,
-        emit logs, flip the output flag, and regenerate the project notebook."""
+        emit logs, flip the output flag, and regenerate the project notebook.
+        Delta terms recorded as skipped (δ≡0) contribute exactly 0.0."""
         protocol = self._composite_for(label)
         if protocol is None:
             return
+        skipped = self._sp_composite_skipped.get(label)
+        if skipped is None:
+            skipped = self._composite_skipped_terms(label, protocol)
+            self._sp_composite_skipped[label] = skipped
         completed = self.output[label]['paths']['sp_composite']
         energies_kJmol: dict[str, float] = {}
         # Each missing entry carries enough context (sub_label + reason +
         # optional path/exception) so the warning payload tells the operator
         # exactly which sub-job to re-run, without crashing the scheduler.
         missing: list[dict[str, str]] = []
-        for _term_label, sub_label, _level in protocol.iter_required_jobs():
+        for term_label, sub_label, _level in protocol.iter_required_jobs():
+            if term_label in skipped:
+                continue
             path = completed.get(sub_label)
             if not path:
                 missing.append({"sub_label": sub_label, "reason": "missing path"})
@@ -1817,7 +2049,8 @@ class Scheduler(object):
             logger.warning(format_log_event(label, "finalize aborted — missing or unparseable sub-jobs",
                 {"missing": missing}))
             return
-        e_total_kJmol = protocol.evaluate(energies_kJmol)
+        e_total_kJmol = sum(0.0 if term.label in skipped else term.evaluate(energies_kJmol)
+                            for term in protocol.terms)
         self.species_dict[label].e_elect = e_total_kJmol
         self.species_dict[label].e_elect_source = "sp_composite"
         self.output[label]['job_types']['sp_composite'] = True
@@ -1827,6 +2060,16 @@ class Scheduler(object):
         # in protocol order. Exposes the individual contribution that landed in
         # the final total — enough to reconstruct the math from the log alone.
         for term in protocol.terms:
+            if term.label in skipped:
+                logger.info(format_log_event(label, "term evaluated", {
+                    "term": term.label,
+                    "type": type(term).__name__,
+                    "sub_labels": [],
+                    "kJ_per_mol": "0.000",
+                    "Hartree": "0.000000000",
+                    "skipped": skipped[term.label],
+                }))
+                continue
             contribution = term.evaluate(energies_kJmol)
             term_sub_labels = [sl for sl, _lvl in term.required_levels()]
             payload = {"term": term.label,
@@ -1861,11 +2104,17 @@ class Scheduler(object):
         that the notebook can round-trip through
         :meth:`CompositeProtocol.from_user_input`. ``preset_name`` and
         ``reference`` come from the protocol itself when available; otherwise
-        they fall back to explicit-recipe defaults.
+        they fall back to explicit-recipe defaults. δ terms skipped as
+        trivially zero are forwarded so the notebook and the YAML report
+        render them with contribution 0.0 and the reason.
         """
         species = self.species_dict[label]
         preset_name = getattr(protocol, "preset_name", None)
         reference = getattr(protocol, "reference", None)
+        skipped = self._sp_composite_skipped.get(label)
+        if skipped is None:
+            skipped = self._composite_skipped_terms(label, protocol)
+            self._sp_composite_skipped[label] = skipped
         flags: list[str] = []
         if not reference:
             reference = ("Explicit sp_composite recipe — no formal reference supplied by "
@@ -1882,6 +2131,7 @@ class Scheduler(object):
             protocol=protocol,
             sub_job_paths=dict(self.output[label]['paths']['sp_composite']),
             flags=flags,
+            skipped_terms=dict(skipped),
         )
 
     def _regenerate_composite_notebook(self) -> None:
@@ -1895,7 +2145,7 @@ class Scheduler(object):
         write_composite_notebook(
             path=nb_path,
             project_name=self.project,
-            arc_version="",  # Phase 4 may surface this; not critical for provenance.
+            arc_version=VERSION,
             timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
             sections=list(self._sp_composite_sections.values()),
             notebook_dir=output_dir,
@@ -1933,8 +2183,8 @@ class Scheduler(object):
             section=section,
             e_elect_kj_per_mol=e_elect,
             timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
-            arc_version="",  # surfaced via Phase 4 if needed
-            arc_commit="",   # surfaced via Phase 4 if needed
+            arc_version=VERSION,
+            arc_commit="",
         )
         logger.info(format_log_event(label, "species report written", {"path": report_path}))
 
@@ -1966,75 +2216,6 @@ class Scheduler(object):
         else:
             self._finalize_composite(label)
 
-    def _mrcc_degenerate_short_circuit(self, label: str, job) -> bool:
-        """If a composite δ-term high-leg sub-job errored with the
-        ``MRCCDegenerateSystem`` keyword, substitute the sister low-leg's
-        recorded path and advance the composite. Returns ``True`` when the
-        short-circuit was applied so the caller can skip ``troubleshoot_ess``.
-
-        Why this exists: for systems too small to accommodate the requested
-        CC excitation rank (atomic H, H2 at CCSDT(Q), etc.) MRCC's xmrcc
-        bails — there's no determinant space to iterate. The two legs of
-        the δ term are mathematically degenerate (all CC ranks reduce to
-        HF), so δ = 0 is the correct physical answer. The trsh ladder
-        cannot fix this; it must be handled at the protocol level.
-
-        Conservative on safety:
-        * Only fires when keywords contain ``'MRCCDegenerateSystem'``.
-        * Only fires when the species has an active composite.
-        * Only fires for ``__high`` sub-labels with a recorded ``__low``
-          sister in ``output[label]['paths']['sp_composite']``. Low-leg
-          failures and high-leg failures without a completed sister fall
-          through so the caller's normal trsh path runs.
-        """
-        keywords = (job.job_status[1] or {}).get('keywords') or []
-        if 'MRCCDegenerateSystem' not in keywords:
-            return False
-        protocol = self._composite_for(label)
-        if protocol is None:
-            return False
-        # Identify which pending sub_label this errored job corresponds to.
-        pending = self._sp_composite_pending.get(label, {})
-        failed_sub_label = next(
-            (sl for sl, lvl in pending.items() if lvl == job.level),
-            None,
-        )
-        if failed_sub_label is None or not failed_sub_label.endswith('__high'):
-            logger.warning(format_log_event(
-                label,
-                "MRCCDegenerateSystem on a non-high sub-job — falling through to trsh",
-                {"sub_label": failed_sub_label, "level": str(job.level)},
-            ))
-            return False
-        sister_low = failed_sub_label[: -len('__high')] + '__low'
-        completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
-        sister_path = completed.get(sister_low)
-        if not sister_path:
-            logger.warning(format_log_event(
-                label,
-                "MRCCDegenerateSystem high-leg failed but low-leg not yet recorded — deferring",
-                {"failed": failed_sub_label, "sister": sister_low},
-            ))
-            return False
-        logger.warning(format_log_event(
-            label,
-            "MRCC degenerate-system fallback: substituting low-leg energy for high-leg",
-            {"failed": failed_sub_label, "sister": sister_low,
-             "reason": "Method exceeds determinant space; δ = 0 by symmetry."},
-        ))
-        # Substitute by re-using the low-leg's path. _record_composite_completion
-        # writes the path into output and clears the pending entry — same as a
-        # normal completion, but pointing both legs at the same file so they
-        # parse to the same energy and the δ evaluates to zero.
-        completed_paths = self.output[label]['paths']['sp_composite']
-        completed_paths[failed_sub_label] = sister_path
-        del pending[failed_sub_label]
-        if pending:
-            self._spawn_composite_pending(label)
-        else:
-            self._finalize_composite(label)
-        return True
-
     def _rehydrate_composite_state(self) -> None:
         """On scheduler init/restart, seed pending for every species with an active
         composite, rebuild the SpeciesSection for species that already finalized,
@@ -2046,6 +2227,20 @@ class Scheduler(object):
                 continue
             self._seed_composite_pending(label)
             if self.output.get(label, {}).get('job_types', {}).get('sp_composite'):
+                # _seed_composite_pending may have stripped missing/unparseable
+                # paths via _validate_composite_completed; re-writing the report
+                # from a stripped dict would KeyError. Skip until the requeued
+                # sub-jobs complete and re-finalize the species.
+                completed = self.output.get(label, {}).get('paths', {}).get('sp_composite', {}) or {}
+                skipped = self._sp_composite_skipped.get(label, {})
+                missing = [sub_label for term_label, sub_label, _level in protocol.iter_required_jobs()
+                           if term_label not in skipped and sub_label not in completed]
+                if missing:
+                    logger.warning(format_log_event(
+                        label, "finalized species is missing sub-job paths — skipping report re-write",
+                        {"missing": missing},
+                    ))
+                    continue
                 self._sp_composite_sections[label] = self._build_species_section(label, protocol)
                 # Re-emit the per-species report so a restart fills in reports
                 # missing on disk (and refreshes any whose protocol metadata
@@ -2098,11 +2293,13 @@ class Scheduler(object):
             level (Level): An alternative level of theory to run at. If ``None``, self.sp_level will be used.
             conformer (int): The conformer number.
         """
-        # Phase 3: for species with an active sp_composite, the SP runs at the
-        # protocol's base.level (unless the caller passed an explicit ``level``).
+        # For species with an active sp_composite, the SP runs at the protocol's
+        # primary base level — the single base level, or the largest-cardinal
+        # CBS leg (unless the caller passed an explicit ``level``). The remaining
+        # base legs and corrections are spawned by _post_sp_actions_composite.
         if level is None:
             _active_protocol = self._composite_for(label)
-            level = _active_protocol.base.level if _active_protocol is not None else self.sp_level
+            level = _active_protocol.primary_base_level if _active_protocol is not None else self.sp_level
         if self.job_types['conf_sp'] and conformer is not None and self.conformer_sp_level != self.conformer_opt_level:
             self.run_job(label=label,
                          xyz=self.species_dict[label].conformers[conformer],
@@ -3631,13 +3828,6 @@ class Scheduler(object):
             if self.species_dict[label].number_of_atoms == 1:
                 # save the geometry from the sp job for monoatomic species for which no opt/freq jobs will be spawned
                 self.output[label]['paths']['geo'] = job.local_path_to_output_file
-        elif self._mrcc_degenerate_short_circuit(label=label, job=job):
-            # MRCC bailed for a degenerate small-system δ-term high leg
-            # (atomic H, H2, etc., where the requested CC excitation rank
-            # exceeds the determinant space). The trsh ladder cannot help —
-            # cause is intrinsic. Helper substituted the low-leg energy and
-            # advanced the composite; nothing further to do here.
-            self.save_restart_dict()
         else:
             self.troubleshoot_ess(label=label,
                                   job=job,
@@ -3657,7 +3847,7 @@ class Scheduler(object):
             sp_path (str): The path to 'output.out' for the single point job.
             level (Level, optional): The level of theory used for the sp job.
         """
-        # Phase 3: when sp_composite is active for this species, route through
+        # When sp_composite is active for this species, route through
         # the composite branch. The legacy path below does not run for composite
         # species — e_elect is set by ``_finalize_composite`` after all sub-jobs
         # complete, not from any single intermediate SP.
@@ -4089,15 +4279,21 @@ class Scheduler(object):
         """
         Check job status on a specific server or on all active servers, get a list of relevant running job IDs.
 
+        Also retains a job_id → normalized queue state map in ``self.server_job_states``
+        (local jobs carry no state info and are absent from the map).
+
         Args:
             specific_server (str, optional): The server to check. If ``None``, check all active servers.
         """
         self.server_job_ids = list()
+        self.server_job_states = dict()
         for server in self.servers:
             if specific_server is None or server == specific_server:
                 if server != 'local':
                     with SSHClient(server) as ssh:
-                        self.server_job_ids.extend(ssh.check_running_jobs_ids())
+                        job_states = ssh.check_running_jobs_ids_and_states()
+                    self.server_job_ids.extend(job_states.keys())
+                    self.server_job_states.update({str(job_id): state for job_id, state in job_states.items()})
                 else:
                     self.server_job_ids.extend(check_running_jobs_ids())
 
@@ -4609,9 +4805,9 @@ class Scheduler(object):
             propagates a RuntimeError up through delete_all_species_jobs →
             troubleshoot_negative_freq → schedule_jobs → __init__ and the
             entire project dies."""
-            logger.info(f'Deleted job {display_name}')
             try:
                 job.delete()
+                logger.info(f'Deleted job {display_name}')
             except Exception as exc:
                 logger.warning(
                     f'Failed to delete job {display_name} for species '
@@ -4633,7 +4829,7 @@ class Scheduler(object):
         # Reset paths for this species. Most keys reset to ''; container-valued
         # keys keep their type so the rest of the pipeline (composite tracking,
         # IRC trajectory list) doesn't crash on a string where it expects a
-        # dict / list. Phase 3 added 'sp_composite' as a dict[sub_label → path];
+        # dict / list. 'sp_composite' is a dict[sub_label → path];
         # without the carve-out below it would collapse to '' here and the next
         # composite sub-job completion would TypeError on item assignment.
         _path_empty = {'irc': list, 'sp_composite': dict}
@@ -4655,6 +4851,7 @@ class Scheduler(object):
         self._pending_pipe_irc.discard((label, 'forward'))
         self._pending_pipe_irc.discard((label, 'reverse'))
         self._sp_composite_pending.pop(label, None)
+        self._sp_composite_skipped.pop(label, None)
         self._sp_composite_sections.pop(label, None)
         # Clean up any IRC species spawned from this TS.
         if label in self.species_dict and self.species_dict[label].is_ts:
@@ -4965,7 +5162,8 @@ class Scheduler(object):
     def _ensure_sp_composite_paths_invariant(self, label: str) -> None:
         """Coerce ``output[label]['paths']['sp_composite']`` to a dict.
 
-        Phase 3 stores sub-job results as ``{sub_label: path}`` here. A non-
+        The composite orchestration stores sub-job results as
+        ``{sub_label: path}`` here. A non-
         dict value (typically a leftover scalar string from an older ARC
         version's restart.yml) is reset to ``{}`` and a single-line warning
         is logged so the user can audit. Empty/absent values are reset
@@ -5120,6 +5318,11 @@ def species_has_sp(species_output_dict: dict,
     """
     Checks whether a species has a valid converged single-point energy using it's output dict.
 
+    For a species computed with an sp_composite protocol (non-empty ``paths['sp_composite']``),
+    the sp phase is complete only once all protocol sub-jobs were recorded and the protocol was
+    evaluated — flagged by ``job_types['sp_composite']``. ``paths['sp']`` (the geometry-consistent
+    base log) is deliberately ignored here, see Scheduler._sync_composite_sp_path.
+
     Args:
         species_output_dict (dict): The species output dict (i.e., Scheduler.output[label]).
         yml_path (str): THe species Arkane YAML file path.
@@ -5129,6 +5332,8 @@ def species_has_sp(species_output_dict: dict,
     """
     if yml_path is not None:
         return True
+    if species_output_dict['paths'].get('sp_composite'):
+        return bool(species_output_dict.get('job_types', {}).get('sp_composite'))
     if species_output_dict['paths']['sp'] or species_output_dict['paths']['composite']:
         return True
     return False

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -5,16 +5,20 @@
 This module contains unit tests for the arc.scheduler module
 """
 
-import unittest
-from unittest.mock import patch
+import logging
 import os
 import shutil
+import unittest
+from unittest.mock import patch
+
+import nbformat
 
 import arc.parser.parser as parser
 from arc.checks.ts import check_ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
 from arc.job.factory import job_factory
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
 from arc.scheduler import Scheduler, species_has_freq, species_has_geo, species_has_sp, species_has_sp_and_freq
 from arc.imports import settings
@@ -281,8 +285,10 @@ H      -1.82570782    0.42754384   -0.56130718"""
                                             'onedmin': False,
                                             'opt': False,
                                             'orbitals': False,
-                                            'sp': False},
-                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': ''},
+                                            'sp': False,
+                                            'sp_composite': False},
+                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': '',
+                                        'sp_composite': {}},
                               'restart': '', 'warnings': ''}
         initialized_output_dict = {'C2H6': empty_species_dict,
                                    'CtripCO': empty_species_dict,
@@ -1043,6 +1049,771 @@ H      -1.82570782    0.42754384   -0.56130718"""
         for project in projects:
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
+    """
+    Phase 3 end-to-end tests for composite orchestration: sub-job dispatch,
+    Level-duplication handling, final energy combination, notebook regeneration,
+    and basic restart recovery. Sub-job completions are simulated by invoking
+    ``post_sp_actions`` with fixture Gaussian-format .out files so the flow
+    exercises the real scheduler code without running any actual QM jobs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', 'arc_project_for_testing_sp_composite_orch'
+        )
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+        os.makedirs(cls.project_directory, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    @staticmethod
+    def _write_gaussian_fixture(path, e_hartree):
+        """Minimal Gaussian-format output that parse_e_elect can consume."""
+        with open(path, "w") as fh:
+            fh.write(" Gaussian 16: test fixture\n")
+            fh.write(f" SCF Done:  E(RHF) =  {e_hartree:.9f}     A.U. after    1 cycles\n")
+
+    @staticmethod
+    def _heat345q_like_recipe():
+        """A small protocol with duplicate Levels across distinct sub_labels."""
+        return {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",    "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)",  "basis": "cc-pVDZ"}},
+                {"label": "delta_Q", "type": "delta",
+                 "high": {"method": "ccsdt(q)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsdt",    "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    def _make_scheduler(self, species_list, sp_composite, output=None):
+        """Build a Scheduler with run_job patched to a no-op.
+
+        We patch at the *class* level because the Phase 3.5 restart kick-start
+        invokes run_job from inside __init__ — instance-level monkey patching
+        would arrive too late.
+        """
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=species_list,
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=sp_composite,
+                output=output,
+                testing=True,
+            )
+        # Also keep the instance-level no-op so subsequent post_sp_actions calls
+        # that spawn pending sub-jobs don't hit the real server machinery.
+        sched.run_job = lambda *args, **kwargs: None
+        return sched
+
+    def _seed_protocol_fixtures(self, tmpdir, protocol, energies_by_sub_label):
+        """Write one fixture .out per sub_label. Returns {sub_label: path}."""
+        paths = {}
+        for _term, sub_label, _level in protocol.iter_required_jobs():
+            p = os.path.join(tmpdir, f"{sub_label}.out")
+            self._write_gaussian_fixture(p, energies_by_sub_label[sub_label])
+            paths[sub_label] = p
+        return paths
+
+    def test_minimal_finalization_sets_e_elect_and_source(self):
+        tmp = os.path.join(self.project_directory, "fx_minimal")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies_H = {"base": -1.10, "delta_T__high": -1.15, "delta_T__low": -1.12}
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies_H)
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+        parsed = {sl: parser.parse_e_elect(p) for sl, p in paths.items()}
+        expected = protocol.evaluate(parsed)
+        self.assertAlmostEqual(spc.e_elect, expected, places=6)
+
+    def test_output_paths_sp_composite_populated(self):
+        tmp = os.path.join(self.project_directory, "fx_paths")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        recorded = sched.output['H2']['paths']['sp_composite']
+        self.assertEqual(set(recorded.keys()),
+                         {"base", "delta_T__high", "delta_T__low"})
+
+    def test_duplicate_levels_share_one_sp_path(self):
+        """delta_T__high and delta_Q__low share the ccsdt/cc-pVDZ Level; one SP
+        output path must map to BOTH sub_labels."""
+        tmp = os.path.join(self.project_directory, "fx_dup")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = ARCSpecies(label='HF', smiles='F')
+        spc.final_xyz = {'symbols': ('H', 'F'), 'coords': ((0, 0, 0), (0, 0, 0.92)),
+                         'isotopes': (1, 19)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -100.10)
+        ccsdt_cc_pVDZ_path = os.path.join(tmp, "ccsdt_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_cc_pVDZ_path, -100.20)
+        ccsd_t_cc_pVDZ_path = os.path.join(tmp, "ccsd_t_pVDZ.out")
+        self._write_gaussian_fixture(ccsd_t_cc_pVDZ_path, -100.22)
+        ccsdt_q_cc_pVDZ_path = os.path.join(tmp, "ccsdt_q_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_q_cc_pVDZ_path, -100.25)
+        sched.post_sp_actions('HF', base_path, protocol.base.level)
+        sched.post_sp_actions('HF', ccsd_t_cc_pVDZ_path, protocol.corrections[0].low)
+        sched.post_sp_actions('HF', ccsdt_cc_pVDZ_path, protocol.corrections[0].high)
+        sched.post_sp_actions('HF', ccsdt_q_cc_pVDZ_path, protocol.corrections[1].high)
+        recorded = sched.output['HF']['paths']['sp_composite']
+        self.assertEqual(recorded["delta_T__high"], recorded["delta_Q__low"])
+        self.assertEqual(recorded["delta_T__high"], ccsdt_cc_pVDZ_path)
+        self.assertTrue(sched.output['HF']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+
+    def test_active_composite_species_uses_base_level_for_sp(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertNotEqual(sched.sp_level.method, "hf")
+        active = sched._composite_for('H2')
+        self.assertIsNotNone(active)
+        self.assertEqual(active.base.level.method, "hf")
+
+    def test_opt_out_species_uses_global_sp_level(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=None)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertIsNone(sched._composite_for('H2'))
+
+    def test_explicit_species_protocol_beats_global(self):
+        global_recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        local_recipe = {"base": {"method": "mp2", "basis": "cc-pVTZ"}, "corrections": []}
+        global_proto = CompositeProtocol.from_user_input(global_recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=global_proto)
+        resolved = sched._composite_for('H2')
+        self.assertEqual(resolved.base.level.method, "mp2")
+
+    def test_ts_species_finalizes_with_kind_ts_section(self):
+        tmp = os.path.join(self.project_directory, "fx_ts")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        ts = ARCSpecies(label='TS1', is_ts=True)
+        ts.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 1.2)),
+                        'isotopes': (1, 1)}
+        sched = self._make_scheduler([ts], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.05)
+        sched.post_sp_actions('TS1', base_path, protocol.base.level)
+        self.assertTrue(sched.output['TS1']['job_types']['sp_composite'])
+        self.assertIn('TS1', sched._sp_composite_sections)
+        self.assertEqual(sched._sp_composite_sections['TS1'].kind, 'ts')
+
+    def test_notebook_regenerated_with_cumulative_sections(self):
+        tmp = os.path.join(self.project_directory, "fx_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='A', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        spc_b = ARCSpecies(label='B', smiles='[H][H]')
+        spc_b.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc_a, spc_b], sp_composite=protocol)
+        p_a = os.path.join(tmp, "a.out")
+        p_b = os.path.join(tmp, "b.out")
+        self._write_gaussian_fixture(p_a, -1.05)
+        self._write_gaussian_fixture(p_b, -1.06)
+        sched.post_sp_actions('A', p_a, protocol.base.level)
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb1 = nbformat.read(nb_path, as_version=4)
+        titles1 = [c.source for c in nb1.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles1))
+        sched.post_sp_actions('B', p_b, protocol.base.level)
+        nb2 = nbformat.read(nb_path, as_version=4)
+        titles2 = [c.source for c in nb2.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles2))
+        self.assertTrue(any("B" in t for t in titles2))
+
+    def test_log_lines_include_sp_composite_events(self):
+        tmp = os.path.join(self.project_directory, "fx_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+        joined = "\n".join(cm.output)
+        self.assertIn("[sp_composite]", joined)
+        # "protocol resolved" is logged at scheduler __init__ time (during
+        # rehydration), so it won't appear in assertLogs here — that's fine;
+        # covered implicitly by the presence of sub-job-completed lines which
+        # only fire if pending was seeded successfully.
+        self.assertIn("sub-job completed", joined)
+        self.assertIn("all sub-jobs complete", joined)
+        self.assertIn("FINAL e_elect", joined)
+        self.assertIn("provenance notebook regenerated", joined)
+
+    def test_restart_reuses_completed_sub_jobs(self):
+        tmp = os.path.join(self.project_directory, "fx_restart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol, output=output_snapshot)
+        pending = sched2._sp_composite_pending['H2']
+        self.assertEqual(set(pending.keys()), {"delta_T__high", "delta_T__low"})
+        sched2.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_missing_sub_job_does_not_finalize(self):
+        tmp = os.path.join(self.project_directory, "fx_miss")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        self.assertIsNone(spc.e_elect_source)
+        self.assertIsNone(spc.e_elect)
+
+    # --- Phase 3.5: restart kick-start ------------------------------------- #
+
+    def test_restart_kick_start_queues_missing_sub_jobs(self):
+        """On restart with base completed and no events firing, the scheduler
+        must queue the missing delta sub-jobs by itself."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        # Build a fresh scheduler from the output snapshot and capture all
+        # run_job calls the kick-start makes.
+        spawned_levels = []
+
+        def capture(self_inner, *args, **kwargs):
+            spawned_levels.append(kwargs.get('level_of_theory'))
+
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", capture):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Kick-start must have spawned exactly the two missing unique Levels.
+        self.assertEqual(len(spawned_levels), 2)
+        spawned_methods = sorted(lvl.method for lvl in spawned_levels)
+        self.assertEqual(spawned_methods, ["ccsd(t)", "ccsdt"])
+        # Pending dict reflects what's queued.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__high", "delta_T__low"})
+
+    def test_kick_start_skips_species_with_no_prior_progress(self):
+        """Species that have never run any composite sub-job (mid-opt or fresh)
+        should NOT be kick-started — they follow the normal opt → SP flow."""
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        spawned = []
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: spawned.append(kw)):
+            Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                testing=True,
+            )
+        # No prior progress → kick-start must not spawn anything.
+        self.assertEqual(spawned, [])
+
+    # --- Phase 3.5: corruption recovery ------------------------------------ #
+
+    def test_corrupted_recorded_output_is_invalidated_and_requeued(self):
+        """A previously-recorded sub-job output that no longer exists on disk
+        must be invalidated, re-added to pending, and re-queued by kick-start."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        # Reset the finalized flags so the second scheduler's rehydration re-runs
+        # validation/seed for this species (otherwise it would skip as already-done).
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        # Simulate on-disk corruption: delete delta_T__low's output.
+        os.unlink(paths["delta_T__low"])
+        # Fresh scheduler from snapshot; rehydration must invalidate only delta_T__low.
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned_levels = []
+        with patch.object(Scheduler, "run_job",
+                          lambda self, *a, **kw: spawned_levels.append(kw.get('level_of_theory'))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Only the corrupted sub_label is pending; only one kick-start spawn.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__low"})
+        self.assertEqual(sched2.output['H2']['job_types']['sp_composite'], False)
+        self.assertEqual(len(spawned_levels), 1)
+        self.assertEqual(spawned_levels[0].method, "ccsd(t)")
+        # Replace the file and re-complete → protocol finalizes normally.
+        sched2.run_job = lambda *args, **kwargs: None
+        self._write_gaussian_fixture(paths["delta_T__low"], -1.12)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_corruption_warning_logged(self):
+        """The warning event must name the species, sub_label, path, and reason."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        # Build a valid initial scheduler + base completion, then point the
+        # recorded path at a file that doesn't exist.
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched1.post_sp_actions('H2', base_path, protocol.base.level)
+        # Corrupt: point the recorded base path at a non-existent file, reset
+        # the finalized flag so the second scheduler re-validates.
+        sched1.output['H2']['paths']['sp_composite']['base'] = '/tmp/does/not/exist.out'
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                Scheduler(
+                    project='sp_composite_orch',
+                    ess_settings=self.ess_settings,
+                    species_list=[spc2],
+                    project_directory=self.project_directory,
+                    opt_level=Level(repr=default_levels_of_theory['opt']),
+                    freq_level=Level(repr=default_levels_of_theory['freq']),
+                    sp_level=Level(repr=default_levels_of_theory['sp']),
+                    conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                    scan_level=Level(repr=default_levels_of_theory['scan']),
+                    ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                    orbitals_level=default_levels_of_theory['orbitals'],
+                    sp_composite=protocol,
+                    output=output_snapshot,
+                    testing=True,
+                )
+        joined = "\n".join(cm.output)
+        self.assertIn("sub-job output invalidated", joined)
+        self.assertIn("sub_label=base", joined)
+        self.assertIn("/tmp/does/not/exist.out", joined)
+
+    # --- Phase 3.5: preset name + reference preservation ------------------- #
+
+    def test_preset_name_and_reference_survive_to_notebook_section(self):
+        """When the protocol is a preset, its preset_name and reference (DOI)
+        must flow through parsing → finalize → SpeciesSection."""
+        tmp = os.path.join(self.project_directory, "fx_preset")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        self.assertEqual(protocol.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', protocol.reference)
+        # Now exercise the scheduler end-to-end with only a bare-bones subset
+        # of sub-jobs (we don't need the full HEAT protocol to fire to verify
+        # the SpeciesSection carries the preset metadata) — build a trivial
+        # protocol with its preset metadata manually preserved.
+        simple = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        simple.preset_name = 'HEAT-345Q'
+        simple.reference = protocol.reference
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=simple)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, simple.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertEqual(section.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', section.reference)
+
+    def test_explicit_recipe_reference_key_preserved(self):
+        """Users can supply a `reference` at the top level of an explicit recipe."""
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+            "reference": "Custom recipe; DOI: 10.9999/custom",
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        self.assertIsNone(protocol.preset_name)
+        self.assertEqual(protocol.reference, "Custom recipe; DOI: 10.9999/custom")
+
+    def test_explicit_recipe_without_reference_falls_back_and_flags(self):
+        """Explicit recipe, no reference → SpeciesSection flags it."""
+        tmp = os.path.join(self.project_directory, "fx_expl")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertIsNone(section.preset_name)
+        self.assertIn("Explicit", section.reference)
+        self.assertTrue(any("No formal reference" in f for f in section.flags))
+
+    def test_protocol_preset_metadata_round_trips_through_as_dict(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        restored = CompositeProtocol.from_dict(protocol.as_dict())
+        self.assertEqual(restored.preset_name, 'HEAT-345Q')
+        self.assertEqual(restored.reference, protocol.reference)
+
+    # --- Phase 3.5: term-level logging ------------------------------------- #
+
+    def test_term_evaluated_log_event_per_term(self):
+        tmp = os.path.join(self.project_directory, "fx_term_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                {"label": "cbs_corr", "type": "cbs_extrapolation",
+                 "formula": "helgaker_corr_2pt",
+                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies = {
+            "base": -1.10,
+            "delta_T__high": -1.15, "delta_T__low": -1.12,
+            "cbs_corr__card_3": -1.14, "cbs_corr__card_4": -1.145,
+        }
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies)
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+            sched.post_sp_actions('H2', paths["cbs_corr__card_3"],
+                                  protocol.corrections[1].levels[0])
+            sched.post_sp_actions('H2', paths["cbs_corr__card_4"],
+                                  protocol.corrections[1].levels[1])
+        joined = "\n".join(cm.output)
+        self.assertIn("term evaluated", joined)
+        # One "term evaluated" per term (base + delta_T + cbs_corr = 3).
+        count = joined.count("term evaluated")
+        self.assertEqual(count, 3)
+        # Each term's label appears.
+        for term_label in ("base", "delta_T", "cbs_corr"):
+            self.assertIn(f"term={term_label}", joined)
+        # CBS term carries a formula field.
+        self.assertIn("formula=helgaker_corr_2pt", joined)
+
+
+    # --- Phase 5: rehydrated-finalized species reappear in regenerated notebook -- #
+
+    def test_rehydrated_finalized_species_appears_in_cumulative_notebook(self):
+        """A species that finalized in a previous ARC run must reappear in the
+        project notebook after restart-time regeneration — with every required
+        sub_label resolved to the actual output file path."""
+        tmp = os.path.join(self.project_directory, "fx_rehydrate_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc_a], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.05, "delta_T__high": -1.07,
+                                              "delta_T__low": -1.06})
+        sched1.post_sp_actions('Afinalized', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched1.output['Afinalized']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+
+        # Restart with the same species list. Rehydration must resurrect the
+        # SpeciesSection so a subsequent notebook regeneration includes it.
+        spc_a2 = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a2.final_xyz = spc_a.final_xyz
+        sched2 = self._make_scheduler([spc_a2], sp_composite=protocol,
+                                      output=output_snapshot)
+        self.assertIn('Afinalized', sched2._sp_composite_sections)
+        sec = sched2._sp_composite_sections['Afinalized']
+        required = {sub for _t, sub, _l in protocol.iter_required_jobs()}
+        # Every required sub_label is present and points at the real output file.
+        self.assertEqual(set(sec.sub_job_paths.keys()), required)
+        for sub_label in required:
+            self.assertEqual(sec.sub_job_paths[sub_label], paths[sub_label])
+            self.assertTrue(os.path.isfile(sec.sub_job_paths[sub_label]))
+        # Trigger a fresh notebook regeneration directly; the rehydrated section
+        # must appear in the cumulative output.
+        sched2._regenerate_composite_notebook()
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb = nbformat.read(nb_path, as_version=4)
+        titles = [c.source for c in nb.cells
+                  if c.cell_type == "markdown"
+                  and c.source.lstrip().startswith("## ")
+                  and "Project summary" not in c.source
+                  and "References" not in c.source]
+        self.assertTrue(any("Afinalized" in t for t in titles))
+
+
+class TestSchedulerSpCompositePassthrough(unittest.TestCase):
+    """
+    Phase 2 contract: Scheduler.__init__ accepts sp_composite and stores it only —
+    no orchestration, no output-dict changes, no jobs queued.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', 'arc_project_for_testing_sp_composite_passthrough'
+        )
+        cls.spc = ARCSpecies(label='H2', smiles='[H][H]')
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    def _make_scheduler(self, sp_composite):
+        return Scheduler(
+            project='sp_composite_passthrough',
+            ess_settings=self.ess_settings,
+            species_list=[self.spc],
+            project_directory=self.project_directory,
+            opt_level=Level(repr=default_levels_of_theory['opt']),
+            freq_level=Level(repr=default_levels_of_theory['freq']),
+            sp_level=Level(repr=default_levels_of_theory['sp']),
+            conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+            scan_level=Level(repr=default_levels_of_theory['scan']),
+            ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+            orbitals_level=default_levels_of_theory['orbitals'],
+            sp_composite=sp_composite,
+            testing=True,
+        )
+
+    def test_stores_sp_composite(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertIs(sched.sp_composite, protocol)
+
+    def test_none_sp_composite_stored_as_none(self):
+        sched = self._make_scheduler(None)
+        self.assertIsNone(sched.sp_composite)
+
+    def test_passthrough_does_not_queue_jobs(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertEqual(sched.running_jobs, {'H2': []})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -839,8 +839,9 @@ H      -1.82570782    0.42754384   -0.56130718"""
         project_directory = os.path.join(ARC_PATH, 'Projects',
                                          'arc_project_for_testing_delete_after_usage4')
         self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        caller_species_list = [ts_spc]
         sched = Scheduler(project='test_switch_ts', ess_settings=self.ess_settings,
-                          species_list=[ts_spc],
+                          species_list=caller_species_list,
                           opt_level=Level(repr=default_levels_of_theory['opt']),
                           freq_level=Level(repr=default_levels_of_theory['freq']),
                           sp_level=Level(repr=default_levels_of_theory['sp']),
@@ -869,7 +870,7 @@ H      -1.82570782    0.42754384   -0.56130718"""
         ts_spc.irc_label = f'{irc_label_1} {irc_label_2}'
         sched.species_dict[irc_label_1] = irc_spc_1
         sched.species_dict[irc_label_2] = irc_spc_2
-        sched.species_list.extend([irc_spc_1, irc_spc_2])
+        caller_species_list.extend([irc_spc_1, irc_spc_2])
         sched.unique_species_labels.extend([irc_label_1, irc_label_2])
         sched.running_jobs[irc_label_1] = ['opt_a100']
         sched.running_jobs[irc_label_2] = ['opt_a101']
@@ -903,6 +904,14 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertNotIn(irc_label_1, sched.unique_species_labels)
         self.assertNotIn(irc_label_2, sched.unique_species_labels)
         self.assertIsNone(sched.species_dict[ts_label].irc_label)
+
+        # Regression: caller's species_list reference must also have IRC species
+        # removed. If cleanup rebinds self.species_list to a new list, the caller's
+        # reference (e.g. ARC.species) keeps zombie IRC species and later crashes
+        # save_project_info_file with KeyError on self.output[IRC_label].
+        self.assertNotIn(irc_spc_1, caller_species_list)
+        self.assertNotIn(irc_spc_2, caller_species_list)
+        self.assertIs(sched.species_list, caller_species_list)
 
         # Verify job_types reset and convergence cleared.
         self.assertFalse(sched.output[ts_label]['job_types']['opt'])

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -7,8 +7,13 @@ This module contains unit tests for the arc.scheduler module
 
 import unittest
 from unittest.mock import MagicMock, patch
+import logging
 import os
 import shutil
+import unittest
+from unittest.mock import patch
+
+import nbformat
 
 
 import arc.parser.parser as parser
@@ -17,6 +22,7 @@ from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, in
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
 from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
                            species_has_sp_and_freq)
@@ -284,8 +290,10 @@ H      -1.82570782    0.42754384   -0.56130718"""
                                             'onedmin': False,
                                             'opt': False,
                                             'orbitals': False,
-                                            'sp': False},
-                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': ''},
+                                            'sp': False,
+                                            'sp_composite': False},
+                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': '',
+                                        'sp_composite': {}},
                               'restart': '', 'warnings': ''}
         initialized_output_dict = {'C2H6': empty_species_dict,
                                    'CtripCO': empty_species_dict,
@@ -1465,6 +1473,1272 @@ class TestSchedulerAdaptiveReactionLevels(unittest.TestCase):
         collider = ARCSpecies(label='CH4_TS0', smiles='O')
         with self.assertRaises(SchedulerError):
             self.build_scheduler(rxn, r + p + [collider], 'adaptive_collision')
+
+
+class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
+    """
+    Phase 3 end-to-end tests for composite orchestration: sub-job dispatch,
+    Level-duplication handling, final energy combination, notebook regeneration,
+    and basic restart recovery. Sub-job completions are simulated by invoking
+    ``post_sp_actions`` with fixture Gaussian-format .out files so the flow
+    exercises the real scheduler code without running any actual QM jobs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', f'arc_project_for_testing_sp_composite_orch_{worker}'
+        )
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+        os.makedirs(cls.project_directory, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    @staticmethod
+    def _write_gaussian_fixture(path, e_hartree):
+        """Minimal Gaussian-format output that parse_e_elect can consume."""
+        with open(path, "w") as fh:
+            fh.write(" Gaussian 16: test fixture\n")
+            fh.write(f" SCF Done:  E(RHF) =  {e_hartree:.9f}     A.U. after    1 cycles\n")
+
+    @staticmethod
+    def _heat345q_like_recipe():
+        """A small protocol with duplicate Levels across distinct sub_labels."""
+        return {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",    "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)",  "basis": "cc-pVDZ"}},
+                {"label": "delta_Q", "type": "delta",
+                 "high": {"method": "ccsdt(q)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsdt",    "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    def _make_scheduler(self, species_list, sp_composite, output=None):
+        """Build a Scheduler with run_job patched to a no-op.
+
+        We patch at the *class* level because the Phase 3.5 restart kick-start
+        invokes run_job from inside __init__ — instance-level monkey patching
+        would arrive too late.
+        """
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=species_list,
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=sp_composite,
+                output=output,
+                testing=True,
+            )
+        # Also keep the instance-level no-op so subsequent post_sp_actions calls
+        # that spawn pending sub-jobs don't hit the real server machinery.
+        sched.run_job = lambda *args, **kwargs: None
+        return sched
+
+    def _seed_protocol_fixtures(self, tmpdir, protocol, energies_by_sub_label):
+        """Write one fixture .out per sub_label. Returns {sub_label: path}."""
+        paths = {}
+        for _term, sub_label, _level in protocol.iter_required_jobs():
+            p = os.path.join(tmpdir, f"{sub_label}.out")
+            self._write_gaussian_fixture(p, energies_by_sub_label[sub_label])
+            paths[sub_label] = p
+        return paths
+
+    def test_minimal_finalization_sets_e_elect_and_source(self):
+        tmp = os.path.join(self.project_directory, "fx_minimal")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies_H = {"base": -1.10, "delta_T__high": -1.15, "delta_T__low": -1.12}
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies_H)
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+        parsed = {sl: parser.parse_e_elect(p) for sl, p in paths.items()}
+        expected = protocol.evaluate(parsed)
+        self.assertAlmostEqual(spc.e_elect, expected, places=6)
+
+    def test_output_paths_sp_composite_populated(self):
+        tmp = os.path.join(self.project_directory, "fx_paths")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        recorded = sched.output['H2']['paths']['sp_composite']
+        self.assertEqual(set(recorded.keys()),
+                         {"base", "delta_T__high", "delta_T__low"})
+
+    def test_duplicate_levels_share_one_sp_path(self):
+        """delta_T__high and delta_Q__low share the ccsdt/cc-pVDZ Level; one SP
+        output path must map to BOTH sub_labels."""
+        tmp = os.path.join(self.project_directory, "fx_dup")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = ARCSpecies(label='HF', smiles='F')
+        spc.final_xyz = {'symbols': ('H', 'F'), 'coords': ((0, 0, 0), (0, 0, 0.92)),
+                         'isotopes': (1, 19)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -100.10)
+        ccsdt_cc_pVDZ_path = os.path.join(tmp, "ccsdt_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_cc_pVDZ_path, -100.20)
+        ccsd_t_cc_pVDZ_path = os.path.join(tmp, "ccsd_t_pVDZ.out")
+        self._write_gaussian_fixture(ccsd_t_cc_pVDZ_path, -100.22)
+        ccsdt_q_cc_pVDZ_path = os.path.join(tmp, "ccsdt_q_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_q_cc_pVDZ_path, -100.25)
+        sched.post_sp_actions('HF', base_path, protocol.base.level)
+        sched.post_sp_actions('HF', ccsd_t_cc_pVDZ_path, protocol.corrections[0].low)
+        sched.post_sp_actions('HF', ccsdt_cc_pVDZ_path, protocol.corrections[0].high)
+        sched.post_sp_actions('HF', ccsdt_q_cc_pVDZ_path, protocol.corrections[1].high)
+        recorded = sched.output['HF']['paths']['sp_composite']
+        self.assertEqual(recorded["delta_T__high"], recorded["delta_Q__low"])
+        self.assertEqual(recorded["delta_T__high"], ccsdt_cc_pVDZ_path)
+        self.assertTrue(sched.output['HF']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+
+    def test_active_composite_species_uses_base_level_for_sp(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertNotEqual(sched.sp_level.method, "hf")
+        active = sched._composite_for('H2')
+        self.assertIsNotNone(active)
+        self.assertEqual(active.base.level.method, "hf")
+
+    def test_opt_out_species_uses_global_sp_level(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=None)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertIsNone(sched._composite_for('H2'))
+
+    def test_explicit_species_protocol_beats_global(self):
+        global_recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        local_recipe = {"base": {"method": "mp2", "basis": "cc-pVTZ"}, "corrections": []}
+        global_proto = CompositeProtocol.from_user_input(global_recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=global_proto)
+        resolved = sched._composite_for('H2')
+        self.assertEqual(resolved.base.level.method, "mp2")
+
+    def test_ts_species_finalizes_with_kind_ts_section(self):
+        tmp = os.path.join(self.project_directory, "fx_ts")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        ts = ARCSpecies(label='TS1', is_ts=True)
+        ts.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 1.2)),
+                        'isotopes': (1, 1)}
+        sched = self._make_scheduler([ts], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.05)
+        sched.post_sp_actions('TS1', base_path, protocol.base.level)
+        self.assertTrue(sched.output['TS1']['job_types']['sp_composite'])
+        self.assertIn('TS1', sched._sp_composite_sections)
+        self.assertEqual(sched._sp_composite_sections['TS1'].kind, 'ts')
+
+    def test_notebook_regenerated_with_cumulative_sections(self):
+        tmp = os.path.join(self.project_directory, "fx_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='A', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        spc_b = ARCSpecies(label='B', smiles='[H][H]')
+        spc_b.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc_a, spc_b], sp_composite=protocol)
+        p_a = os.path.join(tmp, "a.out")
+        p_b = os.path.join(tmp, "b.out")
+        self._write_gaussian_fixture(p_a, -1.05)
+        self._write_gaussian_fixture(p_b, -1.06)
+        sched.post_sp_actions('A', p_a, protocol.base.level)
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb1 = nbformat.read(nb_path, as_version=4)
+        titles1 = [c.source for c in nb1.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles1))
+        sched.post_sp_actions('B', p_b, protocol.base.level)
+        nb2 = nbformat.read(nb_path, as_version=4)
+        titles2 = [c.source for c in nb2.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles2))
+        self.assertTrue(any("B" in t for t in titles2))
+
+    def test_log_lines_include_sp_composite_events(self):
+        tmp = os.path.join(self.project_directory, "fx_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+        joined = "\n".join(cm.output)
+        self.assertIn("[sp_composite]", joined)
+        # "protocol resolved" is logged at scheduler __init__ time (during
+        # rehydration), so it won't appear in assertLogs here — that's fine;
+        # covered implicitly by the presence of sub-job-completed lines which
+        # only fire if pending was seeded successfully.
+        self.assertIn("sub-job completed", joined)
+        self.assertIn("all sub-jobs complete", joined)
+        self.assertIn("FINAL e_elect", joined)
+        self.assertIn("provenance notebook regenerated", joined)
+
+    def test_restart_reuses_completed_sub_jobs(self):
+        tmp = os.path.join(self.project_directory, "fx_restart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol, output=output_snapshot)
+        pending = sched2._sp_composite_pending['H2']
+        self.assertEqual(set(pending.keys()), {"delta_T__high", "delta_T__low"})
+        sched2.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_missing_sub_job_does_not_finalize(self):
+        tmp = os.path.join(self.project_directory, "fx_miss")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        self.assertIsNone(spc.e_elect_source)
+        self.assertIsNone(spc.e_elect)
+
+    # --- Phase 3.5: restart kick-start ------------------------------------- #
+
+    def test_restart_kick_start_queues_missing_sub_jobs(self):
+        """On restart with base completed and no events firing, the scheduler
+        must queue the missing delta sub-jobs by itself."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        # Build a fresh scheduler from the output snapshot and capture all
+        # run_job calls the kick-start makes.
+        spawned_levels = []
+
+        def capture(self_inner, *args, **kwargs):
+            spawned_levels.append(kwargs.get('level_of_theory'))
+
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", capture):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Kick-start must have spawned exactly the two missing unique Levels.
+        self.assertEqual(len(spawned_levels), 2)
+        spawned_methods = sorted(lvl.method for lvl in spawned_levels)
+        self.assertEqual(spawned_methods, ["ccsd(t)", "ccsdt"])
+        # Pending dict reflects what's queued.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__high", "delta_T__low"})
+
+    def test_kick_start_skips_species_with_no_prior_progress(self):
+        """Species that have never run any composite sub-job (mid-opt or fresh)
+        should NOT be kick-started — they follow the normal opt → SP flow."""
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        spawned = []
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: spawned.append(kw)):
+            Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                testing=True,
+            )
+        # No prior progress → kick-start must not spawn anything.
+        self.assertEqual(spawned, [])
+
+    def test_spawn_composite_pending_skips_species_without_geometry(self):
+        """A species whose get_xyz(generate=False) returns None must not spawn sub-jobs."""
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertIsNone(spc.get_xyz(generate=False))
+        self.assertTrue(sched._sp_composite_pending['H2'])
+        calls = []
+        sched.run_job = lambda *args, **kwargs: calls.append(kwargs)
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched._spawn_composite_pending('H2')
+        self.assertEqual(calls, [])
+        joined = '\n'.join(cm.output)
+        self.assertIn('H2', joined)
+        self.assertIn('no geometry', joined)
+
+    def test_restart_kick_start_skips_species_without_geometry(self):
+        """Restart kick-start must not submit sp sub-jobs for a species whose
+        geometry cannot be retrieved (e.g., a corrupted mid-opt restart)."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart_noxyz")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        # Fresh scheduler from the snapshot, but the species carries no 3D info.
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        self.assertIsNone(spc2.get_xyz(generate=False))
+        spawned = []
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: spawned.append(kw)), \
+                self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        self.assertEqual(spawned, [])
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__high", "delta_T__low"})
+        self.assertIn('no geometry', '\n'.join(cm.output))
+
+    # --- Phase 3.5: corruption recovery ------------------------------------ #
+
+    def test_corrupted_recorded_output_is_invalidated_and_requeued(self):
+        """A previously-recorded sub-job output that no longer exists on disk
+        must be invalidated, re-added to pending, and re-queued by kick-start."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        # Reset the finalized flags so the second scheduler's rehydration re-runs
+        # validation/seed for this species (otherwise it would skip as already-done).
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        # Simulate on-disk corruption: delete delta_T__low's output.
+        os.unlink(paths["delta_T__low"])
+        # Fresh scheduler from snapshot; rehydration must invalidate only delta_T__low.
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned_levels = []
+        with patch.object(Scheduler, "run_job",
+                          lambda self, *a, **kw: spawned_levels.append(kw.get('level_of_theory'))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Only the corrupted sub_label is pending; only one kick-start spawn.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__low"})
+        self.assertEqual(sched2.output['H2']['job_types']['sp_composite'], False)
+        self.assertEqual(len(spawned_levels), 1)
+        self.assertEqual(spawned_levels[0].method, "ccsd(t)")
+        # Replace the file and re-complete → protocol finalizes normally.
+        sched2.run_job = lambda *args, **kwargs: None
+        self._write_gaussian_fixture(paths["delta_T__low"], -1.12)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_corruption_warning_logged(self):
+        """The warning event must name the species, sub_label, path, and reason."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        # Build a valid initial scheduler + base completion, then point the
+        # recorded path at a file that doesn't exist.
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched1.post_sp_actions('H2', base_path, protocol.base.level)
+        # Corrupt: point the recorded base path at a non-existent file, reset
+        # the finalized flag so the second scheduler re-validates.
+        sched1.output['H2']['paths']['sp_composite']['base'] = '/tmp/does/not/exist.out'
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                Scheduler(
+                    project='sp_composite_orch',
+                    ess_settings=self.ess_settings,
+                    species_list=[spc2],
+                    project_directory=self.project_directory,
+                    opt_level=Level(repr=default_levels_of_theory['opt']),
+                    freq_level=Level(repr=default_levels_of_theory['freq']),
+                    sp_level=Level(repr=default_levels_of_theory['sp']),
+                    conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                    scan_level=Level(repr=default_levels_of_theory['scan']),
+                    ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                    orbitals_level=default_levels_of_theory['orbitals'],
+                    sp_composite=protocol,
+                    output=output_snapshot,
+                    testing=True,
+                )
+        joined = "\n".join(cm.output)
+        self.assertIn("sub-job output invalidated", joined)
+        self.assertIn("sub_label=base", joined)
+        self.assertIn("/tmp/does/not/exist.out", joined)
+
+    def test_corrupt_paths_sp_composite_scalar_auto_heals(self):
+        """Regression: a project carried over from an older ARC version may
+        persist ``output[label]['paths']['sp_composite']`` as a scalar string
+        rather than the expected ``dict[sub_label → path]``. The first
+        post_sp_actions call would crash with
+        ``TypeError: 'str' object does not support item assignment``.
+
+        The scheduler must auto-heal that state on init (or on first composite
+        write), log a warning, and proceed without error."""
+        tmp = os.path.join(self.project_directory, "fx_str_corrupt")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        # Build a stale output snapshot with the bad scalar value, then build
+        # a fresh scheduler from it — exactly the restart-corruption shape.
+        stale_output = {
+            'H2': {
+                'paths': {
+                    'geo': '', 'geo_coarse': '', 'freq': '',
+                    'sp': '', 'composite': '',
+                    'sp_composite': '/tmp/some/old/sp.out',  # ← scalar, not a dict
+                },
+                'job_types': {'sp_composite': False},
+                'convergence': None,
+                'restart': '', 'errors': '', 'warnings': '', 'info': '',
+                'isomorphism': '', 'conformers': '',
+            }
+        }
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=stale_output,
+                testing=True,
+            )
+        sched.run_job = lambda *a, **kw: None
+        # The bad scalar must be coerced to a dict by init — that's how the
+        # next post_sp_actions call avoids the TypeError.
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        # Now exercise the actual code path that would have crashed.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertEqual(
+            sched.output['H2']['paths']['sp_composite'].get('base'),
+            base_path,
+        )
+
+    def test_delete_all_species_jobs_preserves_sp_composite_dict(self):
+        """Regression: ``delete_all_species_jobs`` rebuilds ``paths`` via a
+        dict-comprehension that maps every key to ``''`` (with one carve-out
+        for ``'irc'`` → list). That clobbers ``paths['sp_composite']`` from
+        ``dict[sub_label → path]`` to an empty string, and the next composite
+        sub-job completion crashes with
+        ``TypeError: 'str' object does not support item assignment``.
+
+        ``sp_composite`` must be preserved as ``dict()`` (parallel to ``irc``
+        being preserved as ``list()``)."""
+        tmp = os.path.join(self.project_directory, "fx_delete_all")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Drive a base completion through the real path so paths['sp_composite']
+        # is a populated dict, not the freshly-init'd empty one.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'], base_path)
+        # Now exercise the path that clobbers it. delete_all_species_jobs
+        # iterates self.job_dict[label] which the no-op test scheduler may
+        # leave empty — that's fine, the dict-comprehension at the end of
+        # the method runs unconditionally and is what corrupts paths.
+        sched.delete_all_species_jobs('H2')
+        # Contract: sp_composite stays a dict (parallel to irc staying a list).
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        # Next sub-job completion must not crash.
+        delta_T_high_path = os.path.join(tmp, "delta_T_high.out")
+        self._write_gaussian_fixture(delta_T_high_path, -1.15)
+        sched.post_sp_actions('H2', delta_T_high_path, protocol.corrections[0].high)
+
+    def test_delete_all_species_jobs_clears_sp_composite_state(self):
+        """Regression: when re-opt is triggered (e.g. by rotor troubleshooting),
+        ``delete_all_species_jobs`` must clear ``_sp_composite_pending[label]``
+        and ``_sp_composite_sections[label]``. Without this, the engine sees
+        stale pending state from the old geometry; the new base SP at the new
+        geometry matches no sub_label and is silently discarded with the
+        warning "sp completion matched no pending sub_label — ignoring", and
+        the species ends up stuck at ``sp: False`` despite a valid SP run.
+
+        The end-to-end re-seed behavior (next base SP re-populates pending) is
+        also exercised here — that's the user-visible payoff of the cleanup."""
+        tmp = os.path.join(self.project_directory, "fx_reset_state")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        h2 = ARCSpecies(label='H2', smiles='[H][H]')
+        h2.final_xyz = {'symbols': ('H', 'H'),
+                        'coords': ((0, 0, 0), (0, 0, 0.74)),
+                        'isotopes': (1, 1)}
+        other = ARCSpecies(label='Other', smiles='C')
+        other.final_xyz = {'symbols': ('C',), 'coords': ((0, 0, 0),), 'isotopes': (12,)}
+        sched = self._make_scheduler([h2, other], sp_composite=protocol)
+        # Init seeds _sp_composite_pending for every configured species.
+        self.assertIn('H2', sched._sp_composite_pending)
+        self.assertIn('Other', sched._sp_composite_pending)
+        # _sp_composite_sections only populates on finalize; inject sentinels
+        # so we can assert the cleanup path without running the full protocol.
+        sentinel_h2, sentinel_other = object(), object()
+        sched._sp_composite_sections['H2'] = sentinel_h2
+        sched._sp_composite_sections['Other'] = sentinel_other
+        # Drive a base SP at the OLD geometry so paths['sp_composite']['base']
+        # is populated — this is what the previous bug stranded across re-opt.
+        base_path = os.path.join(tmp, "base_old_geom.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'], base_path)
+
+        # Simulate rotor-triggered re-opt cleanup.
+        sched.delete_all_species_jobs('H2')
+
+        self.assertNotIn('H2', sched._sp_composite_pending,
+                         "_sp_composite_pending must be cleared so the next base "
+                         "SP re-seeds.")
+        self.assertNotIn('H2', sched._sp_composite_sections,
+                         "_sp_composite_sections must be cleared to prevent stale "
+                         "provenance.")
+        # Other species's state must be untouched.
+        self.assertIn('Other', sched._sp_composite_pending)
+        self.assertIs(sched._sp_composite_sections['Other'], sentinel_other)
+
+        # End-to-end: the next base SP at the new geometry must re-seed and
+        # be recorded — not orphaned with the "no pending sub_label" warning.
+        new_base_path = os.path.join(tmp, "base_new_geom.out")
+        self._write_gaussian_fixture(new_base_path, -1.12)
+        sched.post_sp_actions('H2', new_base_path, protocol.base.level)
+        self.assertIn('H2', sched._sp_composite_pending,
+                      "Re-seed failed: pending dict should be repopulated.")
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'],
+                         new_base_path,
+                         "New base SP must be recorded; previously orphaned.")
+
+    def test_delete_all_species_jobs_tolerates_one_failed_delete(self):
+        """Regression: a single failed ``job.delete()`` (e.g. ``qdel`` couldn't
+        kill the job because the queue is unresponsive) must NOT abort the
+        whole scheduler. ``delete_all_species_jobs`` is best-effort cleanup —
+        an orphaned remote job will exit on its own. The other jobs still
+        need to be deleted, the species's state still needs to be reset, and
+        the scheduler must keep running."""
+        tmp = os.path.join(self.project_directory, "fx_delete_failure")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+
+        class _StubJob:
+            def __init__(self, name, raise_on_delete=False):
+                self.name = name
+                self.execution_type = 'queue'
+                self.deleted = False
+                self.raise_on_delete = raise_on_delete
+
+            def delete(self):
+                if self.raise_on_delete:
+                    raise RuntimeError(f'Could not delete job {self.name}')
+                self.deleted = True
+
+        bad = _StubJob('a4035060', raise_on_delete=True)
+        good_a = _StubJob('a4035061')
+        good_b = _StubJob('a4035062')
+        # job_dict is keyed [label][job_type][job_name → JobAdapter].
+        # The ordering puts the failing job in the middle so we verify both
+        # the deletes before AND after it still run.
+        sched.job_dict['H2'] = {'sp': {
+            'a4035061': good_a,
+            'a4035060': bad,
+            'a4035062': good_b,
+        }}
+        sched.running_jobs['H2'] = ['a4035061', 'a4035060', 'a4035062']
+        # Should not raise.
+        sched.delete_all_species_jobs('H2')
+        self.assertTrue(good_a.deleted, "Pre-failure delete must still run.")
+        self.assertTrue(good_b.deleted, "Post-failure delete must still run.")
+        # And the species's state still got reset (running_jobs cleared, paths
+        # rebuilt with sp_composite as a dict, etc.).
+        self.assertEqual(sched.running_jobs['H2'], [])
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+
+    def test_mrcc_degenerate_high_leg_falls_back_to_low_leg_path(self):
+        """When a δ-term high-leg sub-job errors with ``MRCCDegenerateSystem``
+        (atomic H / H2 at CCSDT(Q): MRCC's xmrcc bails because the requested
+        excitation rank exceeds the determinant space), the trsh ladder
+        cannot help — the cause is intrinsic to the physics, not the
+        numerics. The composite framework must short-circuit by reusing the
+        sister low-leg's output path. The two energies are degenerate by
+        symmetry (all CC ranks reduce to HF for ≤2-electron systems), so
+        δ = 0, which is the correct physical answer."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_degenerate")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Base + low-leg complete normally.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -0.5)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        low_path = os.path.join(tmp, "delta_T__low.out")
+        self._write_gaussian_fixture(low_path, -0.5)  # HF for atomic H
+        sched.post_sp_actions('H2', low_path, protocol.corrections[0].low)
+        # High leg (CCSDT/cc-pVDZ) "fails" with the MRCC degenerate-system
+        # keyword. Build a JobAdapter stub that mimics what check_sp_job sees.
+
+        class _ErroredJobStub:
+            def __init__(self, level, output_path):
+                self.level = level
+                self.local_path_to_output_file = output_path
+                self.job_status = ['done', {
+                    'status': 'errored',
+                    'keywords': ['MRCCDegenerateSystem'],
+                    'error': 'MRCC xmrcc fatal',
+                    'line': 'Fatal error in xmrcc.',
+                }]
+                self.conformer = None
+                self.job_name = 'sp_a999'
+                self.execution_type = 'queue'
+                self.job_id = 'a999'
+
+        # Provide a placeholder output file (it would normally be the
+        # truncated MRCC log; the framework should not parse it).
+        high_failed_path = os.path.join(tmp, "delta_T__high_FAILED.out")
+        with open(high_failed_path, 'w') as fh:
+            fh.write("Fatal error in xmrcc.\n")
+        bad_job = _ErroredJobStub(
+            level=protocol.corrections[0].high,
+            output_path=high_failed_path,
+        )
+        sched.check_sp_job(label='H2', job=bad_job)
+        # The framework must have substituted the low-leg path for the high
+        # leg and finalized the composite (δ_T = 0, e_elect = base energy).
+        self.assertEqual(
+            sched.output['H2']['paths']['sp_composite']['delta_T__high'],
+            low_path,
+            'High-leg path must be substituted with low-leg path on '
+            'MRCCDegenerateSystem fallback.',
+        )
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, 'sp_composite')
+        # Energy contributions: base = parsed from base.out, δ_T = 0 by
+        # construction. Final = base.
+        parsed_base = parser.parse_e_elect(base_path)
+        self.assertAlmostEqual(spc.e_elect, parsed_base, places=6)
+
+    def test_mrcc_degenerate_low_leg_failure_does_not_short_circuit(self):
+        """If the LOW leg fails with MRCCDegenerateSystem (no sister to fall
+        back on), the framework must NOT silently substitute. The species
+        should not finalize from this path; troubleshoot_ess gets called on
+        the assumption a higher level can sort it out."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_low_fail")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Patch troubleshoot_ess to a recording stub so we can verify it
+        # gets called for low-leg failures.
+        called = []
+        sched.troubleshoot_ess = lambda *args, **kwargs: called.append(
+            kwargs.get('job').job_name if kwargs.get('job') else 'unknown')
+
+        class _ErroredJobStub:
+            def __init__(self, level):
+                self.level = level
+                self.local_path_to_output_file = '/tmp/fake.out'
+                self.job_status = ['done', {
+                    'status': 'errored',
+                    'keywords': ['MRCCDegenerateSystem'],
+                    'error': 'MRCC xmrcc fatal',
+                    'line': 'Fatal error in xmrcc.',
+                }]
+                self.conformer = None
+                self.job_name = 'sp_a999'
+                self.execution_type = 'queue'
+                self.job_id = 'a999'
+
+        bad_job = _ErroredJobStub(level=protocol.corrections[0].low)
+        sched.check_sp_job(label='H2', job=bad_job)
+        self.assertEqual(called, ['sp_a999'],
+                         'Low-leg MRCC failure must not be short-circuited.')
+        self.assertNotIn('delta_T__low',
+                         sched.output['H2']['paths']['sp_composite'])
+
+    def test_species_report_yaml_written_on_finalize(self):
+        """Per-species sp_composite YAML report lands at
+        ``<project>/output/Species/<label>/sp_composite_report.yml`` when the
+        composite finalizes, and the file parses to a dict whose ``final``
+        block matches what ARC recorded on the species."""
+        import yaml
+        tmp = os.path.join(self.project_directory, "fx_species_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Drive a 3-sub-job composite to completion.
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+            {"base": -1.10, "delta_T__high": -1.15, "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        report_path = os.path.join(
+            self.project_directory, "output", "Species", "H2",
+            "sp_composite_report.yml",
+        )
+        self.assertTrue(os.path.exists(report_path),
+                        f"Per-species report not written at {report_path}")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        # Identity + protocol shape.
+        self.assertEqual(report["species"], "H2")
+        self.assertEqual(report["kind"], "species")
+        self.assertEqual(len(report["terms"]), 1)
+        self.assertEqual(report["terms"][0]["label"], "delta_T")
+        self.assertEqual(len(report["terms"][0]["sub_jobs"]), 2)
+        # Final block matches what the scheduler set on the species.
+        self.assertAlmostEqual(report["final"]["e_elect_kj_per_mol"],
+                               spc.e_elect, places=6)
+        self.assertEqual(report["final"]["e_elect_source"], "sp_composite")
+
+    def test_species_report_uses_TSs_subdir_for_transition_states(self):
+        """Transition states land under ``output/TSs/<label>/...``, not
+        ``output/Species/...``."""
+        import yaml
+        tmp = os.path.join(self.project_directory, "fx_ts_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        ts = ARCSpecies(label='TS_x', smiles='[H][H]', is_ts=True)
+        ts.final_xyz = {'symbols': ('H', 'H'),
+                        'coords': ((0, 0, 0), (0, 0, 0.74)),
+                        'isotopes': (1, 1)}
+        sched = self._make_scheduler([ts], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('TS_x', base_path, protocol.base.level)
+        ts_report = os.path.join(
+            self.project_directory, "output", "TSs", "TS_x",
+            "sp_composite_report.yml",
+        )
+        species_report = os.path.join(
+            self.project_directory, "output", "Species", "TS_x",
+            "sp_composite_report.yml",
+        )
+        self.assertTrue(os.path.exists(ts_report))
+        self.assertFalse(os.path.exists(species_report))
+        with open(ts_report) as fh:
+            self.assertEqual(yaml.safe_load(fh)["kind"], "ts")
+
+    # --- Phase 3.5: preset name + reference preservation ------------------- #
+
+    def test_preset_name_and_reference_survive_to_notebook_section(self):
+        """When the protocol is a preset, its preset_name and reference (DOI)
+        must flow through parsing → finalize → SpeciesSection."""
+        tmp = os.path.join(self.project_directory, "fx_preset")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        self.assertEqual(protocol.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', protocol.reference)
+        # Now exercise the scheduler end-to-end with only a bare-bones subset
+        # of sub-jobs (we don't need the full HEAT protocol to fire to verify
+        # the SpeciesSection carries the preset metadata) — build a trivial
+        # protocol with its preset metadata manually preserved.
+        simple = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        simple.preset_name = 'HEAT-345Q'
+        simple.reference = protocol.reference
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=simple)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, simple.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertEqual(section.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', section.reference)
+
+    def test_explicit_recipe_reference_key_preserved(self):
+        """Users can supply a `reference` at the top level of an explicit recipe."""
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+            "reference": "Custom recipe; DOI: 10.9999/custom",
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        self.assertIsNone(protocol.preset_name)
+        self.assertEqual(protocol.reference, "Custom recipe; DOI: 10.9999/custom")
+
+    def test_explicit_recipe_without_reference_falls_back_and_flags(self):
+        """Explicit recipe, no reference → SpeciesSection flags it."""
+        tmp = os.path.join(self.project_directory, "fx_expl")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertIsNone(section.preset_name)
+        self.assertIn("Explicit", section.reference)
+        self.assertTrue(any("No formal reference" in f for f in section.flags))
+
+    def test_protocol_preset_metadata_round_trips_through_as_dict(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        restored = CompositeProtocol.from_dict(protocol.as_dict())
+        self.assertEqual(restored.preset_name, 'HEAT-345Q')
+        self.assertEqual(restored.reference, protocol.reference)
+
+    # --- Phase 3.5: term-level logging ------------------------------------- #
+
+    def test_term_evaluated_log_event_per_term(self):
+        tmp = os.path.join(self.project_directory, "fx_term_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                {"label": "cbs_corr", "type": "cbs_extrapolation",
+                 "formula": "helgaker_corr_2pt",
+                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies = {
+            "base": -1.10,
+            "delta_T__high": -1.15, "delta_T__low": -1.12,
+            "cbs_corr__card_3": -1.14, "cbs_corr__card_4": -1.145,
+        }
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies)
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+            sched.post_sp_actions('H2', paths["cbs_corr__card_3"],
+                                  protocol.corrections[1].levels[0])
+            sched.post_sp_actions('H2', paths["cbs_corr__card_4"],
+                                  protocol.corrections[1].levels[1])
+        joined = "\n".join(cm.output)
+        self.assertIn("term evaluated", joined)
+        # One "term evaluated" per term (base + delta_T + cbs_corr = 3).
+        count = joined.count("term evaluated")
+        self.assertEqual(count, 3)
+        # Each term's label appears.
+        for term_label in ("base", "delta_T", "cbs_corr"):
+            self.assertIn(f"term={term_label}", joined)
+        # CBS term carries a formula field.
+        self.assertIn("formula=helgaker_corr_2pt", joined)
+
+
+    # --- Phase 5: rehydrated-finalized species reappear in regenerated notebook -- #
+
+    def test_rehydrated_finalized_species_appears_in_cumulative_notebook(self):
+        """A species that finalized in a previous ARC run must reappear in the
+        project notebook after restart-time regeneration — with every required
+        sub_label resolved to the actual output file path."""
+        tmp = os.path.join(self.project_directory, "fx_rehydrate_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc_a], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.05, "delta_T__high": -1.07,
+                                              "delta_T__low": -1.06})
+        sched1.post_sp_actions('Afinalized', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched1.output['Afinalized']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+
+        # Restart with the same species list. Rehydration must resurrect the
+        # SpeciesSection so a subsequent notebook regeneration includes it.
+        spc_a2 = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a2.final_xyz = spc_a.final_xyz
+        sched2 = self._make_scheduler([spc_a2], sp_composite=protocol,
+                                      output=output_snapshot)
+        self.assertIn('Afinalized', sched2._sp_composite_sections)
+        sec = sched2._sp_composite_sections['Afinalized']
+        required = {sub for _t, sub, _l in protocol.iter_required_jobs()}
+        # Every required sub_label is present and points at the real output file.
+        self.assertEqual(set(sec.sub_job_paths.keys()), required)
+        for sub_label in required:
+            self.assertEqual(sec.sub_job_paths[sub_label], paths[sub_label])
+            self.assertTrue(os.path.isfile(sec.sub_job_paths[sub_label]))
+        # Trigger a fresh notebook regeneration directly; the rehydrated section
+        # must appear in the cumulative output.
+        sched2._regenerate_composite_notebook()
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb = nbformat.read(nb_path, as_version=4)
+        titles = [c.source for c in nb.cells
+                  if c.cell_type == "markdown"
+                  and c.source.lstrip().startswith("## ")
+                  and "Project summary" not in c.source
+                  and "References" not in c.source]
+        self.assertTrue(any("Afinalized" in t for t in titles))
+
+
+class TestSchedulerSpCompositePassthrough(unittest.TestCase):
+    """
+    Phase 2 contract: Scheduler.__init__ accepts sp_composite and stores it only —
+    no orchestration, no output-dict changes, no jobs queued.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', f'arc_project_for_testing_sp_composite_passthrough_{worker}'
+        )
+        cls.spc = ARCSpecies(label='H2', smiles='[H][H]')
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    def _make_scheduler(self, sp_composite):
+        return Scheduler(
+            project='sp_composite_passthrough',
+            ess_settings=self.ess_settings,
+            species_list=[self.spc],
+            project_directory=self.project_directory,
+            opt_level=Level(repr=default_levels_of_theory['opt']),
+            freq_level=Level(repr=default_levels_of_theory['freq']),
+            sp_level=Level(repr=default_levels_of_theory['sp']),
+            conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+            scan_level=Level(repr=default_levels_of_theory['scan']),
+            ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+            orbitals_level=default_levels_of_theory['orbitals'],
+            sp_composite=sp_composite,
+            testing=True,
+        )
+
+    def test_stores_sp_composite(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertIs(sched.sp_composite, protocol)
+
+    def test_none_sp_composite_stored_as_none(self):
+        sched = self._make_scheduler(None)
+        self.assertIsNone(sched.sp_composite)
+
+    def test_passthrough_does_not_queue_jobs(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertEqual(sched.running_jobs, {'H2': []})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -11,23 +11,23 @@ import datetime
 import logging
 import os
 import shutil
-import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import nbformat
+import yaml
 
 
 import arc.parser.parser as parser
 from arc.checks.ts import check_ts
-from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
+from arc.common import ARC_PATH, ARC_TESTING_PATH, VERSION, almost_equal_coords_lists, initialize_job_types, read_yaml_file
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
 from arc.job.zombie import ZOMBIE_GRACE_SECONDS
 from arc.level import Level
 from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
-from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
+from arc.scheduler import (Scheduler, SchedulerError, ZOMBIE_RECHECK_SECONDS, count_correlated_electrons,
+                           count_frozen_core_orbitals, species_has_freq, species_has_geo, species_has_sp,
                            species_has_sp_and_freq)
 from arc.imports import settings
 from arc.reaction import ARCReaction
@@ -1534,7 +1534,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             ],
         }
 
-    def _make_scheduler(self, species_list, sp_composite, output=None):
+    def _make_scheduler(self, species_list, sp_composite, output=None, job_types=None):
         """Build a Scheduler with run_job patched to a no-op.
 
         We patch at the *class* level because the Phase 3.5 restart kick-start
@@ -1546,6 +1546,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                 project='sp_composite_orch',
                 ess_settings=self.ess_settings,
                 species_list=species_list,
+                job_types=job_types,
                 project_directory=self.project_directory,
                 opt_level=Level(repr=default_levels_of_theory['opt']),
                 freq_level=Level(repr=default_levels_of_theory['freq']),
@@ -1579,8 +1580,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1607,8 +1608,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1665,6 +1666,92 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         active = sched._composite_for('H2')
         self.assertIsNotNone(active)
         self.assertEqual(active.base.level.method, "hf")
+
+    @staticmethod
+    def _fpa_like_recipe():
+        """CBS-as-base recipe: two-point CBS base + one delta correction."""
+        return {
+            "base": {"label": "base", "type": "cbs_extrapolation",
+                     "formula": "helgaker_corr_2pt",
+                     "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                                {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    def test_cbs_base_seeds_deterministic_sub_labels(self):
+        """A CBS base seeds one pending sub_label per cardinal — stable keys
+        for restart rehydration."""
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        sched._seed_composite_pending('H2')
+        self.assertEqual(set(sched._sp_composite_pending['H2'].keys()),
+                         {"base__card_3", "base__card_4",
+                          "delta_T__high", "delta_T__low"})
+
+    def test_cbs_base_spawns_one_sp_job_per_cardinal(self):
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        spawned_levels = []
+        sched.run_job = lambda *args, **kwargs: spawned_levels.append(kwargs['level_of_theory'])
+        sched._seed_composite_pending('H2')
+        sched._spawn_composite_pending('H2')
+        spawned_bases = sorted(lvl.basis for lvl in spawned_levels
+                               if lvl.method == 'ccsd(t)' and lvl.basis != 'cc-pvdz')
+        self.assertEqual(spawned_bases, ['cc-pvqz', 'cc-pvtz'])
+        self.assertEqual(len(spawned_levels), 4)
+
+    def test_cbs_base_finalizes_with_extrapolated_energy(self):
+        tmp = os.path.join(self.project_directory, "fx_cbs_base")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies_H = {"base__card_3": -1.170, "base__card_4": -1.172,
+                      "delta_T__high": -1.15, "delta_T__low": -1.12}
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies_H)
+        sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+        recorded = sched.output['H2']['paths']['sp_composite']
+        self.assertEqual(set(recorded.keys()),
+                         {"base__card_3", "base__card_4",
+                          "delta_T__high", "delta_T__low"})
+        parsed = {sl: parser.parse_e_elect(p) for sl, p in paths.items()}
+        e_cbs = (27 * parsed["base__card_3"] - 64 * parsed["base__card_4"]) / (27 - 64)
+        expected = e_cbs + parsed["delta_T__high"] - parsed["delta_T__low"]
+        self.assertAlmostEqual(spc.e_elect, expected, places=6)
+        self.assertAlmostEqual(spc.e_elect, protocol.evaluate(parsed), places=10)
+
+    def test_run_sp_job_defaults_to_largest_cardinal_for_cbs_base(self):
+        """run_sp_job with no explicit level runs the protocol's primary base
+        level — the largest-cardinal CBS leg."""
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        spawned_levels = []
+        sched.run_job = lambda *args, **kwargs: spawned_levels.append(kwargs['level_of_theory'])
+        sched.run_sp_job('H2')
+        self.assertEqual(len(spawned_levels), 1)
+        self.assertEqual(spawned_levels[0].method, 'ccsd(t)')
+        self.assertEqual(spawned_levels[0].basis, 'cc-pvqz')
 
     def test_opt_out_species_uses_global_sp_level(self):
         recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
@@ -1739,8 +1826,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1775,8 +1862,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1808,8 +1895,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1835,8 +1922,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1878,7 +1965,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         # Kick-start must have spawned exactly the two missing unique Levels.
         self.assertEqual(len(spawned_levels), 2)
         spawned_methods = sorted(lvl.method for lvl in spawned_levels)
-        self.assertEqual(spawned_methods, ["ccsd(t)", "ccsdt"])
+        self.assertEqual(spawned_methods, ["ccsd(t)", "mp2"])
         # Pending dict reflects what's queued.
         self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
                          {"delta_T__high", "delta_T__low"})
@@ -1937,8 +2024,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -1989,8 +2076,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2039,7 +2126,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                          {"delta_T__low"})
         self.assertEqual(sched2.output['H2']['job_types']['sp_composite'], False)
         self.assertEqual(len(spawned_levels), 1)
-        self.assertEqual(spawned_levels[0].method, "ccsd(t)")
+        self.assertEqual(spawned_levels[0].method, "mp2")
         # Replace the file and re-complete → protocol finalizes normally.
         sched2.run_job = lambda *args, **kwargs: None
         self._write_gaussian_fixture(paths["delta_T__low"], -1.12)
@@ -2108,8 +2195,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2178,8 +2265,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2224,8 +2311,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2325,144 +2412,176 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         self.assertEqual(sched.running_jobs['H2'], [])
         self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
 
-    def test_mrcc_degenerate_high_leg_falls_back_to_low_leg_path(self):
-        """When a δ-term high-leg sub-job errors with ``MRCCDegenerateSystem``
-        (atomic H / H2 at CCSDT(Q): MRCC's xmrcc bails because the requested
-        excitation rank exceeds the determinant space), the trsh ladder
-        cannot help — the cause is intrinsic to the physics, not the
-        numerics. The composite framework must short-circuit by reusing the
-        sister low-leg's output path. The two energies are degenerate by
-        symmetry (all CC ranks reduce to HF for ≤2-electron systems), so
-        δ = 0, which is the correct physical answer."""
-        tmp = os.path.join(self.project_directory, "fx_mrcc_degenerate")
+    # --- proactive δ≡0 skip for trivially-zero delta corrections ------------ #
+
+    @staticmethod
+    def _mono_species(label, smiles, symbol, isotope):
+        """A monoatomic ARCSpecies with a final geometry."""
+        spc = ARCSpecies(label=label, smiles=smiles)
+        spc.final_xyz = {'symbols': (symbol,), 'coords': ((0., 0., 0.),),
+                         'isotopes': (isotope,)}
+        return spc
+
+    @staticmethod
+    def _ch4_species(label='CH4'):
+        """A CH4 ARCSpecies (10 electrons, 1 frozen-core orbital, n_corr=8)."""
+        spc = ARCSpecies(label=label, smiles='C')
+        spc.final_xyz = {'symbols': ('C', 'H', 'H', 'H', 'H'),
+                         'coords': ((0., 0., 0.), (0.63, 0.63, 0.63),
+                                    (-0.63, -0.63, 0.63), (-0.63, 0.63, -0.63),
+                                    (0.63, -0.63, -0.63)),
+                         'isotopes': (12, 1, 1, 1, 1)}
+        return spc
+
+    def test_h_atom_heat_deltas_skipped_finalizes_base_only(self):
+        """H atom (n_corr=1) through a HEAT-style recipe: both δ terms are
+        decided trivially zero at term-expansion time — neither leg is queued —
+        and the composite finalizes to the base energy alone, with the skip
+        reason surfaced in the log and the species report."""
+        tmp = os.path.join(self.project_directory, "fx_skip_h_atom")
         os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
-        spc = ARCSpecies(label='H2', smiles='[H][H]')
-        spc.final_xyz = {'symbols': ('H', 'H'),
-                         'coords': ((0, 0, 0), (0, 0, 0.74)),
-                         'isotopes': (1, 1)}
-        sched = self._make_scheduler([spc], sp_composite=protocol)
-        # Base + low-leg complete normally.
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('Hskip', '[H]', 'H', 1)
+        sched = self._make_scheduler([spc], sp_composite=protocol,
+                                     job_types=initialize_job_types())
+        self.assertEqual(set(sched._sp_composite_pending['Hskip'].keys()), {'base'})
+        self.assertEqual(set(sched._sp_composite_skipped['Hskip'].keys()),
+                         {'delta_T', 'delta_Q'})
+        spawned = []
+        sched.run_job = lambda *a, **kw: spawned.append(kw.get('level_of_theory'))
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched._seed_composite_pending('Hskip')
+            sched._spawn_composite_pending('Hskip')
+        joined = '\n'.join(cm.output)
+        self.assertIn('δ≡0', joined)
+        self.assertIn('skipped', joined)
+        self.assertEqual(len(spawned), 1, 'Only the base SP may be queued.')
+        self.assertEqual(spawned[0], protocol.base.level)
         base_path = os.path.join(tmp, "base.out")
-        self._write_gaussian_fixture(base_path, -0.5)
-        sched.post_sp_actions('H2', base_path, protocol.base.level)
-        low_path = os.path.join(tmp, "delta_T__low.out")
-        self._write_gaussian_fixture(low_path, -0.5)  # HF for atomic H
-        sched.post_sp_actions('H2', low_path, protocol.corrections[0].low)
-        # High leg (CCSDT/cc-pVDZ) "fails" with the MRCC degenerate-system
-        # keyword. Build a JobAdapter stub that mimics what check_sp_job sees.
-
-        class _ErroredJobStub:
-            def __init__(self, level, output_path):
-                self.level = level
-                self.local_path_to_output_file = output_path
-                self.job_status = ['done', {
-                    'status': 'errored',
-                    'keywords': ['MRCCDegenerateSystem'],
-                    'error': 'MRCC xmrcc fatal',
-                    'line': 'Fatal error in xmrcc.',
-                }]
-                self.conformer = None
-                self.job_name = 'sp_a999'
-                self.execution_type = 'queue'
-                self.job_id = 'a999'
-
-        # Provide a placeholder output file (it would normally be the
-        # truncated MRCC log; the framework should not parse it).
-        high_failed_path = os.path.join(tmp, "delta_T__high_FAILED.out")
-        with open(high_failed_path, 'w') as fh:
-            fh.write("Fatal error in xmrcc.\n")
-        bad_job = _ErroredJobStub(
-            level=protocol.corrections[0].high,
-            output_path=high_failed_path,
-        )
-        sched.check_sp_job(label='H2', job=bad_job)
-        # The framework must have substituted the low-leg path for the high
-        # leg and finalized the composite (δ_T = 0, e_elect = base energy).
-        self.assertEqual(
-            sched.output['H2']['paths']['sp_composite']['delta_T__high'],
-            low_path,
-            'High-leg path must be substituted with low-leg path on '
-            'MRCCDegenerateSystem fallback.',
-        )
-        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self._write_gaussian_fixture(base_path, -0.499)
+        sched.post_sp_actions('Hskip', base_path, protocol.base.level)
+        self.assertTrue(sched.output['Hskip']['job_types']['sp_composite'])
         self.assertEqual(spc.e_elect_source, 'sp_composite')
-        # Energy contributions: base = parsed from base.out, δ_T = 0 by
-        # construction. Final = base.
-        parsed_base = parser.parse_e_elect(base_path)
-        self.assertAlmostEqual(spc.e_elect, parsed_base, places=6)
+        self.assertAlmostEqual(spc.e_elect, parser.parse_e_elect(base_path), places=6)
+        self.assertEqual(len(spawned), 1, 'No δ legs may be queued after the base.')
+        # Provenance: the section and the YAML report carry the skip.
+        section = sched._sp_composite_sections['Hskip']
+        self.assertIn('delta_T', section.skipped_terms)
+        self.assertIn('δ≡0', section.skipped_terms['delta_Q'])
+        report_path = os.path.join(self.project_directory, "output", "Species",
+                                   "Hskip", "sp_composite_report.yml")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        for term in report['terms']:
+            self.assertTrue(term['skipped'])
+            self.assertEqual(term['contribution_kj_per_mol'], 0.0)
+            self.assertIn('δ≡0', term['skip_reason'])
 
-    def test_mrcc_degenerate_low_leg_failure_does_not_short_circuit(self):
-        """If the LOW leg fails with MRCCDegenerateSystem (no sister to fall
-        back on), the framework must NOT silently substitute. The species
-        should not finalize from this path; troubleshoot_ess gets called on
-        the assumption a higher level can sort it out."""
-        tmp = os.path.join(self.project_directory, "fx_mrcc_low_fail")
-        os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
-        spc = ARCSpecies(label='H2', smiles='[H][H]')
-        spc.final_xyz = {'symbols': ('H', 'H'),
-                         'coords': ((0, 0, 0), (0, 0, 0.74)),
-                         'isotopes': (1, 1)}
+    def test_he_heat_deltas_skipped(self):
+        """He (n_corr=2): both HEAT δ terms are trivially zero and skipped."""
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('He', '[He]', 'He', 4)
+        sched = self._make_scheduler([spc], sp_composite=protocol,
+                                     job_types=initialize_job_types())
+        self.assertEqual(set(sched._sp_composite_pending['He'].keys()), {'base'})
+        self.assertEqual(set(sched._sp_composite_skipped['He'].keys()),
+                         {'delta_T', 'delta_Q'})
+
+    def test_ch4_deltas_not_skipped_all_legs_queued(self):
+        """CH4 (n_corr=8): no δ term is trivially zero — every leg is queued."""
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._ch4_species()
         sched = self._make_scheduler([spc], sp_composite=protocol)
-        # Patch troubleshoot_ess to a recording stub so we can verify it
-        # gets called for low-leg failures.
+        self.assertEqual(sched._sp_composite_skipped['CH4'], {})
+        self.assertEqual(set(sched._sp_composite_pending['CH4'].keys()),
+                         {'base', 'delta_T__high', 'delta_T__low',
+                          'delta_Q__high', 'delta_Q__low'})
+        spawned = []
+        sched.run_job = lambda *a, **kw: spawned.append(kw.get('level_of_theory'))
+        sched._spawn_composite_pending('CH4')
+        # 5 sub_labels over 4 unique Levels (delta_T__high == delta_Q__low).
+        self.assertEqual(len(spawned), 4)
+
+    def test_restart_does_not_requeue_skipped_legs(self):
+        """Restart-safety: the skip decision is deterministic from species +
+        protocol, so rehydration re-derives it — skipped legs are not requeued
+        and the finalized species' report section is rebuilt without warnings."""
+        tmp = os.path.join(self.project_directory, "fx_skip_restart")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('Hrestart', '[H]', 'H', 1)
+        sched1 = self._make_scheduler([spc], sp_composite=protocol,
+                                      job_types=initialize_job_types())
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -0.499)
+        sched1.post_sp_actions('Hrestart', base_path, protocol.base.level)
+        self.assertTrue(sched1.output['Hrestart']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+        spc2 = self._mono_species('Hrestart', '[H]', 'H', 1)
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol,
+                                      output=output_snapshot,
+                                      job_types=initialize_job_types())
+        self.assertEqual(sched2._sp_composite_pending['Hrestart'], {})
+        self.assertEqual(set(sched2._sp_composite_skipped['Hrestart'].keys()),
+                         {'delta_T', 'delta_Q'})
+        self.assertIn('Hrestart', sched2._sp_composite_sections)
+
+    @staticmethod
+    def _errored_mrcc_job_stub(level):
+        """Build a minimal errored-job stub carrying the generic MRCC keyword."""
+        return SimpleNamespace(
+            level=level,
+            local_path_to_output_file='/tmp/fake.out',
+            job_status=['done', {'status': 'errored',
+                                 'keywords': ['MRCC'],
+                                 'error': 'MRCC terminated with a fatal error',
+                                 'line': 'Fatal error in mrcc.'}],
+            conformer=None,
+            job_name='sp_a999',
+            execution_type='queue',
+            job_id='a999',
+        )
+
+    def test_mrcc_fatal_on_real_species_routes_to_trsh_not_zeroed(self):
+        """A 'Fatal error in mrcc' on a real polyatomic species' high leg is a
+        mundane crash (OOM, disk, internal error) — it must land in
+        troubleshoot_ess and the δ term must NOT be zeroed or substituted."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_trsh")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._ch4_species('CH4trsh')
+        sched = self._make_scheduler([spc], sp_composite=protocol)
         called = []
         sched.troubleshoot_ess = lambda *args, **kwargs: called.append(
             kwargs.get('job').job_name if kwargs.get('job') else 'unknown')
-
-        class _ErroredJobStub:
-            def __init__(self, level):
-                self.level = level
-                self.local_path_to_output_file = '/tmp/fake.out'
-                self.job_status = ['done', {
-                    'status': 'errored',
-                    'keywords': ['MRCCDegenerateSystem'],
-                    'error': 'MRCC xmrcc fatal',
-                    'line': 'Fatal error in xmrcc.',
-                }]
-                self.conformer = None
-                self.job_name = 'sp_a999'
-                self.execution_type = 'queue'
-                self.job_id = 'a999'
-
-        bad_job = _ErroredJobStub(level=protocol.corrections[0].low)
-        sched.check_sp_job(label='H2', job=bad_job)
-        self.assertEqual(called, ['sp_a999'],
-                         'Low-leg MRCC failure must not be short-circuited.')
-        self.assertNotIn('delta_T__low',
-                         sched.output['H2']['paths']['sp_composite'])
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -40.5)
+        sched.post_sp_actions('CH4trsh', base_path, protocol.base.level)
+        low_path = os.path.join(tmp, "delta_T__low.out")
+        self._write_gaussian_fixture(low_path, -40.6)
+        sched.post_sp_actions('CH4trsh', low_path, protocol.corrections[0].low)
+        bad_job = self._errored_mrcc_job_stub(level=protocol.corrections[0].high)
+        sched.check_sp_job(label='CH4trsh', job=bad_job)
+        self.assertEqual(called, ['sp_a999'], 'MRCC fatals must route to trsh.')
+        recorded = sched.output['CH4trsh']['paths']['sp_composite']
+        self.assertNotIn('delta_T__high', recorded,
+                         'The failed high leg must not be substituted or zeroed.')
+        self.assertIn('delta_T__high', sched._sp_composite_pending['CH4trsh'])
+        self.assertFalse(sched.output['CH4trsh']['job_types']['sp_composite'])
 
     def test_species_report_yaml_written_on_finalize(self):
         """Per-species sp_composite YAML report lands at
         ``<project>/output/Species/<label>/sp_composite_report.yml`` when the
         composite finalizes, and the file parses to a dict whose ``final``
         block matches what ARC recorded on the species."""
-        import yaml
         tmp = os.path.join(self.project_directory, "fx_species_report")
         os.makedirs(tmp, exist_ok=True)
         recipe = {
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2499,7 +2618,6 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
     def test_species_report_uses_TSs_subdir_for_transition_states(self):
         """Transition states land under ``output/TSs/<label>/...``, not
         ``output/Species/...``."""
-        import yaml
         tmp = os.path.join(self.project_directory, "fx_ts_report")
         os.makedirs(tmp, exist_ok=True)
         recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
@@ -2596,48 +2714,32 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
     def test_term_evaluated_log_event_per_term(self):
         tmp = os.path.join(self.project_directory, "fx_term_log")
         os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-                {"label": "cbs_corr", "type": "cbs_extrapolation",
-                 "formula": "helgaker_corr_2pt",
-                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
-                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
         spc = ARCSpecies(label='H2', smiles='[H][H]')
         spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
                          'isotopes': (1, 1)}
         sched = self._make_scheduler([spc], sp_composite=protocol)
         energies = {
-            "base": -1.10,
+            "base__card_3": -1.14, "base__card_4": -1.145,
             "delta_T__high": -1.15, "delta_T__low": -1.12,
-            "cbs_corr__card_3": -1.14, "cbs_corr__card_4": -1.145,
         }
         paths = self._seed_protocol_fixtures(tmp, protocol, energies)
         with self.assertLogs(logger='arc', level=logging.INFO) as cm:
-            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+            sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
             sched.post_sp_actions('H2', paths["delta_T__high"],
                                   protocol.corrections[0].high)
             sched.post_sp_actions('H2', paths["delta_T__low"],
                                   protocol.corrections[0].low)
-            sched.post_sp_actions('H2', paths["cbs_corr__card_3"],
-                                  protocol.corrections[1].levels[0])
-            sched.post_sp_actions('H2', paths["cbs_corr__card_4"],
-                                  protocol.corrections[1].levels[1])
         joined = "\n".join(cm.output)
         self.assertIn("term evaluated", joined)
-        # One "term evaluated" per term (base + delta_T + cbs_corr = 3).
+        # One "term evaluated" per term (base + delta_T = 2).
         count = joined.count("term evaluated")
-        self.assertEqual(count, 3)
+        self.assertEqual(count, 2)
         # Each term's label appears.
-        for term_label in ("base", "delta_T", "cbs_corr"):
+        for term_label in ("base", "delta_T"):
             self.assertIn(f"term={term_label}", joined)
-        # CBS term carries a formula field.
+        # The CBS base carries a formula field.
         self.assertIn("formula=helgaker_corr_2pt", joined)
 
 
@@ -2653,8 +2755,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2699,6 +2801,378 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                   and "Project summary" not in c.source
                   and "References" not in c.source]
         self.assertTrue(any("Afinalized" in t for t in titles))
+
+    def test_restart_kick_start_survives_real_run_job_tail(self):
+        """Regression: the restart kick-start runs from __init__ and reaches
+        run_job, whose tail calls save_restart_dict — which reads attributes
+        (``save_restart`` among others) that used to be assigned only AFTER the
+        rehydration call. Patch only the job-construction layer and let
+        run_job's tail execute for real so the ordering bug would surface as
+        an AttributeError."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart_tail")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned = []
+
+        def fake_job_factory(**kwargs):
+            job = SimpleNamespace(job_name=f'sp_a{len(spawned)}', server=None, job_id=None,
+                                  level=kwargs.get('level'), execute=lambda: None)
+            spawned.append(job)
+            return job
+
+        with patch('arc.scheduler.job_factory', side_effect=fake_job_factory):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        self.assertEqual(len(spawned), 2)
+        self.assertEqual(set(sched2.job_dict['H2']['sp'].keys()),
+                         {job.job_name for job in spawned})
+        self.assertTrue(hasattr(sched2, 'save_restart'))
+
+    def test_species_report_records_arc_version(self):
+        """The per-species report must carry the real ARC version, not a placeholder."""
+        tmp = os.path.join(self.project_directory, "fx_arc_version")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        report_path = os.path.join(self.project_directory, "output", "Species", "H2",
+                                   "sp_composite_report.yml")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        self.assertEqual(report["arc_version"], VERSION)
+
+    def test_rehydrate_skips_report_rewrite_when_paths_stripped(self):
+        """Regression: a species recorded as finalized whose sub-job output was
+        invalidated during rehydration (file gone) must NOT crash __init__ with
+        a KeyError from the report writer — warn and skip the report re-write."""
+        tmp = os.path.join(self.project_directory, "fx_stripped_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2stripped', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.05, "delta_T__high": -1.07,
+                                              "delta_T__low": -1.06})
+        sched1.post_sp_actions('H2stripped', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('H2stripped', paths["delta_T__high"], protocol.corrections[0].high)
+        sched1.post_sp_actions('H2stripped', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched1.output['H2stripped']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+        os.unlink(paths["delta_T__low"])
+        spc2 = ARCSpecies(label='H2stripped', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched2 = self._make_scheduler([spc2], sp_composite=protocol,
+                                          output=output_snapshot)
+        self.assertNotIn('H2stripped', sched2._sp_composite_sections)
+        self.assertIn('delta_T__low', sched2._sp_composite_pending['H2stripped'])
+        joined = '\n'.join(cm.output)
+        self.assertIn('skipping', joined)
+        self.assertIn('delta_T__low', joined)
+
+    # --- paths['sp'] source assignment for composite species ---------------- #
+
+    @staticmethod
+    def _one_delta_recipe():
+        """A single-Level base plus one delta correction."""
+        return {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    @staticmethod
+    def _h2_species(label='H2'):
+        """An H2 ARCSpecies with a final geometry."""
+        spc = ARCSpecies(label=label, smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        return spc
+
+    def test_base_completion_sets_paths_sp(self):
+        """Completing the composite base leg populates paths['sp'] with the base ESS
+        log; delta legs don't; finalization keeps the base log and the composite
+        energy stays protocol-derived."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species()
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base"])
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base"])
+        self.assertEqual(spc.e_elect_source, 'sp_composite')
+
+    def test_cbs_base_sets_paths_sp_to_largest_cardinal_leg(self):
+        """With a CBS base, paths['sp'] is the primary (largest-cardinal) leg's log."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp_cbs")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = self._h2_species()
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base__card_3": -1.170, "base__card_4": -1.172,
+                                              "delta_T__high": -1.15, "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base__card_4"])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base__card_4"])
+
+    def test_paths_sp_cleared_when_base_log_invalidated(self):
+        """If the recorded base log vanishes before a restart, rehydration must clear
+        paths['sp'] along with the invalidated sub-job entry."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp_inval")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species(label='H2inval')
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2inval', paths["base"], protocol.base.level)
+        self.assertEqual(sched1.output['H2inval']['paths']['sp'], paths["base"])
+        output_snapshot = sched1.output
+        os.unlink(paths["base"])
+        spc2 = self._h2_species(label='H2inval')
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol, output=output_snapshot)
+        self.assertEqual(sched2.output['H2inval']['paths']['sp'], '')
+        self.assertIn('base', sched2._sp_composite_pending['H2inval'])
+
+    def test_restart_base_done_respawns_deltas_not_legacy_sp(self):
+        """Restart with the base completed (paths['sp'] set) but delta legs pending:
+        the composite kick-start must respawn the deltas, and the legacy single-sp
+        respawn guard must NOT trigger run_sp_job for the species."""
+        tmp = os.path.join(self.project_directory, "fx_restart_guard")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species(label='H2resume')
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2resume', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        output_snapshot['H2resume']['paths']['geo'] = paths["base"]  # opt phase done
+        spc2 = self._h2_species(label='H2resume')
+        spawned, sp_calls = [], []
+        with patch.object(Scheduler, 'schedule_jobs', lambda self_: None), \
+                patch.object(Scheduler, 'run_sp_job',
+                             lambda self_, label, **kwargs: sp_calls.append(label)), \
+                patch.object(Scheduler, 'run_job',
+                             lambda self_, **kwargs: spawned.append(
+                                 (kwargs.get('job_type'), kwargs.get('level_of_theory')))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                job_types=initialize_job_types(),
+                output=output_snapshot,
+                testing=False,
+            )
+        self.assertEqual(sp_calls, [])
+        sp_levels = [lvl for job_type, lvl in spawned if job_type == 'sp']
+        self.assertIn(protocol.corrections[0].high, sp_levels)
+        self.assertIn(protocol.corrections[0].low, sp_levels)
+        self.assertNotIn(protocol.primary_base_level, sp_levels)
+        self.assertEqual(sched2.output['H2resume']['paths']['sp'], paths["base"])
+
+    def test_monoatomic_composite_restart_does_not_respawn_base(self):
+        """Restart of a monoatomic composite species with the base completed must not
+        re-submit the base SP via the monoatomic respawn guard; only the pending
+        delta legs respawn (via the composite kick-start)."""
+        tmp = os.path.join(self.project_directory, "fx_mono_guard")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = ARCSpecies(label='Hmono', smiles='[H]')
+        spc.final_xyz = {'symbols': ('H',), 'coords': ((0., 0., 0.),), 'isotopes': (1,)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol,
+                                      job_types=initialize_job_types())
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -0.49, "delta_T__high": -0.499,
+                                              "delta_T__low": -0.498})
+        sched1.post_sp_actions('Hmono', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='Hmono', smiles='[H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned = []
+        with patch.object(Scheduler, 'run_job',
+                          lambda self_, **kwargs: spawned.append(
+                              (kwargs.get('job_type'), kwargs.get('level_of_theory')))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                job_types=initialize_job_types(),
+                output=output_snapshot,
+                testing=True,
+            )
+        sp_levels = [lvl for job_type, lvl in spawned if job_type == 'sp']
+        self.assertNotIn(protocol.primary_base_level, sp_levels)
+        self.assertIn(protocol.corrections[0].high, sp_levels)
+        self.assertIn(protocol.corrections[0].low, sp_levels)
+        self.assertEqual(sched2.output['Hmono']['paths']['sp'], paths["base"])
+
+    def test_species_has_sp_composite_semantics(self):
+        """paths['sp'] presence must NOT mark the composite sp phase complete; only
+        the finalize flag (all sub-jobs recorded + protocol evaluated) does."""
+        in_progress = {'paths': {'sp': '/x/base.out', 'composite': '',
+                                 'sp_composite': {'base': '/x/base.out'}},
+                       'job_types': {'sp_composite': False}}
+        self.assertFalse(species_has_sp(in_progress))
+        finalized = {'paths': {'sp': '/x/base.out', 'composite': '',
+                               'sp_composite': {'base': '/x/base.out',
+                                                'delta_T__high': '/x/h.out',
+                                                'delta_T__low': '/x/l.out'}},
+                     'job_types': {'sp_composite': True}}
+        self.assertTrue(species_has_sp(finalized))
+        legacy = {'paths': {'sp': '/x/sp.out', 'composite': '', 'sp_composite': {}}}
+        self.assertTrue(species_has_sp(legacy))
+        self.assertTrue(species_has_sp(in_progress, yml_path='/x/spc.yml'))
+
+    def test_check_rxn_e0_by_spc_runs_for_composite_finalized_reaction(self):
+        """A 3-species reaction (R/TS/P), all composite-finalized: the E0 sanity
+        check is no longer gated off by species_has_sp and writes ts_checks['E0']."""
+        tmp = os.path.join(self.project_directory, "fx_e0_check")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        r_spc = ARCSpecies(label='HCN', smiles='C#N')
+        r_spc.final_xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+                           'coords': ((0, 0, 0), (0, 0, 1.16), (0, 0, -1.07))}
+        p_spc = ARCSpecies(label='HNC', smiles='[C-]#[NH+]')
+        p_spc.final_xyz = {'symbols': ('N', 'C', 'H'), 'isotopes': (14, 12, 1),
+                           'coords': ((0, 0, 0), (0, 0, 1.17), (0, 0, -1.00))}
+        ts_spc = ARCSpecies(label='TS_e0', is_ts=True)
+        ts_spc.final_xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+                            'coords': ((0, 0, 0), (0, 0, 1.18), (0.9, 0, 0.6))}
+        sched = self._make_scheduler([r_spc, p_spc, ts_spc], sp_composite=protocol)
+        for label, e_hartree in [('HCN', -93.0), ('HNC', -92.99), ('TS_e0', -92.9)]:
+            base_path = os.path.join(tmp, f"{label}_base.out")
+            self._write_gaussian_fixture(base_path, e_hartree)
+            sched.post_sp_actions(label, base_path, protocol.base.level)
+            self.assertTrue(sched.output[label]['job_types']['sp_composite'])
+            sched.output[label]['paths']['freq'] = os.path.join(ARC_TESTING_PATH, 'freq', 'nC3H7.out')
+        rxn = ARCReaction(r_species=[r_spc], p_species=[p_spc], ts_label='TS_e0')
+        rxn.ts_species = ts_spc
+        r_spc.e0, p_spc.e0, ts_spc.e0 = 10.0, 20.0, 150.0
+        sched.rxn_list = [rxn]
+        self.assertIsNone(ts_spc.ts_checks['E0'])
+        sched.check_rxn_e0_by_spc('TS_e0')
+        self.assertTrue(ts_spc.ts_checks['E0'])
+
+
+class TestCorrelatedElectronCounting(unittest.TestCase):
+    """Frozen-core orbital and correlated-electron counting helpers."""
+
+    def test_frozen_core_orbitals_first_rows(self):
+        self.assertEqual(count_frozen_core_orbitals(('H',)), 0)
+        self.assertEqual(count_frozen_core_orbitals(('He',)), 0)
+        self.assertEqual(count_frozen_core_orbitals(('C',)), 1)
+        self.assertEqual(count_frozen_core_orbitals(('Ne',)), 1)
+        self.assertEqual(count_frozen_core_orbitals(('S',)), 5)
+        self.assertEqual(count_frozen_core_orbitals(('Br',)), 9)
+        self.assertEqual(count_frozen_core_orbitals(('I',)), 18)
+
+    def test_frozen_core_orbitals_molecule_sums_atoms(self):
+        self.assertEqual(count_frozen_core_orbitals(('C', 'H', 'H', 'H', 'H')), 1)
+        self.assertEqual(count_frozen_core_orbitals(('C', 'S', 'H', 'H')), 6)
+
+    def test_correlated_electrons_atoms(self):
+        self.assertEqual(count_correlated_electrons(('H',)), 1)
+        self.assertEqual(count_correlated_electrons(('He',)), 2)
+        self.assertEqual(count_correlated_electrons(('Be',)), 2)
+        self.assertEqual(count_correlated_electrons(('C',)), 4)
+
+    def test_correlated_electrons_molecules(self):
+        self.assertEqual(count_correlated_electrons(('H', 'H')), 2)
+        self.assertEqual(count_correlated_electrons(('C', 'H', 'H', 'H', 'H')), 8)
+        self.assertEqual(count_correlated_electrons(('N', 'N')), 10)
+
+    def test_correlated_electrons_charge(self):
+        self.assertEqual(count_correlated_electrons(('O', 'H'), charge=-1), 8)
+        self.assertEqual(count_correlated_electrons(('H',), charge=1), 0)
 
 
 class TestSchedulerSpCompositePassthrough(unittest.TestCase):
@@ -2754,15 +3228,17 @@ class TestSchedulerSpCompositePassthrough(unittest.TestCase):
 
 
 class TestSchedulerZombieJobDetection(unittest.TestCase):
-    """A queue-running job that has produced no output traffic by the grace
-    period is treated as a zombie: killed, then resubmitted once. The cap of
-    one resubmit per (species, job_type) prevents loops on bad inputs."""
+    """A queue-RUNNING job that has produced no output traffic by the grace
+    period (measured from the first time it was observed running) is treated
+    as a zombie: killed, then resubmitted once. The cap of one resubmit per
+    (species, job_name) prevents loops on bad inputs."""
 
     @classmethod
     def setUpClass(cls):
         cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
         cls.project_directory = os.path.join(
-            ARC_PATH, 'Projects', 'arc_project_for_testing_zombie'
+            ARC_PATH, 'Projects', f'arc_project_for_testing_zombie_{worker}'
         )
         if os.path.isdir(cls.project_directory):
             shutil.rmtree(cls.project_directory, ignore_errors=True)
@@ -2773,7 +3249,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         if os.path.isdir(cls.project_directory):
             shutil.rmtree(cls.project_directory, ignore_errors=True)
 
-    def _make_sched(self):
+    def _make_sched(self, restart_dict=None):
         spc = ARCSpecies(label='H2', smiles='[H][H]')
         spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
                          'isotopes': (1, 1)}
@@ -2783,6 +3259,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
                 ess_settings=self.ess_settings,
                 species_list=[spc],
                 project_directory=self.project_directory,
+                restart_dict=restart_dict,
                 opt_level=Level(repr=default_levels_of_theory['opt']),
                 freq_level=Level(repr=default_levels_of_theory['freq']),
                 sp_level=Level(repr=default_levels_of_theory['sp']),
@@ -2811,10 +3288,12 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         job.delete = _delete
         return job
 
-    def _install(self, sched, job, label='H2'):
+    def _install(self, sched, job, label='H2', seed_running_since=True):
         sched.job_dict.setdefault(label, {}).setdefault(job.job_type, {})[job.job_name] = job
         sched.running_jobs.setdefault(label, []).append(job.job_name)
         sched.server_job_ids = [job.job_id]
+        if seed_running_since:
+            sched._zombie_running_since[job.job_name] = job.initial_time
 
     def test_zombie_killed_and_resubmitted(self):
         sched = self._make_sched()
@@ -2827,7 +3306,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         self.assertTrue(job.deleted, "Zombie job should have been deleted.")
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
         self.assertNotIn(job.job_name, sched.running_jobs['H2'])
-        self.assertIn('sp', sched._zombie_kills['H2'])
+        self.assertIn(job.job_name, sched._zombie_kills['H2'])
 
     def test_healthy_job_not_killed(self):
         sched = self._make_sched()
@@ -2883,7 +3362,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
 
     def test_cap_prevents_double_resubmit(self):
         sched = self._make_sched()
-        sched._zombie_kills['H2'] = {'sp'}  # Already used the one chance.
+        sched._zombie_kills['H2'] = {'sp_a3177'}  # Already used the one chance.
         job = self._stub_job()
         self._install(sched, job)
         sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit when cap is hit")
@@ -2893,7 +3372,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         self.assertIn(job.job_name, sched.running_jobs['H2'])
 
     def test_second_zombie_pass_is_noop_after_one_kill(self):
-        """A second zombie detection for the same (species, job_type) after one
+        """A second zombie detection for the same (species, job_name) after one
         real kill-and-resubmit cycle must be a no-op: no second delete, no second
         resubmission, and the 'leaving for manual intervention' branch is taken."""
         sched = self._make_sched()
@@ -2905,7 +3384,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
             sched.check_for_zombie_jobs('H2')
             self.assertTrue(job.deleted)
             self.assertEqual(run_calls, [(job.job_name, 'H2')])
-            self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+            self.assertEqual(sched._zombie_kills['H2'], {job.job_name})
             # The resubmitted job wedges too: the queue reports it running again.
             job.deleted = False
             sched.running_jobs['H2'].append(job.job_name)
@@ -2913,33 +3392,188 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
                 sched.check_for_zombie_jobs('H2')
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
         self.assertFalse(job.deleted)
-        self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+        self.assertEqual(sched._zombie_kills['H2'], {job.job_name})
         self.assertIn(job.job_name, sched.running_jobs['H2'])
         self.assertIn('manual intervention', '\n'.join(cm.output))
 
-    def test_cap_is_per_job_type(self):
+    def test_cap_is_per_job_name(self):
         sched = self._make_sched()
-        sched._zombie_kills['H2'] = {'sp'}  # sp already used.
+        sched._zombie_kills['H2'] = {'sp_a3177'}  # That job already used its credit.
         job = self._stub_job(job_type='freq', job_name='freq_a8888')
         self._install(sched, job)
         run_calls = []
         sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
         with patch('arc.job.zombie.output_mtime', return_value=None):
             sched.check_for_zombie_jobs('H2')
-        self.assertTrue(job.deleted, "freq has its own cap budget independent of sp.")
+        self.assertTrue(job.deleted, "freq_a8888 has its own cap budget independent of sp_a3177.")
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
-        self.assertEqual(sched._zombie_kills['H2'], {'sp', 'freq'})
+        self.assertEqual(sched._zombie_kills['H2'], {'sp_a3177', 'freq_a8888'})
 
     def test_zombie_kills_serialized_in_restart(self):
         sched = self._make_sched()
-        sched._zombie_kills = {'H2': {'sp', 'freq'}, 'OH': {'sp'}}
+        sched._zombie_kills = {'H2': {'sp_a3177', 'freq_a8888'}, 'OH': {'sp_a3199'}}
         sched.save_restart = True
         sched.restart_dict = {}
         sched.save_restart_dict()
         saved = sched.restart_dict['_zombie_kills']
         self.assertEqual(set(saved.keys()), {'H2', 'OH'})
-        self.assertEqual(set(saved['H2']), {'sp', 'freq'})
-        self.assertEqual(set(saved['OH']), {'sp'})
+        self.assertEqual(set(saved['H2']), {'sp_a3177', 'freq_a8888'})
+        self.assertEqual(set(saved['OH']), {'sp_a3199'})
+
+    def test_capped_pair_skips_zombie_stat(self):
+        """A (species, job_name) pair that already used its one resubmission
+        must skip the expensive zombie stat entirely."""
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp_a3177'}
+        job = self._stub_job()
+        self._install(sched, job)
+        stat_calls = []
+
+        def record_stat(*args, **kwargs):
+            stat_calls.append(args)
+            return True
+
+        with patch('arc.scheduler._is_zombie_job', side_effect=record_stat):
+            sched.check_for_zombie_jobs('H2')
+        self.assertEqual(stat_calls, [])
+        self.assertFalse(job.deleted)
+
+    def test_manual_intervention_warning_fires_once(self):
+        """The 'manual intervention' warning for a capped pair must fire once
+        per job_name, not on every scheduler loop pass."""
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp_a3177'}
+        job = self._stub_job()
+        self._install(sched, job)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+            with self.assertNoLogs(logger='arc', level=logging.WARNING):
+                sched.check_for_zombie_jobs('H2')
+        self.assertEqual('\n'.join(cm.output).count('manual intervention'), 1)
+
+    def test_recheck_throttle_limits_zombie_stats(self):
+        """A job checked within ZOMBIE_RECHECK_SECONDS must not be re-stat'ed;
+        once the throttle window has passed, the check runs again."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        stat_calls = []
+
+        def record_stat(*args, **kwargs):
+            stat_calls.append(args)
+            return False
+
+        with patch('arc.scheduler._is_zombie_job', side_effect=record_stat):
+            sched.check_for_zombie_jobs('H2')
+            sched.check_for_zombie_jobs('H2')
+            self.assertEqual(len(stat_calls), 1)
+            sched._zombie_last_check[job.job_name] -= ZOMBIE_RECHECK_SECONDS + 1
+            sched.check_for_zombie_jobs('H2')
+        self.assertEqual(len(stat_calls), 2)
+
+    def test_resolve_job_by_name_integer_keyed_subdict(self):
+        """resolve_job_by_name must find jobs stored under integer-keyed
+        sub-dicts (conf_opt/conf_sp/tsg) via the job_name attribute, and
+        return None for unknown names."""
+        sched = self._make_sched()
+        job = self._stub_job(job_type='conf_opt', job_name='conf_opt_a202')
+        sched.job_dict.setdefault('H2', {}).setdefault('conf_opt', {})[0] = job
+        self.assertIs(sched.resolve_job_by_name('H2', 'conf_opt_a202'), job)
+        self.assertIsNone(sched.resolve_job_by_name('H2', 'no_such_job'))
+        self.assertIsNone(sched.resolve_job_by_name('no_such_label', 'conf_opt_a202'))
+
+    def test_resolve_job_by_name_synthetic_conformer_names(self):
+        """resolve_job_by_name must resolve the synthetic running_jobs names
+        ('conf_opt_<n>', 'conf_sp_<n>', 'tsg<n>') via the trailing index."""
+        sched = self._make_sched()
+        job = self._stub_job(job_type='conf_opt', job_name='conformer_real_name')
+        sched.job_dict.setdefault('H2', {}).setdefault('conf_opt', {})[0] = job
+        self.assertIs(sched.resolve_job_by_name('H2', 'conf_opt_0'), job)
+        tsg_job = self._stub_job(job_type='tsg', job_name='some_tsg_adapter_name')
+        sched.job_dict['H2'].setdefault('tsg', {})[2] = tsg_job
+        self.assertIs(sched.resolve_job_by_name('H2', 'tsg2'), tsg_job)
+        self.assertIsNone(sched.resolve_job_by_name('H2', 'conf_sp_5'))
+
+    def test_pending_job_never_killed(self):
+        """A queued (PENDING) job is never killable regardless of age, and the
+        running clock does not start while it is pending."""
+        sched = self._make_sched()
+        job = self._stub_job(initial_offset_seconds=8 * 3600)
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'pending'}
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on a pending job")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertNotIn(job.job_name, sched._zombie_running_since)
+
+    def test_pending_then_running_clock_starts_at_running(self):
+        """PENDING for 8 h then RUNNING for a moment → the grace clock starts
+        at the first running observation, so the job is not flagged."""
+        sched = self._make_sched()
+        job = self._stub_job(initial_offset_seconds=8 * 3600)
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'pending'}
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+            self.assertNotIn(job.job_name, sched._zombie_running_since)
+            sched.server_job_states = {str(job.job_id): 'running'}
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched._zombie_running_since)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+
+    def test_held_job_warns_once_never_killed(self):
+        """A HELD job warns at most once and is never killed."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'held'}
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on a held job")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+            with self.assertNoLogs(logger='arc', level=logging.WARNING):
+                sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertEqual('\n'.join(cm.output).count('held'), 1)
+
+    def test_two_composite_sp_subjobs_killed_independently(self):
+        """Two composite sp sub-jobs of one species flagged in the same pass
+        must both be killed and resubmitted, each consuming its own credit."""
+        sched = self._make_sched()
+        job_1 = self._stub_job(job_name='sp_a0001', job_id=111)
+        job_2 = self._stub_job(job_name='sp_a0002', job_id=222)
+        self._install(sched, job_1)
+        self._install(sched, job_2)
+        sched.server_job_ids = [111, 222]
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append(job.job_name)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job_1.deleted)
+        self.assertTrue(job_2.deleted)
+        self.assertEqual(sorted(run_calls), ['sp_a0001', 'sp_a0002'])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp_a0001', 'sp_a0002'})
+
+    def test_old_format_restart_zombie_kills_is_inert(self):
+        """Old-format restart entries (job_type strings) load without crashing
+        and cap nothing: a zombie job of that type still gets its one credit."""
+        sched = self._make_sched(restart_dict={'_zombie_kills': {'H2': ['sp']}})
+        self.assertEqual(sched._zombie_kills, {'H2': {'sp'}})
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append(job.job_name)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted)
+        self.assertEqual(run_calls, [job.job_name])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp', job.job_name})
+        sched.save_restart = True
+        sched.save_restart_dict()
+        self.assertEqual(sched.restart_dict['_zombie_kills'], {'H2': ['sp', 'sp_a3177']})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -7,10 +7,12 @@ This module contains unit tests for the arc.scheduler module
 
 import unittest
 from unittest.mock import MagicMock, patch
+import datetime
 import logging
 import os
 import shutil
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import nbformat
@@ -21,6 +23,7 @@ from arc.checks.ts import check_ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
+from arc.job.zombie import ZOMBIE_GRACE_SECONDS
 from arc.level import Level
 from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
@@ -2739,6 +2742,195 @@ class TestSchedulerSpCompositePassthrough(unittest.TestCase):
         protocol = CompositeProtocol.from_user_input('HEAT-345Q')
         sched = self._make_scheduler(protocol)
         self.assertEqual(sched.running_jobs, {'H2': []})
+
+
+class TestSchedulerZombieJobDetection(unittest.TestCase):
+    """A queue-running job that has produced no output traffic by the grace
+    period is treated as a zombie: killed, then resubmitted once. The cap of
+    one resubmit per (species, job_type) prevents loops on bad inputs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', 'arc_project_for_testing_zombie'
+        )
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+        os.makedirs(cls.project_directory, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    def _make_sched(self):
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='zombie',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                testing=True,
+            )
+        sched.run_job = lambda *a, **kw: None
+        return sched
+
+    def _stub_job(self, job_adapter='molpro', job_type='sp', execution_type='queue',
+                  initial_offset_seconds=ZOMBIE_GRACE_SECONDS + 3600, job_name='sp_a3177', job_id=12345):
+        job = SimpleNamespace(
+            job_name=job_name, job_type=job_type, job_id=job_id,
+            job_adapter=job_adapter, execution_type=execution_type,
+            initial_time=datetime.datetime.now() - datetime.timedelta(seconds=initial_offset_seconds),
+            server='server1',
+            local_path='/tmp/no/such/path', local_path_to_output_file='/tmp/no/such/output.out',
+            remote_path='/remote/no/such/path',
+            deleted=False,
+        )
+        def _delete():
+            job.deleted = True
+        job.delete = _delete
+        return job
+
+    def _install(self, sched, job, label='H2'):
+        sched.job_dict.setdefault(label, {}).setdefault(job.job_type, {})[job.job_name] = job
+        sched.running_jobs.setdefault(label, []).append(job.job_name)
+        sched.server_job_ids = [job.job_id]
+
+    def test_zombie_killed_and_resubmitted(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted, "Zombie job should have been deleted.")
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertNotIn(job.job_name, sched.running_jobs['H2'])
+        self.assertIn('sp', sched._zombie_kills['H2'])
+
+    def test_healthy_job_not_killed(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit healthy job")
+        # Output mtime well after spawn → healthy.
+        fresh = job.initial_time + datetime.timedelta(seconds=3000)
+        with patch('arc.job.zombie.output_mtime', return_value=fresh):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+        self.assertEqual(sched._zombie_kills, {})
+
+    def test_grace_period_blocks_zombie_check(self):
+        sched = self._make_sched()
+        # Spawned 30 minutes ago — within the grace period.
+        job = self._stub_job(initial_offset_seconds=1800)
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act inside grace window")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_non_periodic_writer_ess_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job(job_adapter='xtb')  # not in _ESS_PERIODIC_WRITERS
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on non-periodic-writer ESS")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_incore_job_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job(execution_type='incore')
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on incore jobs")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_queue_status_done_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        # Queue says the job is no longer running (done / disappeared).
+        sched.server_job_ids = []
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act when queue says not running")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_cap_prevents_double_resubmit(self):
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp'}  # Already used the one chance.
+        job = self._stub_job()
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit when cap is hit")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+
+    def test_second_zombie_pass_is_noop_after_one_kill(self):
+        """A second zombie detection for the same (species, job_type) after one
+        real kill-and-resubmit cycle must be a no-op: no second delete, no second
+        resubmission, and the 'leaving for manual intervention' branch is taken."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+            self.assertTrue(job.deleted)
+            self.assertEqual(run_calls, [(job.job_name, 'H2')])
+            self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+            # The resubmitted job wedges too: the queue reports it running again.
+            job.deleted = False
+            sched.running_jobs['H2'].append(job.job_name)
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertFalse(job.deleted)
+        self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+        self.assertIn('manual intervention', '\n'.join(cm.output))
+
+    def test_cap_is_per_job_type(self):
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp'}  # sp already used.
+        job = self._stub_job(job_type='freq', job_name='freq_a8888')
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted, "freq has its own cap budget independent of sp.")
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp', 'freq'})
+
+    def test_zombie_kills_serialized_in_restart(self):
+        sched = self._make_sched()
+        sched._zombie_kills = {'H2': {'sp', 'freq'}, 'OH': {'sp'}}
+        sched.save_restart = True
+        sched.restart_dict = {}
+        sched.save_restart_dict()
+        saved = sched.restart_dict['_zombie_kills']
+        self.assertEqual(set(saved.keys()), {'H2', 'OH'})
+        self.assertEqual(set(saved['H2']), {'sp', 'freq'})
+        self.assertEqual(set(saved['OH']), {'sp'})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -7,6 +7,7 @@ This module contains unit tests for the arc.scheduler module
 
 import unittest
 from unittest.mock import MagicMock, patch
+import datetime
 import logging
 import os
 import shutil
@@ -20,6 +21,7 @@ from arc.checks.ts import check_ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
+from arc.job.zombie import ZOMBIE_GRACE_SECONDS
 from arc.level import Level
 from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
@@ -3212,6 +3214,195 @@ class TestSchedulerSpCompositePassthrough(unittest.TestCase):
         protocol = CompositeProtocol.from_user_input('HEAT-345Q')
         sched = self._make_scheduler(protocol)
         self.assertEqual(sched.running_jobs, {'H2': []})
+
+
+class TestSchedulerZombieJobDetection(unittest.TestCase):
+    """A queue-running job that has produced no output traffic by the grace
+    period is treated as a zombie: killed, then resubmitted once. The cap of
+    one resubmit per (species, job_type) prevents loops on bad inputs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', 'arc_project_for_testing_zombie'
+        )
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+        os.makedirs(cls.project_directory, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    def _make_sched(self):
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='zombie',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                testing=True,
+            )
+        sched.run_job = lambda *a, **kw: None
+        return sched
+
+    def _stub_job(self, job_adapter='molpro', job_type='sp', execution_type='queue',
+                  initial_offset_seconds=ZOMBIE_GRACE_SECONDS + 3600, job_name='sp_a3177', job_id=12345):
+        job = SimpleNamespace(
+            job_name=job_name, job_type=job_type, job_id=job_id,
+            job_adapter=job_adapter, execution_type=execution_type,
+            initial_time=datetime.datetime.now() - datetime.timedelta(seconds=initial_offset_seconds),
+            server='server1',
+            local_path='/tmp/no/such/path', local_path_to_output_file='/tmp/no/such/output.out',
+            remote_path='/remote/no/such/path',
+            deleted=False,
+        )
+        def _delete():
+            job.deleted = True
+        job.delete = _delete
+        return job
+
+    def _install(self, sched, job, label='H2'):
+        sched.job_dict.setdefault(label, {}).setdefault(job.job_type, {})[job.job_name] = job
+        sched.running_jobs.setdefault(label, []).append(job.job_name)
+        sched.server_job_ids = [job.job_id]
+
+    def test_zombie_killed_and_resubmitted(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted, "Zombie job should have been deleted.")
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertNotIn(job.job_name, sched.running_jobs['H2'])
+        self.assertIn('sp', sched._zombie_kills['H2'])
+
+    def test_healthy_job_not_killed(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit healthy job")
+        # Output mtime well after spawn → healthy.
+        fresh = job.initial_time + datetime.timedelta(seconds=3000)
+        with patch('arc.job.zombie.output_mtime', return_value=fresh):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+        self.assertEqual(sched._zombie_kills, {})
+
+    def test_grace_period_blocks_zombie_check(self):
+        sched = self._make_sched()
+        # Spawned 30 minutes ago — within the grace period.
+        job = self._stub_job(initial_offset_seconds=1800)
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act inside grace window")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_non_periodic_writer_ess_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job(job_adapter='xtb')  # not in _ESS_PERIODIC_WRITERS
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on non-periodic-writer ESS")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_incore_job_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job(execution_type='incore')
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on incore jobs")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_queue_status_done_skipped(self):
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        # Queue says the job is no longer running (done / disappeared).
+        sched.server_job_ids = []
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act when queue says not running")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+
+    def test_cap_prevents_double_resubmit(self):
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp'}  # Already used the one chance.
+        job = self._stub_job()
+        self._install(sched, job)
+        sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit when cap is hit")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+
+    def test_second_zombie_pass_is_noop_after_one_kill(self):
+        """A second zombie detection for the same (species, job_type) after one
+        real kill-and-resubmit cycle must be a no-op: no second delete, no second
+        resubmission, and the 'leaving for manual intervention' branch is taken."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+            self.assertTrue(job.deleted)
+            self.assertEqual(run_calls, [(job.job_name, 'H2')])
+            self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+            # The resubmitted job wedges too: the queue reports it running again.
+            job.deleted = False
+            sched.running_jobs['H2'].append(job.job_name)
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertFalse(job.deleted)
+        self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+        self.assertIn('manual intervention', '\n'.join(cm.output))
+
+    def test_cap_is_per_job_type(self):
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp'}  # sp already used.
+        job = self._stub_job(job_type='freq', job_name='freq_a8888')
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted, "freq has its own cap budget independent of sp.")
+        self.assertEqual(run_calls, [(job.job_name, 'H2')])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp', 'freq'})
+
+    def test_zombie_kills_serialized_in_restart(self):
+        sched = self._make_sched()
+        sched._zombie_kills = {'H2': {'sp', 'freq'}, 'OH': {'sp'}}
+        sched.save_restart = True
+        sched.restart_dict = {}
+        sched.save_restart_dict()
+        saved = sched.restart_dict['_zombie_kills']
+        self.assertEqual(set(saved.keys()), {'H2', 'OH'})
+        self.assertEqual(set(saved['H2']), {'sp', 'freq'})
+        self.assertEqual(set(saved['OH']), {'sp'})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -14,18 +14,20 @@ import shutil
 from types import SimpleNamespace
 
 import nbformat
+import yaml
 
 
 import arc.parser.parser as parser
 from arc.checks.ts import check_ts
-from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
+from arc.common import ARC_PATH, ARC_TESTING_PATH, VERSION, almost_equal_coords_lists, initialize_job_types, read_yaml_file
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
 from arc.job.zombie import ZOMBIE_GRACE_SECONDS
 from arc.level import Level
 from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
-from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
+from arc.scheduler import (Scheduler, SchedulerError, ZOMBIE_RECHECK_SECONDS, count_correlated_electrons,
+                           count_frozen_core_orbitals, species_has_freq, species_has_geo, species_has_sp,
                            species_has_sp_and_freq, tsg_method_matches_adapter)
 from arc.imports import settings
 from arc.reaction import ARCReaction
@@ -2006,7 +2008,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             ],
         }
 
-    def _make_scheduler(self, species_list, sp_composite, output=None):
+    def _make_scheduler(self, species_list, sp_composite, output=None, job_types=None):
         """Build a Scheduler with run_job patched to a no-op.
 
         We patch at the *class* level because the Phase 3.5 restart kick-start
@@ -2018,6 +2020,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                 project='sp_composite_orch',
                 ess_settings=self.ess_settings,
                 species_list=species_list,
+                job_types=job_types,
                 project_directory=self.project_directory,
                 opt_level=Level(repr=default_levels_of_theory['opt']),
                 freq_level=Level(repr=default_levels_of_theory['freq']),
@@ -2051,8 +2054,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2079,8 +2082,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2137,6 +2140,92 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         active = sched._composite_for('H2')
         self.assertIsNotNone(active)
         self.assertEqual(active.base.level.method, "hf")
+
+    @staticmethod
+    def _fpa_like_recipe():
+        """CBS-as-base recipe: two-point CBS base + one delta correction."""
+        return {
+            "base": {"label": "base", "type": "cbs_extrapolation",
+                     "formula": "helgaker_corr_2pt",
+                     "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                                {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    def test_cbs_base_seeds_deterministic_sub_labels(self):
+        """A CBS base seeds one pending sub_label per cardinal — stable keys
+        for restart rehydration."""
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        sched._seed_composite_pending('H2')
+        self.assertEqual(set(sched._sp_composite_pending['H2'].keys()),
+                         {"base__card_3", "base__card_4",
+                          "delta_T__high", "delta_T__low"})
+
+    def test_cbs_base_spawns_one_sp_job_per_cardinal(self):
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        spawned_levels = []
+        sched.run_job = lambda *args, **kwargs: spawned_levels.append(kwargs['level_of_theory'])
+        sched._seed_composite_pending('H2')
+        sched._spawn_composite_pending('H2')
+        spawned_bases = sorted(lvl.basis for lvl in spawned_levels
+                               if lvl.method == 'ccsd(t)' and lvl.basis != 'cc-pvdz')
+        self.assertEqual(spawned_bases, ['cc-pvqz', 'cc-pvtz'])
+        self.assertEqual(len(spawned_levels), 4)
+
+    def test_cbs_base_finalizes_with_extrapolated_energy(self):
+        tmp = os.path.join(self.project_directory, "fx_cbs_base")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies_H = {"base__card_3": -1.170, "base__card_4": -1.172,
+                      "delta_T__high": -1.15, "delta_T__low": -1.12}
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies_H)
+        sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+        recorded = sched.output['H2']['paths']['sp_composite']
+        self.assertEqual(set(recorded.keys()),
+                         {"base__card_3", "base__card_4",
+                          "delta_T__high", "delta_T__low"})
+        parsed = {sl: parser.parse_e_elect(p) for sl, p in paths.items()}
+        e_cbs = (27 * parsed["base__card_3"] - 64 * parsed["base__card_4"]) / (27 - 64)
+        expected = e_cbs + parsed["delta_T__high"] - parsed["delta_T__low"]
+        self.assertAlmostEqual(spc.e_elect, expected, places=6)
+        self.assertAlmostEqual(spc.e_elect, protocol.evaluate(parsed), places=10)
+
+    def test_run_sp_job_defaults_to_largest_cardinal_for_cbs_base(self):
+        """run_sp_job with no explicit level runs the protocol's primary base
+        level — the largest-cardinal CBS leg."""
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        spawned_levels = []
+        sched.run_job = lambda *args, **kwargs: spawned_levels.append(kwargs['level_of_theory'])
+        sched.run_sp_job('H2')
+        self.assertEqual(len(spawned_levels), 1)
+        self.assertEqual(spawned_levels[0].method, 'ccsd(t)')
+        self.assertEqual(spawned_levels[0].basis, 'cc-pvqz')
 
     def test_opt_out_species_uses_global_sp_level(self):
         recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
@@ -2211,8 +2300,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2247,8 +2336,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2280,8 +2369,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2307,8 +2396,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2350,7 +2439,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         # Kick-start must have spawned exactly the two missing unique Levels.
         self.assertEqual(len(spawned_levels), 2)
         spawned_methods = sorted(lvl.method for lvl in spawned_levels)
-        self.assertEqual(spawned_methods, ["ccsd(t)", "ccsdt"])
+        self.assertEqual(spawned_methods, ["ccsd(t)", "mp2"])
         # Pending dict reflects what's queued.
         self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
                          {"delta_T__high", "delta_T__low"})
@@ -2409,8 +2498,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2461,8 +2550,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2511,7 +2600,7 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                          {"delta_T__low"})
         self.assertEqual(sched2.output['H2']['job_types']['sp_composite'], False)
         self.assertEqual(len(spawned_levels), 1)
-        self.assertEqual(spawned_levels[0].method, "ccsd(t)")
+        self.assertEqual(spawned_levels[0].method, "mp2")
         # Replace the file and re-complete → protocol finalizes normally.
         sched2.run_job = lambda *args, **kwargs: None
         self._write_gaussian_fixture(paths["delta_T__low"], -1.12)
@@ -2580,8 +2669,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2650,8 +2739,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2696,8 +2785,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2797,144 +2886,176 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
         self.assertEqual(sched.running_jobs['H2'], [])
         self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
 
-    def test_mrcc_degenerate_high_leg_falls_back_to_low_leg_path(self):
-        """When a δ-term high-leg sub-job errors with ``MRCCDegenerateSystem``
-        (atomic H / H2 at CCSDT(Q): MRCC's xmrcc bails because the requested
-        excitation rank exceeds the determinant space), the trsh ladder
-        cannot help — the cause is intrinsic to the physics, not the
-        numerics. The composite framework must short-circuit by reusing the
-        sister low-leg's output path. The two energies are degenerate by
-        symmetry (all CC ranks reduce to HF for ≤2-electron systems), so
-        δ = 0, which is the correct physical answer."""
-        tmp = os.path.join(self.project_directory, "fx_mrcc_degenerate")
+    # --- proactive δ≡0 skip for trivially-zero delta corrections ------------ #
+
+    @staticmethod
+    def _mono_species(label, smiles, symbol, isotope):
+        """A monoatomic ARCSpecies with a final geometry."""
+        spc = ARCSpecies(label=label, smiles=smiles)
+        spc.final_xyz = {'symbols': (symbol,), 'coords': ((0., 0., 0.),),
+                         'isotopes': (isotope,)}
+        return spc
+
+    @staticmethod
+    def _ch4_species(label='CH4'):
+        """A CH4 ARCSpecies (10 electrons, 1 frozen-core orbital, n_corr=8)."""
+        spc = ARCSpecies(label=label, smiles='C')
+        spc.final_xyz = {'symbols': ('C', 'H', 'H', 'H', 'H'),
+                         'coords': ((0., 0., 0.), (0.63, 0.63, 0.63),
+                                    (-0.63, -0.63, 0.63), (-0.63, 0.63, -0.63),
+                                    (0.63, -0.63, -0.63)),
+                         'isotopes': (12, 1, 1, 1, 1)}
+        return spc
+
+    def test_h_atom_heat_deltas_skipped_finalizes_base_only(self):
+        """H atom (n_corr=1) through a HEAT-style recipe: both δ terms are
+        decided trivially zero at term-expansion time — neither leg is queued —
+        and the composite finalizes to the base energy alone, with the skip
+        reason surfaced in the log and the species report."""
+        tmp = os.path.join(self.project_directory, "fx_skip_h_atom")
         os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
-        spc = ARCSpecies(label='H2', smiles='[H][H]')
-        spc.final_xyz = {'symbols': ('H', 'H'),
-                         'coords': ((0, 0, 0), (0, 0, 0.74)),
-                         'isotopes': (1, 1)}
-        sched = self._make_scheduler([spc], sp_composite=protocol)
-        # Base + low-leg complete normally.
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('Hskip', '[H]', 'H', 1)
+        sched = self._make_scheduler([spc], sp_composite=protocol,
+                                     job_types=initialize_job_types())
+        self.assertEqual(set(sched._sp_composite_pending['Hskip'].keys()), {'base'})
+        self.assertEqual(set(sched._sp_composite_skipped['Hskip'].keys()),
+                         {'delta_T', 'delta_Q'})
+        spawned = []
+        sched.run_job = lambda *a, **kw: spawned.append(kw.get('level_of_theory'))
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched._seed_composite_pending('Hskip')
+            sched._spawn_composite_pending('Hskip')
+        joined = '\n'.join(cm.output)
+        self.assertIn('δ≡0', joined)
+        self.assertIn('skipped', joined)
+        self.assertEqual(len(spawned), 1, 'Only the base SP may be queued.')
+        self.assertEqual(spawned[0], protocol.base.level)
         base_path = os.path.join(tmp, "base.out")
-        self._write_gaussian_fixture(base_path, -0.5)
-        sched.post_sp_actions('H2', base_path, protocol.base.level)
-        low_path = os.path.join(tmp, "delta_T__low.out")
-        self._write_gaussian_fixture(low_path, -0.5)  # HF for atomic H
-        sched.post_sp_actions('H2', low_path, protocol.corrections[0].low)
-        # High leg (CCSDT/cc-pVDZ) "fails" with the MRCC degenerate-system
-        # keyword. Build a JobAdapter stub that mimics what check_sp_job sees.
-
-        class _ErroredJobStub:
-            def __init__(self, level, output_path):
-                self.level = level
-                self.local_path_to_output_file = output_path
-                self.job_status = ['done', {
-                    'status': 'errored',
-                    'keywords': ['MRCCDegenerateSystem'],
-                    'error': 'MRCC xmrcc fatal',
-                    'line': 'Fatal error in xmrcc.',
-                }]
-                self.conformer = None
-                self.job_name = 'sp_a999'
-                self.execution_type = 'queue'
-                self.job_id = 'a999'
-
-        # Provide a placeholder output file (it would normally be the
-        # truncated MRCC log; the framework should not parse it).
-        high_failed_path = os.path.join(tmp, "delta_T__high_FAILED.out")
-        with open(high_failed_path, 'w') as fh:
-            fh.write("Fatal error in xmrcc.\n")
-        bad_job = _ErroredJobStub(
-            level=protocol.corrections[0].high,
-            output_path=high_failed_path,
-        )
-        sched.check_sp_job(label='H2', job=bad_job)
-        # The framework must have substituted the low-leg path for the high
-        # leg and finalized the composite (δ_T = 0, e_elect = base energy).
-        self.assertEqual(
-            sched.output['H2']['paths']['sp_composite']['delta_T__high'],
-            low_path,
-            'High-leg path must be substituted with low-leg path on '
-            'MRCCDegenerateSystem fallback.',
-        )
-        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self._write_gaussian_fixture(base_path, -0.499)
+        sched.post_sp_actions('Hskip', base_path, protocol.base.level)
+        self.assertTrue(sched.output['Hskip']['job_types']['sp_composite'])
         self.assertEqual(spc.e_elect_source, 'sp_composite')
-        # Energy contributions: base = parsed from base.out, δ_T = 0 by
-        # construction. Final = base.
-        parsed_base = parser.parse_e_elect(base_path)
-        self.assertAlmostEqual(spc.e_elect, parsed_base, places=6)
+        self.assertAlmostEqual(spc.e_elect, parser.parse_e_elect(base_path), places=6)
+        self.assertEqual(len(spawned), 1, 'No δ legs may be queued after the base.')
+        # Provenance: the section and the YAML report carry the skip.
+        section = sched._sp_composite_sections['Hskip']
+        self.assertIn('delta_T', section.skipped_terms)
+        self.assertIn('δ≡0', section.skipped_terms['delta_Q'])
+        report_path = os.path.join(self.project_directory, "output", "Species",
+                                   "Hskip", "sp_composite_report.yml")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        for term in report['terms']:
+            self.assertTrue(term['skipped'])
+            self.assertEqual(term['contribution_kj_per_mol'], 0.0)
+            self.assertIn('δ≡0', term['skip_reason'])
 
-    def test_mrcc_degenerate_low_leg_failure_does_not_short_circuit(self):
-        """If the LOW leg fails with MRCCDegenerateSystem (no sister to fall
-        back on), the framework must NOT silently substitute. The species
-        should not finalize from this path; troubleshoot_ess gets called on
-        the assumption a higher level can sort it out."""
-        tmp = os.path.join(self.project_directory, "fx_mrcc_low_fail")
-        os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
-        spc = ARCSpecies(label='H2', smiles='[H][H]')
-        spc.final_xyz = {'symbols': ('H', 'H'),
-                         'coords': ((0, 0, 0), (0, 0, 0.74)),
-                         'isotopes': (1, 1)}
+    def test_he_heat_deltas_skipped(self):
+        """He (n_corr=2): both HEAT δ terms are trivially zero and skipped."""
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('He', '[He]', 'He', 4)
+        sched = self._make_scheduler([spc], sp_composite=protocol,
+                                     job_types=initialize_job_types())
+        self.assertEqual(set(sched._sp_composite_pending['He'].keys()), {'base'})
+        self.assertEqual(set(sched._sp_composite_skipped['He'].keys()),
+                         {'delta_T', 'delta_Q'})
+
+    def test_ch4_deltas_not_skipped_all_legs_queued(self):
+        """CH4 (n_corr=8): no δ term is trivially zero — every leg is queued."""
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._ch4_species()
         sched = self._make_scheduler([spc], sp_composite=protocol)
-        # Patch troubleshoot_ess to a recording stub so we can verify it
-        # gets called for low-leg failures.
+        self.assertEqual(sched._sp_composite_skipped['CH4'], {})
+        self.assertEqual(set(sched._sp_composite_pending['CH4'].keys()),
+                         {'base', 'delta_T__high', 'delta_T__low',
+                          'delta_Q__high', 'delta_Q__low'})
+        spawned = []
+        sched.run_job = lambda *a, **kw: spawned.append(kw.get('level_of_theory'))
+        sched._spawn_composite_pending('CH4')
+        # 5 sub_labels over 4 unique Levels (delta_T__high == delta_Q__low).
+        self.assertEqual(len(spawned), 4)
+
+    def test_restart_does_not_requeue_skipped_legs(self):
+        """Restart-safety: the skip decision is deterministic from species +
+        protocol, so rehydration re-derives it — skipped legs are not requeued
+        and the finalized species' report section is rebuilt without warnings."""
+        tmp = os.path.join(self.project_directory, "fx_skip_restart")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._mono_species('Hrestart', '[H]', 'H', 1)
+        sched1 = self._make_scheduler([spc], sp_composite=protocol,
+                                      job_types=initialize_job_types())
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -0.499)
+        sched1.post_sp_actions('Hrestart', base_path, protocol.base.level)
+        self.assertTrue(sched1.output['Hrestart']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+        spc2 = self._mono_species('Hrestart', '[H]', 'H', 1)
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol,
+                                      output=output_snapshot,
+                                      job_types=initialize_job_types())
+        self.assertEqual(sched2._sp_composite_pending['Hrestart'], {})
+        self.assertEqual(set(sched2._sp_composite_skipped['Hrestart'].keys()),
+                         {'delta_T', 'delta_Q'})
+        self.assertIn('Hrestart', sched2._sp_composite_sections)
+
+    @staticmethod
+    def _errored_mrcc_job_stub(level):
+        """Build a minimal errored-job stub carrying the generic MRCC keyword."""
+        return SimpleNamespace(
+            level=level,
+            local_path_to_output_file='/tmp/fake.out',
+            job_status=['done', {'status': 'errored',
+                                 'keywords': ['MRCC'],
+                                 'error': 'MRCC terminated with a fatal error',
+                                 'line': 'Fatal error in mrcc.'}],
+            conformer=None,
+            job_name='sp_a999',
+            execution_type='queue',
+            job_id='a999',
+        )
+
+    def test_mrcc_fatal_on_real_species_routes_to_trsh_not_zeroed(self):
+        """A 'Fatal error in mrcc' on a real polyatomic species' high leg is a
+        mundane crash (OOM, disk, internal error) — it must land in
+        troubleshoot_ess and the δ term must NOT be zeroed or substituted."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_trsh")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = self._ch4_species('CH4trsh')
+        sched = self._make_scheduler([spc], sp_composite=protocol)
         called = []
         sched.troubleshoot_ess = lambda *args, **kwargs: called.append(
             kwargs.get('job').job_name if kwargs.get('job') else 'unknown')
-
-        class _ErroredJobStub:
-            def __init__(self, level):
-                self.level = level
-                self.local_path_to_output_file = '/tmp/fake.out'
-                self.job_status = ['done', {
-                    'status': 'errored',
-                    'keywords': ['MRCCDegenerateSystem'],
-                    'error': 'MRCC xmrcc fatal',
-                    'line': 'Fatal error in xmrcc.',
-                }]
-                self.conformer = None
-                self.job_name = 'sp_a999'
-                self.execution_type = 'queue'
-                self.job_id = 'a999'
-
-        bad_job = _ErroredJobStub(level=protocol.corrections[0].low)
-        sched.check_sp_job(label='H2', job=bad_job)
-        self.assertEqual(called, ['sp_a999'],
-                         'Low-leg MRCC failure must not be short-circuited.')
-        self.assertNotIn('delta_T__low',
-                         sched.output['H2']['paths']['sp_composite'])
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -40.5)
+        sched.post_sp_actions('CH4trsh', base_path, protocol.base.level)
+        low_path = os.path.join(tmp, "delta_T__low.out")
+        self._write_gaussian_fixture(low_path, -40.6)
+        sched.post_sp_actions('CH4trsh', low_path, protocol.corrections[0].low)
+        bad_job = self._errored_mrcc_job_stub(level=protocol.corrections[0].high)
+        sched.check_sp_job(label='CH4trsh', job=bad_job)
+        self.assertEqual(called, ['sp_a999'], 'MRCC fatals must route to trsh.')
+        recorded = sched.output['CH4trsh']['paths']['sp_composite']
+        self.assertNotIn('delta_T__high', recorded,
+                         'The failed high leg must not be substituted or zeroed.')
+        self.assertIn('delta_T__high', sched._sp_composite_pending['CH4trsh'])
+        self.assertFalse(sched.output['CH4trsh']['job_types']['sp_composite'])
 
     def test_species_report_yaml_written_on_finalize(self):
         """Per-species sp_composite YAML report lands at
         ``<project>/output/Species/<label>/sp_composite_report.yml`` when the
         composite finalizes, and the file parses to a dict whose ``final``
         block matches what ARC recorded on the species."""
-        import yaml
         tmp = os.path.join(self.project_directory, "fx_species_report")
         os.makedirs(tmp, exist_ok=True)
         recipe = {
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -2971,7 +3092,6 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
     def test_species_report_uses_TSs_subdir_for_transition_states(self):
         """Transition states land under ``output/TSs/<label>/...``, not
         ``output/Species/...``."""
-        import yaml
         tmp = os.path.join(self.project_directory, "fx_ts_report")
         os.makedirs(tmp, exist_ok=True)
         recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
@@ -3068,48 +3188,32 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
     def test_term_evaluated_log_event_per_term(self):
         tmp = os.path.join(self.project_directory, "fx_term_log")
         os.makedirs(tmp, exist_ok=True)
-        recipe = {
-            "base": {"method": "hf", "basis": "cc-pVTZ"},
-            "corrections": [
-                {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
-                {"label": "cbs_corr", "type": "cbs_extrapolation",
-                 "formula": "helgaker_corr_2pt",
-                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
-                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
-            ],
-        }
-        protocol = CompositeProtocol.from_user_input(recipe)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
         spc = ARCSpecies(label='H2', smiles='[H][H]')
         spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
                          'isotopes': (1, 1)}
         sched = self._make_scheduler([spc], sp_composite=protocol)
         energies = {
-            "base": -1.10,
+            "base__card_3": -1.14, "base__card_4": -1.145,
             "delta_T__high": -1.15, "delta_T__low": -1.12,
-            "cbs_corr__card_3": -1.14, "cbs_corr__card_4": -1.145,
         }
         paths = self._seed_protocol_fixtures(tmp, protocol, energies)
         with self.assertLogs(logger='arc', level=logging.INFO) as cm:
-            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+            sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
             sched.post_sp_actions('H2', paths["delta_T__high"],
                                   protocol.corrections[0].high)
             sched.post_sp_actions('H2', paths["delta_T__low"],
                                   protocol.corrections[0].low)
-            sched.post_sp_actions('H2', paths["cbs_corr__card_3"],
-                                  protocol.corrections[1].levels[0])
-            sched.post_sp_actions('H2', paths["cbs_corr__card_4"],
-                                  protocol.corrections[1].levels[1])
         joined = "\n".join(cm.output)
         self.assertIn("term evaluated", joined)
-        # One "term evaluated" per term (base + delta_T + cbs_corr = 3).
+        # One "term evaluated" per term (base + delta_T = 2).
         count = joined.count("term evaluated")
-        self.assertEqual(count, 3)
+        self.assertEqual(count, 2)
         # Each term's label appears.
-        for term_label in ("base", "delta_T", "cbs_corr"):
+        for term_label in ("base", "delta_T"):
             self.assertIn(f"term={term_label}", joined)
-        # CBS term carries a formula field.
+        # The CBS base carries a formula field.
         self.assertIn("formula=helgaker_corr_2pt", joined)
 
 
@@ -3125,8 +3229,8 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
             "base": {"method": "hf", "basis": "cc-pVTZ"},
             "corrections": [
                 {"label": "delta_T", "type": "delta",
-                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
-                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
             ],
         }
         protocol = CompositeProtocol.from_user_input(recipe)
@@ -3171,6 +3275,378 @@ class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
                   and "Project summary" not in c.source
                   and "References" not in c.source]
         self.assertTrue(any("Afinalized" in t for t in titles))
+
+    def test_restart_kick_start_survives_real_run_job_tail(self):
+        """Regression: the restart kick-start runs from __init__ and reaches
+        run_job, whose tail calls save_restart_dict — which reads attributes
+        (``save_restart`` among others) that used to be assigned only AFTER the
+        rehydration call. Patch only the job-construction layer and let
+        run_job's tail execute for real so the ordering bug would surface as
+        an AttributeError."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart_tail")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned = []
+
+        def fake_job_factory(**kwargs):
+            job = SimpleNamespace(job_name=f'sp_a{len(spawned)}', server=None, job_id=None,
+                                  level=kwargs.get('level'), execute=lambda: None)
+            spawned.append(job)
+            return job
+
+        with patch('arc.scheduler.job_factory', side_effect=fake_job_factory):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        self.assertEqual(len(spawned), 2)
+        self.assertEqual(set(sched2.job_dict['H2']['sp'].keys()),
+                         {job.job_name for job in spawned})
+        self.assertTrue(hasattr(sched2, 'save_restart'))
+
+    def test_species_report_records_arc_version(self):
+        """The per-species report must carry the real ARC version, not a placeholder."""
+        tmp = os.path.join(self.project_directory, "fx_arc_version")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        report_path = os.path.join(self.project_directory, "output", "Species", "H2",
+                                   "sp_composite_report.yml")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        self.assertEqual(report["arc_version"], VERSION)
+
+    def test_rehydrate_skips_report_rewrite_when_paths_stripped(self):
+        """Regression: a species recorded as finalized whose sub-job output was
+        invalidated during rehydration (file gone) must NOT crash __init__ with
+        a KeyError from the report writer — warn and skip the report re-write."""
+        tmp = os.path.join(self.project_directory, "fx_stripped_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2stripped', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.05, "delta_T__high": -1.07,
+                                              "delta_T__low": -1.06})
+        sched1.post_sp_actions('H2stripped', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('H2stripped', paths["delta_T__high"], protocol.corrections[0].high)
+        sched1.post_sp_actions('H2stripped', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched1.output['H2stripped']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+        os.unlink(paths["delta_T__low"])
+        spc2 = ARCSpecies(label='H2stripped', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched2 = self._make_scheduler([spc2], sp_composite=protocol,
+                                          output=output_snapshot)
+        self.assertNotIn('H2stripped', sched2._sp_composite_sections)
+        self.assertIn('delta_T__low', sched2._sp_composite_pending['H2stripped'])
+        joined = '\n'.join(cm.output)
+        self.assertIn('skipping', joined)
+        self.assertIn('delta_T__low', joined)
+
+    # --- paths['sp'] source assignment for composite species ---------------- #
+
+    @staticmethod
+    def _one_delta_recipe():
+        """A single-Level base plus one delta correction."""
+        return {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsd(t)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "mp2",     "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    @staticmethod
+    def _h2_species(label='H2'):
+        """An H2 ARCSpecies with a final geometry."""
+        spc = ARCSpecies(label=label, smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        return spc
+
+    def test_base_completion_sets_paths_sp(self):
+        """Completing the composite base leg populates paths['sp'] with the base ESS
+        log; delta legs don't; finalization keeps the base log and the composite
+        energy stays protocol-derived."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species()
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base"])
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base"])
+        self.assertEqual(spc.e_elect_source, 'sp_composite')
+
+    def test_cbs_base_sets_paths_sp_to_largest_cardinal_leg(self):
+        """With a CBS base, paths['sp'] is the primary (largest-cardinal) leg's log."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp_cbs")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._fpa_like_recipe())
+        spc = self._h2_species()
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base__card_3": -1.170, "base__card_4": -1.172,
+                                              "delta_T__high": -1.15, "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base__card_3"], protocol.base.levels[0])
+        self.assertEqual(sched.output['H2']['paths']['sp'], '')
+        sched.post_sp_actions('H2', paths["base__card_4"], protocol.base.levels[1])
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base__card_4"])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertEqual(sched.output['H2']['paths']['sp'], paths["base__card_4"])
+
+    def test_paths_sp_cleared_when_base_log_invalidated(self):
+        """If the recorded base log vanishes before a restart, rehydration must clear
+        paths['sp'] along with the invalidated sub-job entry."""
+        tmp = os.path.join(self.project_directory, "fx_paths_sp_inval")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species(label='H2inval')
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2inval', paths["base"], protocol.base.level)
+        self.assertEqual(sched1.output['H2inval']['paths']['sp'], paths["base"])
+        output_snapshot = sched1.output
+        os.unlink(paths["base"])
+        spc2 = self._h2_species(label='H2inval')
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol, output=output_snapshot)
+        self.assertEqual(sched2.output['H2inval']['paths']['sp'], '')
+        self.assertIn('base', sched2._sp_composite_pending['H2inval'])
+
+    def test_restart_base_done_respawns_deltas_not_legacy_sp(self):
+        """Restart with the base completed (paths['sp'] set) but delta legs pending:
+        the composite kick-start must respawn the deltas, and the legacy single-sp
+        respawn guard must NOT trigger run_sp_job for the species."""
+        tmp = os.path.join(self.project_directory, "fx_restart_guard")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = self._h2_species(label='H2resume')
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2resume', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        output_snapshot['H2resume']['paths']['geo'] = paths["base"]  # opt phase done
+        spc2 = self._h2_species(label='H2resume')
+        spawned, sp_calls = [], []
+        with patch.object(Scheduler, 'schedule_jobs', lambda self_: None), \
+                patch.object(Scheduler, 'run_sp_job',
+                             lambda self_, label, **kwargs: sp_calls.append(label)), \
+                patch.object(Scheduler, 'run_job',
+                             lambda self_, **kwargs: spawned.append(
+                                 (kwargs.get('job_type'), kwargs.get('level_of_theory')))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                job_types=initialize_job_types(),
+                output=output_snapshot,
+                testing=False,
+            )
+        self.assertEqual(sp_calls, [])
+        sp_levels = [lvl for job_type, lvl in spawned if job_type == 'sp']
+        self.assertIn(protocol.corrections[0].high, sp_levels)
+        self.assertIn(protocol.corrections[0].low, sp_levels)
+        self.assertNotIn(protocol.primary_base_level, sp_levels)
+        self.assertEqual(sched2.output['H2resume']['paths']['sp'], paths["base"])
+
+    def test_monoatomic_composite_restart_does_not_respawn_base(self):
+        """Restart of a monoatomic composite species with the base completed must not
+        re-submit the base SP via the monoatomic respawn guard; only the pending
+        delta legs respawn (via the composite kick-start)."""
+        tmp = os.path.join(self.project_directory, "fx_mono_guard")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._one_delta_recipe())
+        spc = ARCSpecies(label='Hmono', smiles='[H]')
+        spc.final_xyz = {'symbols': ('H',), 'coords': ((0., 0., 0.),), 'isotopes': (1,)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol,
+                                      job_types=initialize_job_types())
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -0.49, "delta_T__high": -0.499,
+                                              "delta_T__low": -0.498})
+        sched1.post_sp_actions('Hmono', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='Hmono', smiles='[H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned = []
+        with patch.object(Scheduler, 'run_job',
+                          lambda self_, **kwargs: spawned.append(
+                              (kwargs.get('job_type'), kwargs.get('level_of_theory')))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                job_types=initialize_job_types(),
+                output=output_snapshot,
+                testing=True,
+            )
+        sp_levels = [lvl for job_type, lvl in spawned if job_type == 'sp']
+        self.assertNotIn(protocol.primary_base_level, sp_levels)
+        self.assertIn(protocol.corrections[0].high, sp_levels)
+        self.assertIn(protocol.corrections[0].low, sp_levels)
+        self.assertEqual(sched2.output['Hmono']['paths']['sp'], paths["base"])
+
+    def test_species_has_sp_composite_semantics(self):
+        """paths['sp'] presence must NOT mark the composite sp phase complete; only
+        the finalize flag (all sub-jobs recorded + protocol evaluated) does."""
+        in_progress = {'paths': {'sp': '/x/base.out', 'composite': '',
+                                 'sp_composite': {'base': '/x/base.out'}},
+                       'job_types': {'sp_composite': False}}
+        self.assertFalse(species_has_sp(in_progress))
+        finalized = {'paths': {'sp': '/x/base.out', 'composite': '',
+                               'sp_composite': {'base': '/x/base.out',
+                                                'delta_T__high': '/x/h.out',
+                                                'delta_T__low': '/x/l.out'}},
+                     'job_types': {'sp_composite': True}}
+        self.assertTrue(species_has_sp(finalized))
+        legacy = {'paths': {'sp': '/x/sp.out', 'composite': '', 'sp_composite': {}}}
+        self.assertTrue(species_has_sp(legacy))
+        self.assertTrue(species_has_sp(in_progress, yml_path='/x/spc.yml'))
+
+    def test_check_rxn_e0_by_spc_runs_for_composite_finalized_reaction(self):
+        """A 3-species reaction (R/TS/P), all composite-finalized: the E0 sanity
+        check is no longer gated off by species_has_sp and writes ts_checks['E0']."""
+        tmp = os.path.join(self.project_directory, "fx_e0_check")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        r_spc = ARCSpecies(label='HCN', smiles='C#N')
+        r_spc.final_xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+                           'coords': ((0, 0, 0), (0, 0, 1.16), (0, 0, -1.07))}
+        p_spc = ARCSpecies(label='HNC', smiles='[C-]#[NH+]')
+        p_spc.final_xyz = {'symbols': ('N', 'C', 'H'), 'isotopes': (14, 12, 1),
+                           'coords': ((0, 0, 0), (0, 0, 1.17), (0, 0, -1.00))}
+        ts_spc = ARCSpecies(label='TS_e0', is_ts=True)
+        ts_spc.final_xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+                            'coords': ((0, 0, 0), (0, 0, 1.18), (0.9, 0, 0.6))}
+        sched = self._make_scheduler([r_spc, p_spc, ts_spc], sp_composite=protocol)
+        for label, e_hartree in [('HCN', -93.0), ('HNC', -92.99), ('TS_e0', -92.9)]:
+            base_path = os.path.join(tmp, f"{label}_base.out")
+            self._write_gaussian_fixture(base_path, e_hartree)
+            sched.post_sp_actions(label, base_path, protocol.base.level)
+            self.assertTrue(sched.output[label]['job_types']['sp_composite'])
+            sched.output[label]['paths']['freq'] = os.path.join(ARC_TESTING_PATH, 'freq', 'nC3H7.out')
+        rxn = ARCReaction(r_species=[r_spc], p_species=[p_spc], ts_label='TS_e0')
+        rxn.ts_species = ts_spc
+        r_spc.e0, p_spc.e0, ts_spc.e0 = 10.0, 20.0, 150.0
+        sched.rxn_list = [rxn]
+        self.assertIsNone(ts_spc.ts_checks['E0'])
+        sched.check_rxn_e0_by_spc('TS_e0')
+        self.assertTrue(ts_spc.ts_checks['E0'])
+
+
+class TestCorrelatedElectronCounting(unittest.TestCase):
+    """Frozen-core orbital and correlated-electron counting helpers."""
+
+    def test_frozen_core_orbitals_first_rows(self):
+        self.assertEqual(count_frozen_core_orbitals(('H',)), 0)
+        self.assertEqual(count_frozen_core_orbitals(('He',)), 0)
+        self.assertEqual(count_frozen_core_orbitals(('C',)), 1)
+        self.assertEqual(count_frozen_core_orbitals(('Ne',)), 1)
+        self.assertEqual(count_frozen_core_orbitals(('S',)), 5)
+        self.assertEqual(count_frozen_core_orbitals(('Br',)), 9)
+        self.assertEqual(count_frozen_core_orbitals(('I',)), 18)
+
+    def test_frozen_core_orbitals_molecule_sums_atoms(self):
+        self.assertEqual(count_frozen_core_orbitals(('C', 'H', 'H', 'H', 'H')), 1)
+        self.assertEqual(count_frozen_core_orbitals(('C', 'S', 'H', 'H')), 6)
+
+    def test_correlated_electrons_atoms(self):
+        self.assertEqual(count_correlated_electrons(('H',)), 1)
+        self.assertEqual(count_correlated_electrons(('He',)), 2)
+        self.assertEqual(count_correlated_electrons(('Be',)), 2)
+        self.assertEqual(count_correlated_electrons(('C',)), 4)
+
+    def test_correlated_electrons_molecules(self):
+        self.assertEqual(count_correlated_electrons(('H', 'H')), 2)
+        self.assertEqual(count_correlated_electrons(('C', 'H', 'H', 'H', 'H')), 8)
+        self.assertEqual(count_correlated_electrons(('N', 'N')), 10)
+
+    def test_correlated_electrons_charge(self):
+        self.assertEqual(count_correlated_electrons(('O', 'H'), charge=-1), 8)
+        self.assertEqual(count_correlated_electrons(('H',), charge=1), 0)
 
 
 class TestSchedulerSpCompositePassthrough(unittest.TestCase):
@@ -3226,15 +3702,17 @@ class TestSchedulerSpCompositePassthrough(unittest.TestCase):
 
 
 class TestSchedulerZombieJobDetection(unittest.TestCase):
-    """A queue-running job that has produced no output traffic by the grace
-    period is treated as a zombie: killed, then resubmitted once. The cap of
-    one resubmit per (species, job_type) prevents loops on bad inputs."""
+    """A queue-RUNNING job that has produced no output traffic by the grace
+    period (measured from the first time it was observed running) is treated
+    as a zombie: killed, then resubmitted once. The cap of one resubmit per
+    (species, job_name) prevents loops on bad inputs."""
 
     @classmethod
     def setUpClass(cls):
         cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
         cls.project_directory = os.path.join(
-            ARC_PATH, 'Projects', 'arc_project_for_testing_zombie'
+            ARC_PATH, 'Projects', f'arc_project_for_testing_zombie_{worker}'
         )
         if os.path.isdir(cls.project_directory):
             shutil.rmtree(cls.project_directory, ignore_errors=True)
@@ -3245,7 +3723,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         if os.path.isdir(cls.project_directory):
             shutil.rmtree(cls.project_directory, ignore_errors=True)
 
-    def _make_sched(self):
+    def _make_sched(self, restart_dict=None):
         spc = ARCSpecies(label='H2', smiles='[H][H]')
         spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
                          'isotopes': (1, 1)}
@@ -3255,6 +3733,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
                 ess_settings=self.ess_settings,
                 species_list=[spc],
                 project_directory=self.project_directory,
+                restart_dict=restart_dict,
                 opt_level=Level(repr=default_levels_of_theory['opt']),
                 freq_level=Level(repr=default_levels_of_theory['freq']),
                 sp_level=Level(repr=default_levels_of_theory['sp']),
@@ -3283,10 +3762,12 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         job.delete = _delete
         return job
 
-    def _install(self, sched, job, label='H2'):
+    def _install(self, sched, job, label='H2', seed_running_since=True):
         sched.job_dict.setdefault(label, {}).setdefault(job.job_type, {})[job.job_name] = job
         sched.running_jobs.setdefault(label, []).append(job.job_name)
         sched.server_job_ids = [job.job_id]
+        if seed_running_since:
+            sched._zombie_running_since[job.job_name] = job.initial_time
 
     def test_zombie_killed_and_resubmitted(self):
         sched = self._make_sched()
@@ -3299,7 +3780,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         self.assertTrue(job.deleted, "Zombie job should have been deleted.")
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
         self.assertNotIn(job.job_name, sched.running_jobs['H2'])
-        self.assertIn('sp', sched._zombie_kills['H2'])
+        self.assertIn(job.job_name, sched._zombie_kills['H2'])
 
     def test_healthy_job_not_killed(self):
         sched = self._make_sched()
@@ -3355,7 +3836,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
 
     def test_cap_prevents_double_resubmit(self):
         sched = self._make_sched()
-        sched._zombie_kills['H2'] = {'sp'}  # Already used the one chance.
+        sched._zombie_kills['H2'] = {'sp_a3177'}  # Already used the one chance.
         job = self._stub_job()
         self._install(sched, job)
         sched._run_a_job = lambda *a, **kw: self.fail("must not resubmit when cap is hit")
@@ -3365,7 +3846,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
         self.assertIn(job.job_name, sched.running_jobs['H2'])
 
     def test_second_zombie_pass_is_noop_after_one_kill(self):
-        """A second zombie detection for the same (species, job_type) after one
+        """A second zombie detection for the same (species, job_name) after one
         real kill-and-resubmit cycle must be a no-op: no second delete, no second
         resubmission, and the 'leaving for manual intervention' branch is taken."""
         sched = self._make_sched()
@@ -3377,7 +3858,7 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
             sched.check_for_zombie_jobs('H2')
             self.assertTrue(job.deleted)
             self.assertEqual(run_calls, [(job.job_name, 'H2')])
-            self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+            self.assertEqual(sched._zombie_kills['H2'], {job.job_name})
             # The resubmitted job wedges too: the queue reports it running again.
             job.deleted = False
             sched.running_jobs['H2'].append(job.job_name)
@@ -3385,33 +3866,188 @@ class TestSchedulerZombieJobDetection(unittest.TestCase):
                 sched.check_for_zombie_jobs('H2')
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
         self.assertFalse(job.deleted)
-        self.assertEqual(sched._zombie_kills['H2'], {'sp'})
+        self.assertEqual(sched._zombie_kills['H2'], {job.job_name})
         self.assertIn(job.job_name, sched.running_jobs['H2'])
         self.assertIn('manual intervention', '\n'.join(cm.output))
 
-    def test_cap_is_per_job_type(self):
+    def test_cap_is_per_job_name(self):
         sched = self._make_sched()
-        sched._zombie_kills['H2'] = {'sp'}  # sp already used.
+        sched._zombie_kills['H2'] = {'sp_a3177'}  # That job already used its credit.
         job = self._stub_job(job_type='freq', job_name='freq_a8888')
         self._install(sched, job)
         run_calls = []
         sched._run_a_job = lambda job, label: run_calls.append((job.job_name, label))
         with patch('arc.job.zombie.output_mtime', return_value=None):
             sched.check_for_zombie_jobs('H2')
-        self.assertTrue(job.deleted, "freq has its own cap budget independent of sp.")
+        self.assertTrue(job.deleted, "freq_a8888 has its own cap budget independent of sp_a3177.")
         self.assertEqual(run_calls, [(job.job_name, 'H2')])
-        self.assertEqual(sched._zombie_kills['H2'], {'sp', 'freq'})
+        self.assertEqual(sched._zombie_kills['H2'], {'sp_a3177', 'freq_a8888'})
 
     def test_zombie_kills_serialized_in_restart(self):
         sched = self._make_sched()
-        sched._zombie_kills = {'H2': {'sp', 'freq'}, 'OH': {'sp'}}
+        sched._zombie_kills = {'H2': {'sp_a3177', 'freq_a8888'}, 'OH': {'sp_a3199'}}
         sched.save_restart = True
         sched.restart_dict = {}
         sched.save_restart_dict()
         saved = sched.restart_dict['_zombie_kills']
         self.assertEqual(set(saved.keys()), {'H2', 'OH'})
-        self.assertEqual(set(saved['H2']), {'sp', 'freq'})
-        self.assertEqual(set(saved['OH']), {'sp'})
+        self.assertEqual(set(saved['H2']), {'sp_a3177', 'freq_a8888'})
+        self.assertEqual(set(saved['OH']), {'sp_a3199'})
+
+    def test_capped_pair_skips_zombie_stat(self):
+        """A (species, job_name) pair that already used its one resubmission
+        must skip the expensive zombie stat entirely."""
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp_a3177'}
+        job = self._stub_job()
+        self._install(sched, job)
+        stat_calls = []
+
+        def record_stat(*args, **kwargs):
+            stat_calls.append(args)
+            return True
+
+        with patch('arc.scheduler._is_zombie_job', side_effect=record_stat):
+            sched.check_for_zombie_jobs('H2')
+        self.assertEqual(stat_calls, [])
+        self.assertFalse(job.deleted)
+
+    def test_manual_intervention_warning_fires_once(self):
+        """The 'manual intervention' warning for a capped pair must fire once
+        per job_name, not on every scheduler loop pass."""
+        sched = self._make_sched()
+        sched._zombie_kills['H2'] = {'sp_a3177'}
+        job = self._stub_job()
+        self._install(sched, job)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+            with self.assertNoLogs(logger='arc', level=logging.WARNING):
+                sched.check_for_zombie_jobs('H2')
+        self.assertEqual('\n'.join(cm.output).count('manual intervention'), 1)
+
+    def test_recheck_throttle_limits_zombie_stats(self):
+        """A job checked within ZOMBIE_RECHECK_SECONDS must not be re-stat'ed;
+        once the throttle window has passed, the check runs again."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job)
+        stat_calls = []
+
+        def record_stat(*args, **kwargs):
+            stat_calls.append(args)
+            return False
+
+        with patch('arc.scheduler._is_zombie_job', side_effect=record_stat):
+            sched.check_for_zombie_jobs('H2')
+            sched.check_for_zombie_jobs('H2')
+            self.assertEqual(len(stat_calls), 1)
+            sched._zombie_last_check[job.job_name] -= ZOMBIE_RECHECK_SECONDS + 1
+            sched.check_for_zombie_jobs('H2')
+        self.assertEqual(len(stat_calls), 2)
+
+    def test_resolve_job_by_name_integer_keyed_subdict(self):
+        """resolve_job_by_name must find jobs stored under integer-keyed
+        sub-dicts (conf_opt/conf_sp/tsg) via the job_name attribute, and
+        return None for unknown names."""
+        sched = self._make_sched()
+        job = self._stub_job(job_type='conf_opt', job_name='conf_opt_a202')
+        sched.job_dict.setdefault('H2', {}).setdefault('conf_opt', {})[0] = job
+        self.assertIs(sched.resolve_job_by_name('H2', 'conf_opt_a202'), job)
+        self.assertIsNone(sched.resolve_job_by_name('H2', 'no_such_job'))
+        self.assertIsNone(sched.resolve_job_by_name('no_such_label', 'conf_opt_a202'))
+
+    def test_resolve_job_by_name_synthetic_conformer_names(self):
+        """resolve_job_by_name must resolve the synthetic running_jobs names
+        ('conf_opt_<n>', 'conf_sp_<n>', 'tsg<n>') via the trailing index."""
+        sched = self._make_sched()
+        job = self._stub_job(job_type='conf_opt', job_name='conformer_real_name')
+        sched.job_dict.setdefault('H2', {}).setdefault('conf_opt', {})[0] = job
+        self.assertIs(sched.resolve_job_by_name('H2', 'conf_opt_0'), job)
+        tsg_job = self._stub_job(job_type='tsg', job_name='some_tsg_adapter_name')
+        sched.job_dict['H2'].setdefault('tsg', {})[2] = tsg_job
+        self.assertIs(sched.resolve_job_by_name('H2', 'tsg2'), tsg_job)
+        self.assertIsNone(sched.resolve_job_by_name('H2', 'conf_sp_5'))
+
+    def test_pending_job_never_killed(self):
+        """A queued (PENDING) job is never killable regardless of age, and the
+        running clock does not start while it is pending."""
+        sched = self._make_sched()
+        job = self._stub_job(initial_offset_seconds=8 * 3600)
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'pending'}
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on a pending job")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertNotIn(job.job_name, sched._zombie_running_since)
+
+    def test_pending_then_running_clock_starts_at_running(self):
+        """PENDING for 8 h then RUNNING for a moment → the grace clock starts
+        at the first running observation, so the job is not flagged."""
+        sched = self._make_sched()
+        job = self._stub_job(initial_offset_seconds=8 * 3600)
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'pending'}
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+            self.assertNotIn(job.job_name, sched._zombie_running_since)
+            sched.server_job_states = {str(job.job_id): 'running'}
+            sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertIn(job.job_name, sched._zombie_running_since)
+        self.assertIn(job.job_name, sched.running_jobs['H2'])
+
+    def test_held_job_warns_once_never_killed(self):
+        """A HELD job warns at most once and is never killed."""
+        sched = self._make_sched()
+        job = self._stub_job()
+        self._install(sched, job, seed_running_since=False)
+        sched.server_job_states = {str(job.job_id): 'held'}
+        sched._run_a_job = lambda *a, **kw: self.fail("must not act on a held job")
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                sched.check_for_zombie_jobs('H2')
+            with self.assertNoLogs(logger='arc', level=logging.WARNING):
+                sched.check_for_zombie_jobs('H2')
+        self.assertFalse(job.deleted)
+        self.assertEqual('\n'.join(cm.output).count('held'), 1)
+
+    def test_two_composite_sp_subjobs_killed_independently(self):
+        """Two composite sp sub-jobs of one species flagged in the same pass
+        must both be killed and resubmitted, each consuming its own credit."""
+        sched = self._make_sched()
+        job_1 = self._stub_job(job_name='sp_a0001', job_id=111)
+        job_2 = self._stub_job(job_name='sp_a0002', job_id=222)
+        self._install(sched, job_1)
+        self._install(sched, job_2)
+        sched.server_job_ids = [111, 222]
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append(job.job_name)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job_1.deleted)
+        self.assertTrue(job_2.deleted)
+        self.assertEqual(sorted(run_calls), ['sp_a0001', 'sp_a0002'])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp_a0001', 'sp_a0002'})
+
+    def test_old_format_restart_zombie_kills_is_inert(self):
+        """Old-format restart entries (job_type strings) load without crashing
+        and cap nothing: a zombie job of that type still gets its one credit."""
+        sched = self._make_sched(restart_dict={'_zombie_kills': {'H2': ['sp']}})
+        self.assertEqual(sched._zombie_kills, {'H2': {'sp'}})
+        job = self._stub_job()
+        self._install(sched, job)
+        run_calls = []
+        sched._run_a_job = lambda job, label: run_calls.append(job.job_name)
+        with patch('arc.job.zombie.output_mtime', return_value=None):
+            sched.check_for_zombie_jobs('H2')
+        self.assertTrue(job.deleted)
+        self.assertEqual(run_calls, [job.job_name])
+        self.assertEqual(sched._zombie_kills['H2'], {'sp', job.job_name})
+        sched.save_restart = True
+        sched.save_restart_dict()
+        self.assertEqual(sched.restart_dict['_zombie_kills'], {'H2': ['sp', 'sp_a3177']})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -7,9 +7,12 @@ This module contains unit tests for the arc.scheduler module
 
 import unittest
 from unittest.mock import MagicMock, patch
+import logging
 import os
 import shutil
 from types import SimpleNamespace
+
+import nbformat
 
 
 import arc.parser.parser as parser
@@ -18,6 +21,7 @@ from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, in
 from arc.job.adapters.common import default_incore_adapters, ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular
 from arc.job.factory import job_factory
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.plotter import save_conformers_file
 from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
                            species_has_sp_and_freq, tsg_method_matches_adapter)
@@ -367,8 +371,10 @@ H      -1.82570782    0.42754384   -0.56130718"""
                                             'onedmin': False,
                                             'opt': False,
                                             'orbitals': False,
-                                            'sp': False},
-                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': ''},
+                                            'sp': False,
+                                            'sp_composite': False},
+                              'paths': {'composite': '', 'freq': '', 'geo': '', 'geo_coarse': '', 'sp': '',
+                                        'sp_composite': {}},
                               'restart': '', 'warnings': ''}
         initialized_output_dict = {'C2H6': empty_species_dict,
                                    'CtripCO': empty_species_dict,
@@ -1940,6 +1946,1272 @@ class TestSchedulerAdaptiveReactionLevels(unittest.TestCase):
         collider = ARCSpecies(label='CH4_TS0', smiles='O')
         with self.assertRaises(SchedulerError):
             self.build_scheduler(rxn, r + p + [collider], 'adaptive_collision')
+
+
+class TestSchedulerSpCompositeOrchestration(unittest.TestCase):
+    """
+    Phase 3 end-to-end tests for composite orchestration: sub-job dispatch,
+    Level-duplication handling, final energy combination, notebook regeneration,
+    and basic restart recovery. Sub-job completions are simulated by invoking
+    ``post_sp_actions`` with fixture Gaussian-format .out files so the flow
+    exercises the real scheduler code without running any actual QM jobs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', f'arc_project_for_testing_sp_composite_orch_{worker}'
+        )
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+        os.makedirs(cls.project_directory, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    @staticmethod
+    def _write_gaussian_fixture(path, e_hartree):
+        """Minimal Gaussian-format output that parse_e_elect can consume."""
+        with open(path, "w") as fh:
+            fh.write(" Gaussian 16: test fixture\n")
+            fh.write(f" SCF Done:  E(RHF) =  {e_hartree:.9f}     A.U. after    1 cycles\n")
+
+    @staticmethod
+    def _heat345q_like_recipe():
+        """A small protocol with duplicate Levels across distinct sub_labels."""
+        return {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",    "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)",  "basis": "cc-pVDZ"}},
+                {"label": "delta_Q", "type": "delta",
+                 "high": {"method": "ccsdt(q)", "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsdt",    "basis": "cc-pVDZ"}},
+            ],
+        }
+
+    def _make_scheduler(self, species_list, sp_composite, output=None):
+        """Build a Scheduler with run_job patched to a no-op.
+
+        We patch at the *class* level because the Phase 3.5 restart kick-start
+        invokes run_job from inside __init__ — instance-level monkey patching
+        would arrive too late.
+        """
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=species_list,
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=sp_composite,
+                output=output,
+                testing=True,
+            )
+        # Also keep the instance-level no-op so subsequent post_sp_actions calls
+        # that spawn pending sub-jobs don't hit the real server machinery.
+        sched.run_job = lambda *args, **kwargs: None
+        return sched
+
+    def _seed_protocol_fixtures(self, tmpdir, protocol, energies_by_sub_label):
+        """Write one fixture .out per sub_label. Returns {sub_label: path}."""
+        paths = {}
+        for _term, sub_label, _level in protocol.iter_required_jobs():
+            p = os.path.join(tmpdir, f"{sub_label}.out")
+            self._write_gaussian_fixture(p, energies_by_sub_label[sub_label])
+            paths[sub_label] = p
+        return paths
+
+    def test_minimal_finalization_sets_e_elect_and_source(self):
+        tmp = os.path.join(self.project_directory, "fx_minimal")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies_H = {"base": -1.10, "delta_T__high": -1.15, "delta_T__low": -1.12}
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies_H)
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+        parsed = {sl: parser.parse_e_elect(p) for sl, p in paths.items()}
+        expected = protocol.evaluate(parsed)
+        self.assertAlmostEqual(spc.e_elect, expected, places=6)
+
+    def test_output_paths_sp_composite_populated(self):
+        tmp = os.path.join(self.project_directory, "fx_paths")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        recorded = sched.output['H2']['paths']['sp_composite']
+        self.assertEqual(set(recorded.keys()),
+                         {"base", "delta_T__high", "delta_T__low"})
+
+    def test_duplicate_levels_share_one_sp_path(self):
+        """delta_T__high and delta_Q__low share the ccsdt/cc-pVDZ Level; one SP
+        output path must map to BOTH sub_labels."""
+        tmp = os.path.join(self.project_directory, "fx_dup")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input(self._heat345q_like_recipe())
+        spc = ARCSpecies(label='HF', smiles='F')
+        spc.final_xyz = {'symbols': ('H', 'F'), 'coords': ((0, 0, 0), (0, 0, 0.92)),
+                         'isotopes': (1, 19)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -100.10)
+        ccsdt_cc_pVDZ_path = os.path.join(tmp, "ccsdt_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_cc_pVDZ_path, -100.20)
+        ccsd_t_cc_pVDZ_path = os.path.join(tmp, "ccsd_t_pVDZ.out")
+        self._write_gaussian_fixture(ccsd_t_cc_pVDZ_path, -100.22)
+        ccsdt_q_cc_pVDZ_path = os.path.join(tmp, "ccsdt_q_pVDZ.out")
+        self._write_gaussian_fixture(ccsdt_q_cc_pVDZ_path, -100.25)
+        sched.post_sp_actions('HF', base_path, protocol.base.level)
+        sched.post_sp_actions('HF', ccsd_t_cc_pVDZ_path, protocol.corrections[0].low)
+        sched.post_sp_actions('HF', ccsdt_cc_pVDZ_path, protocol.corrections[0].high)
+        sched.post_sp_actions('HF', ccsdt_q_cc_pVDZ_path, protocol.corrections[1].high)
+        recorded = sched.output['HF']['paths']['sp_composite']
+        self.assertEqual(recorded["delta_T__high"], recorded["delta_Q__low"])
+        self.assertEqual(recorded["delta_T__high"], ccsdt_cc_pVDZ_path)
+        self.assertTrue(sched.output['HF']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, "sp_composite")
+
+    def test_active_composite_species_uses_base_level_for_sp(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertNotEqual(sched.sp_level.method, "hf")
+        active = sched._composite_for('H2')
+        self.assertIsNotNone(active)
+        self.assertEqual(active.base.level.method, "hf")
+
+    def test_opt_out_species_uses_global_sp_level(self):
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=None)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertIsNone(sched._composite_for('H2'))
+
+    def test_explicit_species_protocol_beats_global(self):
+        global_recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        local_recipe = {"base": {"method": "mp2", "basis": "cc-pVTZ"}, "corrections": []}
+        global_proto = CompositeProtocol.from_user_input(global_recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]', sp_composite=local_recipe)
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=global_proto)
+        resolved = sched._composite_for('H2')
+        self.assertEqual(resolved.base.level.method, "mp2")
+
+    def test_ts_species_finalizes_with_kind_ts_section(self):
+        tmp = os.path.join(self.project_directory, "fx_ts")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        ts = ARCSpecies(label='TS1', is_ts=True)
+        ts.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 1.2)),
+                        'isotopes': (1, 1)}
+        sched = self._make_scheduler([ts], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.05)
+        sched.post_sp_actions('TS1', base_path, protocol.base.level)
+        self.assertTrue(sched.output['TS1']['job_types']['sp_composite'])
+        self.assertIn('TS1', sched._sp_composite_sections)
+        self.assertEqual(sched._sp_composite_sections['TS1'].kind, 'ts')
+
+    def test_notebook_regenerated_with_cumulative_sections(self):
+        tmp = os.path.join(self.project_directory, "fx_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='A', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        spc_b = ARCSpecies(label='B', smiles='[H][H]')
+        spc_b.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc_a, spc_b], sp_composite=protocol)
+        p_a = os.path.join(tmp, "a.out")
+        p_b = os.path.join(tmp, "b.out")
+        self._write_gaussian_fixture(p_a, -1.05)
+        self._write_gaussian_fixture(p_b, -1.06)
+        sched.post_sp_actions('A', p_a, protocol.base.level)
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb1 = nbformat.read(nb_path, as_version=4)
+        titles1 = [c.source for c in nb1.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles1))
+        sched.post_sp_actions('B', p_b, protocol.base.level)
+        nb2 = nbformat.read(nb_path, as_version=4)
+        titles2 = [c.source for c in nb2.cells
+                   if c.cell_type == "markdown" and c.source.lstrip().startswith("## ")]
+        self.assertTrue(any("A" in t for t in titles2))
+        self.assertTrue(any("B" in t for t in titles2))
+
+    def test_log_lines_include_sp_composite_events(self):
+        tmp = os.path.join(self.project_directory, "fx_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+        joined = "\n".join(cm.output)
+        self.assertIn("[sp_composite]", joined)
+        # "protocol resolved" is logged at scheduler __init__ time (during
+        # rehydration), so it won't appear in assertLogs here — that's fine;
+        # covered implicitly by the presence of sub-job-completed lines which
+        # only fire if pending was seeded successfully.
+        self.assertIn("sub-job completed", joined)
+        self.assertIn("all sub-jobs complete", joined)
+        self.assertIn("FINAL e_elect", joined)
+        self.assertIn("provenance notebook regenerated", joined)
+
+    def test_restart_reuses_completed_sub_jobs(self):
+        tmp = os.path.join(self.project_directory, "fx_restart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        sched2 = self._make_scheduler([spc2], sp_composite=protocol, output=output_snapshot)
+        pending = sched2._sp_composite_pending['H2']
+        self.assertEqual(set(pending.keys()), {"delta_T__high", "delta_T__low"})
+        sched2.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_missing_sub_job_does_not_finalize(self):
+        tmp = os.path.join(self.project_directory, "fx_miss")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertFalse(sched.output['H2']['job_types']['sp_composite'])
+        self.assertIsNone(spc.e_elect_source)
+        self.assertIsNone(spc.e_elect)
+
+    # --- Phase 3.5: restart kick-start ------------------------------------- #
+
+    def test_restart_kick_start_queues_missing_sub_jobs(self):
+        """On restart with base completed and no events firing, the scheduler
+        must queue the missing delta sub-jobs by itself."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        # Build a fresh scheduler from the output snapshot and capture all
+        # run_job calls the kick-start makes.
+        spawned_levels = []
+
+        def capture(self_inner, *args, **kwargs):
+            spawned_levels.append(kwargs.get('level_of_theory'))
+
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", capture):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Kick-start must have spawned exactly the two missing unique Levels.
+        self.assertEqual(len(spawned_levels), 2)
+        spawned_methods = sorted(lvl.method for lvl in spawned_levels)
+        self.assertEqual(spawned_methods, ["ccsd(t)", "ccsdt"])
+        # Pending dict reflects what's queued.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__high", "delta_T__low"})
+
+    def test_kick_start_skips_species_with_no_prior_progress(self):
+        """Species that have never run any composite sub-job (mid-opt or fresh)
+        should NOT be kick-started — they follow the normal opt → SP flow."""
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        spawned = []
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: spawned.append(kw)):
+            Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                testing=True,
+            )
+        # No prior progress → kick-start must not spawn anything.
+        self.assertEqual(spawned, [])
+
+    def test_spawn_composite_pending_skips_species_without_geometry(self):
+        """A species whose get_xyz(generate=False) returns None must not spawn sub-jobs."""
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        self.assertIsNone(spc.get_xyz(generate=False))
+        self.assertTrue(sched._sp_composite_pending['H2'])
+        calls = []
+        sched.run_job = lambda *args, **kwargs: calls.append(kwargs)
+        with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched._spawn_composite_pending('H2')
+        self.assertEqual(calls, [])
+        joined = '\n'.join(cm.output)
+        self.assertIn('H2', joined)
+        self.assertIn('no geometry', joined)
+
+    def test_restart_kick_start_skips_species_without_geometry(self):
+        """Restart kick-start must not submit sp sub-jobs for a species whose
+        geometry cannot be retrieved (e.g., a corrupted mid-opt restart)."""
+        tmp = os.path.join(self.project_directory, "fx_kickstart_noxyz")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        output_snapshot = sched1.output
+        # Fresh scheduler from the snapshot, but the species carries no 3D info.
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        self.assertIsNone(spc2.get_xyz(generate=False))
+        spawned = []
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: spawned.append(kw)), \
+                self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        self.assertEqual(spawned, [])
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__high", "delta_T__low"})
+        self.assertIn('no geometry', '\n'.join(cm.output))
+
+    # --- Phase 3.5: corruption recovery ------------------------------------ #
+
+    def test_corrupted_recorded_output_is_invalidated_and_requeued(self):
+        """A previously-recorded sub-job output that no longer exists on disk
+        must be invalidated, re-added to pending, and re-queued by kick-start."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.10, "delta_T__high": -1.15,
+                                              "delta_T__low": -1.12})
+        sched1.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('H2', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        # Reset the finalized flags so the second scheduler's rehydration re-runs
+        # validation/seed for this species (otherwise it would skip as already-done).
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        # Simulate on-disk corruption: delete delta_T__low's output.
+        os.unlink(paths["delta_T__low"])
+        # Fresh scheduler from snapshot; rehydration must invalidate only delta_T__low.
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        spawned_levels = []
+        with patch.object(Scheduler, "run_job",
+                          lambda self, *a, **kw: spawned_levels.append(kw.get('level_of_theory'))):
+            sched2 = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc2],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=output_snapshot,
+                testing=True,
+            )
+        # Only the corrupted sub_label is pending; only one kick-start spawn.
+        self.assertEqual(set(sched2._sp_composite_pending['H2'].keys()),
+                         {"delta_T__low"})
+        self.assertEqual(sched2.output['H2']['job_types']['sp_composite'], False)
+        self.assertEqual(len(spawned_levels), 1)
+        self.assertEqual(spawned_levels[0].method, "ccsd(t)")
+        # Replace the file and re-complete → protocol finalizes normally.
+        sched2.run_job = lambda *args, **kwargs: None
+        self._write_gaussian_fixture(paths["delta_T__low"], -1.12)
+        sched2.post_sp_actions('H2', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched2.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc2.e_elect_source, "sp_composite")
+
+    def test_corruption_warning_logged(self):
+        """The warning event must name the species, sub_label, path, and reason."""
+        tmp = os.path.join(self.project_directory, "fx_corrupt_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        # Build a valid initial scheduler + base completion, then point the
+        # recorded path at a file that doesn't exist.
+        sched1 = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched1.post_sp_actions('H2', base_path, protocol.base.level)
+        # Corrupt: point the recorded base path at a non-existent file, reset
+        # the finalized flag so the second scheduler re-validates.
+        sched1.output['H2']['paths']['sp_composite']['base'] = '/tmp/does/not/exist.out'
+        sched1.output['H2']['job_types']['sp_composite'] = False
+        output_snapshot = sched1.output
+        spc2 = ARCSpecies(label='H2', smiles='[H][H]')
+        spc2.final_xyz = spc.final_xyz
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            with self.assertLogs(logger='arc', level=logging.WARNING) as cm:
+                Scheduler(
+                    project='sp_composite_orch',
+                    ess_settings=self.ess_settings,
+                    species_list=[spc2],
+                    project_directory=self.project_directory,
+                    opt_level=Level(repr=default_levels_of_theory['opt']),
+                    freq_level=Level(repr=default_levels_of_theory['freq']),
+                    sp_level=Level(repr=default_levels_of_theory['sp']),
+                    conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                    scan_level=Level(repr=default_levels_of_theory['scan']),
+                    ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                    orbitals_level=default_levels_of_theory['orbitals'],
+                    sp_composite=protocol,
+                    output=output_snapshot,
+                    testing=True,
+                )
+        joined = "\n".join(cm.output)
+        self.assertIn("sub-job output invalidated", joined)
+        self.assertIn("sub_label=base", joined)
+        self.assertIn("/tmp/does/not/exist.out", joined)
+
+    def test_corrupt_paths_sp_composite_scalar_auto_heals(self):
+        """Regression: a project carried over from an older ARC version may
+        persist ``output[label]['paths']['sp_composite']`` as a scalar string
+        rather than the expected ``dict[sub_label → path]``. The first
+        post_sp_actions call would crash with
+        ``TypeError: 'str' object does not support item assignment``.
+
+        The scheduler must auto-heal that state on init (or on first composite
+        write), log a warning, and proceed without error."""
+        tmp = os.path.join(self.project_directory, "fx_str_corrupt")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        # Build a stale output snapshot with the bad scalar value, then build
+        # a fresh scheduler from it — exactly the restart-corruption shape.
+        stale_output = {
+            'H2': {
+                'paths': {
+                    'geo': '', 'geo_coarse': '', 'freq': '',
+                    'sp': '', 'composite': '',
+                    'sp_composite': '/tmp/some/old/sp.out',  # ← scalar, not a dict
+                },
+                'job_types': {'sp_composite': False},
+                'convergence': None,
+                'restart': '', 'errors': '', 'warnings': '', 'info': '',
+                'isomorphism': '', 'conformers': '',
+            }
+        }
+        with patch.object(Scheduler, "run_job", lambda self, *a, **kw: None):
+            sched = Scheduler(
+                project='sp_composite_orch',
+                ess_settings=self.ess_settings,
+                species_list=[spc],
+                project_directory=self.project_directory,
+                opt_level=Level(repr=default_levels_of_theory['opt']),
+                freq_level=Level(repr=default_levels_of_theory['freq']),
+                sp_level=Level(repr=default_levels_of_theory['sp']),
+                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+                scan_level=Level(repr=default_levels_of_theory['scan']),
+                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                orbitals_level=default_levels_of_theory['orbitals'],
+                sp_composite=protocol,
+                output=stale_output,
+                testing=True,
+            )
+        sched.run_job = lambda *a, **kw: None
+        # The bad scalar must be coerced to a dict by init — that's how the
+        # next post_sp_actions call avoids the TypeError.
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        # Now exercise the actual code path that would have crashed.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertEqual(
+            sched.output['H2']['paths']['sp_composite'].get('base'),
+            base_path,
+        )
+
+    def test_delete_all_species_jobs_preserves_sp_composite_dict(self):
+        """Regression: ``delete_all_species_jobs`` rebuilds ``paths`` via a
+        dict-comprehension that maps every key to ``''`` (with one carve-out
+        for ``'irc'`` → list). That clobbers ``paths['sp_composite']`` from
+        ``dict[sub_label → path]`` to an empty string, and the next composite
+        sub-job completion crashes with
+        ``TypeError: 'str' object does not support item assignment``.
+
+        ``sp_composite`` must be preserved as ``dict()`` (parallel to ``irc``
+        being preserved as ``list()``)."""
+        tmp = os.path.join(self.project_directory, "fx_delete_all")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Drive a base completion through the real path so paths['sp_composite']
+        # is a populated dict, not the freshly-init'd empty one.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'], base_path)
+        # Now exercise the path that clobbers it. delete_all_species_jobs
+        # iterates self.job_dict[label] which the no-op test scheduler may
+        # leave empty — that's fine, the dict-comprehension at the end of
+        # the method runs unconditionally and is what corrupts paths.
+        sched.delete_all_species_jobs('H2')
+        # Contract: sp_composite stays a dict (parallel to irc staying a list).
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+        # Next sub-job completion must not crash.
+        delta_T_high_path = os.path.join(tmp, "delta_T_high.out")
+        self._write_gaussian_fixture(delta_T_high_path, -1.15)
+        sched.post_sp_actions('H2', delta_T_high_path, protocol.corrections[0].high)
+
+    def test_delete_all_species_jobs_clears_sp_composite_state(self):
+        """Regression: when re-opt is triggered (e.g. by rotor troubleshooting),
+        ``delete_all_species_jobs`` must clear ``_sp_composite_pending[label]``
+        and ``_sp_composite_sections[label]``. Without this, the engine sees
+        stale pending state from the old geometry; the new base SP at the new
+        geometry matches no sub_label and is silently discarded with the
+        warning "sp completion matched no pending sub_label — ignoring", and
+        the species ends up stuck at ``sp: False`` despite a valid SP run.
+
+        The end-to-end re-seed behavior (next base SP re-populates pending) is
+        also exercised here — that's the user-visible payoff of the cleanup."""
+        tmp = os.path.join(self.project_directory, "fx_reset_state")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        h2 = ARCSpecies(label='H2', smiles='[H][H]')
+        h2.final_xyz = {'symbols': ('H', 'H'),
+                        'coords': ((0, 0, 0), (0, 0, 0.74)),
+                        'isotopes': (1, 1)}
+        other = ARCSpecies(label='Other', smiles='C')
+        other.final_xyz = {'symbols': ('C',), 'coords': ((0, 0, 0),), 'isotopes': (12,)}
+        sched = self._make_scheduler([h2, other], sp_composite=protocol)
+        # Init seeds _sp_composite_pending for every configured species.
+        self.assertIn('H2', sched._sp_composite_pending)
+        self.assertIn('Other', sched._sp_composite_pending)
+        # _sp_composite_sections only populates on finalize; inject sentinels
+        # so we can assert the cleanup path without running the full protocol.
+        sentinel_h2, sentinel_other = object(), object()
+        sched._sp_composite_sections['H2'] = sentinel_h2
+        sched._sp_composite_sections['Other'] = sentinel_other
+        # Drive a base SP at the OLD geometry so paths['sp_composite']['base']
+        # is populated — this is what the previous bug stranded across re-opt.
+        base_path = os.path.join(tmp, "base_old_geom.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'], base_path)
+
+        # Simulate rotor-triggered re-opt cleanup.
+        sched.delete_all_species_jobs('H2')
+
+        self.assertNotIn('H2', sched._sp_composite_pending,
+                         "_sp_composite_pending must be cleared so the next base "
+                         "SP re-seeds.")
+        self.assertNotIn('H2', sched._sp_composite_sections,
+                         "_sp_composite_sections must be cleared to prevent stale "
+                         "provenance.")
+        # Other species's state must be untouched.
+        self.assertIn('Other', sched._sp_composite_pending)
+        self.assertIs(sched._sp_composite_sections['Other'], sentinel_other)
+
+        # End-to-end: the next base SP at the new geometry must re-seed and
+        # be recorded — not orphaned with the "no pending sub_label" warning.
+        new_base_path = os.path.join(tmp, "base_new_geom.out")
+        self._write_gaussian_fixture(new_base_path, -1.12)
+        sched.post_sp_actions('H2', new_base_path, protocol.base.level)
+        self.assertIn('H2', sched._sp_composite_pending,
+                      "Re-seed failed: pending dict should be repopulated.")
+        self.assertEqual(sched.output['H2']['paths']['sp_composite']['base'],
+                         new_base_path,
+                         "New base SP must be recorded; previously orphaned.")
+
+    def test_delete_all_species_jobs_tolerates_one_failed_delete(self):
+        """Regression: a single failed ``job.delete()`` (e.g. ``qdel`` couldn't
+        kill the job because the queue is unresponsive) must NOT abort the
+        whole scheduler. ``delete_all_species_jobs`` is best-effort cleanup —
+        an orphaned remote job will exit on its own. The other jobs still
+        need to be deleted, the species's state still needs to be reset, and
+        the scheduler must keep running."""
+        tmp = os.path.join(self.project_directory, "fx_delete_failure")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+
+        class _StubJob:
+            def __init__(self, name, raise_on_delete=False):
+                self.name = name
+                self.execution_type = 'queue'
+                self.deleted = False
+                self.raise_on_delete = raise_on_delete
+
+            def delete(self):
+                if self.raise_on_delete:
+                    raise RuntimeError(f'Could not delete job {self.name}')
+                self.deleted = True
+
+        bad = _StubJob('a4035060', raise_on_delete=True)
+        good_a = _StubJob('a4035061')
+        good_b = _StubJob('a4035062')
+        # job_dict is keyed [label][job_type][job_name → JobAdapter].
+        # The ordering puts the failing job in the middle so we verify both
+        # the deletes before AND after it still run.
+        sched.job_dict['H2'] = {'sp': {
+            'a4035061': good_a,
+            'a4035060': bad,
+            'a4035062': good_b,
+        }}
+        sched.running_jobs['H2'] = ['a4035061', 'a4035060', 'a4035062']
+        # Should not raise.
+        sched.delete_all_species_jobs('H2')
+        self.assertTrue(good_a.deleted, "Pre-failure delete must still run.")
+        self.assertTrue(good_b.deleted, "Post-failure delete must still run.")
+        # And the species's state still got reset (running_jobs cleared, paths
+        # rebuilt with sp_composite as a dict, etc.).
+        self.assertEqual(sched.running_jobs['H2'], [])
+        self.assertIsInstance(sched.output['H2']['paths']['sp_composite'], dict)
+
+    def test_mrcc_degenerate_high_leg_falls_back_to_low_leg_path(self):
+        """When a δ-term high-leg sub-job errors with ``MRCCDegenerateSystem``
+        (atomic H / H2 at CCSDT(Q): MRCC's xmrcc bails because the requested
+        excitation rank exceeds the determinant space), the trsh ladder
+        cannot help — the cause is intrinsic to the physics, not the
+        numerics. The composite framework must short-circuit by reusing the
+        sister low-leg's output path. The two energies are degenerate by
+        symmetry (all CC ranks reduce to HF for ≤2-electron systems), so
+        δ = 0, which is the correct physical answer."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_degenerate")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Base + low-leg complete normally.
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -0.5)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        low_path = os.path.join(tmp, "delta_T__low.out")
+        self._write_gaussian_fixture(low_path, -0.5)  # HF for atomic H
+        sched.post_sp_actions('H2', low_path, protocol.corrections[0].low)
+        # High leg (CCSDT/cc-pVDZ) "fails" with the MRCC degenerate-system
+        # keyword. Build a JobAdapter stub that mimics what check_sp_job sees.
+
+        class _ErroredJobStub:
+            def __init__(self, level, output_path):
+                self.level = level
+                self.local_path_to_output_file = output_path
+                self.job_status = ['done', {
+                    'status': 'errored',
+                    'keywords': ['MRCCDegenerateSystem'],
+                    'error': 'MRCC xmrcc fatal',
+                    'line': 'Fatal error in xmrcc.',
+                }]
+                self.conformer = None
+                self.job_name = 'sp_a999'
+                self.execution_type = 'queue'
+                self.job_id = 'a999'
+
+        # Provide a placeholder output file (it would normally be the
+        # truncated MRCC log; the framework should not parse it).
+        high_failed_path = os.path.join(tmp, "delta_T__high_FAILED.out")
+        with open(high_failed_path, 'w') as fh:
+            fh.write("Fatal error in xmrcc.\n")
+        bad_job = _ErroredJobStub(
+            level=protocol.corrections[0].high,
+            output_path=high_failed_path,
+        )
+        sched.check_sp_job(label='H2', job=bad_job)
+        # The framework must have substituted the low-leg path for the high
+        # leg and finalized the composite (δ_T = 0, e_elect = base energy).
+        self.assertEqual(
+            sched.output['H2']['paths']['sp_composite']['delta_T__high'],
+            low_path,
+            'High-leg path must be substituted with low-leg path on '
+            'MRCCDegenerateSystem fallback.',
+        )
+        self.assertTrue(sched.output['H2']['job_types']['sp_composite'])
+        self.assertEqual(spc.e_elect_source, 'sp_composite')
+        # Energy contributions: base = parsed from base.out, δ_T = 0 by
+        # construction. Final = base.
+        parsed_base = parser.parse_e_elect(base_path)
+        self.assertAlmostEqual(spc.e_elect, parsed_base, places=6)
+
+    def test_mrcc_degenerate_low_leg_failure_does_not_short_circuit(self):
+        """If the LOW leg fails with MRCCDegenerateSystem (no sister to fall
+        back on), the framework must NOT silently substitute. The species
+        should not finalize from this path; troubleshoot_ess gets called on
+        the assumption a higher level can sort it out."""
+        tmp = os.path.join(self.project_directory, "fx_mrcc_low_fail")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Patch troubleshoot_ess to a recording stub so we can verify it
+        # gets called for low-leg failures.
+        called = []
+        sched.troubleshoot_ess = lambda *args, **kwargs: called.append(
+            kwargs.get('job').job_name if kwargs.get('job') else 'unknown')
+
+        class _ErroredJobStub:
+            def __init__(self, level):
+                self.level = level
+                self.local_path_to_output_file = '/tmp/fake.out'
+                self.job_status = ['done', {
+                    'status': 'errored',
+                    'keywords': ['MRCCDegenerateSystem'],
+                    'error': 'MRCC xmrcc fatal',
+                    'line': 'Fatal error in xmrcc.',
+                }]
+                self.conformer = None
+                self.job_name = 'sp_a999'
+                self.execution_type = 'queue'
+                self.job_id = 'a999'
+
+        bad_job = _ErroredJobStub(level=protocol.corrections[0].low)
+        sched.check_sp_job(label='H2', job=bad_job)
+        self.assertEqual(called, ['sp_a999'],
+                         'Low-leg MRCC failure must not be short-circuited.')
+        self.assertNotIn('delta_T__low',
+                         sched.output['H2']['paths']['sp_composite'])
+
+    def test_species_report_yaml_written_on_finalize(self):
+        """Per-species sp_composite YAML report lands at
+        ``<project>/output/Species/<label>/sp_composite_report.yml`` when the
+        composite finalizes, and the file parses to a dict whose ``final``
+        block matches what ARC recorded on the species."""
+        import yaml
+        tmp = os.path.join(self.project_directory, "fx_species_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'),
+                         'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        # Drive a 3-sub-job composite to completion.
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+            {"base": -1.10, "delta_T__high": -1.15, "delta_T__low": -1.12})
+        sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+        sched.post_sp_actions('H2', paths["delta_T__high"], protocol.corrections[0].high)
+        sched.post_sp_actions('H2', paths["delta_T__low"], protocol.corrections[0].low)
+        report_path = os.path.join(
+            self.project_directory, "output", "Species", "H2",
+            "sp_composite_report.yml",
+        )
+        self.assertTrue(os.path.exists(report_path),
+                        f"Per-species report not written at {report_path}")
+        with open(report_path) as fh:
+            report = yaml.safe_load(fh)
+        # Identity + protocol shape.
+        self.assertEqual(report["species"], "H2")
+        self.assertEqual(report["kind"], "species")
+        self.assertEqual(len(report["terms"]), 1)
+        self.assertEqual(report["terms"][0]["label"], "delta_T")
+        self.assertEqual(len(report["terms"][0]["sub_jobs"]), 2)
+        # Final block matches what the scheduler set on the species.
+        self.assertAlmostEqual(report["final"]["e_elect_kj_per_mol"],
+                               spc.e_elect, places=6)
+        self.assertEqual(report["final"]["e_elect_source"], "sp_composite")
+
+    def test_species_report_uses_TSs_subdir_for_transition_states(self):
+        """Transition states land under ``output/TSs/<label>/...``, not
+        ``output/Species/...``."""
+        import yaml
+        tmp = os.path.join(self.project_directory, "fx_ts_report")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        ts = ARCSpecies(label='TS_x', smiles='[H][H]', is_ts=True)
+        ts.final_xyz = {'symbols': ('H', 'H'),
+                        'coords': ((0, 0, 0), (0, 0, 0.74)),
+                        'isotopes': (1, 1)}
+        sched = self._make_scheduler([ts], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('TS_x', base_path, protocol.base.level)
+        ts_report = os.path.join(
+            self.project_directory, "output", "TSs", "TS_x",
+            "sp_composite_report.yml",
+        )
+        species_report = os.path.join(
+            self.project_directory, "output", "Species", "TS_x",
+            "sp_composite_report.yml",
+        )
+        self.assertTrue(os.path.exists(ts_report))
+        self.assertFalse(os.path.exists(species_report))
+        with open(ts_report) as fh:
+            self.assertEqual(yaml.safe_load(fh)["kind"], "ts")
+
+    # --- Phase 3.5: preset name + reference preservation ------------------- #
+
+    def test_preset_name_and_reference_survive_to_notebook_section(self):
+        """When the protocol is a preset, its preset_name and reference (DOI)
+        must flow through parsing → finalize → SpeciesSection."""
+        tmp = os.path.join(self.project_directory, "fx_preset")
+        os.makedirs(tmp, exist_ok=True)
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        self.assertEqual(protocol.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', protocol.reference)
+        # Now exercise the scheduler end-to-end with only a bare-bones subset
+        # of sub-jobs (we don't need the full HEAT protocol to fire to verify
+        # the SpeciesSection carries the preset metadata) — build a trivial
+        # protocol with its preset metadata manually preserved.
+        simple = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        simple.preset_name = 'HEAT-345Q'
+        simple.reference = protocol.reference
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=simple)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, simple.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertEqual(section.preset_name, 'HEAT-345Q')
+        self.assertIn('DOI', section.reference)
+
+    def test_explicit_recipe_reference_key_preserved(self):
+        """Users can supply a `reference` at the top level of an explicit recipe."""
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+            "reference": "Custom recipe; DOI: 10.9999/custom",
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        self.assertIsNone(protocol.preset_name)
+        self.assertEqual(protocol.reference, "Custom recipe; DOI: 10.9999/custom")
+
+    def test_explicit_recipe_without_reference_falls_back_and_flags(self):
+        """Explicit recipe, no reference → SpeciesSection flags it."""
+        tmp = os.path.join(self.project_directory, "fx_expl")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {"base": {"method": "hf", "basis": "cc-pVTZ"}, "corrections": []}
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        base_path = os.path.join(tmp, "base.out")
+        self._write_gaussian_fixture(base_path, -1.10)
+        sched.post_sp_actions('H2', base_path, protocol.base.level)
+        section = sched._sp_composite_sections['H2']
+        self.assertIsNone(section.preset_name)
+        self.assertIn("Explicit", section.reference)
+        self.assertTrue(any("No formal reference" in f for f in section.flags))
+
+    def test_protocol_preset_metadata_round_trips_through_as_dict(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        restored = CompositeProtocol.from_dict(protocol.as_dict())
+        self.assertEqual(restored.preset_name, 'HEAT-345Q')
+        self.assertEqual(restored.reference, protocol.reference)
+
+    # --- Phase 3.5: term-level logging ------------------------------------- #
+
+    def test_term_evaluated_log_event_per_term(self):
+        tmp = os.path.join(self.project_directory, "fx_term_log")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+                {"label": "cbs_corr", "type": "cbs_extrapolation",
+                 "formula": "helgaker_corr_2pt",
+                 "levels": [{"method": "ccsd(t)", "basis": "cc-pVTZ"},
+                            {"method": "ccsd(t)", "basis": "cc-pVQZ"}]},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc = ARCSpecies(label='H2', smiles='[H][H]')
+        spc.final_xyz = {'symbols': ('H', 'H'), 'coords': ((0, 0, 0), (0, 0, 0.74)),
+                         'isotopes': (1, 1)}
+        sched = self._make_scheduler([spc], sp_composite=protocol)
+        energies = {
+            "base": -1.10,
+            "delta_T__high": -1.15, "delta_T__low": -1.12,
+            "cbs_corr__card_3": -1.14, "cbs_corr__card_4": -1.145,
+        }
+        paths = self._seed_protocol_fixtures(tmp, protocol, energies)
+        with self.assertLogs(logger='arc', level=logging.INFO) as cm:
+            sched.post_sp_actions('H2', paths["base"], protocol.base.level)
+            sched.post_sp_actions('H2', paths["delta_T__high"],
+                                  protocol.corrections[0].high)
+            sched.post_sp_actions('H2', paths["delta_T__low"],
+                                  protocol.corrections[0].low)
+            sched.post_sp_actions('H2', paths["cbs_corr__card_3"],
+                                  protocol.corrections[1].levels[0])
+            sched.post_sp_actions('H2', paths["cbs_corr__card_4"],
+                                  protocol.corrections[1].levels[1])
+        joined = "\n".join(cm.output)
+        self.assertIn("term evaluated", joined)
+        # One "term evaluated" per term (base + delta_T + cbs_corr = 3).
+        count = joined.count("term evaluated")
+        self.assertEqual(count, 3)
+        # Each term's label appears.
+        for term_label in ("base", "delta_T", "cbs_corr"):
+            self.assertIn(f"term={term_label}", joined)
+        # CBS term carries a formula field.
+        self.assertIn("formula=helgaker_corr_2pt", joined)
+
+
+    # --- Phase 5: rehydrated-finalized species reappear in regenerated notebook -- #
+
+    def test_rehydrated_finalized_species_appears_in_cumulative_notebook(self):
+        """A species that finalized in a previous ARC run must reappear in the
+        project notebook after restart-time regeneration — with every required
+        sub_label resolved to the actual output file path."""
+        tmp = os.path.join(self.project_directory, "fx_rehydrate_nb")
+        os.makedirs(tmp, exist_ok=True)
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [
+                {"label": "delta_T", "type": "delta",
+                 "high": {"method": "ccsdt",   "basis": "cc-pVDZ"},
+                 "low":  {"method": "ccsd(t)", "basis": "cc-pVDZ"}},
+            ],
+        }
+        protocol = CompositeProtocol.from_user_input(recipe)
+        spc_a = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a.final_xyz = {'symbols': ('H', 'H'),
+                           'coords': ((0, 0, 0), (0, 0, 0.74)), 'isotopes': (1, 1)}
+        sched1 = self._make_scheduler([spc_a], sp_composite=protocol)
+        paths = self._seed_protocol_fixtures(tmp, protocol,
+                                             {"base": -1.05, "delta_T__high": -1.07,
+                                              "delta_T__low": -1.06})
+        sched1.post_sp_actions('Afinalized', paths["base"], protocol.base.level)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__high"],
+                               protocol.corrections[0].high)
+        sched1.post_sp_actions('Afinalized', paths["delta_T__low"],
+                               protocol.corrections[0].low)
+        self.assertTrue(sched1.output['Afinalized']['job_types']['sp_composite'])
+        output_snapshot = sched1.output
+
+        # Restart with the same species list. Rehydration must resurrect the
+        # SpeciesSection so a subsequent notebook regeneration includes it.
+        spc_a2 = ARCSpecies(label='Afinalized', smiles='[H][H]')
+        spc_a2.final_xyz = spc_a.final_xyz
+        sched2 = self._make_scheduler([spc_a2], sp_composite=protocol,
+                                      output=output_snapshot)
+        self.assertIn('Afinalized', sched2._sp_composite_sections)
+        sec = sched2._sp_composite_sections['Afinalized']
+        required = {sub for _t, sub, _l in protocol.iter_required_jobs()}
+        # Every required sub_label is present and points at the real output file.
+        self.assertEqual(set(sec.sub_job_paths.keys()), required)
+        for sub_label in required:
+            self.assertEqual(sec.sub_job_paths[sub_label], paths[sub_label])
+            self.assertTrue(os.path.isfile(sec.sub_job_paths[sub_label]))
+        # Trigger a fresh notebook regeneration directly; the rehydrated section
+        # must appear in the cumulative output.
+        sched2._regenerate_composite_notebook()
+        nb_path = os.path.join(self.project_directory, "output", "sp_composite.ipynb")
+        self.assertTrue(os.path.exists(nb_path))
+        nb = nbformat.read(nb_path, as_version=4)
+        titles = [c.source for c in nb.cells
+                  if c.cell_type == "markdown"
+                  and c.source.lstrip().startswith("## ")
+                  and "Project summary" not in c.source
+                  and "References" not in c.source]
+        self.assertTrue(any("Afinalized" in t for t in titles))
+
+
+class TestSchedulerSpCompositePassthrough(unittest.TestCase):
+    """
+    Phase 2 contract: Scheduler.__init__ accepts sp_composite and stores it only —
+    no orchestration, no output-dict changes, no jobs queued.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1']}
+        worker = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        cls.project_directory = os.path.join(
+            ARC_PATH, 'Projects', f'arc_project_for_testing_sp_composite_passthrough_{worker}'
+        )
+        cls.spc = ARCSpecies(label='H2', smiles='[H][H]')
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.project_directory):
+            shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+    def _make_scheduler(self, sp_composite):
+        return Scheduler(
+            project='sp_composite_passthrough',
+            ess_settings=self.ess_settings,
+            species_list=[self.spc],
+            project_directory=self.project_directory,
+            opt_level=Level(repr=default_levels_of_theory['opt']),
+            freq_level=Level(repr=default_levels_of_theory['freq']),
+            sp_level=Level(repr=default_levels_of_theory['sp']),
+            conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
+            scan_level=Level(repr=default_levels_of_theory['scan']),
+            ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+            orbitals_level=default_levels_of_theory['orbitals'],
+            sp_composite=sp_composite,
+            testing=True,
+        )
+
+    def test_stores_sp_composite(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertIs(sched.sp_composite, protocol)
+
+    def test_none_sp_composite_stored_as_none(self):
+        sched = self._make_scheduler(None)
+        self.assertIsNone(sched.sp_composite)
+
+    def test_passthrough_does_not_queue_jobs(self):
+        protocol = CompositeProtocol.from_user_input('HEAT-345Q')
+        sched = self._make_scheduler(protocol)
+        self.assertEqual(sched.running_jobs, {'H2': []})
 
 
 if __name__ == '__main__':

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -1042,8 +1042,9 @@ H      -1.82570782    0.42754384   -0.56130718"""
         project_directory = os.path.join(ARC_PATH, 'Projects',
                                          'arc_project_for_testing_delete_after_usage4')
         self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        caller_species_list = [ts_spc]
         sched = Scheduler(project='test_switch_ts', ess_settings=self.ess_settings,
-                          species_list=[ts_spc],
+                          species_list=caller_species_list,
                           opt_level=Level(repr=default_levels_of_theory['opt']),
                           freq_level=Level(repr=default_levels_of_theory['freq']),
                           sp_level=Level(repr=default_levels_of_theory['sp']),
@@ -1072,7 +1073,7 @@ H      -1.82570782    0.42754384   -0.56130718"""
         ts_spc.irc_label = f'{irc_label_1} {irc_label_2}'
         sched.species_dict[irc_label_1] = irc_spc_1
         sched.species_dict[irc_label_2] = irc_spc_2
-        sched.species_list.extend([irc_spc_1, irc_spc_2])
+        caller_species_list.extend([irc_spc_1, irc_spc_2])
         sched.unique_species_labels.extend([irc_label_1, irc_label_2])
         sched.running_jobs[irc_label_1] = ['opt_a100']
         sched.running_jobs[irc_label_2] = ['opt_a101']
@@ -1106,6 +1107,14 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertNotIn(irc_label_1, sched.unique_species_labels)
         self.assertNotIn(irc_label_2, sched.unique_species_labels)
         self.assertIsNone(sched.species_dict[ts_label].irc_label)
+
+        # Regression: caller's species_list reference must also have IRC species
+        # removed. If cleanup rebinds self.species_list to a new list, the caller's
+        # reference (e.g. ARC.species) keeps zombie IRC species and later crashes
+        # save_project_info_file with KeyError on self.output[IRC_label].
+        self.assertNotIn(irc_spc_1, caller_species_list)
+        self.assertNotIn(irc_spc_2, caller_species_list)
+        self.assertIs(sched.species_list, caller_species_list)
 
         # Verify job_types reset and convergence cleared.
         self.assertFalse(sched.output[ts_label]['job_types']['opt'])

--- a/arc/settings/inputs.py
+++ b/arc/settings/inputs.py
@@ -21,6 +21,11 @@ frequencies = Log('{freq_path}')
 
 """,
 
+    # Historical template. ARC's live Arkane renderer uses the Mako
+    # ``species_input_template`` defined in ``arc/statmech/arkane.py`` and
+    # branches inline on ``e_elect_hartree`` when ``sp_composite`` is active.
+    # This string-format variant is kept only as a reference for external
+    # scripts that might still import it; it is not invoked by ARC itself.
     'arkane_input_species_explicit_e': """#!/usr/bin/env python3
 # encoding: utf-8
 

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -282,8 +282,8 @@ valid_chars = "-_[]=.,%s%s" % (string.ascii_letters, string.digits)
 rotor_scan_resolution = 8.0  # degrees. Default: 8.0
 
 # rotor validation parameters
-maximum_barrier = 40    # a rotor threshold (kJ/mol) above which the mode will be considered as vibrational if
-                        # there's only one well. Default: 40 (~10 kcal/mol)
+maximum_barrier = 60    # a rotor threshold (kJ/mol) above which the mode will be considered as vibrational if
+                        # there's only one well. Default: 60 (~14 kcal/mol)
 minimum_barrier = 1.0   # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 1.0 kJ/mol
 inconsistency_az = 5    # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
 inconsistency_ab = 0.3  # maximum allowed inconsistency between consecutive points in the scan given as a fraction

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -140,6 +140,11 @@ delete_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qdel
                   'HTCondor': 'condor_rm',
                   }
 
+# Default grace period (in seconds) before a queue-RUNNING job with no output traffic is
+# treated as a zombie and resubmitted. Override per server by adding an optional
+# 'zombie_grace_seconds' key to the respective entry in the ``servers`` dict above.
+zombie_grace_seconds = 21600  # 6 h
+
 list_available_nodes_command = {
     'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qstat -f | grep "/8 " | grep "long" | grep -v "8/8"| grep -v "aAu"',
     'Slurm': 'sinfo -o "%n %t %O %E"',

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -164,6 +164,11 @@ delete_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qdel
                   'HTCondor': 'condor_rm',
                   }
 
+# Default grace period (in seconds) before a queue-RUNNING job with no output traffic is
+# treated as a zombie and resubmitted. Override per server by adding an optional
+# 'zombie_grace_seconds' key to the respective entry in the ``servers`` dict above.
+zombie_grace_seconds = 21600  # 6 h
+
 list_available_nodes_command = {
     'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qstat -f | grep "/8 " | grep "long" | grep -v "8/8"| grep -v "aAu"',
     'Slurm': 'sinfo -o "%n %t %O %E"',

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -313,8 +313,8 @@ valid_chars = "-_[]=.,%s%s" % (string.ascii_letters, string.digits)
 rotor_scan_resolution = 8.0  # degrees. Default: 8.0
 
 # rotor validation parameters
-maximum_barrier = 40    # a rotor threshold (kJ/mol) above which the mode will be considered as vibrational if
-                        # there's only one well. Default: 40 (~10 kcal/mol)
+maximum_barrier = 60    # a rotor threshold (kJ/mol) above which the mode will be considered as vibrational if
+                        # there's only one well. Default: 60 (~14 kcal/mol)
 minimum_barrier = 1.0   # a rotor threshold (kJ/mol) below which it is considered a FreeRotor. Default: 1.0 kJ/mol
 inconsistency_az = 5    # maximum allowed inconsistency (kJ/mol) between initial and final rotor scan points. Default: 5
 inconsistency_ab = 0.3  # maximum allowed inconsistency between consecutive points in the scan given as a fraction

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -25,7 +25,8 @@ from arc.common import (SYMBOL_BY_NUMBER,
 from arc.exceptions import AtomTypeError, InputError, InvalidAdjacencyListError, RotorError, SpeciesError, TSError, \
     SanitizationError
 from arc.imports import settings
-from arc.level import Level
+from arc.level import INHERIT, Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.atomtype import ATOMTYPES
 from arc.molecule.molecule import Atom, Bond, Molecule
 from arc.molecule.resonance import generate_aromatic_resonance_structure, generate_kekule_structure, generate_resonance_structures_safely
@@ -59,6 +60,26 @@ from arc.species.vectors import calculate_angle, calculate_distance, calculate_d
 logger = get_logger()
 
 valid_chars, minimum_barrier = settings['valid_chars'], settings['minimum_barrier']
+
+
+def _resolve_sp_composite_input(value):
+    """Convert a user-supplied ``sp_composite`` value into ``(state, protocol)``.
+
+    Phase 2 three-state model:
+
+    * ``INHERIT`` sentinel → ``("inherit", None)`` — user didn't set this field.
+    * ``None``             → ``("opt_out", None)`` — user wrote ``null``.
+    * str / dict / CompositeProtocol → ``("explicit", CompositeProtocol)``.
+
+    Raised exceptions propagate from :meth:`CompositeProtocol.from_user_input`.
+    """
+    if value is INHERIT:
+        return "inherit", None
+    if value is None:
+        return "opt_out", None
+    if isinstance(value, CompositeProtocol):
+        return "explicit", value
+    return "explicit", CompositeProtocol.from_user_input(value)
 
 
 class ARCSpecies(object):
@@ -335,6 +356,7 @@ class ARCSpecies(object):
                  yml_path: Optional[str] = None,
                  keep_mol: bool = False,
                  project_directory: Optional[str] = None,
+                 sp_composite=INHERIT,
                  ):
         self.t1 = None
         self.ts_number = ts_number
@@ -378,6 +400,7 @@ class ARCSpecies(object):
         self.label = label
         self.symmetry_number = None
         self.index = None
+        self.sp_composite_state, self.sp_composite = _resolve_sp_composite_input(sp_composite)
 
         if species_dict is not None:
             # Reading from a dictionary (it's possible that the dict contains only a 'yml_path' argument, check first)
@@ -395,6 +418,10 @@ class ARCSpecies(object):
             self.ts_conf_spawned = False
             self.ts_guesses_exhausted = False
             self.e_elect = None
+            # Provenance of e_elect. None for legacy SP; 'sp_composite' when the
+            # Scheduler's composite finalize sets the value. Read by Phase 4
+            # Arkane plumbing to decide whether to render the explicit-energy template.
+            self.e_elect_source = None
             self.e0 = None
             self.arkane_file = None
             self.conf_is_isomorphic = None
@@ -821,6 +848,13 @@ class ARCSpecies(object):
             # this marks the species to skip rotor scans (it is not an empty dict)
             # this is valuable information, store it in the restart file
             species_dict['rotors_dict'] = self.rotors_dict
+        if self.sp_composite_state == "opt_out":
+            species_dict['sp_composite'] = None
+        elif self.sp_composite_state == "explicit":
+            species_dict['sp_composite'] = self.sp_composite.as_dict()
+        # Provenance flag (Phase 3). Only emit when set; legacy output stays clean.
+        if getattr(self, "e_elect_source", None) is not None:
+            species_dict['e_elect_source'] = self.e_elect_source
         return species_dict
 
     def from_dict(self, species_dict):
@@ -835,6 +869,7 @@ class ARCSpecies(object):
         self.original_label = species_dict['original_label'] if 'original_label' in species_dict else None
         self.t1 = species_dict['t1'] if 't1' in species_dict else None
         self.e_elect = species_dict['e_elect'] if 'e_elect' in species_dict else None
+        self.e_elect_source = species_dict['e_elect_source'] if 'e_elect_source' in species_dict else None
         self.freqs = species_dict.get('freqs')
         self.e0 = species_dict['e0'] if 'e0' in species_dict else None
         self.tsg_spawned = species_dict['tsg_spawned'] if 'tsg_spawned' in species_dict else False
@@ -895,6 +930,13 @@ class ARCSpecies(object):
         self.optical_isomers = species_dict['optical_isomers'] if 'optical_isomers' in species_dict else None
         self.neg_freqs_trshed = species_dict['neg_freqs_trshed'] if 'neg_freqs_trshed' in species_dict else list()
         self.bond_corrections = species_dict['bond_corrections'] if 'bond_corrections' in species_dict else dict()
+        if 'sp_composite' not in species_dict:
+            self.sp_composite_state, self.sp_composite = "inherit", None
+        elif species_dict['sp_composite'] is None:
+            self.sp_composite_state, self.sp_composite = "opt_out", None
+        else:
+            self.sp_composite_state = "explicit"
+            self.sp_composite = CompositeProtocol.from_user_input(species_dict['sp_composite'])
         if 'mol' in species_dict:
             if isinstance(species_dict['mol'], str):
                 try:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -65,17 +65,26 @@ logger = get_logger()
 valid_chars, minimum_barrier = settings['valid_chars'], settings['minimum_barrier']
 
 
-def _resolve_sp_composite_input(value):
+def _resolve_sp_composite_input(value: str | dict | CompositeProtocol | None | object,
+                                ) -> tuple[str, CompositeProtocol | None]:
     """
     Convert a user-supplied ``sp_composite`` value into ``(state, protocol)``.
 
-    Phase 2 three-state model:
+    Three-state model:
 
     * ``INHERIT`` sentinel → ``("inherit", None)`` — user didn't set this field.
     * ``None``             → ``("opt_out", None)`` — user wrote ``null``.
     * str / dict / CompositeProtocol → ``("explicit", CompositeProtocol)``.
 
     Raised exceptions propagate from :meth:`CompositeProtocol.from_user_input`.
+
+    Args:
+        value (str | dict | CompositeProtocol | None | object): The raw ``sp_composite`` input,
+            possibly the ``INHERIT`` sentinel.
+
+    Returns:
+        tuple[str, CompositeProtocol | None]: The species ``sp_composite`` state
+        (one of ``"inherit"``, ``"opt_out"``, ``"explicit"``) and the resolved protocol (or ``None``).
     """
     if value is INHERIT:
         return "inherit", None
@@ -435,8 +444,8 @@ class ARCSpecies(object):
             self.ts_guesses_exhausted = False
             self.e_elect = None
             # Provenance of e_elect. None for legacy SP; 'sp_composite' when the
-            # Scheduler's composite finalize sets the value. Read by Phase 4
-            # Arkane plumbing to decide whether to render the explicit-energy template.
+            # Scheduler's composite finalize sets the value. Read by the Arkane
+            # plumbing to decide whether to render the explicit-energy template.
             self.e_elect_source = None
             self.e0 = None
             self.arkane_file = None
@@ -874,7 +883,7 @@ class ARCSpecies(object):
             species_dict['sp_composite'] = None
         elif self.sp_composite_state == "explicit":
             species_dict['sp_composite'] = self.sp_composite.as_dict()
-        # Provenance flag (Phase 3). Only emit when set; legacy output stays clean.
+        # Provenance flag. Only emit when set; legacy output stays clean.
         if getattr(self, "e_elect_source", None) is not None:
             species_dict['e_elect_source'] = self.e_elect_source
         return species_dict

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import os
 from math import isclose
+from typing import TYPE_CHECKING
 
 import arc.molecule.element as elements
 from arc.common import (SYMBOL_BY_NUMBER,
@@ -24,7 +25,8 @@ from arc.common import (SYMBOL_BY_NUMBER,
 from arc.exceptions import AtomTypeError, InputError, InvalidAdjacencyListError, RotorError, SpeciesError, TSError, \
     SanitizationError
 from arc.imports import settings
-from arc.level import Level
+from arc.level import INHERIT, Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.atomtype import ATOMTYPES
 from arc.molecule.molecule import Atom, Bond, Molecule
 from arc.molecule.resonance import generate_aromatic_resonance_structure, generate_kekule_structure, generate_resonance_structures_safely
@@ -55,9 +57,33 @@ from arc.species.converter import (check_isomorphism,
 from arc.species.perceive import perceive_molecule_from_xyz, is_mol_valid
 from arc.species.vectors import calculate_angle, calculate_distance, calculate_dihedral_angle
 
+if TYPE_CHECKING:
+    from arc.reaction import ARCReaction
+
 logger = get_logger()
 
 valid_chars, minimum_barrier = settings['valid_chars'], settings['minimum_barrier']
+
+
+def _resolve_sp_composite_input(value):
+    """
+    Convert a user-supplied ``sp_composite`` value into ``(state, protocol)``.
+
+    Phase 2 three-state model:
+
+    * ``INHERIT`` sentinel → ``("inherit", None)`` — user didn't set this field.
+    * ``None``             → ``("opt_out", None)`` — user wrote ``null``.
+    * str / dict / CompositeProtocol → ``("explicit", CompositeProtocol)``.
+
+    Raised exceptions propagate from :meth:`CompositeProtocol.from_user_input`.
+    """
+    if value is INHERIT:
+        return "inherit", None
+    if value is None:
+        return "opt_out", None
+    if isinstance(value, CompositeProtocol):
+        return "explicit", value
+    return "explicit", CompositeProtocol.from_user_input(value)
 
 
 class ARCSpecies(object):
@@ -346,6 +372,7 @@ class ARCSpecies(object):
                  yml_path: str | None = None,
                  keep_mol: bool = False,
                  project_directory: str | None = None,
+                 sp_composite=INHERIT,
                  ):
         self.t1 = None
         self.ts_number = ts_number
@@ -389,6 +416,7 @@ class ARCSpecies(object):
         self.label = label
         self.symmetry_number = None
         self.index = None
+        self.sp_composite_state, self.sp_composite = _resolve_sp_composite_input(sp_composite)
 
         if species_dict is not None:
             # Reading from a dictionary (it's possible that the dict contains only a 'yml_path' argument, check first)
@@ -406,6 +434,10 @@ class ARCSpecies(object):
             self.ts_conf_spawned = False
             self.ts_guesses_exhausted = False
             self.e_elect = None
+            # Provenance of e_elect. None for legacy SP; 'sp_composite' when the
+            # Scheduler's composite finalize sets the value. Read by Phase 4
+            # Arkane plumbing to decide whether to render the explicit-energy template.
+            self.e_elect_source = None
             self.e0 = None
             self.arkane_file = None
             self.conf_is_isomorphic = None
@@ -838,6 +870,13 @@ class ARCSpecies(object):
             # this marks the species to skip rotor scans (it is not an empty dict)
             # this is valuable information, store it in the restart file
             species_dict['rotors_dict'] = self.rotors_dict
+        if self.sp_composite_state == "opt_out":
+            species_dict['sp_composite'] = None
+        elif self.sp_composite_state == "explicit":
+            species_dict['sp_composite'] = self.sp_composite.as_dict()
+        # Provenance flag (Phase 3). Only emit when set; legacy output stays clean.
+        if getattr(self, "e_elect_source", None) is not None:
+            species_dict['e_elect_source'] = self.e_elect_source
         return species_dict
 
     def from_dict(self, species_dict):
@@ -852,6 +891,7 @@ class ARCSpecies(object):
         self.original_label = species_dict['original_label'] if 'original_label' in species_dict else None
         self.t1 = species_dict['t1'] if 't1' in species_dict else None
         self.e_elect = species_dict['e_elect'] if 'e_elect' in species_dict else None
+        self.e_elect_source = species_dict['e_elect_source'] if 'e_elect_source' in species_dict else None
         self.freqs = species_dict.get('freqs')
         self.e0 = species_dict['e0'] if 'e0' in species_dict else None
         self.tsg_spawned = species_dict['tsg_spawned'] if 'tsg_spawned' in species_dict else False
@@ -914,6 +954,13 @@ class ARCSpecies(object):
         self.optical_isomers = species_dict['optical_isomers'] if 'optical_isomers' in species_dict else None
         self.neg_freqs_trshed = species_dict['neg_freqs_trshed'] if 'neg_freqs_trshed' in species_dict else list()
         self.bond_corrections = species_dict['bond_corrections'] if 'bond_corrections' in species_dict else dict()
+        if 'sp_composite' not in species_dict:
+            self.sp_composite_state, self.sp_composite = "inherit", None
+        elif species_dict['sp_composite'] is None:
+            self.sp_composite_state, self.sp_composite = "opt_out", None
+        else:
+            self.sp_composite_state = "explicit"
+            self.sp_composite = CompositeProtocol.from_user_input(species_dict['sp_composite'])
         if 'mol' in species_dict:
             if isinstance(species_dict['mol'], str):
                 try:
@@ -2314,7 +2361,7 @@ class TSGuess(object):
                  success: bool | None = None,
                  family: str | None = None,
                  xyz: dict | str | None = None,
-                 arc_reaction: Optional = None,
+                 arc_reaction: ARCReaction | None = None,
                  ts_dict: dict | None = None,
                  energy: float | None = None,
                  cluster: list[int] | None = None,

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -66,17 +66,26 @@ logger = get_logger()
 valid_chars, minimum_barrier = settings['valid_chars'], settings['minimum_barrier']
 
 
-def _resolve_sp_composite_input(value):
+def _resolve_sp_composite_input(value: str | dict | CompositeProtocol | None | object,
+                                ) -> tuple[str, CompositeProtocol | None]:
     """
     Convert a user-supplied ``sp_composite`` value into ``(state, protocol)``.
 
-    Phase 2 three-state model:
+    Three-state model:
 
     * ``INHERIT`` sentinel → ``("inherit", None)`` — user didn't set this field.
     * ``None``             → ``("opt_out", None)`` — user wrote ``null``.
     * str / dict / CompositeProtocol → ``("explicit", CompositeProtocol)``.
 
     Raised exceptions propagate from :meth:`CompositeProtocol.from_user_input`.
+
+    Args:
+        value (str | dict | CompositeProtocol | None | object): The raw ``sp_composite`` input,
+            possibly the ``INHERIT`` sentinel.
+
+    Returns:
+        tuple[str, CompositeProtocol | None]: The species ``sp_composite`` state
+        (one of ``"inherit"``, ``"opt_out"``, ``"explicit"``) and the resolved protocol (or ``None``).
     """
     if value is INHERIT:
         return "inherit", None
@@ -436,8 +445,8 @@ class ARCSpecies(object):
             self.ts_guesses_exhausted = False
             self.e_elect = None
             # Provenance of e_elect. None for legacy SP; 'sp_composite' when the
-            # Scheduler's composite finalize sets the value. Read by Phase 4
-            # Arkane plumbing to decide whether to render the explicit-energy template.
+            # Scheduler's composite finalize sets the value. Read by the Arkane
+            # plumbing to decide whether to render the explicit-energy template.
             self.e_elect_source = None
             self.e0 = None
             self.arkane_file = None
@@ -879,7 +888,7 @@ class ARCSpecies(object):
             species_dict['sp_composite'] = None
         elif self.sp_composite_state == "explicit":
             species_dict['sp_composite'] = self.sp_composite.as_dict()
-        # Provenance flag (Phase 3). Only emit when set; legacy output stays clean.
+        # Provenance flag. Only emit when set; legacy output stays clean.
         if getattr(self, "e_elect_source", None) is not None:
             species_dict['e_elect_source'] = self.e_elect_source
         return species_dict

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import os
 from math import isclose
+from typing import TYPE_CHECKING
 
 import arc.molecule.element as elements
 from arc.common import (almost_equal_coords,
@@ -25,7 +26,8 @@ from arc.common import (almost_equal_coords,
 from arc.exceptions import AtomTypeError, InputError, InvalidAdjacencyListError, RotorError, SpeciesError, TSError, \
     SanitizationError
 from arc.imports import settings
-from arc.level import Level
+from arc.level import INHERIT, Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.atomtype import ATOMTYPES
 from arc.molecule.molecule import Atom, Bond, Molecule
 from arc.molecule.resonance import generate_aromatic_resonance_structure, generate_kekule_structure, generate_resonance_structures_safely
@@ -56,9 +58,33 @@ from arc.species.converter import (check_isomorphism,
 from arc.species.perceive import perceive_molecule_from_xyz, is_mol_valid
 from arc.species.vectors import calculate_angle, calculate_distance, calculate_dihedral_angle
 
+if TYPE_CHECKING:
+    from arc.reaction import ARCReaction
+
 logger = get_logger()
 
 valid_chars, minimum_barrier = settings['valid_chars'], settings['minimum_barrier']
+
+
+def _resolve_sp_composite_input(value):
+    """
+    Convert a user-supplied ``sp_composite`` value into ``(state, protocol)``.
+
+    Phase 2 three-state model:
+
+    * ``INHERIT`` sentinel → ``("inherit", None)`` — user didn't set this field.
+    * ``None``             → ``("opt_out", None)`` — user wrote ``null``.
+    * str / dict / CompositeProtocol → ``("explicit", CompositeProtocol)``.
+
+    Raised exceptions propagate from :meth:`CompositeProtocol.from_user_input`.
+    """
+    if value is INHERIT:
+        return "inherit", None
+    if value is None:
+        return "opt_out", None
+    if isinstance(value, CompositeProtocol):
+        return "explicit", value
+    return "explicit", CompositeProtocol.from_user_input(value)
 
 
 class ARCSpecies(object):
@@ -347,6 +373,7 @@ class ARCSpecies(object):
                  yml_path: str | None = None,
                  keep_mol: bool = False,
                  project_directory: str | None = None,
+                 sp_composite=INHERIT,
                  ):
         self.t1 = None
         self.ts_number = ts_number
@@ -390,6 +417,7 @@ class ARCSpecies(object):
         self.label = label
         self.symmetry_number = None
         self.index = None
+        self.sp_composite_state, self.sp_composite = _resolve_sp_composite_input(sp_composite)
 
         if species_dict is not None:
             # Reading from a dictionary (it's possible that the dict contains only a 'yml_path' argument, check first)
@@ -407,6 +435,10 @@ class ARCSpecies(object):
             self.ts_conf_spawned = False
             self.ts_guesses_exhausted = False
             self.e_elect = None
+            # Provenance of e_elect. None for legacy SP; 'sp_composite' when the
+            # Scheduler's composite finalize sets the value. Read by Phase 4
+            # Arkane plumbing to decide whether to render the explicit-energy template.
+            self.e_elect_source = None
             self.e0 = None
             self.arkane_file = None
             self.conf_is_isomorphic = None
@@ -843,6 +875,13 @@ class ARCSpecies(object):
             # this marks the species to skip rotor scans (it is not an empty dict)
             # this is valuable information, store it in the restart file
             species_dict['rotors_dict'] = self.rotors_dict
+        if self.sp_composite_state == "opt_out":
+            species_dict['sp_composite'] = None
+        elif self.sp_composite_state == "explicit":
+            species_dict['sp_composite'] = self.sp_composite.as_dict()
+        # Provenance flag (Phase 3). Only emit when set; legacy output stays clean.
+        if getattr(self, "e_elect_source", None) is not None:
+            species_dict['e_elect_source'] = self.e_elect_source
         return species_dict
 
     def from_dict(self, species_dict):
@@ -857,6 +896,7 @@ class ARCSpecies(object):
         self.original_label = species_dict['original_label'] if 'original_label' in species_dict else None
         self.t1 = species_dict['t1'] if 't1' in species_dict else None
         self.e_elect = species_dict['e_elect'] if 'e_elect' in species_dict else None
+        self.e_elect_source = species_dict['e_elect_source'] if 'e_elect_source' in species_dict else None
         self.freqs = species_dict.get('freqs')
         self.e0 = species_dict['e0'] if 'e0' in species_dict else None
         self.tsg_spawned = species_dict['tsg_spawned'] if 'tsg_spawned' in species_dict else False
@@ -920,6 +960,13 @@ class ARCSpecies(object):
         self.optical_isomers = species_dict['optical_isomers'] if 'optical_isomers' in species_dict else None
         self.neg_freqs_trshed = species_dict['neg_freqs_trshed'] if 'neg_freqs_trshed' in species_dict else list()
         self.bond_corrections = species_dict['bond_corrections'] if 'bond_corrections' in species_dict else dict()
+        if 'sp_composite' not in species_dict:
+            self.sp_composite_state, self.sp_composite = "inherit", None
+        elif species_dict['sp_composite'] is None:
+            self.sp_composite_state, self.sp_composite = "opt_out", None
+        else:
+            self.sp_composite_state = "explicit"
+            self.sp_composite = CompositeProtocol.from_user_input(species_dict['sp_composite'])
         if 'mol' in species_dict:
             if isinstance(species_dict['mol'], str):
                 try:

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -13,6 +13,7 @@ from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, ch
 from arc.species.converter import check_xyz_dict
 from arc.exceptions import SpeciesError
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.molecule import Molecule
 from arc.parser.parser import parse_e_elect
 from arc.plotter import save_conformers_file
@@ -2842,6 +2843,107 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         # Test incorrect map_ length
         with self.assertRaises(SpeciesError):
             self.spc1.kabsch(self.spc1, [0, 1, 2])
+
+
+class TestARCSpeciesSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for the three-state per-species ``sp_composite`` model.
+
+    * No kwarg passed    → ``sp_composite_state == "inherit"`` (fall back to project default)
+    * ``sp_composite=None`` passed → ``sp_composite_state == "opt_out"`` (bypass project default)
+    * ``sp_composite`` is a str/dict/CompositeProtocol → ``sp_composite_state == "explicit"``
+    """
+
+    def test_inherit_is_the_default_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertEqual(spc.sp_composite_state, "inherit")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_opt_out_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        self.assertEqual(spc.sp_composite_state, "opt_out")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_explicit_state_from_preset_name(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+
+    def test_explicit_state_from_recipe_dict(self):
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        }
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=recipe)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+        self.assertEqual(spc.sp_composite.base.level.method, "hf")
+
+    def test_explicit_state_from_already_built_protocol(self):
+        proto = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=proto)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIs(spc.sp_composite, proto)
+
+    def test_as_dict_omits_key_when_inheriting(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertNotIn("sp_composite", spc.as_dict())
+
+    def test_as_dict_emits_null_when_opting_out(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsNone(d["sp_composite"])
+
+    def test_as_dict_emits_protocol_when_explicit(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsInstance(d["sp_composite"], dict)
+        self.assertIn("base", d["sp_composite"])
+        self.assertIn("corrections", d["sp_composite"])
+
+    def test_round_trip_inherit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "inherit")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_round_trip_opt_out(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "opt_out")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_e_elect_source_defaults_to_none(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertIsNone(spc.e_elect_source)
+
+    def test_e_elect_source_round_trips_when_set(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        spc.e_elect = -123.456
+        spc.e_elect_source = "sp_composite"
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertEqual(rebuilt.e_elect_source, "sp_composite")
+
+    def test_e_elect_source_round_trips_when_unset(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertIsNone(rebuilt.e_elect_source)
+
+    def test_round_trip_explicit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "explicit")
+        self.assertIsInstance(rebuilt.sp_composite, CompositeProtocol)
+        # Same structure preserved.
+        self.assertEqual(
+            [t.label for t in rebuilt.sp_composite.corrections],
+            [t.label for t in original.sp_composite.corrections],
+        )
 
 
 class TestTSGuess(unittest.TestCase):

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -13,6 +13,7 @@ from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, ch
 from arc.species.converter import check_xyz_dict
 from arc.exceptions import SpeciesError
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.molecule import Molecule
 from arc.parser.parser import parse_e_elect
 from arc.plotter import save_conformers_file
@@ -3034,6 +3035,107 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         mol1.atoms[0].radical_electrons = 0
         with self.assertRaises(SpeciesError):
             spc._assign_radicals_after_scission(mol=mol1, label='fragment_A', added_radical=added_radical)
+
+
+class TestARCSpeciesSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for the three-state per-species ``sp_composite`` model.
+
+    * No kwarg passed    → ``sp_composite_state == "inherit"`` (fall back to project default)
+    * ``sp_composite=None`` passed → ``sp_composite_state == "opt_out"`` (bypass project default)
+    * ``sp_composite`` is a str/dict/CompositeProtocol → ``sp_composite_state == "explicit"``
+    """
+
+    def test_inherit_is_the_default_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertEqual(spc.sp_composite_state, "inherit")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_opt_out_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        self.assertEqual(spc.sp_composite_state, "opt_out")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_explicit_state_from_preset_name(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+
+    def test_explicit_state_from_recipe_dict(self):
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        }
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=recipe)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+        self.assertEqual(spc.sp_composite.base.level.method, "hf")
+
+    def test_explicit_state_from_already_built_protocol(self):
+        proto = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=proto)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIs(spc.sp_composite, proto)
+
+    def test_as_dict_omits_key_when_inheriting(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertNotIn("sp_composite", spc.as_dict())
+
+    def test_as_dict_emits_null_when_opting_out(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsNone(d["sp_composite"])
+
+    def test_as_dict_emits_protocol_when_explicit(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsInstance(d["sp_composite"], dict)
+        self.assertIn("base", d["sp_composite"])
+        self.assertIn("corrections", d["sp_composite"])
+
+    def test_round_trip_inherit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "inherit")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_round_trip_opt_out(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "opt_out")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_e_elect_source_defaults_to_none(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertIsNone(spc.e_elect_source)
+
+    def test_e_elect_source_round_trips_when_set(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        spc.e_elect = -123.456
+        spc.e_elect_source = "sp_composite"
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertEqual(rebuilt.e_elect_source, "sp_composite")
+
+    def test_e_elect_source_round_trips_when_unset(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertIsNone(rebuilt.e_elect_source)
+
+    def test_round_trip_explicit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "explicit")
+        self.assertIsInstance(rebuilt.sp_composite, CompositeProtocol)
+        # Same structure preserved.
+        self.assertEqual(
+            [t.label for t in rebuilt.sp_composite.corrections],
+            [t.label for t in original.sp_composite.corrections],
+        )
 
 
 class TestTSGuess(unittest.TestCase):

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -19,6 +19,7 @@ from arc.common import (ARC_PATH,
 from arc.species.converter import check_xyz_dict
 from arc.exceptions import SpeciesError
 from arc.level import Level
+from arc.level.protocol import CompositeProtocol
 from arc.molecule.molecule import Molecule
 from arc.parser.parser import parse_e_elect
 from arc.plotter import save_conformers_file
@@ -3399,6 +3400,107 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         mol1.atoms[0].radical_electrons = 0
         with self.assertRaises(SpeciesError):
             spc._assign_radicals_after_scission(mol=mol1, label='fragment_A', added_radical=added_radical)
+
+
+class TestARCSpeciesSpComposite(unittest.TestCase):
+    """
+    Phase 2 tests for the three-state per-species ``sp_composite`` model.
+
+    * No kwarg passed    → ``sp_composite_state == "inherit"`` (fall back to project default)
+    * ``sp_composite=None`` passed → ``sp_composite_state == "opt_out"`` (bypass project default)
+    * ``sp_composite`` is a str/dict/CompositeProtocol → ``sp_composite_state == "explicit"``
+    """
+
+    def test_inherit_is_the_default_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertEqual(spc.sp_composite_state, "inherit")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_opt_out_state(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        self.assertEqual(spc.sp_composite_state, "opt_out")
+        self.assertIsNone(spc.sp_composite)
+
+    def test_explicit_state_from_preset_name(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+
+    def test_explicit_state_from_recipe_dict(self):
+        recipe = {
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        }
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=recipe)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIsInstance(spc.sp_composite, CompositeProtocol)
+        self.assertEqual(spc.sp_composite.base.level.method, "hf")
+
+    def test_explicit_state_from_already_built_protocol(self):
+        proto = CompositeProtocol.from_user_input({
+            "base": {"method": "hf", "basis": "cc-pVTZ"},
+            "corrections": [],
+        })
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=proto)
+        self.assertEqual(spc.sp_composite_state, "explicit")
+        self.assertIs(spc.sp_composite, proto)
+
+    def test_as_dict_omits_key_when_inheriting(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertNotIn("sp_composite", spc.as_dict())
+
+    def test_as_dict_emits_null_when_opting_out(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsNone(d["sp_composite"])
+
+    def test_as_dict_emits_protocol_when_explicit(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        d = spc.as_dict()
+        self.assertIn("sp_composite", d)
+        self.assertIsInstance(d["sp_composite"], dict)
+        self.assertIn("base", d["sp_composite"])
+        self.assertIn("corrections", d["sp_composite"])
+
+    def test_round_trip_inherit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "inherit")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_round_trip_opt_out(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite=None)
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "opt_out")
+        self.assertIsNone(rebuilt.sp_composite)
+
+    def test_e_elect_source_defaults_to_none(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        self.assertIsNone(spc.e_elect_source)
+
+    def test_e_elect_source_round_trips_when_set(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        spc.e_elect = -123.456
+        spc.e_elect_source = "sp_composite"
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertEqual(rebuilt.e_elect_source, "sp_composite")
+
+    def test_e_elect_source_round_trips_when_unset(self):
+        spc = ARCSpecies(label="H2", smiles="[H][H]")
+        rebuilt = ARCSpecies(species_dict=spc.as_dict())
+        self.assertIsNone(rebuilt.e_elect_source)
+
+    def test_round_trip_explicit(self):
+        original = ARCSpecies(label="H2", smiles="[H][H]", sp_composite="HEAT-345Q")
+        rebuilt = ARCSpecies(species_dict=original.as_dict())
+        self.assertEqual(rebuilt.sp_composite_state, "explicit")
+        self.assertIsInstance(rebuilt.sp_composite, CompositeProtocol)
+        # Same structure preserved.
+        self.assertEqual(
+            [t.label for t in rebuilt.sp_composite.corrections],
+            [t.label for t in original.sp_composite.corrections],
+        )
 
 
 class TestTSGuess(unittest.TestCase):

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -12,6 +12,7 @@ from mako.template import Template
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, get_logger, read_yaml_file
+from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
 from arc.imports import incore_commands, settings
 from arc.job.local import execute_command
@@ -100,7 +101,14 @@ species_input_template = """#!/usr/bin/env python
 linear = ${linear}
 spinMultiplicity = ${spin_multiplicity}
 
+%if e_elect_hartree is not None:
+# Electronic energy supplied explicitly (Hartree) from ${e_elect_source or 'explicit numeric value'}.
+# Arkane reads a bare ``energy = <float>`` as Hartree. The original ARC value was
+# ${e_elect_kJmol_display} kJ/mol (converted via E_h_kJmol).
+energy = ${e_elect_hartree}
+%else:
 energy = Log('${sp_path}')
+%endif
 geometry = Log('${freq_path}')
 frequencies = Log('${freq_path}')
 
@@ -437,6 +445,23 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             os.remove(file_path)
         rotors = [rotor for rotor in species.rotors_dict.values() if rotor['success']] if species.rotors_dict else list()
         use_rotors = not skip_rotors and bool(rotors)
+        # Composite protocols (sp_composite) bypass Arkane's file-based energy
+        # parser and inject the numeric total directly. species.e_elect is in
+        # kJ/mol per ARC convention; Arkane expects Hartree for a bare `energy`
+        # value, so convert at this boundary via E_h_kJmol.
+        e_elect_source = getattr(species, "e_elect_source", None)
+        e_elect_hartree = None
+        e_elect_kJmol_display = None
+        if e_elect_source == 'sp_composite':
+            if species.e_elect is None:
+                raise ValueError(
+                    f"Species {species.label} has e_elect_source='sp_composite' but "
+                    f"species.e_elect is None. Cannot render Arkane species file: the "
+                    f"composite protocol must complete and set e_elect before statmech "
+                    f"runs."
+                )
+            e_elect_hartree = species.e_elect / E_h_kJmol
+            e_elect_kJmol_display = f"{species.e_elect:.6f}"
         content = Template(species_input_template).render(
             linear=species.is_linear,
             spin_multiplicity=species.multiplicity,
@@ -444,6 +469,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             freq_path=self.output_dict[species.label]['paths']['freq'] or self.output_dict[species.label]['paths']['sp'],
             use_hindered_rotors=use_rotors,
             rotors=rotors,
+            e_elect_hartree=e_elect_hartree,
+            e_elect_source=e_elect_source,
+            e_elect_kJmol_display=e_elect_kJmol_display,
         )
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(content)

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -12,6 +12,7 @@ from mako.template import Template
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, get_logger, read_yaml_file
+from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
 from arc.imports import incore_commands, settings
 from arc.job.local import execute_command
@@ -101,7 +102,14 @@ species_input_template = """#!/usr/bin/env python
 linear = ${linear}
 spinMultiplicity = ${spin_multiplicity}
 
+%if e_elect_hartree is not None:
+# Electronic energy supplied explicitly (Hartree) from ${e_elect_source or 'explicit numeric value'}.
+# Arkane reads a bare ``energy = <float>`` as Hartree. The original ARC value was
+# ${e_elect_kJmol_display} kJ/mol (converted via E_h_kJmol).
+energy = ${e_elect_hartree}
+%else:
 energy = Log('${sp_path}')
+%endif
 geometry = Log('${freq_path}')
 frequencies = Log('${freq_path}')
 
@@ -438,6 +446,23 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             os.remove(file_path)
         rotors = [rotor for rotor in species.rotors_dict.values() if rotor['success']] if species.rotors_dict else list()
         use_rotors = not skip_rotors and bool(rotors)
+        # Composite protocols (sp_composite) bypass Arkane's file-based energy
+        # parser and inject the numeric total directly. species.e_elect is in
+        # kJ/mol per ARC convention; Arkane expects Hartree for a bare `energy`
+        # value, so convert at this boundary via E_h_kJmol.
+        e_elect_source = getattr(species, "e_elect_source", None)
+        e_elect_hartree = None
+        e_elect_kJmol_display = None
+        if e_elect_source == 'sp_composite':
+            if species.e_elect is None:
+                raise ValueError(
+                    f"Species {species.label} has e_elect_source='sp_composite' but "
+                    f"species.e_elect is None. Cannot render Arkane species file: the "
+                    f"composite protocol must complete and set e_elect before statmech "
+                    f"runs."
+                )
+            e_elect_hartree = species.e_elect / E_h_kJmol
+            e_elect_kJmol_display = f"{species.e_elect:.6f}"
         content = Template(species_input_template).render(
             linear=species.is_linear,
             spin_multiplicity=species.multiplicity,
@@ -445,6 +470,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             freq_path=self.output_dict[species.label]['paths']['freq'] or self.output_dict[species.label]['paths']['sp'],
             use_hindered_rotors=use_rotors,
             rotors=rotors,
+            e_elect_hartree=e_elect_hartree,
+            e_elect_source=e_elect_source,
+            e_elect_kJmol_display=e_elect_kJmol_display,
         )
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(content)

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -394,8 +394,13 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             e0_only (bool, optional): Whether to only run statmech (w/o thermo) to compute E0. Default: ``False``.
         """
         species_list = list()
+        seen_labels = set()
         for spc in self.species:
             if e0_only or spc.compute_thermo:
+                if spc.label in seen_labels:
+                    # A catalyst species may appear on both sides of a reaction; declare it only once.
+                    continue
+                seen_labels.add(spc.label)
                 species_list.append({'label': spc.label,
                                      'path': spc.yml_path or os.path.join(statmech_dir, 'species', f'{spc.label}.py'),
                                      'smiles': spc.mol.copy(deep=True).to_smiles() if not spc.is_ts else '',

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -29,6 +29,60 @@ RMG_DB_PATH = settings['RMG_DB_PATH']
 RMG_ENV_NAME = settings.get('RMG_ENV_NAME', 'rmg_env')
 logger = get_logger()
 
+# Substrings that indicate a stderr line is harmless shell-init / library
+# noise rather than a real subprocess failure. Any line containing one of
+# these substrings is dropped by ``filter_real_stderr_lines``. Add new
+# patterns here when a benign emitter trips us up.
+_STDERR_NOISE_SUBSTRINGS = (
+    # Open Babel valence warnings around InChI generation.
+    "Open Babel Warning",
+    "Accepted unusual valence",
+    "==============================",
+    # JAX / TF startup chatter on some clusters.
+    "pjrt_executable.cc",
+    # Lmod (module system) "module load X" failures from the user's shell
+    # init when the named module was renamed/removed on the cluster. These
+    # don't break the spawned subprocess — Lmod just complains and moves on.
+    "Lmod has detected",
+    "module spider",
+    "module --ignore_cache",
+    "modulefiles written in TCL",
+    "#%Module",
+    "Please check the spelling or version number",
+    "It is also possible your cache file is out-of-date",
+    "Error while loading conda entry point",
+)
+
+
+def filter_real_stderr_lines(stderr):
+    """Drop harmless shell-init / library noise from a subprocess's stderr.
+
+    Accepts either a list of lines or a single multi-line string. Empty /
+    whitespace-only lines and bare quoted module names (e.g. ``"openmpi"``
+    on a Lmod-error line) are also dropped.
+
+    Returns a list of stripped lines that survived the filter — what's left
+    is genuine error output the caller should surface.
+    """
+    if isinstance(stderr, str):
+        lines = stderr.splitlines()
+    else:
+        lines = list(stderr)
+    real = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        if any(s in line for s in _STDERR_NOISE_SUBSTRINGS):
+            continue
+        # Lmod prints the offending module name on its own line as a bare
+        # quoted token (e.g. `"openmpi"`). Drop those too.
+        if (line.startswith('"') and line.endswith('"') and len(line) <= 64
+                and ' ' not in line[1:-1]):
+            continue
+        real.append(line)
+    return real
+
 # Section boundary markers in the RMG quantum_corrections/data.py file.
 AEC_SECTION_START = "atom_energies = {"
 AEC_SECTION_END = "pbac = {"
@@ -505,8 +559,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
                     'fi"',
                     ]
         stdout, stderr = execute_command(command=commands, executable='/bin/bash')
-        if len(stderr):
-            logger.error(f'Error while running Arkane thermo script:\n{stderr}')
+        real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+        if real_stderr:
+            logger.error(f'Error while running Arkane thermo script:\n{real_stderr}')
         thermo_yaml_path = os.path.join(statmech_dir, 'thermo.yaml')
         if os.path.isfile(thermo_yaml_path):
             content = read_yaml_file(thermo_yaml_path) or {}
@@ -596,21 +651,7 @@ fi' '''
                                        no_fail=True,
                                        executable='/bin/bash')
     if std_err:
-        ignorable_phrases = [
-            "Open Babel Warning",
-            "Accepted unusual valence",
-            "==============================",
-            "pjrt_executable.cc",
-        ]
-
-        real_errors = []
-        for line in std_err:
-            line = line.strip()
-            if not line:
-                continue
-            if not any(phrase in line for phrase in ignorable_phrases):
-                real_errors.append(line)
-
+        real_errors = filter_real_stderr_lines(std_err)
         if real_errors:
             logger.info(f'Arkane run failed with errors:\n{std_err}')
             return False

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -54,33 +54,42 @@ _STDERR_NOISE_SUBSTRINGS = (
 )
 
 
-def filter_real_stderr_lines(stderr):
-    """Drop harmless shell-init / library noise from a subprocess's stderr.
-
-    Accepts either a list of lines or a single multi-line string. Empty /
-    whitespace-only lines and bare quoted module names (e.g. ``"openmpi"``
-    on a Lmod-error line) are also dropped.
-
-    Returns a list of stripped lines that survived the filter — what's left
-    is genuine error output the caller should surface.
+def filter_real_stderr_lines(stderr: str | list[str]) -> list[str]:
     """
-    if isinstance(stderr, str):
-        lines = stderr.splitlines()
-    else:
-        lines = list(stderr)
-    real = []
+    Drop harmless shell-init / library noise from a subprocess's stderr.
+
+    The substring matching is intentionally broad, so real error content can be
+    suppressed (e.g., any separator banner matches the ``=====`` entry). When
+    triaging a failure that surfaces nowhere, enable debug logging: every line
+    dropped here is logged at debug level.
+
+    Args:
+        stderr (str | list[str]): The stderr stream as a list of lines or a single multi-line string.
+                                  Empty / whitespace-only lines and bare quoted module names
+                                  (e.g., ``"openmpi"`` on a Lmod-error line) are also dropped.
+
+    Returns:
+        list[str]: Stripped lines that survived the filter — genuine error output the caller should surface.
+    """
+    lines = stderr.splitlines() if isinstance(stderr, str) else list(stderr)
+    real, dropped = [], []
     for raw in lines:
         line = raw.strip()
         if not line:
             continue
         if any(s in line for s in _STDERR_NOISE_SUBSTRINGS):
+            dropped.append(line)
             continue
         # Lmod prints the offending module name on its own line as a bare
         # quoted token (e.g. `"openmpi"`). Drop those too.
         if (line.startswith('"') and line.endswith('"') and len(line) <= 64
                 and ' ' not in line[1:-1]):
+            dropped.append(line)
             continue
         real.append(line)
+    if dropped:
+        logger.debug('filter_real_stderr_lines dropped the following stderr lines as noise:\n'
+                     + '\n'.join(dropped))
     return real
 
 # Section boundary markers in the RMG quantum_corrections/data.py file.
@@ -658,7 +667,10 @@ fi' '''
     if std_err:
         real_errors = filter_real_stderr_lines(std_err)
         if real_errors:
-            logger.info(f'Arkane run failed with errors:\n{std_err}')
+            errors = '\n'.join(real_errors)
+            raw_std_err = std_err if isinstance(std_err, str) else '\n'.join(std_err)
+            logger.info(f'Arkane run failed with errors:\n{errors}')
+            logger.debug(f'Full raw Arkane stderr:\n{raw_std_err}')
             return False
 
     output_file = os.path.join(statmech_dir, 'output.py')

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -466,7 +466,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             linear=species.is_linear,
             spin_multiplicity=species.multiplicity,
             sp_path=self.output_dict[species.label]['paths']['composite'] or self.output_dict[species.label]['paths']['sp'],
-            freq_path=self.output_dict[species.label]['paths']['freq'] or self.output_dict[species.label]['paths']['sp'],
+            freq_path=(self.output_dict[species.label]['paths']['freq']
+                       or self.output_dict[species.label]['paths']['composite']
+                       or self.output_dict[species.label]['paths']['sp']),
             use_hindered_rotors=use_rotors,
             rotors=rotors,
             e_elect_hartree=e_elect_hartree,

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -399,8 +399,13 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             e0_only (bool, optional): Whether to only run statmech (w/o thermo) to compute E0. Default: ``False``.
         """
         species_list = list()
+        seen_labels = set()
         for spc in self.species:
             if e0_only or spc.compute_thermo:
+                if spc.label in seen_labels:
+                    # A catalyst species may appear on both sides of a reaction; declare it only once.
+                    continue
+                seen_labels.add(spc.label)
                 smiles = spc.mol.copy(deep=True).to_smiles() if not spc.is_ts else ''
                 adjlist = ''
                 if smiles:

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -12,6 +12,7 @@ from mako.template import Template
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, get_logger, read_yaml_file
+from arc.constants import E_h_kJmol
 from arc.exceptions import AtomTypeError, InputError
 from arc.imports import incore_commands, settings
 from arc.molecule.molecule import Molecule
@@ -105,7 +106,14 @@ species_input_template = """#!/usr/bin/env python
 linear = ${linear}
 spinMultiplicity = ${spin_multiplicity}
 
+%if e_elect_hartree is not None:
+# Electronic energy supplied explicitly (Hartree) from ${e_elect_source or 'explicit numeric value'}.
+# Arkane reads a bare ``energy = <float>`` as Hartree. The original ARC value was
+# ${e_elect_kJmol_display} kJ/mol (converted via E_h_kJmol).
+energy = ${e_elect_hartree}
+%else:
 energy = Log('${sp_path}')
+%endif
 geometry = Log('${freq_path}')
 frequencies = Log('${freq_path}')
 
@@ -458,6 +466,23 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             os.remove(file_path)
         rotors = [rotor for rotor in species.rotors_dict.values() if rotor['success']] if species.rotors_dict else list()
         use_rotors = not skip_rotors and bool(rotors)
+        # Composite protocols (sp_composite) bypass Arkane's file-based energy
+        # parser and inject the numeric total directly. species.e_elect is in
+        # kJ/mol per ARC convention; Arkane expects Hartree for a bare `energy`
+        # value, so convert at this boundary via E_h_kJmol.
+        e_elect_source = getattr(species, "e_elect_source", None)
+        e_elect_hartree = None
+        e_elect_kJmol_display = None
+        if e_elect_source == 'sp_composite':
+            if species.e_elect is None:
+                raise ValueError(
+                    f"Species {species.label} has e_elect_source='sp_composite' but "
+                    f"species.e_elect is None. Cannot render Arkane species file: the "
+                    f"composite protocol must complete and set e_elect before statmech "
+                    f"runs."
+                )
+            e_elect_hartree = species.e_elect / E_h_kJmol
+            e_elect_kJmol_display = f"{species.e_elect:.6f}"
         content = Template(species_input_template).render(
             linear=species.is_linear,
             spin_multiplicity=species.multiplicity,
@@ -465,6 +490,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             freq_path=self.output_dict[species.label]['paths']['freq'] or self.output_dict[species.label]['paths']['sp'],
             use_hindered_rotors=use_rotors,
             rotors=rotors,
+            e_elect_hartree=e_elect_hartree,
+            e_elect_source=e_elect_source,
+            e_elect_kJmol_display=e_elect_kJmol_display,
         )
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(content)

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -30,6 +30,60 @@ if TYPE_CHECKING:
 RMG_DB_PATH = settings['RMG_DB_PATH']
 logger = get_logger()
 
+# Substrings that indicate a stderr line is harmless shell-init / library
+# noise rather than a real subprocess failure. Any line containing one of
+# these substrings is dropped by ``filter_real_stderr_lines``. Add new
+# patterns here when a benign emitter trips us up.
+_STDERR_NOISE_SUBSTRINGS = (
+    # Open Babel valence warnings around InChI generation.
+    "Open Babel Warning",
+    "Accepted unusual valence",
+    "==============================",
+    # JAX / TF startup chatter on some clusters.
+    "pjrt_executable.cc",
+    # Lmod (module system) "module load X" failures from the user's shell
+    # init when the named module was renamed/removed on the cluster. These
+    # don't break the spawned subprocess — Lmod just complains and moves on.
+    "Lmod has detected",
+    "module spider",
+    "module --ignore_cache",
+    "modulefiles written in TCL",
+    "#%Module",
+    "Please check the spelling or version number",
+    "It is also possible your cache file is out-of-date",
+    "Error while loading conda entry point",
+)
+
+
+def filter_real_stderr_lines(stderr):
+    """Drop harmless shell-init / library noise from a subprocess's stderr.
+
+    Accepts either a list of lines or a single multi-line string. Empty /
+    whitespace-only lines and bare quoted module names (e.g. ``"openmpi"``
+    on a Lmod-error line) are also dropped.
+
+    Returns a list of stripped lines that survived the filter — what's left
+    is genuine error output the caller should surface.
+    """
+    if isinstance(stderr, str):
+        lines = stderr.splitlines()
+    else:
+        lines = list(stderr)
+    real = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        if any(s in line for s in _STDERR_NOISE_SUBSTRINGS):
+            continue
+        # Lmod prints the offending module name on its own line as a bare
+        # quoted token (e.g. `"openmpi"`). Drop those too.
+        if (line.startswith('"') and line.endswith('"') and len(line) <= 64
+                and ' ' not in line[1:-1]):
+            continue
+        real.append(line)
+    return real
+
 # Section boundary markers in the RMG quantum_corrections/data.py file.
 AEC_SECTION_START = "atom_energies = {"
 AEC_SECTION_END = "pbac = {"
@@ -517,8 +571,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
                                   cwd=statmech_dir,
                                   env_vars={'RMG_DB_PATH': rmg_db_path, 'RMG_DATABASE': rmg_db_path})
         stdout, stderr = execute_command(command=command, shell=True, executable='/bin/bash')
-        if len(stderr):
-            logger.error(f'Error while running Arkane thermo script:\n{stderr}')
+        real_stderr = filter_real_stderr_lines(stderr) if stderr else []
+        if real_stderr:
+            logger.error(f'Error while running Arkane thermo script:\n{real_stderr}')
         thermo_yaml_path = os.path.join(statmech_dir, 'thermo.yaml')
         if os.path.isfile(thermo_yaml_path):
             content = read_yaml_file(thermo_yaml_path) or {}

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -487,7 +487,9 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             linear=species.is_linear,
             spin_multiplicity=species.multiplicity,
             sp_path=self.output_dict[species.label]['paths']['composite'] or self.output_dict[species.label]['paths']['sp'],
-            freq_path=self.output_dict[species.label]['paths']['freq'] or self.output_dict[species.label]['paths']['sp'],
+            freq_path=(self.output_dict[species.label]['paths']['freq']
+                       or self.output_dict[species.label]['paths']['composite']
+                       or self.output_dict[species.label]['paths']['sp']),
             use_hindered_rotors=use_rotors,
             rotors=rotors,
             e_elect_hartree=e_elect_hartree,

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -55,33 +55,42 @@ _STDERR_NOISE_SUBSTRINGS = (
 )
 
 
-def filter_real_stderr_lines(stderr):
-    """Drop harmless shell-init / library noise from a subprocess's stderr.
-
-    Accepts either a list of lines or a single multi-line string. Empty /
-    whitespace-only lines and bare quoted module names (e.g. ``"openmpi"``
-    on a Lmod-error line) are also dropped.
-
-    Returns a list of stripped lines that survived the filter — what's left
-    is genuine error output the caller should surface.
+def filter_real_stderr_lines(stderr: str | list[str]) -> list[str]:
     """
-    if isinstance(stderr, str):
-        lines = stderr.splitlines()
-    else:
-        lines = list(stderr)
-    real = []
+    Drop harmless shell-init / library noise from a subprocess's stderr.
+
+    The substring matching is intentionally broad, so real error content can be
+    suppressed (e.g., any separator banner matches the ``=====`` entry). When
+    triaging a failure that surfaces nowhere, enable debug logging: every line
+    dropped here is logged at debug level.
+
+    Args:
+        stderr (str | list[str]): The stderr stream as a list of lines or a single multi-line string.
+                                  Empty / whitespace-only lines and bare quoted module names
+                                  (e.g., ``"openmpi"`` on a Lmod-error line) are also dropped.
+
+    Returns:
+        list[str]: Stripped lines that survived the filter — genuine error output the caller should surface.
+    """
+    lines = stderr.splitlines() if isinstance(stderr, str) else list(stderr)
+    real, dropped = [], []
     for raw in lines:
         line = raw.strip()
         if not line:
             continue
         if any(s in line for s in _STDERR_NOISE_SUBSTRINGS):
+            dropped.append(line)
             continue
         # Lmod prints the offending module name on its own line as a bare
         # quoted token (e.g. `"openmpi"`). Drop those too.
         if (line.startswith('"') and line.endswith('"') and len(line) <= 64
                 and ' ' not in line[1:-1]):
+            dropped.append(line)
             continue
         real.append(line)
+    if dropped:
+        logger.debug('filter_real_stderr_lines dropped the following stderr lines as noise:\n'
+                     + '\n'.join(dropped))
     return real
 
 # Section boundary markers in the RMG quantum_corrections/data.py file.

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -6,11 +6,13 @@ This module contains unit tests for ARC's statmech.arkane module
 """
 
 import os
+import re
 import shutil
 import tempfile
 import unittest
 
 from arc.common import ARC_PATH, ARC_TESTING_PATH
+from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -679,6 +681,157 @@ class TestCheckArkaneCorrections(unittest.TestCase):
             with self.assertLogs('arc', level='INFO') as cm:
                 result = check_arkane_bacs(sp_level=level, bac_type='p')
         self.assertTrue(result)
+
+
+class TestArkaneSpCompositeRendering(unittest.TestCase):
+    """
+    Phase 4: verify the Arkane species-file rendering branch for species whose
+    ``e_elect_source == 'sp_composite'``. The composite total (kJ/mol) must be
+    converted to Hartree and written as a bare ``energy = <float>`` assignment
+    so Arkane consumes it directly (not via ``Log(...)``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="arkane_composite_")
+        cls.opt_path = os.path.join(ARC_TESTING_PATH, 'opt', 'iC3H7.out')
+        cls.freq_path = os.path.join(ARC_TESTING_PATH, 'freq', 'iC3H7.out')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def _make_adapter(self, species):
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        return ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': self.freq_path, 'sp': self.opt_path, 'opt': self.opt_path,
+                'composite': '',
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+
+    def test_composite_species_renders_explicit_numeric_energy(self):
+        """``energy = <hartree_float>``, NOT ``energy = Log('...')``."""
+        species = ARCSpecies(label='H2comp', smiles='[H][H]')
+        species.e_elect = -200512.34  # kJ/mol (arbitrary realistic value)
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        # Must NOT use Log() for energy; must contain a bare numeric assignment.
+        self.assertNotIn("energy = Log(", content)
+        expected_hartree = species.e_elect / E_h_kJmol
+        # Arkane's file-format expects Hartree. Avoid an exact-string match
+        # against ``str(expected_hartree)`` — Python's float repr and Mako's
+        # formatting can differ in trailing digits / scientific-notation choice.
+        # Extract the rendered value and compare numerically.
+        match = re.search(r"^energy = ([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)$",
+                          content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No bare numeric ``energy = …`` line:\n{content}")
+        self.assertAlmostEqual(float(match.group(1)), expected_hartree, places=9)
+        # Geometry / frequencies still use Log().
+        self.assertIn("geometry = Log(", content)
+        self.assertIn("frequencies = Log(", content)
+        # The template's provenance comment mentions sp_composite.
+        self.assertIn("sp_composite", content)
+        self.assertIn("kJ/mol", content)
+
+    def test_noncomposite_species_unchanged_energy_log_path(self):
+        """Species without sp_composite must render the legacy ``energy = Log('sp_path')``."""
+        species = ARCSpecies(label='iC3H7_legacy', smiles='C[CH]C')
+        # e_elect_source stays None; e_elect is not set/relevant to legacy rendering.
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"energy = Log('{self.opt_path}')", content)
+        self.assertNotIn("sp_composite", content)
+
+    def test_composite_species_with_missing_e_elect_raises(self):
+        """e_elect_source='sp_composite' but no e_elect → clear error, not a silently broken file."""
+        species = ARCSpecies(label='H2broken', smiles='[H][H]')
+        species.e_elect = None
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        with self.assertRaises(ValueError) as ctx:
+            adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        self.assertIn("sp_composite", str(ctx.exception))
+        self.assertIn("e_elect is None", str(ctx.exception))
+
+    def test_composite_rendered_energy_equals_kJmol_over_E_h_kJmol(self):
+        """Round-trip: hartree written = (kJ/mol stored) / E_h_kJmol, to within fp precision."""
+        species = ARCSpecies(label='H2precise', smiles='[H][H]')
+        species.e_elect = -123456.789012
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        match = re.search(r"^energy = (-?\d+\.\d+(?:e[+-]?\d+)?)$", content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No ``energy = <float>`` line in:\n{content}")
+        rendered = float(match.group(1))
+        self.assertAlmostEqual(rendered, species.e_elect / E_h_kJmol, places=9)
+
+
+class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
+    """
+    Phase 5: lock the invariant that ``set_reaction_dh_rxn`` consumes
+    ``spc.e_elect`` in kJ/mol after an sp_composite finalization. The Hartree
+    conversion happens *only* at the Arkane species-file rendering boundary
+    (``generate_species_file``); everywhere else — including reaction ΔH and
+    reaction energetics — ``spc.e_elect`` stays in kJ/mol.
+    """
+
+    def test_dh_rxn_uses_kJmol_e_elect_for_composite_species(self):
+        tmpdir = tempfile.mkdtemp(prefix="arkane_dhrxn_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        # Two composite-finalized "species" standing in as reactant + product.
+        reactant = ARCSpecies(label='R', smiles='[H][H]')
+        reactant.e_elect = -200000.0            # kJ/mol
+        reactant.e_elect_source = 'sp_composite'
+        reactant.thermo = None                  # force the e_elect branch
+        product = ARCSpecies(label='P', smiles='[H][H]')
+        product.e_elect = -200100.0             # kJ/mol
+        product.e_elect_source = 'sp_composite'
+        product.thermo = None
+        rxn = ARCReaction(r_species=[reactant], p_species=[product])
+        rxn.thermo = None
+        adapter = ArkaneAdapter(
+            output_directory=tmpdir,
+            calcs_directory=tmpdir,
+            output_dict={},
+            bac_type=None,
+            species=[reactant, product],
+            reactions=[rxn],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        adapter.set_reaction_dh_rxn(estimate_dh_rxn=True)
+        # dh_rxn298 = (product.e_elect - reactant.e_elect) * 1e3 (J/mol conversion).
+        expected_J = (product.e_elect - reactant.e_elect) * 1e3
+        self.assertAlmostEqual(rxn.dh_rxn298, expected_J, places=6)
+        # Sanity: the raw kJ/mol difference is -100; dh_rxn298 should be -1e5 J/mol.
+        self.assertAlmostEqual(rxn.dh_rxn298, -1e5, places=6)
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -6,11 +6,13 @@ This module contains unit tests for ARC's statmech.arkane module
 """
 
 import os
+import re
 import shutil
 import tempfile
 import unittest
 
 from arc.common import ARC_PATH, ARC_TESTING_PATH
+from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -678,6 +680,157 @@ class TestCheckArkaneCorrections(unittest.TestCase):
             with self.assertLogs('arc', level='INFO') as cm:
                 result = check_arkane_bacs(sp_level=level, bac_type='p')
         self.assertTrue(result)
+
+
+class TestArkaneSpCompositeRendering(unittest.TestCase):
+    """
+    Phase 4: verify the Arkane species-file rendering branch for species whose
+    ``e_elect_source == 'sp_composite'``. The composite total (kJ/mol) must be
+    converted to Hartree and written as a bare ``energy = <float>`` assignment
+    so Arkane consumes it directly (not via ``Log(...)``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="arkane_composite_")
+        cls.opt_path = os.path.join(ARC_TESTING_PATH, 'opt', 'iC3H7.out')
+        cls.freq_path = os.path.join(ARC_TESTING_PATH, 'freq', 'iC3H7.out')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def _make_adapter(self, species):
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        return ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': self.freq_path, 'sp': self.opt_path, 'opt': self.opt_path,
+                'composite': '',
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+
+    def test_composite_species_renders_explicit_numeric_energy(self):
+        """``energy = <hartree_float>``, NOT ``energy = Log('...')``."""
+        species = ARCSpecies(label='H2comp', smiles='[H][H]')
+        species.e_elect = -200512.34  # kJ/mol (arbitrary realistic value)
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        # Must NOT use Log() for energy; must contain a bare numeric assignment.
+        self.assertNotIn("energy = Log(", content)
+        expected_hartree = species.e_elect / E_h_kJmol
+        # Arkane's file-format expects Hartree. Avoid an exact-string match
+        # against ``str(expected_hartree)`` — Python's float repr and Mako's
+        # formatting can differ in trailing digits / scientific-notation choice.
+        # Extract the rendered value and compare numerically.
+        match = re.search(r"^energy = ([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)$",
+                          content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No bare numeric ``energy = …`` line:\n{content}")
+        self.assertAlmostEqual(float(match.group(1)), expected_hartree, places=9)
+        # Geometry / frequencies still use Log().
+        self.assertIn("geometry = Log(", content)
+        self.assertIn("frequencies = Log(", content)
+        # The template's provenance comment mentions sp_composite.
+        self.assertIn("sp_composite", content)
+        self.assertIn("kJ/mol", content)
+
+    def test_noncomposite_species_unchanged_energy_log_path(self):
+        """Species without sp_composite must render the legacy ``energy = Log('sp_path')``."""
+        species = ARCSpecies(label='iC3H7_legacy', smiles='C[CH]C')
+        # e_elect_source stays None; e_elect is not set/relevant to legacy rendering.
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"energy = Log('{self.opt_path}')", content)
+        self.assertNotIn("sp_composite", content)
+
+    def test_composite_species_with_missing_e_elect_raises(self):
+        """e_elect_source='sp_composite' but no e_elect → clear error, not a silently broken file."""
+        species = ARCSpecies(label='H2broken', smiles='[H][H]')
+        species.e_elect = None
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        with self.assertRaises(ValueError) as ctx:
+            adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        self.assertIn("sp_composite", str(ctx.exception))
+        self.assertIn("e_elect is None", str(ctx.exception))
+
+    def test_composite_rendered_energy_equals_kJmol_over_E_h_kJmol(self):
+        """Round-trip: hartree written = (kJ/mol stored) / E_h_kJmol, to within fp precision."""
+        species = ARCSpecies(label='H2precise', smiles='[H][H]')
+        species.e_elect = -123456.789012
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        match = re.search(r"^energy = (-?\d+\.\d+(?:e[+-]?\d+)?)$", content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No ``energy = <float>`` line in:\n{content}")
+        rendered = float(match.group(1))
+        self.assertAlmostEqual(rendered, species.e_elect / E_h_kJmol, places=9)
+
+
+class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
+    """
+    Phase 5: lock the invariant that ``set_reaction_dh_rxn`` consumes
+    ``spc.e_elect`` in kJ/mol after an sp_composite finalization. The Hartree
+    conversion happens *only* at the Arkane species-file rendering boundary
+    (``generate_species_file``); everywhere else — including reaction ΔH and
+    reaction energetics — ``spc.e_elect`` stays in kJ/mol.
+    """
+
+    def test_dh_rxn_uses_kJmol_e_elect_for_composite_species(self):
+        tmpdir = tempfile.mkdtemp(prefix="arkane_dhrxn_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        # Two composite-finalized "species" standing in as reactant + product.
+        reactant = ARCSpecies(label='R', smiles='[H][H]')
+        reactant.e_elect = -200000.0            # kJ/mol
+        reactant.e_elect_source = 'sp_composite'
+        reactant.thermo = None                  # force the e_elect branch
+        product = ARCSpecies(label='P', smiles='[H][H]')
+        product.e_elect = -200100.0             # kJ/mol
+        product.e_elect_source = 'sp_composite'
+        product.thermo = None
+        rxn = ARCReaction(r_species=[reactant], p_species=[product])
+        rxn.thermo = None
+        adapter = ArkaneAdapter(
+            output_directory=tmpdir,
+            calcs_directory=tmpdir,
+            output_dict={},
+            bac_type=None,
+            species=[reactant, product],
+            reactions=[rxn],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        adapter.set_reaction_dh_rxn(estimate_dh_rxn=True)
+        # dh_rxn298 = (product.e_elect - reactant.e_elect) * 1e3 (J/mol conversion).
+        expected_J = (product.e_elect - reactant.e_elect) * 1e3
+        self.assertAlmostEqual(rxn.dh_rxn298, expected_J, places=6)
+        # Sanity: the raw kJ/mol difference is -100; dh_rxn298 should be -1e5 J/mol.
+        self.assertAlmostEqual(rxn.dh_rxn298, -1e5, places=6)
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -5,12 +5,14 @@
 This module contains unit tests for ARC's statmech.arkane module
 """
 
+import logging
 import os
 import re
 import shutil
 import tempfile
 import unittest
 
+import arc.parser.parser as parser
 from arc.common import ARC_PATH, ARC_TESTING_PATH
 from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
@@ -35,6 +37,7 @@ from arc.statmech.arkane import (
     check_arkane_bacs,
     filter_real_stderr_lines,
     get_arkane_model_chemistry,
+    run_arkane,
 )
 from unittest.mock import patch
 
@@ -827,6 +830,63 @@ class TestArkaneSpCompositeRendering(unittest.TestCase):
         rendered = float(match.group(1))
         self.assertAlmostEqual(rendered, species.e_elect / E_h_kJmol, places=9)
 
+    def test_composite_energy_precedence_over_base_sp_log(self):
+        """With paths['sp'] populated by the composite base log (scheduler invariant),
+        the rendered energy must be the explicit composite total — not a value
+        re-parsed from the base log."""
+        species = ARCSpecies(label='iC3H7prec', smiles='C[CH]C')
+        species.e_elect = -310000.0  # kJ/mol; deliberately differs from the base log
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)  # paths['sp'] = a real, parseable log
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertNotIn("energy = Log(", content)
+        match = re.search(r"^energy = ([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)$",
+                          content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No bare numeric ``energy = …`` line:\n{content}")
+        rendered_kJmol = float(match.group(1)) * E_h_kJmol
+        self.assertAlmostEqual(rendered_kJmol, species.e_elect, places=6)
+        base_log_e_elect = parser.parse_e_elect(self.opt_path)  # kJ/mol
+        self.assertNotAlmostEqual(rendered_kJmol, base_log_e_elect, places=1)
+
+    def test_monoatomic_composite_falls_back_to_base_sp_log(self):
+        """A monoatomic composite species (no freq job, no legacy composite job):
+        geometry/frequencies must fall back to paths['sp'] — the composite base
+        log set by the scheduler — and never render Log('')."""
+        base_path = os.path.join(self.tmpdir, "Hmono_base_sp.out")
+        with open(base_path, 'w') as f:
+            f.write("placeholder")
+        species = ARCSpecies(label='Hmono', smiles='[H]')
+        species.e_elect = -1312.753
+        species.e_elect_source = 'sp_composite'
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        adapter = ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': '', 'sp': base_path, 'opt': '', 'composite': '',
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"geometry = Log('{base_path}')", content)
+        self.assertIn(f"frequencies = Log('{base_path}')", content)
+        self.assertNotIn("Log('')", content)
+
 
 class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
     """
@@ -971,6 +1031,63 @@ class TestFilterRealStderrLines(unittest.TestCase):
             'Genuine error: foo\n'
         )
         self.assertEqual(filter_real_stderr_lines(s), ["Genuine error: foo"])
+
+    def test_dropped_lines_are_logged_at_debug(self):
+        """Every line eaten by the filter must be recoverable from the debug log."""
+        lines = [
+            'Lmod has detected the following error: blah',
+            '"openmpi"',
+            'RuntimeError: real failure',
+        ]
+        with self.assertLogs('arc', level='DEBUG') as cm:
+            result = filter_real_stderr_lines(lines)
+        self.assertEqual(result, ['RuntimeError: real failure'])
+        # Filter by levelno: arc.common.initialize_log renames level names via
+        # logging.addLevelName, so levelname is '' once any ARC project ran.
+        debug_msgs = [r.getMessage() for r in cm.records if r.levelno == logging.DEBUG]
+        self.assertTrue(any('Lmod has detected the following error: blah' in msg
+                            and '"openmpi"' in msg for msg in debug_msgs))
+
+    def test_no_debug_log_when_nothing_dropped(self):
+        """The filter stays silent when no lines are dropped."""
+        with self.assertNoLogs('arc', level='DEBUG'):
+            result = filter_real_stderr_lines(['RuntimeError: real failure'])
+        self.assertEqual(result, ['RuntimeError: real failure'])
+
+
+class TestRunArkaneStderrLogging(unittest.TestCase):
+    """``run_arkane`` must log only the filtered (real) stderr lines at info
+    level, while keeping the full raw stderr recoverable at debug level."""
+
+    def setUp(self):
+        self.statmech_dir = tempfile.mkdtemp(prefix='arkane_run_')
+        with open(os.path.join(self.statmech_dir, 'input.py'), 'w') as f:
+            f.write('# dummy Arkane input\n')
+
+    def tearDown(self):
+        shutil.rmtree(self.statmech_dir, ignore_errors=True)
+
+    def test_info_logs_filtered_errors_and_debug_logs_raw_stderr(self):
+        """The info message must exclude noise; the raw stderr (noise included)
+        must appear in a debug message alongside the real error."""
+        std_err = [
+            'Lmod has detected the following error: The following module(s) are unknown:',
+            '"openmpi"',
+            'RuntimeError: Arkane exploded',
+        ]
+        with patch('arc.statmech.arkane.execute_command', return_value=([], std_err)):
+            with self.assertLogs('arc', level='DEBUG') as cm:
+                result = run_arkane(self.statmech_dir)
+        self.assertFalse(result)
+        info_msgs = [r.getMessage() for r in cm.records if r.levelno == logging.INFO]
+        failure_msgs = [msg for msg in info_msgs if 'Arkane run failed' in msg]
+        self.assertEqual(len(failure_msgs), 1)
+        self.assertIn('RuntimeError: Arkane exploded', failure_msgs[0])
+        self.assertNotIn('Lmod', failure_msgs[0])
+        self.assertNotIn('openmpi', failure_msgs[0])
+        debug_msgs = [r.getMessage() for r in cm.records if r.levelno == logging.DEBUG]
+        self.assertTrue(any('Lmod has detected' in msg and 'RuntimeError: Arkane exploded' in msg
+                            for msg in debug_msgs))
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -775,6 +775,41 @@ class TestArkaneSpCompositeRendering(unittest.TestCase):
         self.assertIn("sp_composite", str(ctx.exception))
         self.assertIn("e_elect is None", str(ctx.exception))
 
+    def test_composite_atom_geometry_falls_back_to_composite_path(self):
+        """Atoms under sp_composite have no freq job; geometry/frequencies Log() must
+        fall back to paths['composite'], not render Log('')."""
+        composite_path = os.path.join(self.tmpdir, "H_base_sp.out")
+        # The file does not need to be parseable here; the test checks rendering only.
+        with open(composite_path, 'w') as f:
+            f.write("placeholder")
+        species = ARCSpecies(label='Hatom', smiles='[H]')
+        species.e_elect = -1312.753
+        species.e_elect_source = 'sp_composite'
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        adapter = ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': '', 'sp': '', 'opt': '', 'composite': composite_path,
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"geometry = Log('{composite_path}')", content)
+        self.assertIn(f"frequencies = Log('{composite_path}')", content)
+        self.assertNotIn("Log('')", content)
+
     def test_composite_rendered_energy_equals_kJmol_over_E_h_kJmol(self):
         """Round-trip: hartree written = (kJ/mol stored) / E_h_kJmol, to within fp precision."""
         species = ARCSpecies(label='H2precise', smiles='[H][H]')

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -33,6 +33,7 @@ from arc.statmech.arkane import (
     _warn_no_match,
     check_arkane_aec,
     check_arkane_bacs,
+    filter_real_stderr_lines,
     get_arkane_model_chemistry,
 )
 from unittest.mock import patch
@@ -867,6 +868,109 @@ class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
         self.assertAlmostEqual(rxn.dh_rxn298, expected_J, places=6)
         # Sanity: the raw kJ/mol difference is -100; dh_rxn298 should be -1e5 J/mol.
         self.assertAlmostEqual(rxn.dh_rxn298, -1e5, places=6)
+
+
+class TestFilterRealStderrLines(unittest.TestCase):
+    """``filter_real_stderr_lines`` strips harmless shell-init / library noise
+    from a subprocess's stderr so ARC doesn't classify a successful Arkane run
+    as a failure."""
+
+    def test_open_babel_unusual_valence_warning_is_noise(self):
+        """Existing carve-out: Open Babel's InChI-code warnings are harmless."""
+        lines = [
+            "==============================",
+            "*** Open Babel Warning  in InChI code",
+            "  #1 :Accepted unusual valence(s): C(2)",
+            "==============================",
+        ]
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_lmod_unknown_module_warning_is_noise(self):
+        """Regression: a stale ``module load openmpi`` in shell init prints a
+        Lmod block to stderr. ARC was treating it as a fatal Arkane failure
+        even though Arkane completed successfully."""
+        lines = [
+            'Lmod has detected the following error: The following module(s) are unknown:',
+            '"openmpi"',
+            '',
+            'Please check the spelling or version number. Also try "module spider ..."',
+            'It is also possible your cache file is out-of-date; it may help to try:',
+            '  $ module --ignore_cache load "openmpi"',
+            '',
+            'Also make sure that all modulefiles written in TCL start with the string',
+            '#%Module',
+        ]
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_conda_libmamba_solver_load_failure_is_noise(self):
+        """A broken `_sqlite3` in the base conda (missing `sqlite3_deserialize`)
+        causes conda-libmamba-solver to fail loading and emit a stderr line on
+        every `conda run` invocation. The subprocess itself succeeds — conda
+        falls back to the classic solver — so this line is benign noise."""
+        lines = [
+            ('Error while loading conda entry point: conda-libmamba-solver '
+             '(/home/alon/miniconda3/lib/python3.11/lib-dynload/'
+             '_sqlite3.cpython-311-x86_64-linux-gnu.so: undefined symbol: '
+             'sqlite3_deserialize)'),
+        ] * 4
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_conda_entry_point_noise_does_not_mask_real_error(self):
+        """Conda-entry-point noise is filtered, but a real traceback emitted by
+        the same script must still survive."""
+        lines = [
+            'Error while loading conda entry point: conda-libmamba-solver (...)',
+            'Traceback (most recent call last):',
+            'RuntimeError: thermo failed',
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertEqual(
+            result,
+            ['Traceback (most recent call last):', 'RuntimeError: thermo failed'],
+        )
+
+    def test_real_error_is_preserved(self):
+        """A genuine traceback line passes through."""
+        lines = [
+            "==============================",
+            "*** Open Babel Warning",
+            "Traceback (most recent call last):",
+            '  File "arkane/main.py", line 123, in run',
+            "RuntimeError: Could not parse output",
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertIn("Traceback (most recent call last):", result)
+        self.assertIn("RuntimeError: Could not parse output", result)
+        self.assertNotIn("==============================", result)
+
+    def test_mixed_lmod_and_real_error_keeps_only_real(self):
+        """When Lmod noise and a real error coexist, only the real error
+        survives. (The user's H/H2/OH composite SP failures should still
+        surface even if the shell init is noisy.)"""
+        lines = [
+            'Lmod has detected the following error: ...',
+            '"openmpi"',
+            '#%Module',
+            "AttributeError: 'NoneType' object has no attribute 'thermo'",
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertEqual(
+            result,
+            ["AttributeError: 'NoneType' object has no attribute 'thermo'"],
+        )
+
+    def test_empty_and_whitespace_only_lines_dropped(self):
+        self.assertEqual(filter_real_stderr_lines(["", "   ", "\t"]), [])
+
+    def test_accepts_string_as_well_as_list(self):
+        """Some call sites pass a multiline string; the helper splits it."""
+        s = (
+            'Lmod has detected the following error: blah\n'
+            '"openmpi"\n'
+            '\n'
+            'Genuine error: foo\n'
+        )
+        self.assertEqual(filter_real_stderr_lines(s), ["Genuine error: foo"])
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -5,12 +5,14 @@
 This module contains unit tests for ARC's statmech.arkane module
 """
 
+import logging
 import os
 import re
 import shutil
 import tempfile
 import unittest
 
+import arc.parser.parser as parser
 from arc.common import ARC_PATH, ARC_TESTING_PATH
 from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
@@ -35,6 +37,7 @@ from arc.statmech.arkane import (
     check_arkane_bacs,
     filter_real_stderr_lines,
     get_arkane_model_chemistry,
+    run_arkane,
 )
 from unittest.mock import patch
 
@@ -994,6 +997,63 @@ class TestArkaneSpCompositeRendering(unittest.TestCase):
         rendered = float(match.group(1))
         self.assertAlmostEqual(rendered, species.e_elect / E_h_kJmol, places=9)
 
+    def test_composite_energy_precedence_over_base_sp_log(self):
+        """With paths['sp'] populated by the composite base log (scheduler invariant),
+        the rendered energy must be the explicit composite total — not a value
+        re-parsed from the base log."""
+        species = ARCSpecies(label='iC3H7prec', smiles='C[CH]C')
+        species.e_elect = -310000.0  # kJ/mol; deliberately differs from the base log
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)  # paths['sp'] = a real, parseable log
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertNotIn("energy = Log(", content)
+        match = re.search(r"^energy = ([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)$",
+                          content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No bare numeric ``energy = …`` line:\n{content}")
+        rendered_kJmol = float(match.group(1)) * E_h_kJmol
+        self.assertAlmostEqual(rendered_kJmol, species.e_elect, places=6)
+        base_log_e_elect = parser.parse_e_elect(self.opt_path)  # kJ/mol
+        self.assertNotAlmostEqual(rendered_kJmol, base_log_e_elect, places=1)
+
+    def test_monoatomic_composite_falls_back_to_base_sp_log(self):
+        """A monoatomic composite species (no freq job, no legacy composite job):
+        geometry/frequencies must fall back to paths['sp'] — the composite base
+        log set by the scheduler — and never render Log('')."""
+        base_path = os.path.join(self.tmpdir, "Hmono_base_sp.out")
+        with open(base_path, 'w') as f:
+            f.write("placeholder")
+        species = ARCSpecies(label='Hmono', smiles='[H]')
+        species.e_elect = -1312.753
+        species.e_elect_source = 'sp_composite'
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        adapter = ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': '', 'sp': base_path, 'opt': '', 'composite': '',
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"geometry = Log('{base_path}')", content)
+        self.assertIn(f"frequencies = Log('{base_path}')", content)
+        self.assertNotIn("Log('')", content)
+
 
 class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
     """
@@ -1138,6 +1198,28 @@ class TestFilterRealStderrLines(unittest.TestCase):
             'Genuine error: foo\n'
         )
         self.assertEqual(filter_real_stderr_lines(s), ["Genuine error: foo"])
+
+    def test_dropped_lines_are_logged_at_debug(self):
+        """Every line eaten by the filter must be recoverable from the debug log."""
+        lines = [
+            'Lmod has detected the following error: blah',
+            '"openmpi"',
+            'RuntimeError: real failure',
+        ]
+        with self.assertLogs('arc', level='DEBUG') as cm:
+            result = filter_real_stderr_lines(lines)
+        self.assertEqual(result, ['RuntimeError: real failure'])
+        # Filter by levelno: arc.common.initialize_log renames level names via
+        # logging.addLevelName, so levelname is '' once any ARC project ran.
+        debug_msgs = [r.getMessage() for r in cm.records if r.levelno == logging.DEBUG]
+        self.assertTrue(any('Lmod has detected the following error: blah' in msg
+                            and '"openmpi"' in msg for msg in debug_msgs))
+
+    def test_no_debug_log_when_nothing_dropped(self):
+        """The filter stays silent when no lines are dropped."""
+        with self.assertNoLogs('arc', level='DEBUG'):
+            result = filter_real_stderr_lines(['RuntimeError: real failure'])
+        self.assertEqual(result, ['RuntimeError: real failure'])
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -942,6 +942,41 @@ class TestArkaneSpCompositeRendering(unittest.TestCase):
         self.assertIn("sp_composite", str(ctx.exception))
         self.assertIn("e_elect is None", str(ctx.exception))
 
+    def test_composite_atom_geometry_falls_back_to_composite_path(self):
+        """Atoms under sp_composite have no freq job; geometry/frequencies Log() must
+        fall back to paths['composite'], not render Log('')."""
+        composite_path = os.path.join(self.tmpdir, "H_base_sp.out")
+        # The file does not need to be parseable here; the test checks rendering only.
+        with open(composite_path, 'w') as f:
+            f.write("placeholder")
+        species = ARCSpecies(label='Hatom', smiles='[H]')
+        species.e_elect = -1312.753
+        species.e_elect_source = 'sp_composite'
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        adapter = ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': '', 'sp': '', 'opt': '', 'composite': composite_path,
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"geometry = Log('{composite_path}')", content)
+        self.assertIn(f"frequencies = Log('{composite_path}')", content)
+        self.assertNotIn("Log('')", content)
+
     def test_composite_rendered_energy_equals_kJmol_over_E_h_kJmol(self):
         """Round-trip: hartree written = (kJ/mol stored) / E_h_kJmol, to within fp precision."""
         species = ARCSpecies(label='H2precise', smiles='[H][H]')

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -6,11 +6,13 @@ This module contains unit tests for ARC's statmech.arkane module
 """
 
 import os
+import re
 import shutil
 import tempfile
 import unittest
 
 from arc.common import ARC_PATH, ARC_TESTING_PATH
+from arc.constants import E_h_kJmol
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -846,6 +848,157 @@ class TestSummarizeArkaneStderr(unittest.TestCase):
 
     def test_single_line_no_extra_suffix(self):
         self.assertEqual(self._summarize(['RuntimeError: boom']), 'RuntimeError: boom')
+
+
+class TestArkaneSpCompositeRendering(unittest.TestCase):
+    """
+    Phase 4: verify the Arkane species-file rendering branch for species whose
+    ``e_elect_source == 'sp_composite'``. The composite total (kJ/mol) must be
+    converted to Hartree and written as a bare ``energy = <float>`` assignment
+    so Arkane consumes it directly (not via ``Log(...)``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="arkane_composite_")
+        cls.opt_path = os.path.join(ARC_TESTING_PATH, 'opt', 'iC3H7.out')
+        cls.freq_path = os.path.join(ARC_TESTING_PATH, 'freq', 'iC3H7.out')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def _make_adapter(self, species):
+        output_dir = os.path.join(self.tmpdir, "output", species.label)
+        calcs_dir = os.path.join(self.tmpdir, "calcs", species.label)
+        for d in (output_dir, calcs_dir):
+            os.makedirs(d, exist_ok=True)
+        return ArkaneAdapter(
+            output_directory=output_dir,
+            calcs_directory=calcs_dir,
+            output_dict={species.label: {'paths': {
+                'freq': self.freq_path, 'sp': self.opt_path, 'opt': self.opt_path,
+                'composite': '',
+            }}},
+            bac_type=None,
+            species=[species],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+
+    def test_composite_species_renders_explicit_numeric_energy(self):
+        """``energy = <hartree_float>``, NOT ``energy = Log('...')``."""
+        species = ARCSpecies(label='H2comp', smiles='[H][H]')
+        species.e_elect = -200512.34  # kJ/mol (arbitrary realistic value)
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        # Must NOT use Log() for energy; must contain a bare numeric assignment.
+        self.assertNotIn("energy = Log(", content)
+        expected_hartree = species.e_elect / E_h_kJmol
+        # Arkane's file-format expects Hartree. Avoid an exact-string match
+        # against ``str(expected_hartree)`` — Python's float repr and Mako's
+        # formatting can differ in trailing digits / scientific-notation choice.
+        # Extract the rendered value and compare numerically.
+        match = re.search(r"^energy = ([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)$",
+                          content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No bare numeric ``energy = …`` line:\n{content}")
+        self.assertAlmostEqual(float(match.group(1)), expected_hartree, places=9)
+        # Geometry / frequencies still use Log().
+        self.assertIn("geometry = Log(", content)
+        self.assertIn("frequencies = Log(", content)
+        # The template's provenance comment mentions sp_composite.
+        self.assertIn("sp_composite", content)
+        self.assertIn("kJ/mol", content)
+
+    def test_noncomposite_species_unchanged_energy_log_path(self):
+        """Species without sp_composite must render the legacy ``energy = Log('sp_path')``."""
+        species = ARCSpecies(label='iC3H7_legacy', smiles='C[CH]C')
+        # e_elect_source stays None; e_elect is not set/relevant to legacy rendering.
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        self.assertIn(f"energy = Log('{self.opt_path}')", content)
+        self.assertNotIn("sp_composite", content)
+
+    def test_composite_species_with_missing_e_elect_raises(self):
+        """e_elect_source='sp_composite' but no e_elect → clear error, not a silently broken file."""
+        species = ARCSpecies(label='H2broken', smiles='[H][H]')
+        species.e_elect = None
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        with self.assertRaises(ValueError) as ctx:
+            adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        self.assertIn("sp_composite", str(ctx.exception))
+        self.assertIn("e_elect is None", str(ctx.exception))
+
+    def test_composite_rendered_energy_equals_kJmol_over_E_h_kJmol(self):
+        """Round-trip: hartree written = (kJ/mol stored) / E_h_kJmol, to within fp precision."""
+        species = ARCSpecies(label='H2precise', smiles='[H][H]')
+        species.e_elect = -123456.789012
+        species.e_elect_source = 'sp_composite'
+        adapter = self._make_adapter(species)
+        species_dir = os.path.join(self.tmpdir, "species_" + species.label)
+        os.makedirs(species_dir, exist_ok=True)
+        adapter.generate_species_file(species, species_dir, skip_rotors=True)
+        with open(species.arkane_file) as fh:
+            content = fh.read()
+        match = re.search(r"^energy = (-?\d+\.\d+(?:e[+-]?\d+)?)$", content, re.MULTILINE)
+        self.assertIsNotNone(match, f"No ``energy = <float>`` line in:\n{content}")
+        rendered = float(match.group(1))
+        self.assertAlmostEqual(rendered, species.e_elect / E_h_kJmol, places=9)
+
+
+class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
+    """
+    Phase 5: lock the invariant that ``set_reaction_dh_rxn`` consumes
+    ``spc.e_elect`` in kJ/mol after an sp_composite finalization. The Hartree
+    conversion happens *only* at the Arkane species-file rendering boundary
+    (``generate_species_file``); everywhere else — including reaction ΔH and
+    reaction energetics — ``spc.e_elect`` stays in kJ/mol.
+    """
+
+    def test_dh_rxn_uses_kJmol_e_elect_for_composite_species(self):
+        tmpdir = tempfile.mkdtemp(prefix="arkane_dhrxn_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        # Two composite-finalized "species" standing in as reactant + product.
+        reactant = ARCSpecies(label='R', smiles='[H][H]')
+        reactant.e_elect = -200000.0            # kJ/mol
+        reactant.e_elect_source = 'sp_composite'
+        reactant.thermo = None                  # force the e_elect branch
+        product = ARCSpecies(label='P', smiles='[H][H]')
+        product.e_elect = -200100.0             # kJ/mol
+        product.e_elect_source = 'sp_composite'
+        product.thermo = None
+        rxn = ARCReaction(r_species=[reactant], p_species=[product])
+        rxn.thermo = None
+        adapter = ArkaneAdapter(
+            output_directory=tmpdir,
+            calcs_directory=tmpdir,
+            output_dict={},
+            bac_type=None,
+            species=[reactant, product],
+            reactions=[rxn],
+            sp_level=Level('gfn2'),
+            freq_level=Level('gfn2'),
+            freq_scale_factor=1.0,
+        )
+        adapter.set_reaction_dh_rxn(estimate_dh_rxn=True)
+        # dh_rxn298 = (product.e_elect - reactant.e_elect) * 1e3 (J/mol conversion).
+        expected_J = (product.e_elect - reactant.e_elect) * 1e3
+        self.assertAlmostEqual(rxn.dh_rxn298, expected_J, places=6)
+        # Sanity: the raw kJ/mol difference is -100; dh_rxn298 should be -1e5 J/mol.
+        self.assertAlmostEqual(rxn.dh_rxn298, -1e5, places=6)
 
 
 if __name__ == '__main__':

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -33,6 +33,7 @@ from arc.statmech.arkane import (
     _warn_no_match,
     check_arkane_aec,
     check_arkane_bacs,
+    filter_real_stderr_lines,
     get_arkane_model_chemistry,
 )
 from unittest.mock import patch
@@ -1034,6 +1035,109 @@ class TestReactionDhRxnConsumesKJmol(unittest.TestCase):
         self.assertAlmostEqual(rxn.dh_rxn298, expected_J, places=6)
         # Sanity: the raw kJ/mol difference is -100; dh_rxn298 should be -1e5 J/mol.
         self.assertAlmostEqual(rxn.dh_rxn298, -1e5, places=6)
+
+
+class TestFilterRealStderrLines(unittest.TestCase):
+    """``filter_real_stderr_lines`` strips harmless shell-init / library noise
+    from a subprocess's stderr so ARC doesn't classify a successful Arkane run
+    as a failure."""
+
+    def test_open_babel_unusual_valence_warning_is_noise(self):
+        """Existing carve-out: Open Babel's InChI-code warnings are harmless."""
+        lines = [
+            "==============================",
+            "*** Open Babel Warning  in InChI code",
+            "  #1 :Accepted unusual valence(s): C(2)",
+            "==============================",
+        ]
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_lmod_unknown_module_warning_is_noise(self):
+        """Regression: a stale ``module load openmpi`` in shell init prints a
+        Lmod block to stderr. ARC was treating it as a fatal Arkane failure
+        even though Arkane completed successfully."""
+        lines = [
+            'Lmod has detected the following error: The following module(s) are unknown:',
+            '"openmpi"',
+            '',
+            'Please check the spelling or version number. Also try "module spider ..."',
+            'It is also possible your cache file is out-of-date; it may help to try:',
+            '  $ module --ignore_cache load "openmpi"',
+            '',
+            'Also make sure that all modulefiles written in TCL start with the string',
+            '#%Module',
+        ]
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_conda_libmamba_solver_load_failure_is_noise(self):
+        """A broken `_sqlite3` in the base conda (missing `sqlite3_deserialize`)
+        causes conda-libmamba-solver to fail loading and emit a stderr line on
+        every `conda run` invocation. The subprocess itself succeeds — conda
+        falls back to the classic solver — so this line is benign noise."""
+        lines = [
+            ('Error while loading conda entry point: conda-libmamba-solver '
+             '(/home/alon/miniconda3/lib/python3.11/lib-dynload/'
+             '_sqlite3.cpython-311-x86_64-linux-gnu.so: undefined symbol: '
+             'sqlite3_deserialize)'),
+        ] * 4
+        self.assertEqual(filter_real_stderr_lines(lines), [])
+
+    def test_conda_entry_point_noise_does_not_mask_real_error(self):
+        """Conda-entry-point noise is filtered, but a real traceback emitted by
+        the same script must still survive."""
+        lines = [
+            'Error while loading conda entry point: conda-libmamba-solver (...)',
+            'Traceback (most recent call last):',
+            'RuntimeError: thermo failed',
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertEqual(
+            result,
+            ['Traceback (most recent call last):', 'RuntimeError: thermo failed'],
+        )
+
+    def test_real_error_is_preserved(self):
+        """A genuine traceback line passes through."""
+        lines = [
+            "==============================",
+            "*** Open Babel Warning",
+            "Traceback (most recent call last):",
+            '  File "arkane/main.py", line 123, in run',
+            "RuntimeError: Could not parse output",
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertIn("Traceback (most recent call last):", result)
+        self.assertIn("RuntimeError: Could not parse output", result)
+        self.assertNotIn("==============================", result)
+
+    def test_mixed_lmod_and_real_error_keeps_only_real(self):
+        """When Lmod noise and a real error coexist, only the real error
+        survives. (The user's H/H2/OH composite SP failures should still
+        surface even if the shell init is noisy.)"""
+        lines = [
+            'Lmod has detected the following error: ...',
+            '"openmpi"',
+            '#%Module',
+            "AttributeError: 'NoneType' object has no attribute 'thermo'",
+        ]
+        result = filter_real_stderr_lines(lines)
+        self.assertEqual(
+            result,
+            ["AttributeError: 'NoneType' object has no attribute 'thermo'"],
+        )
+
+    def test_empty_and_whitespace_only_lines_dropped(self):
+        self.assertEqual(filter_real_stderr_lines(["", "   ", "\t"]), [])
+
+    def test_accepts_string_as_well_as_list(self):
+        """Some call sites pass a multiline string; the helper splits it."""
+        s = (
+            'Lmod has detected the following error: blah\n'
+            '"openmpi"\n'
+            '\n'
+            'Genuine error: foo\n'
+        )
+        self.assertEqual(filter_real_stderr_lines(s), ["Genuine error: foo"])
 
 
 if __name__ == '__main__':

--- a/arc/testing/trsh/molpro/mrcc_rohf_unsupported.out
+++ b/arc/testing/trsh/molpro/mrcc_rohf_unsupported.out
@@ -1,0 +1,14 @@
+
+ Primary working directories    : /scratch/user/12345
+ Secondary working directories  : /scratch/user/12345
+
+ PROGRAM SYSTEM MOLPRO
+
+ Variables initialized (889), CPU time= 0.01 sec
+ Commands  initialized (702), CPU time= 0.01 sec
+
+ Executing external program mrcc ...
+
+ Use semicanonical orbitals! standard ROHF orbitals are not supported for approximate CC methods.
+
+ Fatal error in mrcc.

--- a/arc/testing/trsh/molpro/mrcc_semicanonical_note_success.out
+++ b/arc/testing/trsh/molpro/mrcc_semicanonical_note_success.out
@@ -1,0 +1,24 @@
+ Primary working directories    : /scratch/user/12345
+ Secondary working directories  : /scratch/user/12345
+
+ PROGRAM SYSTEM MOLPRO
+
+ Variables initialized (889), CPU time= 0.01 sec
+ Commands  initialized (702), CPU time= 0.01 sec
+
+ Executing external program mrcc ...
+
+ Use semicanonical orbitals! standard ROHF orbitals are not supported for approximate CC methods.
+
+ Executing external program mrcc ...
+
+ Total CCSDT(Q) energy [au]:           -75.123456789012
+
+ RESULTS
+ =======
+
+  CCSDT(Q)        =       -75.123456789012
+
+ Variable memory released
+
+ Molpro calculation terminated

--- a/arc/testing/trsh/molpro/mrcc_xmrcc_fatal.out
+++ b/arc/testing/trsh/molpro/mrcc_xmrcc_fatal.out
@@ -1,0 +1,12 @@
+
+ Primary working directories    : /scratch/user/12345
+ Secondary working directories  : /scratch/user/12345
+
+ PROGRAM SYSTEM MOLPRO
+
+ Variables initialized (889), CPU time= 0.01 sec
+ Commands  initialized (702), CPU time= 0.01 sec
+
+ Executing external program xmrcc ...
+
+ Fatal error in xmrcc: the requested excitation rank exceeds the determinant space.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -248,6 +248,183 @@ ARC extracts active space parameters from Molpro CCSD output files to guide subs
 The method returns a dictionary containing the ``'e_o'`` tuple (electrons, orbitals) alongside lists of occupied (``'occ'``) and closed-shell (``'closed'``) orbitals per irreducible representation.
 
 
+Composite single-point protocols (``sp_composite``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``sp_composite`` expresses the final electronic energy of each stationary point
+as a sum of contributions computed at *different* levels of theory — a
+HEAT-style focal-point analysis. This is distinct from the legacy
+``composite_method`` (which means a Gaussian-style single-job composite like
+``CBS-QB3``); the two are mutually exclusive at the project level.
+
+**When is it for you?**
+When a single level of theory is insufficient for the accuracy you need on a
+transition state. A typical motivation: ``CCSD(T)-F12/cc-pVTZ-F12`` wells agree
+with ATcT, but TS barriers miss experiment by several kJ/mol. Adding small
+post-(T) corrections (``δ[CCSDT]``, ``δ[CCSDT(Q)]``), plus core-valence and
+scalar-relativistic terms, closes the gap without any empirical fitting.
+
+**Four YAML forms.**
+
+**Form 1 — preset by name.** The quickest path::
+
+    project: h2o_heat345q
+    sp_composite: HEAT-345Q
+    species:
+      - label: H2O
+        smiles: O
+
+ARC ships a few presets in ``arc/level/presets.yml``:
+
+* ``HEAT-345`` — HEAT-style recipe inspired by Tajti et al. (see references)
+* ``HEAT-345Q`` — HEAT-345 plus a ``δ[CCSDT(Q)]`` correction
+* ``FPA-min`` — minimal focal-point recipe with a CBS extrapolation term
+
+**Form 2 — preset with partial override.** Replace specific fields of named
+terms in the preset::
+
+    sp_composite:
+      preset: HEAT-345Q
+      overrides:
+        delta_T:
+          high: {method: ccsdt, basis: cc-pVTZ}
+
+The override dict keys are term labels (``base``, ``delta_T``, ``delta_Q``,
+``delta_CV``, ``delta_rel``, ...). Unknown target labels raise ``InputError``.
+
+**Form 3 — fully explicit recipe, including a CBS extrapolation term.** No
+preset, complete control::
+
+    sp_composite:
+      reference: "My recipe; DOI: 10.1234/example"
+      base:
+        method: ccsd(t)-f12
+        basis: cc-pVTZ-f12
+      corrections:
+        - label: delta_T
+          type: delta
+          high: {method: ccsdt,   basis: cc-pVDZ}
+          low:  {method: ccsd(t), basis: cc-pVDZ}
+        - label: cbs_corr
+          type: cbs_extrapolation
+          formula: helgaker_corr_2pt
+          components: total      # only "total" is currently supported
+          levels:
+            - {method: ccsd(t), basis: cc-pVTZ}
+            - {method: ccsd(t), basis: cc-pVQZ}
+
+Term types:
+
+* ``single_point`` — one absolute SP (only the ``base`` is usually one).
+* ``delta`` — ``E[high] − E[low]`` between two levels (same basis typically).
+* ``cbs_extrapolation`` — CBS extrapolation from ≥2 levels with the same
+  method but different basis cardinalities. Built-in formulas:
+  ``helgaker_hf_2pt`` (Halkier et al. 1998), ``helgaker_corr_2pt``
+  (Helgaker et al. 1997), ``martin_3pt`` (Martin 1996). Alternatively,
+  supply a user formula string referencing ``X``, ``Y``, ``Z`` (cardinals)
+  and ``E_X``, ``E_Y``, ``E_Z`` (energies); it is parsed through a
+  whitelisted AST evaluator — no ``eval()``.
+
+**Form 4 — per-species override.** Three states are distinguishable::
+
+    project: mixed
+    sp_composite: HEAT-345Q          # applies by default to every species
+    species:
+      - label: H2O                   # inherits the project-wide protocol
+        smiles: O
+      - label: H2O_uncorrected
+        smiles: O
+        sp_composite: null           # opt out — use plain sp_level
+      - label: TS1
+        xyz: ...
+        sp_composite:                # species-specific override
+          base: {method: mp2, basis: cc-pVTZ}
+          corrections: []
+
+Internally each species is in one of three states: ``"inherit"`` (key absent),
+``"opt_out"`` (explicit ``null``), ``"explicit"`` (preset name or recipe).
+These three survive ``as_dict`` / ``from_dict`` and restart-dict round-trip.
+
+**Interactions with other parameters.**
+
+* **``sp_level``** — coexists. If you omit ``sp_level`` while setting
+  ``sp_composite``, ARC derives ``sp_level`` from ``sp_composite.base.level``
+  so downstream code that reads ``sp_level`` (opt-out species, legacy paths)
+  keeps working. If you supply ``sp_level`` explicitly, it is preserved.
+* **``composite_method`` (legacy)** — mutually exclusive with ``sp_composite``.
+  Project fails to start with ``InputError`` if both are set.
+* **``adaptive_levels``** — mutually exclusive in the current release. Raises
+  ``InputError``. A future release may allow compatible combinations.
+* **``conformer_sp_level``** — unaffected. Conformer ranking stays at its own
+  level; ``sp_composite`` kicks in only at the final SP stage on the
+  optimized geometry.
+
+**AEC / BAC behavior.**
+When ``sp_composite`` is active, ARC automatically routes Arkane's AEC lookup
+through ``sp_composite.base.level``. The BAC lookup is **skipped entirely**
+with a single warning — BAC was derived for a single LoT and is not meaningful
+on top of a δ-corrected composite. If you need BAC, compute it externally
+against the base level and add it as a literal term in the recipe.
+
+Known limitation: per-species AEC is *not* implemented. When species carry
+mixed per-species protocols, the global AEC lookup uses the *project-level*
+``sp_composite.base.level``. Users who need per-species AEC should set
+``arkane_level_of_theory`` explicitly per project.
+
+**Restart behavior.**
+Composite sub-jobs are tracked in the persistent output dict
+(``output[label]['paths']['sp_composite']: {sub_label → path}``). Restart
+re-runs only the sub-jobs missing from that dict. On init the scheduler
+*validates* every recorded path (file exists, ``parse_e_elect`` returns a
+number); invalidated entries are pushed back to pending with a warning. After
+seeding, the scheduler kick-starts any pending sub-jobs for species with prior
+composite progress, so a restart with no other events still makes forward
+progress.
+
+**Provenance notebook.**
+Every time a composite finalizes, ARC regenerates a single project-level
+Jupyter notebook at ``<project>/output/sp_composite.ipynb``. It is
+**unexecuted on write**: it contains cell sources but no outputs. The user
+opens the notebook and runs "Run All" to independently verify the result —
+each section reconstructs its ``CompositeProtocol`` from a literal recipe
+dict, re-parses every sub-job QM output via ``arc.parser.parse_e_elect``, and
+re-evaluates the total. Citations (with DOI when supplied) carry through
+from ``presets.yml`` (or from the user's explicit ``reference:`` key) into the
+notebook's markdown.
+
+**Units.**
+``arc.parser.parse_e_elect`` returns kJ/mol. ``CompositeProtocol.evaluate``
+is a pass-through sum and preserves whatever units its inputs use. ARC always
+stores ``species.e_elect`` in kJ/mol. Hartree is used only at display /
+logging boundaries (division by ``arc.constants.E_h_kJmol``) and in the
+Arkane species-file renderer, which converts once when writing the numeric
+``energy = <Hartree>`` assignment.
+
+**Known limitations.**
+
+* **MRCC adapter**: the composite framework is ESS-agnostic, but ARC does not
+  yet ship a dedicated MRCC adapter. For ``CCSDT(Q)``, route through CFOUR
+  (NCC module) or Molpro.
+* **Per-species AEC/BAC**: see the AEC/BAC section above.
+* **``adaptive_levels`` interaction**: currently rejected; may relax later.
+
+**References.**
+
+* Allen, East, Császár — focal-point analysis review (general FPA methodology).
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1804498 — HEAT protocol.
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation CBS extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0
+  — two-point HF CBS extrapolation; fitted ``α = 1.63``.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996). DOI: 10.1016/0009-2614(96)00898-6
+  — three-point Schwartz-style extrapolation.
+* Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153 —
+  correlation-consistent basis-set families; cardinal-number convention used
+  by ``cardinal_from_basis``.
+
+
 Adaptive levels of theory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 ARC allows users to adapt the level of theory to the size of the molecule.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -248,6 +248,348 @@ ARC extracts active space parameters from Molpro CCSD output files to guide subs
 The method returns a dictionary containing the ``'e_o'`` tuple (electrons, orbitals) alongside lists of occupied (``'occ'``) and closed-shell (``'closed'``) orbitals per irreducible representation.
 
 
+Composite single-point protocols (``sp_composite``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``sp_composite`` expresses the final electronic energy of each stationary point
+as a sum of contributions computed at *different* levels of theory — a
+HEAT-style focal-point analysis. This is distinct from the legacy
+``composite_method`` (which means a Gaussian-style single-job composite like
+``CBS-QB3``); the two are mutually exclusive at the project level.
+
+**When is it for you?**
+When a single level of theory is insufficient for the accuracy you need on a
+transition state. A typical motivation: ``CCSD(T)-F12/cc-pVTZ-F12`` wells agree
+with ATcT, but TS barriers miss experiment by several kJ/mol. Adding small
+post-(T) corrections (``δ[CCSDT]``, ``δ[CCSDT(Q)]``), plus core-valence and
+scalar-relativistic terms, closes the gap without any empirical fitting.
+
+**Four YAML forms.**
+
+**Form 1 — preset by name.** The quickest path::
+
+    project: h2o_heat345q
+    sp_composite: HEAT-345Q
+    species:
+      - label: H2O
+        smiles: O
+
+ARC ships the following presets in ``arc/level/presets.yml``:
+
+*HEAT family (Tajti / Bomble / Stanton lineage):*
+
+* ``HEAT-345`` — HEAT-style recipe inspired by Tajti et al. (see references).
+  Includes δ[CCSDT], δ_CV (core-valence, all-electron CCSD(T)/cc-pCVTZ vs
+  frozen-core), and δ_rel (DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK).
+* ``HEAT-345Q`` — HEAT-345 plus a δ[CCSDT(Q)] correction.
+* ``HEAT-345_noC`` / ``HEAT-345Q_noC`` — same as the corresponding HEAT
+  variant but with the **δ_CV** (core-valence) correction omitted. The omission
+  is part of the preset name and reference string so users can cite the
+  protocol honestly when the all-electron leg is unavailable on their ESS.
+  Use these when targeting an ESS without a clean Molpro-style
+  ``core,...`` directive (or when the core-valence contribution is known to
+  be negligible — typically < 0.5 kJ/mol for first-row systems).
+* ``HEAT-345QP`` — HEAT-345Q extended with full quadruples (δ[CCSDTQ]) and
+  perturbative pentuples (δ[CCSDTQ(P)]). The δ_QQ and δ_P legs route
+  through the MRCC interface — modern Molpro builds with MRCC linked in
+  accept ``ccsdtq`` and ``ccsdtq(p)`` via the same path used for
+  ``ccsdt`` / ``ccsdt(q)`` in HEAT-345Q. CFOUR-NCC is an alternative back
+  end. A plain Molpro install without MRCC cannot run these sub-jobs.
+* ``HEAT-456Q`` — same correction stack as ``HEAT-345Q`` but with a tighter
+  base. The published HEAT-456 series uses cardinals {Q,5,6} for the HF /
+  CCSD(T) CBS reference; the ARC adaptation pins the anchor to
+  ``CCSD(T)-F12/cc-pVQZ-F12`` (single-anchor approximation of that CBS limit).
+
+*W\ :sub:`n` family (Karton/Martin / Boese):*
+
+* ``W2`` / ``W2-F12`` — high-quality CCSD(T) anchor + δ_CV + δ_rel. The
+  ``-F12`` variant uses ``CCSD(T)-F12/cc-pVQZ-F12`` for near-CBS quality
+  from a single SP. The non-F12 variant uses ``CCSD(T)/aug-cc-pVQZ``.
+* ``W3`` / ``W3-F12`` — W2 + δ[CCSDT]. *Note:* there is no canonical
+  primary publication titled "W3-F12"; ARC's preset is an extension by
+  analogy to the published W2-F12 (see references below). Cite as
+  "W3-F12 (ARC adaptation)".
+* ``W4`` / ``W4-F12`` — W3 + δ[CCSDT(Q)] + δ[CCSDTQ]. The δ_QQ leg goes
+  through the MRCC interface (Molpro-with-MRCC or CFOUR-NCC) — see the
+  note under HEAT-345QP above; the same back-end requirement applies.
+
+*Focal-point analysis:*
+
+* ``FPA-min`` — minimal focal-point recipe with a two-point Helgaker CBS
+  extrapolation term and a δ[CCSDT] correction.
+
+.. note::
+
+   The W\ :sub:`n` family in ARC is a **single-anchor adaptation** of the
+   canonical Karton/Martin protocols: the W\ :sub:`n` HF/CCSD/(T) basis-cardinal
+   CBS extrapolations are absorbed into the anchor SP rather than being
+   evaluated as separate stacked terms. This is faithful to the W\ :sub:`n`
+   spirit (high-quality CCSD(T) anchor + post-(T) / CV / rel corrections)
+   but not byte-identical to the published prescription. When citing, use
+   "W2 (ARC adaptation)" / "W4-F12 (ARC adaptation)" rather than the
+   bare protocol name to avoid implying a strict reproduction.
+
+**ESS syntax for δ_CV and δ_rel.** The HEAT presets shipped here target the
+**Molpro** adapter:
+
+* δ_CV — all-electron CCSD(T)/cc-pCVTZ via Molpro's ``core,0,...`` directive
+  (``args.keyword.core: 'core,0,0,0,0,0,0,0,0;'``). Trailing zeros are
+  harmless for lower-symmetry point groups.
+* δ_rel — DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK via the canonical
+  Molpro directive ``SET,DKHO=2`` (passed as
+  ``args.keyword.dkho: 'SET,DKHO=2;'``). The Molpro manual
+  (https://www.molpro.net/manual/doku.php?id=relativistic_corrections)
+  explicitly recommends ``DKHO`` over the legacy ``DKROLL``. The directive
+  must appear *before* ``int;`` so the integrals are evaluated with the
+  DK-transformed Hamiltonian.
+
+Other ESSes need different keywords; pointing a HEAT-345 / HEAT-345Q preset
+at, say, the CFOUR or Orca adapter for those SPs will write the wrong
+directive. Until per-ESS preset families ship, either supply an explicit
+recipe or use a ``_noC`` variant.
+
+**Form 2 — preset with partial override.** Replace specific fields of named
+terms in the preset::
+
+    sp_composite:
+      preset: HEAT-345Q
+      overrides:
+        delta_T:
+          high: {method: ccsdt, basis: cc-pVTZ}
+
+The override dict keys are term labels (``base``, ``delta_T``, ``delta_Q``,
+``delta_CV``, ``delta_rel``, ...). Unknown target labels raise ``InputError``.
+
+**Form 3 — fully explicit recipe, including a CBS extrapolation term.** No
+preset, complete control::
+
+    sp_composite:
+      reference: "My recipe; DOI: 10.1234/example"
+      base:
+        method: ccsd(t)-f12
+        basis: cc-pVTZ-f12
+      corrections:
+        - label: delta_T
+          type: delta
+          high: {method: ccsdt,   basis: cc-pVDZ}
+          low:  {method: ccsd(t), basis: cc-pVDZ}
+        - label: cbs_corr
+          type: cbs_extrapolation
+          formula: helgaker_corr_2pt
+          components: total      # only "total" is currently supported
+          levels:
+            - {method: ccsd(t), basis: cc-pVTZ}
+            - {method: ccsd(t), basis: cc-pVQZ}
+
+Term types:
+
+* ``single_point`` — one absolute SP (only the ``base`` is usually one).
+* ``delta`` — ``E[high] − E[low]`` between two levels (same basis typically).
+* ``cbs_extrapolation`` — CBS extrapolation from ≥2 levels with the same
+  method but different basis cardinalities. Built-in formulas:
+  ``helgaker_hf_2pt`` (Halkier et al. 1998), ``helgaker_corr_2pt``
+  (Helgaker et al. 1997), ``martin_3pt`` (Martin 1996). Alternatively,
+  supply a user formula string referencing ``X``, ``Y``, ``Z`` (cardinals)
+  and ``E_X``, ``E_Y``, ``E_Z`` (energies); it is parsed through a
+  whitelisted AST evaluator — no ``eval()``.
+
+**Form 4 — per-species override.** Three states are distinguishable::
+
+    project: mixed
+    sp_composite: HEAT-345Q          # applies by default to every species
+    species:
+      - label: H2O                   # inherits the project-wide protocol
+        smiles: O
+      - label: H2O_uncorrected
+        smiles: O
+        sp_composite: null           # opt out — use plain sp_level
+      - label: TS1
+        xyz: ...
+        sp_composite:                # species-specific override
+          base: {method: mp2, basis: cc-pVTZ}
+          corrections: []
+
+Internally each species is in one of three states: ``"inherit"`` (key absent),
+``"opt_out"`` (explicit ``null``), ``"explicit"`` (preset name or recipe).
+These three survive ``as_dict`` / ``from_dict`` and restart-dict round-trip.
+
+.. note::
+
+   A per-species ``"explicit"`` protocol affects only that species' composite
+   energy: Arkane's atom energy correction (AEC) lookup still uses the
+   project-global ``sp_composite.base.level``, not the species-level base.
+   If a species needs AEC at a different level, set ``arkane_level_of_theory``
+   explicitly for the project.
+
+**Form 5 — W\ :sub:`n` family for high-accuracy anchor energies.** When
+δ-corrections beyond CCSD(T) are *not* the bottleneck and you mainly want a
+near-CBS CCSD(T) reference with the canonical core-valence and scalar-
+relativistic corrections, the W2/W3 family is a good fit::
+
+    project: barriers_w3f12
+    sp_composite: W3-F12
+    species:
+      - label: TS1
+        xyz: ...
+
+This is cheaper than a HEAT-345Q and converges quickly because the F12 anchor
+already absorbs most of the CBS basis-set limit. ``W3-F12`` adds δ[CCSDT] on
+top, which is typically the largest post-(T) effect for small organic TSs.
+
+**Form 6 — HEAT-456Q for tighter CBS reference on small molecules.** For
+small molecules where HF and CCSD(T) basis incompleteness matters, swap the
+``cc-pVTZ-F12`` anchor for the ``cc-pVQZ-F12`` anchor::
+
+    sp_composite: HEAT-456Q
+
+This preset has the same correction stack as ``HEAT-345Q`` (δ[CCSDT],
+δ[CCSDT(Q)], δ_CV, δ_rel) but a more accurate base, mirroring the published
+HEAT-456 series whose HF/CCSD(T) CBS uses cardinals {Q,5,6}.
+
+**Form 7 — preset + per-term basis upgrade.** Combine a published preset
+with a partial override to refine just the term you care about::
+
+    sp_composite:
+      preset: HEAT-345Q
+      overrides:
+        delta_T:
+          high: {method: ccsdt,   basis: cc-pVTZ}
+          low:  {method: ccsd(t), basis: cc-pVTZ}
+
+This keeps the inexpensive δ[CCSDT(Q)]/cc-pVDZ leg, the cheap δ_CV/cc-pCVTZ
+core-valence pair, and the standard δ_rel — but moves only the δ[CCSDT]
+correction to a tighter basis. Useful when one term is responsible for most
+of the residual basis-set error in a barrier.
+
+**Form 8 — explicit recipe with W\ :sub:`n`-style stacked deltas.** For
+direct control of the entire ladder, write the recipe out::
+
+    sp_composite:
+      reference: "W3-style stack with custom anchor; DOI: 10.1063/1.1638736"
+      base:
+        method: ccsd(t)-f12
+        basis: cc-pVQZ-f12
+      corrections:
+        - label: delta_T
+          type: delta
+          high: {method: ccsdt,    basis: cc-pVDZ}
+          low:  {method: ccsd(t),  basis: cc-pVDZ}
+        - label: delta_CV
+          type: delta
+          high: {method: ccsd(t),  basis: cc-pCVTZ,
+                 args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+          low:  {method: ccsd(t),  basis: cc-pCVTZ}
+        - label: delta_rel
+          type: delta
+          high: {method: ccsd(t),  basis: cc-pVTZ-DK,
+                 args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+          low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+This is essentially what ``W3-F12`` expands to internally — useful as a
+template when you want to deviate from a shipped preset.
+
+**Interactions with other parameters.**
+
+* **``sp_level``** — coexists. If you omit ``sp_level`` while setting
+  ``sp_composite``, ARC derives ``sp_level`` from ``sp_composite.base.level``
+  so downstream code that reads ``sp_level`` (opt-out species, legacy paths)
+  keeps working. If you supply ``sp_level`` explicitly, it is preserved.
+* **``composite_method`` (legacy)** — mutually exclusive with ``sp_composite``.
+  Project fails to start with ``InputError`` if both are set.
+* **``adaptive_levels``** — mutually exclusive in the current release. Raises
+  ``InputError``. A future release may allow compatible combinations.
+* **``conformer_sp_level``** — unaffected. Conformer ranking stays at its own
+  level; ``sp_composite`` kicks in only at the final SP stage on the
+  optimized geometry.
+
+**AEC / BAC behavior.**
+When ``sp_composite`` is active, ARC automatically routes Arkane's AEC lookup
+through ``sp_composite.base.level``. The BAC lookup is **skipped entirely**
+with a single warning — BAC was derived for a single LoT and is not meaningful
+on top of a δ-corrected composite. If you need BAC, compute it externally
+against the base level and add it as a literal term in the recipe.
+
+Known limitation: per-species AEC is *not* implemented. When species carry
+mixed per-species protocols, the global AEC lookup uses the *project-level*
+``sp_composite.base.level``. Users who need per-species AEC should set
+``arkane_level_of_theory`` explicitly per project.
+
+**Restart behavior.**
+Composite sub-jobs are tracked in the persistent output dict
+(``output[label]['paths']['sp_composite']: {sub_label → path}``). Restart
+re-runs only the sub-jobs missing from that dict. On init the scheduler
+*validates* every recorded path (file exists, ``parse_e_elect`` returns a
+number); invalidated entries are pushed back to pending with a warning. After
+seeding, the scheduler kick-starts any pending sub-jobs for species with prior
+composite progress, so a restart with no other events still makes forward
+progress.
+
+**Provenance notebook.**
+Every time a composite finalizes, ARC regenerates a single project-level
+Jupyter notebook at ``<project>/output/sp_composite.ipynb``. It is
+**unexecuted on write**: it contains cell sources but no outputs. The user
+opens the notebook and runs "Run All" to independently verify the result —
+each section reconstructs its ``CompositeProtocol`` from a literal recipe
+dict, re-parses every sub-job QM output via ``arc.parser.parse_e_elect``, and
+re-evaluates the total. Citations (with DOI when supplied) carry through
+from ``presets.yml`` (or from the user's explicit ``reference:`` key) into the
+notebook's markdown.
+
+**Units.**
+``arc.parser.parse_e_elect`` returns kJ/mol. ``CompositeProtocol.evaluate``
+is a pass-through sum and preserves whatever units its inputs use. ARC always
+stores ``species.e_elect`` in kJ/mol. Hartree is used only at display /
+logging boundaries (division by ``arc.constants.E_h_kJmol``) and in the
+Arkane species-file renderer, which converts once when writing the numeric
+``energy = <Hartree>`` assignment.
+
+**Known limitations.**
+
+* **MRCC adapter**: ARC does not ship a dedicated standalone MRCC adapter.
+  Methods that route through MRCC (``CCSDT``, ``CCSDT(Q)``, ``CCSDTQ``,
+  ``CCSDTQ(P)``) work today through the Molpro adapter when Molpro is built
+  with the MRCC interface, or through CFOUR-NCC.
+* **Per-species AEC/BAC**: see the AEC/BAC section above.
+* **``adaptive_levels`` interaction**: currently rejected; may relax later.
+
+**References.**
+
+* Allen, East, Császár — focal-point analysis review (general FPA methodology).
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT-345 protocol.
+* Bomble, Vázquez, Kállay, Michauk, Szalay, Császár, Gauss, Stanton,
+  *J. Chem. Phys.* **125**, 064108 (2006). DOI: 10.1063/1.2206789 — HEAT-345(Q)
+  and HEAT-456 series.
+* Martin, de Oliveira, *J. Chem. Phys.* **111**, 1843 (1999).
+  DOI: 10.1063/1.479454 — W1 / W2 protocols.
+* Boese, Oren, Atasoylu, Martin, Kállay, Gauss, *J. Chem. Phys.* **120**, 4129
+  (2004). DOI: 10.1063/1.1638736 — W3 protocol.
+* Karton, Rabinovich, Martin, Ruscic, *J. Chem. Phys.* **125**, 144108 (2006).
+  DOI: 10.1063/1.2348881 — W4 protocol.
+* Karton, Martin, *J. Chem. Phys.* **136**, 124114 (2012).
+  DOI: 10.1063/1.3697678 — W1-F12 and W2-F12 protocols. ARC's ``W3-F12``
+  preset is an adaptation by analogy (no canonical primary publication
+  titled "W3-F12"): it stacks δ[CCSDT] on top of the W2-F12 anchor in the
+  spirit of how W3 (Boese et al. 2004) extended W2.
+* Sylvetsky, Peterson, Karton, Martin, *J. Chem. Phys.* **144**, 214101
+  (2016). DOI: 10.1063/1.4952410 — W4-F12 protocol.
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation CBS extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0
+  — extends the two-point correlation-energy CBS extrapolation to Ne, N\ :sub:`2`,
+  and H\ :sub:`2`\ O.
+* Halkier, Helgaker, Jørgensen, Klopper, Olsen, *Chem. Phys. Lett.* **302**,
+  437-446 (1999). DOI: 10.1016/S0009-2614(99)00179-7 — two-point HF-energy CBS
+  extrapolation; source of the fitted ``α = 1.63`` exponential decay parameter
+  used by ``helgaker_hf_2pt``.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996). DOI: 10.1016/0009-2614(96)00898-6
+  — three-point Schwartz-style extrapolation.
+* Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153 —
+  correlation-consistent basis-set families; cardinal-number convention used
+  by ``cardinal_from_basis``.
+
+
 Adaptive levels of theory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 ARC allows users to adapt the level of theory to the size of the molecule.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -264,7 +264,10 @@ with ATcT, but TS barriers miss experiment by several kJ/mol. Adding small
 post-(T) corrections (``δ[CCSDT]``, ``δ[CCSDT(Q)]``), plus core-valence and
 scalar-relativistic terms, closes the gap without any empirical fitting.
 
-**Four YAML forms.**
+**YAML forms.**
+Forms 1–4 below are the core input shapes (preset by name, preset with partial
+override, fully explicit recipe, and per-species override); forms 5–8 are
+worked variants of these shapes for specific protocols.
 
 **Form 1 — preset by name.** The quickest path::
 
@@ -315,8 +318,14 @@ ARC ships the following presets in ``arc/level/presets.yml``:
 
 *Focal-point analysis:*
 
-* ``FPA-min`` — minimal focal-point recipe with a two-point Helgaker CBS
-  extrapolation term and a δ[CCSDT] correction.
+* ``FPA-min`` — minimal focal-point recipe using **CBS-as-base**: the absolute
+  energy is a two-point Helgaker ``X^-3`` extrapolation of the
+  ``CCSD(T)/cc-pVTZ`` + ``cc-pVQZ`` **total** energies, with a δ[CCSDT]
+  correction on top. Note the ``X^-3`` form was derived for the correlation
+  energy; applying it to total energies technically mis-treats the
+  exponentially-converging HF component. At {T,Q} cardinals the residual is
+  small and this is common practice — the preset's reference string states
+  this explicitly so users can cite it honestly.
 
 .. note::
 
@@ -360,26 +369,30 @@ terms in the preset::
 The override dict keys are term labels (``base``, ``delta_T``, ``delta_Q``,
 ``delta_CV``, ``delta_rel``, ...). Unknown target labels raise ``InputError``.
 
-**Form 3 — fully explicit recipe, including a CBS extrapolation term.** No
-preset, complete control::
+**Form 3 — fully explicit recipe, with a CBS extrapolation as the base.** No
+preset, complete control. This is the canonical focal-point shape: the
+absolute energy is the CBS-extrapolated value, and δ-corrections stack on
+top::
 
     sp_composite:
       reference: "My recipe; DOI: 10.1234/example"
       base:
-        method: ccsd(t)-f12
-        basis: cc-pVTZ-f12
+        label: base
+        type: cbs_extrapolation
+        formula: helgaker_corr_2pt
+        components: total      # only "total" is currently supported
+        levels:
+          - {method: ccsd(t), basis: cc-pVTZ}
+          - {method: ccsd(t), basis: cc-pVQZ}
       corrections:
         - label: delta_T
           type: delta
           high: {method: ccsdt,   basis: cc-pVDZ}
           low:  {method: ccsd(t), basis: cc-pVDZ}
-        - label: cbs_corr
-          type: cbs_extrapolation
-          formula: helgaker_corr_2pt
-          components: total      # only "total" is currently supported
-          levels:
-            - {method: ccsd(t), basis: cc-pVTZ}
-            - {method: ccsd(t), basis: cc-pVQZ}
+
+The ``base`` may equally be a plain level (``base: {method: ccsd(t)-f12,
+basis: cc-pVTZ-f12}`` or a ``"method/basis"`` string) when a single anchor SP
+is preferred over an extrapolation.
 
 Term types:
 
@@ -391,7 +404,22 @@ Term types:
   (Helgaker et al. 1997), ``martin_3pt`` (Martin 1996). Alternatively,
   supply a user formula string referencing ``X``, ``Y``, ``Z`` (cardinals)
   and ``E_X``, ``E_Y``, ``E_Z`` (energies); it is parsed through a
-  whitelisted AST evaluator — no ``eval()``.
+  whitelisted AST evaluator — no ``eval()``. **A** ``cbs_extrapolation``
+  **term is accepted only as the** ``base``: with ``components: total`` (the
+  only supported value) it evaluates to an absolute energy, so listing it
+  under ``corrections`` would double-count the base — ARC rejects this with
+  an ``InputError`` pointing at CBS-as-base usage or the HEAT / W\ :sub:`n`
+  presets. The CBS base's sub-jobs are tracked under the deterministic
+  sub_labels ``base__card_<X>`` (one per cardinal).
+
+.. note::
+
+   Applying a two-point ``X^-3`` formula to **total** energies technically
+   mis-treats the HF component, which converges exponentially with cardinal
+   number rather than as ``X^-3``. At {T,Q} cardinals the residual is small
+   and extrapolating totals is common practice. ARC currently parses only
+   total electronic energies; component-wise extrapolation
+   (``components: hf`` / ``corr``) awaits adapter-level component parsing.
 
 **Form 4 — per-species override.** Three states are distinguishable::
 
@@ -417,9 +445,10 @@ These three survive ``as_dict`` / ``from_dict`` and restart-dict round-trip.
 
    A per-species ``"explicit"`` protocol affects only that species' composite
    energy: Arkane's atom energy correction (AEC) lookup still uses the
-   project-global ``sp_composite.base.level``, not the species-level base.
-   If a species needs AEC at a different level, set ``arkane_level_of_theory``
-   explicitly for the project.
+   project-global protocol's primary base level (the single base level, or
+   the largest-cardinal CBS leg), not the species-level base. If a species
+   needs AEC at a different level, set ``arkane_level_of_theory`` explicitly
+   for the project.
 
 **Form 5 — W\ :sub:`n` family for high-accuracy anchor energies.** When
 δ-corrections beyond CCSD(T) are *not* the bottleneck and you mainly want a
@@ -491,9 +520,12 @@ template when you want to deviate from a shipped preset.
 **Interactions with other parameters.**
 
 * **``sp_level``** — coexists. If you omit ``sp_level`` while setting
-  ``sp_composite``, ARC derives ``sp_level`` from ``sp_composite.base.level``
-  so downstream code that reads ``sp_level`` (opt-out species, legacy paths)
-  keeps working. If you supply ``sp_level`` explicitly, it is preserved.
+  ``sp_composite``, ARC derives ``sp_level`` from the protocol's primary base
+  level so downstream code that reads ``sp_level`` (opt-out species, legacy
+  paths) keeps working. For a single-SP base this is simply the base level;
+  for a CBS base — which has no single level — it is the **largest-cardinal**
+  leg of the extrapolation (e.g. ``ccsd(t)/cc-pvqz`` for ``FPA-min``). If you
+  supply ``sp_level`` explicitly, it is preserved.
 * **``composite_method`` (legacy)** — mutually exclusive with ``sp_composite``.
   Project fails to start with ``InputError`` if both are set.
 * **``adaptive_levels``** — mutually exclusive in the current release. Raises
@@ -504,14 +536,15 @@ template when you want to deviate from a shipped preset.
 
 **AEC / BAC behavior.**
 When ``sp_composite`` is active, ARC automatically routes Arkane's AEC lookup
-through ``sp_composite.base.level``. The BAC lookup is **skipped entirely**
-with a single warning — BAC was derived for a single LoT and is not meaningful
-on top of a δ-corrected composite. If you need BAC, compute it externally
+through the protocol's primary base level (the single base level, or the
+largest-cardinal CBS leg). The BAC lookup is **skipped entirely** with a
+single warning — BAC was derived for a single LoT and is not meaningful on
+top of a δ-corrected composite. If you need BAC, compute it externally
 against the base level and add it as a literal term in the recipe.
 
 Known limitation: per-species AEC is *not* implemented. When species carry
 mixed per-species protocols, the global AEC lookup uses the *project-level*
-``sp_composite.base.level``. Users who need per-species AEC should set
+protocol's primary base level. Users who need per-species AEC should set
 ``arkane_level_of_theory`` explicitly per project.
 
 **Restart behavior.**

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -223,6 +223,348 @@ Support is adapter-dependent. Gaussian, ORCA, and xTB currently have solvation
 handling in their job adapters; always choose method and solvent names in the
 format expected by the selected ESS.
 
+Composite single-point protocols (``sp_composite``)
+---------------------------------------------------
+
+``sp_composite`` expresses the final electronic energy of each stationary point
+as a sum of contributions computed at *different* levels of theory — a
+HEAT-style focal-point analysis. This is distinct from the legacy
+``composite_method`` (which means a Gaussian-style single-job composite like
+``CBS-QB3``); the two are mutually exclusive at the project level.
+
+**When is it for you?**
+When a single level of theory is insufficient for the accuracy you need on a
+transition state. A typical motivation: ``CCSD(T)-F12/cc-pVTZ-F12`` wells agree
+with ATcT, but TS barriers miss experiment by several kJ/mol. Adding small
+post-(T) corrections (``δ[CCSDT]``, ``δ[CCSDT(Q)]``), plus core-valence and
+scalar-relativistic terms, closes the gap without any empirical fitting.
+
+**Four YAML forms.**
+
+**Form 1 — preset by name.** The quickest path::
+
+    project: h2o_heat345q
+    sp_composite: HEAT-345Q
+    species:
+      - label: H2O
+        smiles: O
+
+ARC ships the following presets in ``arc/level/presets.yml``:
+
+*HEAT family (Tajti / Bomble / Stanton lineage):*
+
+* ``HEAT-345`` — HEAT-style recipe inspired by Tajti et al. (see references).
+  Includes δ[CCSDT], δ_CV (core-valence, all-electron CCSD(T)/cc-pCVTZ vs
+  frozen-core), and δ_rel (DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK).
+* ``HEAT-345Q`` — HEAT-345 plus a δ[CCSDT(Q)] correction.
+* ``HEAT-345_noC`` / ``HEAT-345Q_noC`` — same as the corresponding HEAT
+  variant but with the **δ_CV** (core-valence) correction omitted. The omission
+  is part of the preset name and reference string so users can cite the
+  protocol honestly when the all-electron leg is unavailable on their ESS.
+  Use these when targeting an ESS without a clean Molpro-style
+  ``core,...`` directive (or when the core-valence contribution is known to
+  be negligible — typically < 0.5 kJ/mol for first-row systems).
+* ``HEAT-345QP`` — HEAT-345Q extended with full quadruples (δ[CCSDTQ]) and
+  perturbative pentuples (δ[CCSDTQ(P)]). The δ_QQ and δ_P legs route
+  through the MRCC interface — modern Molpro builds with MRCC linked in
+  accept ``ccsdtq`` and ``ccsdtq(p)`` via the same path used for
+  ``ccsdt`` / ``ccsdt(q)`` in HEAT-345Q. CFOUR-NCC is an alternative back
+  end. A plain Molpro install without MRCC cannot run these sub-jobs.
+* ``HEAT-456Q`` — same correction stack as ``HEAT-345Q`` but with a tighter
+  base. The published HEAT-456 series uses cardinals {Q,5,6} for the HF /
+  CCSD(T) CBS reference; the ARC adaptation pins the anchor to
+  ``CCSD(T)-F12/cc-pVQZ-F12`` (single-anchor approximation of that CBS limit).
+
+*W\ :sub:`n` family (Karton/Martin / Boese):*
+
+* ``W2`` / ``W2-F12`` — high-quality CCSD(T) anchor + δ_CV + δ_rel. The
+  ``-F12`` variant uses ``CCSD(T)-F12/cc-pVQZ-F12`` for near-CBS quality
+  from a single SP. The non-F12 variant uses ``CCSD(T)/aug-cc-pVQZ``.
+* ``W3`` / ``W3-F12`` — W2 + δ[CCSDT]. *Note:* there is no canonical
+  primary publication titled "W3-F12"; ARC's preset is an extension by
+  analogy to the published W2-F12 (see references below). Cite as
+  "W3-F12 (ARC adaptation)".
+* ``W4`` / ``W4-F12`` — W3 + δ[CCSDT(Q)] + δ[CCSDTQ]. The δ_QQ leg goes
+  through the MRCC interface (Molpro-with-MRCC or CFOUR-NCC) — see the
+  note under HEAT-345QP above; the same back-end requirement applies.
+
+*Focal-point analysis:*
+
+* ``FPA-min`` — minimal focal-point recipe with a two-point Helgaker CBS
+  extrapolation term and a δ[CCSDT] correction.
+
+.. note::
+
+   The W\ :sub:`n` family in ARC is a **single-anchor adaptation** of the
+   canonical Karton/Martin protocols: the W\ :sub:`n` HF/CCSD/(T) basis-cardinal
+   CBS extrapolations are absorbed into the anchor SP rather than being
+   evaluated as separate stacked terms. This is faithful to the W\ :sub:`n`
+   spirit (high-quality CCSD(T) anchor + post-(T) / CV / rel corrections)
+   but not byte-identical to the published prescription. When citing, use
+   "W2 (ARC adaptation)" / "W4-F12 (ARC adaptation)" rather than the
+   bare protocol name to avoid implying a strict reproduction.
+
+**ESS syntax for δ_CV and δ_rel.** The HEAT presets shipped here target the
+**Molpro** adapter:
+
+* δ_CV — all-electron CCSD(T)/cc-pCVTZ via Molpro's ``core,0,...`` directive
+  (``args.keyword.core: 'core,0,0,0,0,0,0,0,0;'``). Trailing zeros are
+  harmless for lower-symmetry point groups.
+* δ_rel — DKH2 scalar-relativistic CCSD(T)/cc-pVTZ-DK via the canonical
+  Molpro directive ``SET,DKHO=2`` (passed as
+  ``args.keyword.dkho: 'SET,DKHO=2;'``). The Molpro manual
+  (https://www.molpro.net/manual/doku.php?id=relativistic_corrections)
+  explicitly recommends ``DKHO`` over the legacy ``DKROLL``. The directive
+  must appear *before* ``int;`` so the integrals are evaluated with the
+  DK-transformed Hamiltonian.
+
+Other ESSes need different keywords; pointing a HEAT-345 / HEAT-345Q preset
+at, say, the CFOUR or Orca adapter for those SPs will write the wrong
+directive. Until per-ESS preset families ship, either supply an explicit
+recipe or use a ``_noC`` variant.
+
+**Form 2 — preset with partial override.** Replace specific fields of named
+terms in the preset::
+
+    sp_composite:
+      preset: HEAT-345Q
+      overrides:
+        delta_T:
+          high: {method: ccsdt, basis: cc-pVTZ}
+
+The override dict keys are term labels (``base``, ``delta_T``, ``delta_Q``,
+``delta_CV``, ``delta_rel``, ...). Unknown target labels raise ``InputError``.
+
+**Form 3 — fully explicit recipe, including a CBS extrapolation term.** No
+preset, complete control::
+
+    sp_composite:
+      reference: "My recipe; DOI: 10.1234/example"
+      base:
+        method: ccsd(t)-f12
+        basis: cc-pVTZ-f12
+      corrections:
+        - label: delta_T
+          type: delta
+          high: {method: ccsdt,   basis: cc-pVDZ}
+          low:  {method: ccsd(t), basis: cc-pVDZ}
+        - label: cbs_corr
+          type: cbs_extrapolation
+          formula: helgaker_corr_2pt
+          components: total      # only "total" is currently supported
+          levels:
+            - {method: ccsd(t), basis: cc-pVTZ}
+            - {method: ccsd(t), basis: cc-pVQZ}
+
+Term types:
+
+* ``single_point`` — one absolute SP (only the ``base`` is usually one).
+* ``delta`` — ``E[high] − E[low]`` between two levels (same basis typically).
+* ``cbs_extrapolation`` — CBS extrapolation from ≥2 levels with the same
+  method but different basis cardinalities. Built-in formulas:
+  ``helgaker_hf_2pt`` (Halkier et al. 1998), ``helgaker_corr_2pt``
+  (Helgaker et al. 1997), ``martin_3pt`` (Martin 1996). Alternatively,
+  supply a user formula string referencing ``X``, ``Y``, ``Z`` (cardinals)
+  and ``E_X``, ``E_Y``, ``E_Z`` (energies); it is parsed through a
+  whitelisted AST evaluator — no ``eval()``.
+
+**Form 4 — per-species override.** Three states are distinguishable::
+
+    project: mixed
+    sp_composite: HEAT-345Q          # applies by default to every species
+    species:
+      - label: H2O                   # inherits the project-wide protocol
+        smiles: O
+      - label: H2O_uncorrected
+        smiles: O
+        sp_composite: null           # opt out — use plain sp_level
+      - label: TS1
+        xyz: ...
+        sp_composite:                # species-specific override
+          base: {method: mp2, basis: cc-pVTZ}
+          corrections: []
+
+Internally each species is in one of three states: ``"inherit"`` (key absent),
+``"opt_out"`` (explicit ``null``), ``"explicit"`` (preset name or recipe).
+These three survive ``as_dict`` / ``from_dict`` and restart-dict round-trip.
+
+.. note::
+
+   A per-species ``"explicit"`` protocol affects only that species' composite
+   energy: Arkane's atom energy correction (AEC) lookup still uses the
+   project-global ``sp_composite.base.level``, not the species-level base.
+   If a species needs AEC at a different level, set ``arkane_level_of_theory``
+   explicitly for the project.
+
+**Form 5 — W\ :sub:`n` family for high-accuracy anchor energies.** When
+δ-corrections beyond CCSD(T) are *not* the bottleneck and you mainly want a
+near-CBS CCSD(T) reference with the canonical core-valence and scalar-
+relativistic corrections, the W2/W3 family is a good fit::
+
+    project: barriers_w3f12
+    sp_composite: W3-F12
+    species:
+      - label: TS1
+        xyz: ...
+
+This is cheaper than a HEAT-345Q and converges quickly because the F12 anchor
+already absorbs most of the CBS basis-set limit. ``W3-F12`` adds δ[CCSDT] on
+top, which is typically the largest post-(T) effect for small organic TSs.
+
+**Form 6 — HEAT-456Q for tighter CBS reference on small molecules.** For
+small molecules where HF and CCSD(T) basis incompleteness matters, swap the
+``cc-pVTZ-F12`` anchor for the ``cc-pVQZ-F12`` anchor::
+
+    sp_composite: HEAT-456Q
+
+This preset has the same correction stack as ``HEAT-345Q`` (δ[CCSDT],
+δ[CCSDT(Q)], δ_CV, δ_rel) but a more accurate base, mirroring the published
+HEAT-456 series whose HF/CCSD(T) CBS uses cardinals {Q,5,6}.
+
+**Form 7 — preset + per-term basis upgrade.** Combine a published preset
+with a partial override to refine just the term you care about::
+
+    sp_composite:
+      preset: HEAT-345Q
+      overrides:
+        delta_T:
+          high: {method: ccsdt,   basis: cc-pVTZ}
+          low:  {method: ccsd(t), basis: cc-pVTZ}
+
+This keeps the inexpensive δ[CCSDT(Q)]/cc-pVDZ leg, the cheap δ_CV/cc-pCVTZ
+core-valence pair, and the standard δ_rel — but moves only the δ[CCSDT]
+correction to a tighter basis. Useful when one term is responsible for most
+of the residual basis-set error in a barrier.
+
+**Form 8 — explicit recipe with W\ :sub:`n`-style stacked deltas.** For
+direct control of the entire ladder, write the recipe out::
+
+    sp_composite:
+      reference: "W3-style stack with custom anchor; DOI: 10.1063/1.1638736"
+      base:
+        method: ccsd(t)-f12
+        basis: cc-pVQZ-f12
+      corrections:
+        - label: delta_T
+          type: delta
+          high: {method: ccsdt,    basis: cc-pVDZ}
+          low:  {method: ccsd(t),  basis: cc-pVDZ}
+        - label: delta_CV
+          type: delta
+          high: {method: ccsd(t),  basis: cc-pCVTZ,
+                 args: {keyword: {core: 'core,0,0,0,0,0,0,0,0;'}, block: {}}}
+          low:  {method: ccsd(t),  basis: cc-pCVTZ}
+        - label: delta_rel
+          type: delta
+          high: {method: ccsd(t),  basis: cc-pVTZ-DK,
+                 args: {keyword: {dkho: 'SET,DKHO=2;'}, block: {}}}
+          low:  {method: ccsd(t),  basis: cc-pVTZ}
+
+This is essentially what ``W3-F12`` expands to internally — useful as a
+template when you want to deviate from a shipped preset.
+
+**Interactions with other parameters.**
+
+* **``sp_level``** — coexists. If you omit ``sp_level`` while setting
+  ``sp_composite``, ARC derives ``sp_level`` from ``sp_composite.base.level``
+  so downstream code that reads ``sp_level`` (opt-out species, legacy paths)
+  keeps working. If you supply ``sp_level`` explicitly, it is preserved.
+* **``composite_method`` (legacy)** — mutually exclusive with ``sp_composite``.
+  Project fails to start with ``InputError`` if both are set.
+* **``adaptive_levels``** — mutually exclusive in the current release. Raises
+  ``InputError``. A future release may allow compatible combinations.
+* **``conformer_sp_level``** — unaffected. Conformer ranking stays at its own
+  level; ``sp_composite`` kicks in only at the final SP stage on the
+  optimized geometry.
+
+**AEC / BAC behavior.**
+When ``sp_composite`` is active, ARC automatically routes Arkane's AEC lookup
+through ``sp_composite.base.level``. The BAC lookup is **skipped entirely**
+with a single warning — BAC was derived for a single LoT and is not meaningful
+on top of a δ-corrected composite. If you need BAC, compute it externally
+against the base level and add it as a literal term in the recipe.
+
+Known limitation: per-species AEC is *not* implemented. When species carry
+mixed per-species protocols, the global AEC lookup uses the *project-level*
+``sp_composite.base.level``. Users who need per-species AEC should set
+``arkane_level_of_theory`` explicitly per project.
+
+**Restart behavior.**
+Composite sub-jobs are tracked in the persistent output dict
+(``output[label]['paths']['sp_composite']: {sub_label → path}``). Restart
+re-runs only the sub-jobs missing from that dict. On init the scheduler
+*validates* every recorded path (file exists, ``parse_e_elect`` returns a
+number); invalidated entries are pushed back to pending with a warning. After
+seeding, the scheduler kick-starts any pending sub-jobs for species with prior
+composite progress, so a restart with no other events still makes forward
+progress.
+
+**Provenance notebook.**
+Every time a composite finalizes, ARC regenerates a single project-level
+Jupyter notebook at ``<project>/output/sp_composite.ipynb``. It is
+**unexecuted on write**: it contains cell sources but no outputs. The user
+opens the notebook and runs "Run All" to independently verify the result —
+each section reconstructs its ``CompositeProtocol`` from a literal recipe
+dict, re-parses every sub-job QM output via ``arc.parser.parse_e_elect``, and
+re-evaluates the total. Citations (with DOI when supplied) carry through
+from ``presets.yml`` (or from the user's explicit ``reference:`` key) into the
+notebook's markdown.
+
+**Units.**
+``arc.parser.parse_e_elect`` returns kJ/mol. ``CompositeProtocol.evaluate``
+is a pass-through sum and preserves whatever units its inputs use. ARC always
+stores ``species.e_elect`` in kJ/mol. Hartree is used only at display /
+logging boundaries (division by ``arc.constants.E_h_kJmol``) and in the
+Arkane species-file renderer, which converts once when writing the numeric
+``energy = <Hartree>`` assignment.
+
+**Known limitations.**
+
+* **MRCC adapter**: ARC does not ship a dedicated standalone MRCC adapter.
+  Methods that route through MRCC (``CCSDT``, ``CCSDT(Q)``, ``CCSDTQ``,
+  ``CCSDTQ(P)``) work today through the Molpro adapter when Molpro is built
+  with the MRCC interface, or through CFOUR-NCC.
+* **Per-species AEC/BAC**: see the AEC/BAC section above.
+* **``adaptive_levels`` interaction**: currently rejected; may relax later.
+
+**References.**
+
+* Allen, East, Császár — focal-point analysis review (general FPA methodology).
+* Tajti, Szalay, Császár, Kállay, Gauss, Valeev, Flowers, Vázquez, Stanton,
+  *J. Chem. Phys.* **121**, 11599 (2004). DOI: 10.1063/1.1811608 — HEAT-345 protocol.
+* Bomble, Vázquez, Kállay, Michauk, Szalay, Császár, Gauss, Stanton,
+  *J. Chem. Phys.* **125**, 064108 (2006). DOI: 10.1063/1.2206789 — HEAT-345(Q)
+  and HEAT-456 series.
+* Martin, de Oliveira, *J. Chem. Phys.* **111**, 1843 (1999).
+  DOI: 10.1063/1.479454 — W1 / W2 protocols.
+* Boese, Oren, Atasoylu, Martin, Kállay, Gauss, *J. Chem. Phys.* **120**, 4129
+  (2004). DOI: 10.1063/1.1638736 — W3 protocol.
+* Karton, Rabinovich, Martin, Ruscic, *J. Chem. Phys.* **125**, 144108 (2006).
+  DOI: 10.1063/1.2348881 — W4 protocol.
+* Karton, Martin, *J. Chem. Phys.* **136**, 124114 (2012).
+  DOI: 10.1063/1.3697678 — W1-F12 and W2-F12 protocols. ARC's ``W3-F12``
+  preset is an adaptation by analogy (no canonical primary publication
+  titled "W3-F12"): it stacks δ[CCSDT] on top of the W2-F12 anchor in the
+  spirit of how W3 (Boese et al. 2004) extended W2.
+* Sylvetsky, Peterson, Karton, Martin, *J. Chem. Phys.* **144**, 214101
+  (2016). DOI: 10.1063/1.4952410 — W4-F12 protocol.
+* Helgaker, Klopper, Koch, Noga, *J. Chem. Phys.* **106**, 9639 (1997).
+  DOI: 10.1063/1.473863 — two-point correlation CBS extrapolation.
+* Halkier, Helgaker, Jørgensen, Klopper, Koch, Olsen, Wilson,
+  *Chem. Phys. Lett.* **286**, 243-252 (1998). DOI: 10.1016/S0009-2614(98)00111-0
+  — extends the two-point correlation-energy CBS extrapolation to Ne, N\ :sub:`2`,
+  and H\ :sub:`2`\ O.
+* Halkier, Helgaker, Jørgensen, Klopper, Olsen, *Chem. Phys. Lett.* **302**,
+  437-446 (1999). DOI: 10.1016/S0009-2614(99)00179-7 — two-point HF-energy CBS
+  extrapolation; source of the fitted ``α = 1.63`` exponential decay parameter
+  used by ``helgaker_hf_2pt``.
+* Martin, *Chem. Phys. Lett.* **259**, 669-678 (1996). DOI: 10.1016/0009-2614(96)00898-6
+  — three-point Schwartz-style extrapolation.
+* Dunning, *J. Chem. Phys.* **90**, 1007 (1989). DOI: 10.1063/1.456153 —
+  correlation-consistent basis-set families; cardinal-number convention used
+  by ``cardinal_from_basis``.
+
+
 Adaptive Levels
 ---------------
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -239,7 +239,10 @@ with ATcT, but TS barriers miss experiment by several kJ/mol. Adding small
 post-(T) corrections (``δ[CCSDT]``, ``δ[CCSDT(Q)]``), plus core-valence and
 scalar-relativistic terms, closes the gap without any empirical fitting.
 
-**Four YAML forms.**
+**YAML forms.**
+Forms 1–4 below are the core input shapes (preset by name, preset with partial
+override, fully explicit recipe, and per-species override); forms 5–8 are
+worked variants of these shapes for specific protocols.
 
 **Form 1 — preset by name.** The quickest path::
 
@@ -290,8 +293,14 @@ ARC ships the following presets in ``arc/level/presets.yml``:
 
 *Focal-point analysis:*
 
-* ``FPA-min`` — minimal focal-point recipe with a two-point Helgaker CBS
-  extrapolation term and a δ[CCSDT] correction.
+* ``FPA-min`` — minimal focal-point recipe using **CBS-as-base**: the absolute
+  energy is a two-point Helgaker ``X^-3`` extrapolation of the
+  ``CCSD(T)/cc-pVTZ`` + ``cc-pVQZ`` **total** energies, with a δ[CCSDT]
+  correction on top. Note the ``X^-3`` form was derived for the correlation
+  energy; applying it to total energies technically mis-treats the
+  exponentially-converging HF component. At {T,Q} cardinals the residual is
+  small and this is common practice — the preset's reference string states
+  this explicitly so users can cite it honestly.
 
 .. note::
 
@@ -335,26 +344,30 @@ terms in the preset::
 The override dict keys are term labels (``base``, ``delta_T``, ``delta_Q``,
 ``delta_CV``, ``delta_rel``, ...). Unknown target labels raise ``InputError``.
 
-**Form 3 — fully explicit recipe, including a CBS extrapolation term.** No
-preset, complete control::
+**Form 3 — fully explicit recipe, with a CBS extrapolation as the base.** No
+preset, complete control. This is the canonical focal-point shape: the
+absolute energy is the CBS-extrapolated value, and δ-corrections stack on
+top::
 
     sp_composite:
       reference: "My recipe; DOI: 10.1234/example"
       base:
-        method: ccsd(t)-f12
-        basis: cc-pVTZ-f12
+        label: base
+        type: cbs_extrapolation
+        formula: helgaker_corr_2pt
+        components: total      # only "total" is currently supported
+        levels:
+          - {method: ccsd(t), basis: cc-pVTZ}
+          - {method: ccsd(t), basis: cc-pVQZ}
       corrections:
         - label: delta_T
           type: delta
           high: {method: ccsdt,   basis: cc-pVDZ}
           low:  {method: ccsd(t), basis: cc-pVDZ}
-        - label: cbs_corr
-          type: cbs_extrapolation
-          formula: helgaker_corr_2pt
-          components: total      # only "total" is currently supported
-          levels:
-            - {method: ccsd(t), basis: cc-pVTZ}
-            - {method: ccsd(t), basis: cc-pVQZ}
+
+The ``base`` may equally be a plain level (``base: {method: ccsd(t)-f12,
+basis: cc-pVTZ-f12}`` or a ``"method/basis"`` string) when a single anchor SP
+is preferred over an extrapolation.
 
 Term types:
 
@@ -366,7 +379,22 @@ Term types:
   (Helgaker et al. 1997), ``martin_3pt`` (Martin 1996). Alternatively,
   supply a user formula string referencing ``X``, ``Y``, ``Z`` (cardinals)
   and ``E_X``, ``E_Y``, ``E_Z`` (energies); it is parsed through a
-  whitelisted AST evaluator — no ``eval()``.
+  whitelisted AST evaluator — no ``eval()``. **A** ``cbs_extrapolation``
+  **term is accepted only as the** ``base``: with ``components: total`` (the
+  only supported value) it evaluates to an absolute energy, so listing it
+  under ``corrections`` would double-count the base — ARC rejects this with
+  an ``InputError`` pointing at CBS-as-base usage or the HEAT / W\ :sub:`n`
+  presets. The CBS base's sub-jobs are tracked under the deterministic
+  sub_labels ``base__card_<X>`` (one per cardinal).
+
+.. note::
+
+   Applying a two-point ``X^-3`` formula to **total** energies technically
+   mis-treats the HF component, which converges exponentially with cardinal
+   number rather than as ``X^-3``. At {T,Q} cardinals the residual is small
+   and extrapolating totals is common practice. ARC currently parses only
+   total electronic energies; component-wise extrapolation
+   (``components: hf`` / ``corr``) awaits adapter-level component parsing.
 
 **Form 4 — per-species override.** Three states are distinguishable::
 
@@ -392,9 +420,10 @@ These three survive ``as_dict`` / ``from_dict`` and restart-dict round-trip.
 
    A per-species ``"explicit"`` protocol affects only that species' composite
    energy: Arkane's atom energy correction (AEC) lookup still uses the
-   project-global ``sp_composite.base.level``, not the species-level base.
-   If a species needs AEC at a different level, set ``arkane_level_of_theory``
-   explicitly for the project.
+   project-global protocol's primary base level (the single base level, or
+   the largest-cardinal CBS leg), not the species-level base. If a species
+   needs AEC at a different level, set ``arkane_level_of_theory`` explicitly
+   for the project.
 
 **Form 5 — W\ :sub:`n` family for high-accuracy anchor energies.** When
 δ-corrections beyond CCSD(T) are *not* the bottleneck and you mainly want a
@@ -466,9 +495,12 @@ template when you want to deviate from a shipped preset.
 **Interactions with other parameters.**
 
 * **``sp_level``** — coexists. If you omit ``sp_level`` while setting
-  ``sp_composite``, ARC derives ``sp_level`` from ``sp_composite.base.level``
-  so downstream code that reads ``sp_level`` (opt-out species, legacy paths)
-  keeps working. If you supply ``sp_level`` explicitly, it is preserved.
+  ``sp_composite``, ARC derives ``sp_level`` from the protocol's primary base
+  level so downstream code that reads ``sp_level`` (opt-out species, legacy
+  paths) keeps working. For a single-SP base this is simply the base level;
+  for a CBS base — which has no single level — it is the **largest-cardinal**
+  leg of the extrapolation (e.g. ``ccsd(t)/cc-pvqz`` for ``FPA-min``). If you
+  supply ``sp_level`` explicitly, it is preserved.
 * **``composite_method`` (legacy)** — mutually exclusive with ``sp_composite``.
   Project fails to start with ``InputError`` if both are set.
 * **``adaptive_levels``** — mutually exclusive in the current release. Raises
@@ -479,14 +511,15 @@ template when you want to deviate from a shipped preset.
 
 **AEC / BAC behavior.**
 When ``sp_composite`` is active, ARC automatically routes Arkane's AEC lookup
-through ``sp_composite.base.level``. The BAC lookup is **skipped entirely**
-with a single warning — BAC was derived for a single LoT and is not meaningful
-on top of a δ-corrected composite. If you need BAC, compute it externally
+through the protocol's primary base level (the single base level, or the
+largest-cardinal CBS leg). The BAC lookup is **skipped entirely** with a
+single warning — BAC was derived for a single LoT and is not meaningful on
+top of a δ-corrected composite. If you need BAC, compute it externally
 against the base level and add it as a literal term in the recipe.
 
 Known limitation: per-species AEC is *not* implemented. When species carry
 mixed per-species protocols, the global AEC lookup uses the *project-level*
-``sp_composite.base.level``. Users who need per-species AEC should set
+protocol's primary base level. Users who need per-species AEC should set
 ``arkane_level_of_theory`` explicitly per project.
 
 **Restart behavior.**

--- a/examples/Composite/README.md
+++ b/examples/Composite/README.md
@@ -1,0 +1,54 @@
+# `sp_composite` examples
+
+These inputs demonstrate the YAML forms accepted by ARC's `sp_composite`
+feature — composite single-point protocols for refined electronic energies
+(HEAT-style focal-point analysis, W\ :sub:`n` family, and CBS extrapolation).
+
+| File | Demonstrates |
+|---|---|
+| `heat345q_preset/input.yml` | **Form 1** — preset by name (`HEAT-345Q`). Smallest possible composite input. |
+| `heat345q_partial_override/input.yml` | **Form 2** — preset with partial override: swap one basis set on a single term. |
+| `explicit_fpa/input.yml` | **Form 3** — fully explicit recipe, including a `cbs_extrapolation` term (Helgaker 2-pt correlation). |
+| `per_species_override/input.yml` | **Form 4** — per-species override: one species keeps the project default, one opts out via `null`, one uses a species-specific protocol. |
+| `w3f12_preset/input.yml` | **W\ :sub:`n` family** — `W3-F12` preset (CCSD(T)-F12/QZ anchor + δ[CCSDT] + δ_CV + δ_rel). Cheaper than HEAT-345Q when post-(T) effects beyond CCSDT are not the bottleneck. |
+| `heat456q_preset/input.yml` | **Tighter base** — `HEAT-456Q` preset: same correction stack as `HEAT-345Q` but with a `cc-pVQZ-F12` anchor for systems where CCSD(T) basis incompleteness drives residual barrier error. |
+| `w2f12_partial_override/input.yml` | **F12 + override** — `W2-F12` with the δ_CV core-valence basis upgraded from `cc-pCVTZ` to `cc-pCVQZ`. Demonstrates that overrides on a δ leg must carry the Molpro `core,...;` directive through to the *high* leg. |
+
+## Running
+
+Activate the ARC conda environment (`environment.yml`), then from the repo root:
+
+    python ARC.py examples/Composite/heat345q_preset/input.yml
+
+After the run finishes, a provenance notebook is generated at
+`<project_directory>/output/sp_composite.ipynb`. Open it in Jupyter or VS Code
+and select **Run All** — each section re-parses the actual QM output files via
+`arc.parser.parse_e_elect` and re-evaluates the `CompositeProtocol` to verify
+the final `e_elect` matches what ARC recorded in `output.yml`.
+
+## A note on cost
+
+The HEAT-style examples include `CCSDT` and `CCSDT(Q)` post-(T) corrections
+that require the CFOUR (NCC module) or Molpro adapters to actually execute.
+These are *illustrative*: the recipes are scientifically meaningful for small
+molecules (4–6 atoms, tight TSs) but become prohibitive quickly. The minimal
+`heat345q_preset` example uses `H2` and `O` as smoke-test species; adapt the
+level of theory (or drop expensive terms via overrides) for larger systems.
+
+For small methodological demos that do not require an expensive post-(T)
+reference calculation, see `explicit_fpa/input.yml`, which shows the CBS
+extrapolation form using only CCSD(T)/cc-pV{T,Q}Z.
+
+## Units
+
+`species.e_elect` is stored in kJ/mol throughout. The notebook and ARC log
+display Hartree only at boundaries via division by `E_h_kJmol`
+(≈ 2625.4996 kJ/mol/Hartree). The Arkane species file (under
+`<project>/output/Species/<label>/arkane/species.py`) is rendered with a bare
+`energy = <Hartree>` assignment when `sp_composite` is active — matching
+Arkane's numeric-energy convention.
+
+## More
+
+Full documentation: `docs/source/advanced.rst`, section
+*Composite single-point protocols (sp_composite)*.

--- a/examples/Composite/README.md
+++ b/examples/Composite/README.md
@@ -1,0 +1,51 @@
+# `sp_composite` examples
+
+These inputs demonstrate the four YAML forms accepted by ARC's `sp_composite`
+feature — composite single-point protocols for refined electronic energies
+(HEAT-style focal-point analysis and CBS extrapolation).
+
+| File | Demonstrates |
+|---|---|
+| `heat345q_preset/input.yml` | **Form 1** — preset by name (`HEAT-345Q`). Smallest possible composite input. |
+| `heat345q_partial_override/input.yml` | **Form 2** — preset with partial override: swap one basis set on a single term. |
+| `explicit_fpa/input.yml` | **Form 3** — fully explicit recipe, including a `cbs_extrapolation` term (Helgaker 2-pt correlation). |
+| `per_species_override/input.yml` | **Form 4** — per-species override: one species keeps the project default, one opts out via `null`, one uses a species-specific protocol. |
+
+## Running
+
+Activate the ARC conda environment (`environment.yml`), then from the repo root:
+
+    python ARC.py examples/Composite/heat345q_preset/input.yml
+
+After the run finishes, a provenance notebook is generated at
+`<project_directory>/output/sp_composite.ipynb`. Open it in Jupyter or VS Code
+and select **Run All** — each section re-parses the actual QM output files via
+`arc.parser.parse_e_elect` and re-evaluates the `CompositeProtocol` to verify
+the final `e_elect` matches what ARC recorded in `output.yml`.
+
+## A note on cost
+
+The HEAT-style examples include `CCSDT` and `CCSDT(Q)` post-(T) corrections
+that require the CFOUR (NCC module) or Molpro adapters to actually execute.
+These are *illustrative*: the recipes are scientifically meaningful for small
+molecules (4–6 atoms, tight TSs) but become prohibitive quickly. The minimal
+`heat345q_preset` example uses `H2` and `O` as smoke-test species; adapt the
+level of theory (or drop expensive terms via overrides) for larger systems.
+
+For small methodological demos that do not require an expensive post-(T)
+reference calculation, see `explicit_fpa/input.yml`, which shows the CBS
+extrapolation form using only CCSD(T)/cc-pV{T,Q}Z.
+
+## Units
+
+`species.e_elect` is stored in kJ/mol throughout. The notebook and ARC log
+display Hartree only at boundaries via division by `E_h_kJmol`
+(≈ 2625.4996 kJ/mol/Hartree). The Arkane species file (under
+`<project>/output/Species/<label>/arkane/species.py`) is rendered with a bare
+`energy = <Hartree>` assignment when `sp_composite` is active — matching
+Arkane's numeric-energy convention.
+
+## More
+
+Full documentation: `docs/source/advanced.rst`, section
+*Composite single-point protocols (sp_composite)*.

--- a/examples/Composite/README.md
+++ b/examples/Composite/README.md
@@ -8,7 +8,7 @@ feature — composite single-point protocols for refined electronic energies
 |---|---|
 | `heat345q_preset/input.yml` | **Form 1** — preset by name (`HEAT-345Q`). Smallest possible composite input. |
 | `heat345q_partial_override/input.yml` | **Form 2** — preset with partial override: swap one basis set on a single term. |
-| `explicit_fpa/input.yml` | **Form 3** — fully explicit recipe, including a `cbs_extrapolation` term (Helgaker 2-pt correlation). |
+| `explicit_fpa/input.yml` | **Form 3** — fully explicit recipe with a `cbs_extrapolation` *base* (Helgaker 2-pt, CBS-as-base) plus a δ[CCSDT] correction. |
 | `per_species_override/input.yml` | **Form 4** — per-species override: one species keeps the project default, one opts out via `null`, one uses a species-specific protocol. |
 | `w3f12_preset/input.yml` | **W\ :sub:`n` family** — `W3-F12` preset (CCSD(T)-F12/QZ anchor + δ[CCSDT] + δ_CV + δ_rel). Cheaper than HEAT-345Q when post-(T) effects beyond CCSDT are not the bottleneck. |
 | `heat456q_preset/input.yml` | **Tighter base** — `HEAT-456Q` preset: same correction stack as `HEAT-345Q` but with a `cc-pVQZ-F12` anchor for systems where CCSD(T) basis incompleteness drives residual barrier error. |
@@ -36,8 +36,8 @@ molecules (4–6 atoms, tight TSs) but become prohibitive quickly. The minimal
 level of theory (or drop expensive terms via overrides) for larger systems.
 
 For small methodological demos that do not require an expensive post-(T)
-reference calculation, see `explicit_fpa/input.yml`, which shows the CBS
-extrapolation form using only CCSD(T)/cc-pV{T,Q}Z.
+reference calculation, see `explicit_fpa/input.yml`, which shows the
+CBS-as-base form using only CCSD(T)/cc-pV{T,Q}Z.
 
 ## Units
 

--- a/examples/Composite/explicit_fpa/input.yml
+++ b/examples/Composite/explicit_fpa/input.yml
@@ -1,0 +1,41 @@
+# Form 3 — fully explicit recipe, with a CBS extrapolation term.
+#
+# A minimal Allen-style focal-point analysis:
+#   E_final = E[CCSD(T)-F12/cc-pVTZ-F12]            (base)
+#           + E_CBS(CCSD(T) corr) − E[CCSD(T)/cc-pVTZ]   (CBS extrapolation)
+#           + δ[CCSDT]                              (post-(T) correction)
+#
+# Does NOT require MRCC. CCSDT at cc-pVDZ runs in CFOUR (NCC) or Molpro.
+# CBS term uses Helgaker 2-point correlation-energy formula:
+#   (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)
+# See Helgaker, Klopper, Koch, Noga, J. Chem. Phys. 106, 9639 (1997).
+#
+# The top-level ``reference`` key carries a user-supplied citation; it flows
+# into the generated provenance notebook's References block.
+project: composite_explicit_fpa
+
+sp_composite:
+  reference: >-
+    Minimal focal-point analysis; cites Helgaker et al.
+    J. Chem. Phys. 106, 9639 (1997); DOI: 10.1063/1.473863.
+  base:
+    method: ccsd(t)-f12
+    basis: cc-pVTZ-f12
+  corrections:
+    - label: cbs_corr
+      type: cbs_extrapolation
+      formula: helgaker_corr_2pt
+      # Only ``components: total`` is currently supported — adapter-level
+      # correlation-only parsing is a future addition. Formula name documents intent.
+      components: total
+      levels:
+        - {method: ccsd(t), basis: cc-pVTZ}
+        - {method: ccsd(t), basis: cc-pVQZ}
+    - label: delta_T
+      type: delta
+      high: {method: ccsdt,   basis: cc-pVDZ}
+      low:  {method: ccsd(t), basis: cc-pVDZ}
+
+species:
+  - label: OH
+    smiles: '[OH]'

--- a/examples/Composite/explicit_fpa/input.yml
+++ b/examples/Composite/explicit_fpa/input.yml
@@ -1,14 +1,18 @@
-# Form 3 — fully explicit recipe, with a CBS extrapolation term.
+# Form 3 — fully explicit recipe, with a CBS extrapolation as the base.
 #
 # A minimal Allen-style focal-point analysis:
-#   E_final = E[CCSD(T)-F12/cc-pVTZ-F12]            (base)
-#           + E_CBS(CCSD(T) corr) − E[CCSD(T)/cc-pVTZ]   (CBS extrapolation)
-#           + δ[CCSDT]                              (post-(T) correction)
+#   E_final = E_CBS[CCSD(T)/cc-pV{T,Q}Z]   (base: two-point CBS extrapolation)
+#           + δ[CCSDT]                     (post-(T) correction)
 #
 # Does NOT require MRCC. CCSDT at cc-pVDZ runs in CFOUR (NCC) or Molpro.
-# CBS term uses Helgaker 2-point correlation-energy formula:
-#   (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)
+# The base uses the Helgaker 2-point X^-3 formula:
+#   E_CBS = (X^3·E_X − Y^3·E_Y) / (X^3 − Y^3)
 # See Helgaker, Klopper, Koch, Noga, J. Chem. Phys. 106, 9639 (1997).
+#
+# Honesty note: the X^-3 form was derived for the correlation energy, but it
+# is applied here to TOTAL energies (the only component ARC's parsers surface)
+# — the exponentially-converging HF component is technically mis-treated. At
+# {T,Q} cardinals the residual is small and this is common practice.
 #
 # The top-level ``reference`` key carries a user-supplied citation; it flows
 # into the generated provenance notebook's References block.
@@ -18,19 +22,18 @@ sp_composite:
   reference: >-
     Minimal focal-point analysis; cites Helgaker et al.
     J. Chem. Phys. 106, 9639 (1997); DOI: 10.1063/1.473863.
+    Two-point X^-3 extrapolation applied to total energies.
   base:
-    method: ccsd(t)-f12
-    basis: cc-pVTZ-f12
+    label: base
+    type: cbs_extrapolation
+    formula: helgaker_corr_2pt
+    # Only ``components: total`` is currently supported — adapter-level
+    # HF/correlation component parsing is a future addition.
+    components: total
+    levels:
+      - {method: ccsd(t), basis: cc-pVTZ}
+      - {method: ccsd(t), basis: cc-pVQZ}
   corrections:
-    - label: cbs_corr
-      type: cbs_extrapolation
-      formula: helgaker_corr_2pt
-      # Only ``components: total`` is currently supported — adapter-level
-      # correlation-only parsing is a future addition. Formula name documents intent.
-      components: total
-      levels:
-        - {method: ccsd(t), basis: cc-pVTZ}
-        - {method: ccsd(t), basis: cc-pVQZ}
     - label: delta_T
       type: delta
       high: {method: ccsdt,   basis: cc-pVDZ}

--- a/examples/Composite/heat345q_partial_override/input.yml
+++ b/examples/Composite/heat345q_partial_override/input.yml
@@ -1,0 +1,20 @@
+# Form 2 — preset with partial override.
+#
+# Keeps HEAT-345Q everywhere except for the δ[CCSDT] term, whose basis is
+# promoted from cc-pVDZ to cc-pVTZ. All other terms (δ[CCSDT(Q)], δ[CV],
+# δ[rel]) stay at the preset's defaults.
+#
+# Override target labels must match term labels in presets.yml; unknown
+# target labels raise InputError.
+project: composite_heat345q_partial_override
+
+sp_composite:
+  preset: HEAT-345Q
+  overrides:
+    delta_T:
+      high: {method: ccsdt,   basis: cc-pVTZ}
+      low:  {method: ccsd(t), basis: cc-pVTZ}
+
+species:
+  - label: OH
+    smiles: '[OH]'

--- a/examples/Composite/heat345q_preset/input.yml
+++ b/examples/Composite/heat345q_preset/input.yml
@@ -1,0 +1,15 @@
+# Form 1 — preset by name. The smallest possible composite input.
+#
+# Requires the CFOUR (NCC module) or Molpro adapters to run the post-(T)
+# corrections in HEAT-345Q (δ[CCSDT], δ[CCSDT(Q)]). For small species
+# (H2, OH, small diatomics) this is feasible; for anything larger, use
+# explicit_fpa/input.yml as a starting point.
+project: composite_heat345q_preset
+
+sp_composite: HEAT-345Q
+
+species:
+  - label: H2
+    smiles: '[H][H]'
+  - label: O
+    smiles: '[O]'

--- a/examples/Composite/per_species_override/input.yml
+++ b/examples/Composite/per_species_override/input.yml
@@ -1,0 +1,28 @@
+# Form 4 — per-species override (three distinguishable states).
+#
+# * H2     → no ``sp_composite`` key     ⇒ inherits the project-wide HEAT-345Q
+# * H2O    → ``sp_composite: null``      ⇒ opt out; plain ``sp_level`` is used
+# * OH     → species-specific ``sp_composite`` ⇒ a cheap MP2-only "composite"
+#
+# The three states are distinguishable in ARCSpecies: ``sp_composite_state``
+# is "inherit" / "opt_out" / "explicit" respectively. All three survive the
+# restart-dict round-trip.
+project: composite_per_species_override
+
+sp_composite: HEAT-345Q          # project-wide default
+sp_level: wb97xd/def2-tzvp        # used by the opt-out species ("H2O" below)
+
+species:
+  - label: H2
+    smiles: '[H][H]'
+    # (inherit the project-wide HEAT-345Q protocol)
+
+  - label: H2O
+    smiles: O
+    sp_composite: null             # opt out — use plain sp_level above
+
+  - label: OH
+    smiles: '[OH]'
+    sp_composite:
+      base: {method: mp2, basis: cc-pVTZ}
+      corrections: []


### PR DESCRIPTION
## Summary

Add `sp_composite`: composite single-point energy protocols for ARC.

This adds HEAT-style / focal-point composite SP workflows and CBS extrapolation, with:
- preset or explicit recipe input
- per-species inherit / override / opt-out
- Scheduler orchestration and restart support
- project-level provenance notebook
- Arkane explicit-energy support

Legacy `composite_method` remains unchanged.

## User-facing behavior

New YAML key:

```yaml
sp_composite: HEAT-345Q
````

Supported forms:

* preset by name
* preset + `overrides`
* fully explicit `base` + `corrections`
* per-species override or `sp_composite: null`

Notes:

* mutually exclusive with `composite_method`
* incompatible with `adaptive_levels`
* if `sp_level` is omitted, ARC uses `sp_composite.base.level`
* `conformer_sp_level` is unchanged
* CBS currently supports `components: total` only

## Implementation

* relocates legacy `Level` into the new `arc/level/` package while preserving `from arc.level import Level`
* adds `CompositeProtocol`, `SinglePointTerm`, `DeltaTerm`, and `CBSExtrapolationTerm`
* adds preset expansion from `presets.yml`
* adds Scheduler handling for composite sub-jobs, restart rehydration, and final energy combination
* writes a project notebook at:

```text
<project>/output/sp_composite.ipynb
```

* adds Arkane rendering for explicit composite electronic energies

