### PR TITLE
trsh: drop checkfile on SCF/Unconverged/BasisSet failures

### DIFF
--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -127,6 +127,13 @@ def determine_ess_status(output_path: str,
                         keywords = ['GL301']
                     elif 'l401.exe' in line:
                         keywords = ['GL401']
+                    elif 'l601.exe' in line:
+                        # L601 with RdWrB1 typically signals a checkpoint/read-write file
+                        # collision (e.g., concurrent jobs sharing a chk path) — Gaussian
+                        # cannot read the chk safely, so the next attempt must rebuild it.
+                        keywords = ['CheckFile', 'GL601']
+                        error = ('Gaussian L601 read-write error, often from a chk/rwf '
+                                 'collision between concurrent jobs.')
                     elif 'l502.exe' in line:
                         # Check if Inaccurate quadrature in CalDSu
                         inacc_quad = False

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -912,7 +912,18 @@ def trsh_ess_job(label: str,
         # - Changing Computational Parameters
         remove_checkfile, ess_trsh_methods, couldnt_trsh = trsh_keyword_checkfile(job_status, ess_trsh_methods, couldnt_trsh)
         if remove_checkfile:
-             logger_info.append('that failed with "Basis set data is not on the checkpoint file" by removing the checkfile.')
+            chk_drop_keywords = job_status.get('keywords', []) or []
+            if 'CheckFile' in chk_drop_keywords:
+                chk_drop_reason = '"Basis set data is not on the checkpoint file"'
+            elif 'BasisSet' in chk_drop_keywords:
+                chk_drop_reason = 'a failed basis-set projection from the prior checkpoint'
+            elif 'SCF' in chk_drop_keywords:
+                chk_drop_reason = 'an unconverged SCF in the prior job'
+            elif 'Unconverged' in chk_drop_keywords:
+                chk_drop_reason = 'an unconverged wavefunction in the prior job'
+            else:
+                chk_drop_reason = 'a checkpoint-related issue'
+            logger_info.append(f'that failed with {chk_drop_reason} by removing the checkfile.')
 
         # Check if InternalCoordinateError is in the keyword or opt=(cartesian)
         ess_trsh_methods, trsh_keyword, couldnt_trsh = trsh_keyword_cartesian(job_status, ess_trsh_methods, job_type, trsh_keyword,couldnt_trsh)

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -1754,9 +1754,17 @@ def scan_quality_check(label: str,
 
 def trsh_keyword_checkfile(job_status, ess_trsh_methods, couldnt_trsh) -> tuple[bool, list, bool]:
     """
-    Check if the job requires removal of checkfile
+    Check if the job requires removal of checkfile.
+
+    Drops the checkfile when the prior job either could not read it
+    ('CheckFile' from L301/L401), produced a non-converged wavefunction
+    ('SCF' from L502, 'Unconverged' from L508), or reported a failed
+    basis projection ('BasisSet' from L401). Reusing MOs from a
+    non-converged or basis-incompatible chk re-seeds the same failure.
     """
-    if 'CheckFile' in job_status.get('keywords', '') and 'checkfile=None' not in ess_trsh_methods:
+    keywords = job_status.get('keywords', []) or []
+    bad_wavefunction = any(k in keywords for k in ('CheckFile', 'SCF', 'Unconverged', 'BasisSet'))
+    if bad_wavefunction and 'checkfile=None' not in ess_trsh_methods:
         ess_trsh_methods.append('checkfile=None')
         couldnt_trsh = False
         return True, ess_trsh_methods, couldnt_trsh

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -796,6 +796,25 @@ class TestTrsh(unittest.TestCase):
                               num_heavy_atoms, cpu_cores, ess_trsh_methods,
                               is_h=True, is_monoatomic=True)
 
+    def test_trsh_keyword_checkfile_drops_on_bad_wavefunction(self):
+        """SCF/Unconverged failures must drop the checkfile so the rerun uses guess=mix."""
+        for kw in ('CheckFile', 'SCF', 'Unconverged', 'BasisSet'):
+            ess_trsh_methods = []
+            remove, ess_trsh_methods, couldnt = trsh.trsh_keyword_checkfile(
+                {'keywords': [kw]}, ess_trsh_methods, couldnt_trsh=True,
+            )
+            self.assertTrue(remove, f'{kw} should drop the checkfile')
+            self.assertIn('checkfile=None', ess_trsh_methods)
+            self.assertFalse(couldnt)
+
+        # Failures unrelated to wavefunction quality must keep the checkfile.
+        for kw in ('MaxOptCycles', 'InternalCoordinateError', 'DiskSpace', 'OptOrientation'):
+            remove, methods, _ = trsh.trsh_keyword_checkfile(
+                {'keywords': [kw]}, ess_trsh_methods=[], couldnt_trsh=True,
+            )
+            self.assertFalse(remove, f'{kw} must not drop the checkfile')
+            self.assertNotIn('checkfile=None', methods)
+
     def test_determine_job_log_memory_issues(self):
         """Test the determine_job_log_memory_issues() function."""
         job_log_path_1 = os.path.join(ARC_TESTING_PATH, 'job_log', 'no_issues.log')

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -97,6 +97,16 @@ class TestTrsh(unittest.TestCase):
         self.assertIn("Error termination via Lnk1e", line)
         self.assertIn("g09/l401.exe", line)
 
+        path = os.path.join(self.base_path["gaussian"], "l601.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="Zr2O4H", job_type="opt"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["CheckFile", "GL601"])
+        self.assertIn("L601", error)
+        self.assertIn("Error termination via Lnk1e", line)
+        self.assertIn("l601.exe", line)
+
         path = os.path.join(self.base_path["gaussian"], "l9999.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="Zr2O4H", job_type="opt"

--- a/arc/testing/trsh/gaussian/l601.out
+++ b/arc/testing/trsh/gaussian/l601.out
@@ -1,0 +1,10 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /usr/local/g16/l1.exe "/scratch/Gau-l601.inp" -scrdir="/scratch/"
+ ----------------
+ # opt freq m062x
+ ----------------
+ Charge =  0 Multiplicity = 1
+ RdWrB1: read garbage pointers; chk/rwf collision detected.
+ Error termination via Lnk1e in /usr/local/g16/l601.exe at Wed Apr 22 18:23:01 2026.
+ Job cpu time:       0 days  0 hours  0 minutes  3.2 seconds.


### PR DESCRIPTION
## Summary

Make ARC's Gaussian checkpoint handling robust to wavefunction-quality failures.

`trsh_keyword_checkfile` only fired on the `CheckFile` keyword, so a job that died with unconverged SCF (L502) had its partial `check.chk` inherited by the rerun. The next job's Gaussian adapter then auto-emitted `guess=read` against MOs from a non-converged iteration, typically failing with L401 (`"Basis set data is not on the checkpoint file"`) and wasting a full Gaussian invocation before self-healing back to `guess=mix`.

This PR widens the chk-drop guard, fixes the misleading log line that resulted, and adds a missing detector for L601 chk/rwf collisions.

## Observed in the wild

`Paper_ROTORS_TS/rmg_rxn_1142` (Zeus): opt_a6355 → SCF unconverged → opt_a6358 ran with `guess=read` against the partial chk → L401 → opt_a6359 finally fell back to `guess=mix` after the existing `CheckFile`-keyword self-heal. After this PR, opt_a6358 goes straight to `guess=mix` with `scf=(qc) nosymm`, skipping the L401 detour.

## Commits in this PR

### 1. `trsh: drop checkfile on SCF/Unconverged/BasisSet failures`

Extend `trsh_keyword_checkfile` to drop the chk on four wavefunction-quality keywords:

| Keyword | Source | Why drop chk |
|---|---|---|
| `CheckFile` | L301/L401 chk-data missing | Existing — chk is structurally broken |
| `SCF` | L502 unconverged SCF | New — MOs are mid-iteration garbage |
| `Unconverged` | L508 / GL9999 generic | New — wavefunction quality is the issue |
| `BasisSet` | L401 basis projection failed | New — old MOs incompatible with new basis |

Non-wavefunction failures (`MaxOptCycles`, `InternalCoordinateError`, `DiskSpace`, `OptOrientation`, etc.) remain unaffected, so the warm-start cycle savings on those paths are preserved. `level_of_theory` is read-only inside `trsh.py`, so there's no method/charge/multiplicity-change path during trsh that needs guarding.

### 2. `trsh: branch the chk-drop log message by triggering keyword`

After widening the guard, the hardcoded log line *"that failed with 'Basis set data is not on the checkpoint file' by removing the checkfile."* falsely claimed a chk-data failure for unrelated wavefunction failures. Pick the explanatory phrase from `job_status['keywords']` so the log reflects the actual failure mode (chk-read error, basis projection, unconverged SCF, or generic unconverged wavefunction).

### 3. `trsh: detect Gaussian L601 (RdWrB1) chk/rwf collision`

Concurrent Gaussian jobs sharing a checkpoint or read-write file path can trigger L601 with an RdWrB1 garbage-pointer error. ARC had no `l601.exe` handler in `determine_ess_status`, so these failures fell through to the generic `Unknown` bucket and bypassed the chk-drop logic even though the chk is exactly what's at fault. Routes L601 to the `CheckFile` keyword so the existing plumbing clears the chk before the rerun.

## Test plan
- [x] `pytest arc/job/trsh_test.py` passes (9 tests, including new regressions)
- [x] New `test_trsh_keyword_checkfile_drops_on_bad_wavefunction` covers a fresh `ess_trsh_methods` list per drop-keyword (the existing `test_trsh_ess_job` masked the bug because sub-cases mutated a shared list) and pins keep-keyword behavior so the warm-start path can't regress silently
- [x] `test_determine_ess_status` extended with a new `l601.out` fixture verifying L601 routes to `['CheckFile', 'GL601']`
- [ ] Re-run a known SCF-failure case end-to-end on Zeus to confirm trsh chain skips the L401 detour

## Out of scope (tracking separately)

Related cleanups surfaced while reading wang/leng Gaussian-error references but kept out of this PR to preserve scope:
- Possible `no_xqc` (L508 keyword) vs `no_qc` (ess_trsh_method) wiring mismatch in `trsh_keyword_scf` — would let ARC de-escalate `scf=(qc)` when L508 says QC was the problem
- `stable=opt` for TS first-opt to catch saddle-point SCF convergences (Class 4 wrong-solution)
- Energy-trajectory parsing to distinguish SCF oscillation vs drift vs divergence (lets us *keep* the chk on Class 2 drift)
- Scheduler-side guard preventing failed jobs from promoting their chk to `species.checkfile` in the first place