### PR TITLE
Break down monolithic driver and heuristics tests

### DIFF
--- a/arc/job/adapters/ts/heuristics_test.py
+++ b/arc/job/adapters/ts/heuristics_test.py
@@ -1125,63 +1125,58 @@ H      -3.45360689    0.15275707   -0.76116277""")
         heuristics_1.execute_incore()
         self.assertEqual(len(rxn1.ts_species.ts_guesses), 12)
 
-    def test_heuristics_for_hydrolysis(self):
+    def test_heuristics_for_carbonyl_based_hydrolysis(self):
         """
-        Test that ARC can generate TS guesses based on heuristics for different hydrolysis families reactions.
+        Test heuristics for carbonyl-based hydrolysis: C2H4O2 + H2O <=> CH2O2 + CH4O.
         """
-        # Carbonyl-based hydrolysis
-        # C2H4O2 + H2O <=> CH2O2 + CH4O
-        methylformate = self.methylformate
-        formicacid = self.formicacid
-        methanol = self.methanol
-        water = self.water
-        rxn1 = ARCReaction(r_species=[methylformate, water], p_species=[formicacid, methanol],
-                           family='carbonyl_based_hydrolysis')
-        heuristics_1 = HeuristicsAdapter(job_type='tsg',
-                                         reactions=[rxn1],
-                                         testing=True,
-                                         project='test',
-                                         project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics')
-                                         )
-        heuristics_1.execute_incore()
-        self.assertEqual(rxn1.family, 'carbonyl_based_hydrolysis')
-        self.assertTrue(rxn1.ts_species.is_ts)
-        self.assertEqual(rxn1.ts_species.ts_guesses[0].initial_xyz['symbols'],
+        rxn = ARCReaction(r_species=[self.methylformate, self.water],
+                          p_species=[self.formicacid, self.methanol],
+                          family='carbonyl_based_hydrolysis')
+        adapter = HeuristicsAdapter(job_type='tsg',
+                                    reactions=[rxn],
+                                    testing=True,
+                                    project='test',
+                                    project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics_carbonyl'))
+        adapter.execute_incore()
+        self.assertEqual(rxn.family, 'carbonyl_based_hydrolysis')
+        self.assertTrue(rxn.ts_species.is_ts)
+        self.assertEqual(rxn.ts_species.ts_guesses[0].initial_xyz['symbols'],
                          ('C', 'O', 'C', 'O', 'H', 'H', 'H', 'H', 'O', 'H', 'H'))
-        self.assertEqual(len(rxn1.ts_species.ts_guesses), 6)
-        # Ether hydrolysis
-        # C3H8O + H2O <=> C2H6O + CH4O
-        allylmethylether = self.allylmethylether
-        allylalcohol = self.allylalcohol
-        methanol = self.methanol
-        rxn2 = ARCReaction(r_species=[allylmethylether, water], p_species=[allylalcohol, methanol])
-        heuristics_2 = HeuristicsAdapter(job_type='tsg',
-                                         reactions=[rxn2],
-                                         testing=True,
-                                         project='test',
-                                         project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics')
-                                         )
-        heuristics_2.execute_incore()
-        self.assertEqual(rxn2.family, 'ether_hydrolysis')
-        self.assertTrue(rxn2.ts_species.is_ts)
-        self.assertEqual(rxn2.ts_species.ts_guesses[0].initial_xyz['symbols'],
+        self.assertEqual(len(rxn.ts_species.ts_guesses), 6)
+
+    def test_heuristics_for_ether_hydrolysis(self):
+        """
+        Test heuristics for ether hydrolysis: C3H8O + H2O <=> C2H6O + CH4O.
+        """
+        rxn = ARCReaction(r_species=[self.allylmethylether, self.water],
+                          p_species=[self.allylalcohol, self.methanol])
+        adapter = HeuristicsAdapter(job_type='tsg',
+                                    reactions=[rxn],
+                                    testing=True,
+                                    project='test',
+                                    project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics_ether'))
+        adapter.execute_incore()
+        self.assertEqual(rxn.family, 'ether_hydrolysis')
+        self.assertTrue(rxn.ts_species.is_ts)
+        self.assertEqual(rxn.ts_species.ts_guesses[0].initial_xyz['symbols'],
                          ('C', 'C', 'C', 'O', 'C', 'H', 'H', 'H', 'H', 'H', 'H', 'H', 'H', 'O', 'H', 'H'))
-        self.assertEqual(len(rxn2.ts_species.ts_guesses), 4)
-        # Nitrile hydrolysis
-        # N#CC(C#N) + H2O <=> N=C(O)C(C#N)
-        malononitrile = self.malononitrile
-        iminopropanoic_acid = self.iminopropanoic_acid
-        rxn4 = ARCReaction(r_species=[malononitrile, water], p_species=[iminopropanoic_acid])
-        heuristics_4 = HeuristicsAdapter(job_type='tsg',
-                                         reactions=[rxn4],
-                                         testing=True,
-                                         project='test',
-                                         project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics')
-                                         )
-        heuristics_4.execute_incore()
-        self.assertEqual(rxn4.family, 'nitrile_hydrolysis')
-        self.assertTrue(rxn4.ts_species.is_ts)
-        self.assertEqual(rxn4.ts_species.ts_guesses[0].initial_xyz['symbols'],
+        self.assertEqual(len(rxn.ts_species.ts_guesses), 4)
+
+    def test_heuristics_for_nitrile_hydrolysis(self):
+        """
+        Test heuristics for nitrile hydrolysis: N#CC(C#N) + H2O <=> N=C(O)C(C#N).
+        """
+        rxn = ARCReaction(r_species=[self.malononitrile, self.water],
+                          p_species=[self.iminopropanoic_acid])
+        adapter = HeuristicsAdapter(job_type='tsg',
+                                    reactions=[rxn],
+                                    testing=True,
+                                    project='test',
+                                    project_directory=os.path.join(ARC_TESTING_PATH, 'heuristics_nitrile'))
+        adapter.execute_incore()
+        self.assertEqual(rxn.family, 'nitrile_hydrolysis')
+        self.assertTrue(rxn.ts_species.is_ts)
+        self.assertEqual(rxn.ts_species.ts_guesses[0].initial_xyz['symbols'],
                          ('N', 'C', 'C', 'C', 'N', 'H', 'H', 'O', 'H', 'H'))
 
     def test_keeping_atom_order_in_ts(self):
@@ -1958,90 +1953,65 @@ H      -3.45360689    0.15275707   -0.76116277""")
         self.assertEqual(find_distant_neighbor(mol=mol_3, start=2), 4)
         self.assertEqual(find_distant_neighbor(mol=mol_3, start=2), 4)
 
-    def test_are_h_abs_wells_reversed(self):
-        """
-        Test the are_h_abs_wells_reversed() function.
-        The expected order is: R(*1)-H(*2) + R(*3)j <=> R(*1)j + R(*3)-H(*2)
-        """
-        rxn_1 = ARCReaction(r_species=[ARCSpecies(label='C2H6', smiles='CC'), ARCSpecies(label='OH', smiles='[OH]')],
-                            # none are reversed
-                            p_species=[ARCSpecies(label='C2H5', smiles='[CH2]C'), ARCSpecies(label='H2O', smiles='O')])
-        rxn_2 = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'), ARCSpecies(label='C2H6', smiles='CC')],
-                            # r reversed
-                            p_species=[ARCSpecies(label='C2H5', smiles='[CH2]C'), ARCSpecies(label='H2O', smiles='O')])
-        rxn_3 = ARCReaction(r_species=[ARCSpecies(label='C2H6', smiles='CC'), ARCSpecies(label='OH', smiles='[OH]')],
-                            # p reversed
-                            p_species=[ARCSpecies(label='H2O', smiles='O'), ARCSpecies(label='C2H5', smiles='[CH2]C')])
-        rxn_4 = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'), ARCSpecies(label='C2H6', smiles='CC')],
-                            # r and p reversed
-                            p_species=[ARCSpecies(label='H2O', smiles='O'), ARCSpecies(label='C2H5', smiles='[CH2]C')])
-
-        product_dicts = get_reaction_family_products(rxn=rxn_1,
-                                                     rmg_family_set=[rxn_1.family],
+    def _check_h_abs_wells_reversed(self, rxn: 'ARCReaction', expected_r_reversed: bool, expected_p_reversed: bool):
+        """Helper: run are_h_abs_wells_reversed against the family products and assert the orientations."""
+        product_dicts = get_reaction_family_products(rxn=rxn,
+                                                     rmg_family_set=[rxn.family],
                                                      consider_rmg_families=True,
                                                      consider_arc_families=False,
                                                      discover_own_reverse_rxns_in_reverse=False,
                                                      )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_1, product_dict=product_dicts[0])
-        self.assertFalse(r_reversed)
-        self.assertFalse(p_reversed)
+        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn, product_dict=product_dicts[0])
+        self.assertEqual(r_reversed, expected_r_reversed)
+        self.assertEqual(p_reversed, expected_p_reversed)
 
-        product_dicts = get_reaction_family_products(rxn=rxn_2,
-                                                     rmg_family_set=[rxn_2.family],
-                                                     consider_rmg_families=True,
-                                                     consider_arc_families=False,
-                                                     discover_own_reverse_rxns_in_reverse=False,
-                                                     )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_2, product_dict=product_dicts[0])
-        self.assertTrue(r_reversed)
-        self.assertFalse(p_reversed)
+    def test_are_h_abs_wells_reversed_neither_reversed(self):
+        """C2H6 + OH <=> C2H5 + H2O — neither r nor p reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='C2H6', smiles='CC'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='C2H5', smiles='[CH2]C'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=False, expected_p_reversed=False)
 
-        product_dicts = get_reaction_family_products(rxn=rxn_3,
-                                                     rmg_family_set=[rxn_3.family],
-                                                     consider_rmg_families=True,
-                                                     consider_arc_families=False,
-                                                     discover_own_reverse_rxns_in_reverse=False,
-                                                     )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_3, product_dict=product_dicts[0])
-        self.assertFalse(r_reversed)
-        self.assertTrue(p_reversed)
+    def test_are_h_abs_wells_reversed_r_reversed(self):
+        """OH + C2H6 <=> C2H5 + H2O — reactants reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                     ARCSpecies(label='C2H6', smiles='CC')],
+                          p_species=[ARCSpecies(label='C2H5', smiles='[CH2]C'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=True, expected_p_reversed=False)
 
-        product_dicts = get_reaction_family_products(rxn=rxn_4,
-                                                     rmg_family_set=[rxn_4.family],
-                                                     consider_rmg_families=True,
-                                                     consider_arc_families=False,
-                                                     discover_own_reverse_rxns_in_reverse=False,
-                                                     )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_4, product_dict=product_dicts[0])
-        self.assertTrue(r_reversed)
-        self.assertTrue(p_reversed)
+    def test_are_h_abs_wells_reversed_p_reversed(self):
+        """C2H6 + OH <=> H2O + C2H5 — products reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='C2H6', smiles='CC'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='H2O', smiles='O'),
+                                     ARCSpecies(label='C2H5', smiles='[CH2]C')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=False, expected_p_reversed=True)
 
-        rxn_5 = ARCReaction(r_species=[ARCSpecies(label='H', smiles='[H]'), ARCSpecies(label='H2O', smiles='O')],
-                            # r and p reversed
-                            p_species=[ARCSpecies(label='H2', smiles='[H][H]'), ARCSpecies(label='OH', smiles='[OH]')])
-        product_dicts = get_reaction_family_products(rxn=rxn_5,
-                                                     rmg_family_set=[rxn_5.family],
-                                                     consider_rmg_families=True,
-                                                     consider_arc_families=False,
-                                                     discover_own_reverse_rxns_in_reverse=False,
-                                                     )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_5, product_dict=product_dicts[0])
-        self.assertTrue(r_reversed)
-        self.assertTrue(p_reversed)
+    def test_are_h_abs_wells_reversed_both_reversed(self):
+        """OH + C2H6 <=> H2O + C2H5 — reactants and products reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                     ARCSpecies(label='C2H6', smiles='CC')],
+                          p_species=[ARCSpecies(label='H2O', smiles='O'),
+                                     ARCSpecies(label='C2H5', smiles='[CH2]C')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=True, expected_p_reversed=True)
 
-        rxn_6 = ARCReaction(
-            r_species=[ARCSpecies(label='CCCC(O)=O', smiles='CCCC(O)=O'), ARCSpecies(label='OH', smiles='[OH]')],
-            # none are reversed
-            p_species=[ARCSpecies(label='CCCC([O])=O', smiles='CCCC([O])=O'), ARCSpecies(label='H2O', smiles='O')])
-        product_dicts = get_reaction_family_products(rxn=rxn_6,
-                                                     rmg_family_set=[rxn_6.family],
-                                                     consider_rmg_families=True,
-                                                     consider_arc_families=False,
-                                                     discover_own_reverse_rxns_in_reverse=False,
-                                                     )
-        r_reversed, p_reversed = are_h_abs_wells_reversed(rxn_6, product_dict=product_dicts[0])
-        self.assertFalse(r_reversed)
-        self.assertFalse(p_reversed)
+    def test_are_h_abs_wells_reversed_h_plus_h2o(self):
+        """H + H2O <=> H2 + OH — reactants and products reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='H', smiles='[H]'),
+                                     ARCSpecies(label='H2O', smiles='O')],
+                          p_species=[ARCSpecies(label='H2', smiles='[H][H]'),
+                                     ARCSpecies(label='OH', smiles='[OH]')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=True, expected_p_reversed=True)
+
+    def test_are_h_abs_wells_reversed_butyrate(self):
+        """CCCC(O)=O + OH <=> CCCC([O])=O + H2O — neither r nor p reversed."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CCCC(O)=O', smiles='CCCC(O)=O'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='CCCC([O])=O', smiles='CCCC([O])=O'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        self._check_h_abs_wells_reversed(rxn, expected_r_reversed=False, expected_p_reversed=False)
 
     def test_process_hydrolysis_reaction(self):
         """Test the process_hydrolysis_reaction() function."""
@@ -2254,8 +2224,8 @@ H      -0.30139889    0.23142254    3.12085495"""
         A function that is run ONCE after all unit tests in this class.
         Delete all project directories created during these unit tests.
         """
-        shutil.rmtree(os.path.join(ARC_TESTING_PATH, 'heuristics'), ignore_errors=True)
-        shutil.rmtree(os.path.join(ARC_TESTING_PATH, 'heuristics_1'), ignore_errors=True)
+        for sub in ('heuristics', 'heuristics_1', 'heuristics_carbonyl', 'heuristics_ether', 'heuristics_nitrile'):
+            shutil.rmtree(os.path.join(ARC_TESTING_PATH, sub), ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/arc/mapping/driver_test.py
+++ b/arc/mapping/driver_test.py
@@ -415,11 +415,61 @@ class TestMappingDriver(unittest.TestCase):
                             H       1.36260637    0.37153887   -0.86221771"""
         cls.rxn12 = ARCReaction(r_species=[ARCSpecies(label='NH', smiles='[NH]'), ARCSpecies(label='N2H3', smiles='N[NH]')],
                                 p_species=[ARCSpecies(label='NH2', smiles='[NH2]'), ARCSpecies(label='N2H2(T)', smiles='[NH][NH]')])
+        cls.ch3oo_xyz = """C      -0.41690000    0.03757000    0.00590000
+                           O       0.83973000    0.69383000   -0.05239000
+                           O       1.79663000   -0.33527000   -0.02406000
+                           H      -0.54204000   -0.62249000   -0.85805000
+                           H      -1.20487000    0.79501000   -0.01439000
+                           H      -0.50439000   -0.53527000    0.93431000"""
+        cls.ch3ch2oh_xyz = """C      -0.97459464    0.29181710    0.10303882
+                              C       0.39565894   -0.35143697    0.10221676
+                              H      -1.68942501   -0.32359616    0.65926091
+                              H      -0.93861751    1.28685508    0.55523033
+                              H      -1.35943743    0.38135479   -0.91822428
+                              H       0.76858330   -0.46187184    1.12485643
+                              H       1.10301149    0.25256708   -0.47388355
+                              O       0.30253309   -1.63748710   -0.49196889
+                              H       1.19485981   -2.02360458   -0.47786539"""
+        cls.ch3ooh_xyz = """C      -0.76039072    0.01483858   -0.00903344
+                            H      -1.56632337    0.61401630   -0.44251282
+                            H      -1.02943316   -0.30449156    1.00193709
+                            O       0.16024511    1.92327904    0.86381800
+                            H      -0.60052507   -0.86954495   -0.63086438
+                            O       0.44475333    0.76952102    0.02291303
+                            H       0.30391344    2.59629139    0.17435159"""
+        cls.ch3ch2o_xyz = """C       0.79799272   -0.01511040    0.00517437
+                             H      -1.13881231   -0.99286049    0.06963185
+                             O       1.17260343   -0.72227959   -1.04851579
+                             H      -1.14162013    0.59700303    0.84092854
+                             H      -1.13266865    0.46233725   -0.93283228
+                             C      -0.74046271    0.02568566   -0.00568694
+                             H       1.11374677    1.03794239    0.06905096
+                             H       1.06944350   -0.38306117    1.00698657"""
+        cls.ch3nh2_xyz = {'coords': ((-0.5734111454228507, 0.0203516083213337, 0.03088703933770556),
+                                     (0.8105595891860601, 0.00017446498908627427, -0.4077728757313545),
+                                     (-1.1234549667791063, -0.8123899006368857, -0.41607711106038836),
+                                     (-0.6332220120842996, -0.06381791823047896, 1.1196983583774054),
+                                     (-1.053200912106195, 0.9539501896695028, -0.27567270246542575),
+                                     (1.3186422395164141, 0.7623906284020254, 0.038976118645639976),
+                                     (1.2540872076899663, -0.8606590725145833, -0.09003882710357966)),
+                          'isotopes': (12, 14, 1, 1, 1, 1, 1),
+                          'symbols': ('C', 'N', 'H', 'H', 'H', 'H', 'H')}
+        cls.ch2nh2_xyz = {'coords': ((0.6919493009211066, 0.054389375309083846, 0.02065422596281878),
+                                     (1.3094508022837807, -0.830934909576592, 0.14456347719459348),
+                                     (1.1649142139806816, 1.030396183273415, 0.08526955368597328),
+                                     (-0.7278194451655412, -0.06628299353512612, -0.30657582460750543),
+                                     (-1.2832757211903472, 0.7307667658607352, 0.00177732009031573),
+                                     (-1.155219150829674, -0.9183344213315149, 0.05431124767380799)),
+                          'isotopes': (12, 1, 1, 14, 1, 1),
+                          'symbols': ('C', 'H', 'H', 'N', 'H', 'H')}
 
-    def test_map_abstractions(self):
-        """Test the map_abstractions() function."""
-        # H + CH4 <=> H2 + CH3
-        r_1 = ARCSpecies(label='H', smiles='[H]', xyz={'coords': ((0, 0, 0),), 'isotopes': (1,), 'symbols': ('H',)})
+    @staticmethod
+    def _h_atom() -> 'ARCSpecies':
+        return ARCSpecies(label='H', smiles='[H]', xyz={'coords': ((0, 0, 0),), 'isotopes': (1,), 'symbols': ('H',)})
+
+    def test_map_abstractions_h_plus_ch4_to_h2_plus_ch3(self):
+        """H + CH4 <=> H2 + CH3"""
+        r_1 = self._h_atom()
         r_2 = ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz)
         p_1 = ARCSpecies(label='H2', smiles='[H][H]', xyz=self.h2_xyz)
         p_2 = ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz)
@@ -432,7 +482,12 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [0, 1] for r_index in [2, 3, 4, 5]))
         self.assertTrue(check_atom_map(rxn))
 
-        # H + CH4 <=> CH3 + H2 (different order)
+    def test_map_abstractions_h_plus_ch4_to_ch3_plus_h2(self):
+        """H + CH4 <=> CH3 + H2 (reversed product order)"""
+        r_1 = self._h_atom()
+        r_2 = ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz)
+        p_1 = ARCSpecies(label='H2', smiles='[H][H]', xyz=self.h2_xyz)
+        p_2 = ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz)
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_2, p_1])
         atom_map = rxn.atom_map
         self.assertIn(atom_map[0], [4, 5])
@@ -442,7 +497,12 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [4, 5] for r_index in [2, 3, 4, 5]))
         self.assertTrue(check_atom_map(rxn))
 
-        # CH4 + H <=> H2 + CH3 (different order)
+    def test_map_abstractions_ch4_plus_h_to_h2_plus_ch3(self):
+        """CH4 + H <=> H2 + CH3 (reversed reactant order)"""
+        r_1 = self._h_atom()
+        r_2 = ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz)
+        p_1 = ARCSpecies(label='H2', smiles='[H][H]', xyz=self.h2_xyz)
+        p_2 = ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz)
         rxn = ARCReaction(r_species=[r_2, r_1], p_species=[p_1, p_2])
         atom_map = rxn.atom_map
         self.assertEqual(atom_map[0], 2)
@@ -452,7 +512,12 @@ class TestMappingDriver(unittest.TestCase):
         self.assertIn(atom_map[5], [0, 1])
         self.assertTrue(check_atom_map(rxn))
 
-        # CH4 + H <=> CH3 + H2 (different order)
+    def test_map_abstractions_ch4_plus_h_to_ch3_plus_h2(self):
+        """CH4 + H <=> CH3 + H2 (reactant and product orders both reversed)"""
+        r_1 = self._h_atom()
+        r_2 = ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz)
+        p_1 = ARCSpecies(label='H2', smiles='[H][H]', xyz=self.h2_xyz)
+        p_2 = ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz)
         rxn = ARCReaction(r_species=[r_2, r_1], p_species=[p_2, p_1])
         atom_map = rxn.atom_map
         self.assertEqual(atom_map[0], 0)
@@ -461,32 +526,16 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [4, 5] for r_index in [1, 2, 3, 4]))
         self.assertIn(atom_map[5], [4, 5])
         self.assertTrue(check_atom_map(rxn))
-        
-        # H + CH3NH2 <=> H2 + CH2NH2
-        ch3nh2_xyz = {'coords': ((-0.5734111454228507, 0.0203516083213337, 0.03088703933770556),
-                                 (0.8105595891860601, 0.00017446498908627427, -0.4077728757313545),
-                                 (-1.1234549667791063, -0.8123899006368857, -0.41607711106038836),
-                                 (-0.6332220120842996, -0.06381791823047896, 1.1196983583774054),
-                                 (-1.053200912106195, 0.9539501896695028, -0.27567270246542575),
-                                 (1.3186422395164141, 0.7623906284020254, 0.038976118645639976),
-                                 (1.2540872076899663, -0.8606590725145833, -0.09003882710357966)),
-                      'isotopes': (12, 14, 1, 1, 1, 1, 1),
-                      'symbols': ('C', 'N', 'H', 'H', 'H', 'H', 'H')}
-        ch2nh2_xyz = {'coords': ((0.6919493009211066, 0.054389375309083846, 0.02065422596281878),
-                                 (1.3094508022837807, -0.830934909576592, 0.14456347719459348),
-                                 (1.1649142139806816, 1.030396183273415, 0.08526955368597328),
-                                 (-0.7278194451655412, -0.06628299353512612, -0.30657582460750543),
-                                 (-1.2832757211903472, 0.7307667658607352, 0.00177732009031573),
-                                 (-1.155219150829674, -0.9183344213315149, 0.05431124767380799)),
-                      'isotopes': (12, 1, 1, 14, 1, 1),
-                      'symbols': ('C', 'H', 'H', 'N', 'H', 'H')}
-        r_1 = ARCSpecies(label='H', smiles='[H]', xyz={'coords': ((0, 0, 0),), 'isotopes': (1,), 'symbols': ('H',)})
-        r_2 = ARCSpecies(label='CH3NH2', smiles='CN', xyz=ch3nh2_xyz)
+
+    def test_map_abstractions_h_plus_ch3nh2_to_h2_plus_ch2nh2(self):
+        """H + CH3NH2 <=> H2 + CH2NH2"""
+        r_1 = self._h_atom()
+        r_2 = ARCSpecies(label='CH3NH2', smiles='CN', xyz=self.ch3nh2_xyz)
         p_1 = ARCSpecies(label='H2', smiles='[H][H]', xyz=self.h2_xyz)
-        p_2 = ARCSpecies(label='CH2NH2', smiles='[CH2]N', xyz=ch2nh2_xyz)
+        p_2 = ARCSpecies(label='CH2NH2', smiles='[CH2]N', xyz=self.ch2nh2_xyz)
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_1, p_2])
         atom_map = rxn.atom_map
-        self.assertIn(atom_map[0], [0,1])
+        self.assertIn(atom_map[0], [0, 1])
         self.assertEqual(atom_map[1], 2)
         self.assertEqual(atom_map[2], 5)
         self.assertIn(atom_map[3], [0, 1, 3, 4])
@@ -497,7 +546,8 @@ class TestMappingDriver(unittest.TestCase):
         self.assertIn(atom_map[7], [6, 7])
         self.assertTrue(check_atom_map(rxn))
 
-        # CH4 + OH <=> CH3 + H2O
+    def test_map_abstractions_ch4_plus_oh(self):
+        """CH4 + OH <=> CH3 + H2O"""
         r_1 = ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz)
         r_2 = ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)
         p_1 = ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz)
@@ -514,7 +564,8 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [5, 6] for r_index in [1, 2, 3, 4]))
         self.assertTrue(check_atom_map(rxn))
 
-        # NH2 + N2H4 <=> NH3 + N2H3
+    def test_map_abstractions_nh2_plus_n2h4_to_nh3_plus_n2h3(self):
+        """NH2 + N2H4 <=> NH3 + N2H3"""
         r_1 = ARCSpecies(label='NH2', smiles='[NH2]', xyz=self.nh2_xyz)
         r_2 = ARCSpecies(label='N2H4', smiles='NN', xyz=self.n2h4_xyz)
         p_1 = ARCSpecies(label='NH3', smiles='N', xyz=self.nh3_xyz)
@@ -529,7 +580,12 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [1, 2, 3] for r_index in [5, 6, 7, 8]))
         self.assertTrue(check_atom_map(rxn))
 
-        # NH2 + N2H4 <=> N2H3 + NH3 (reversed product order compared to the above reaction)
+    def test_map_abstractions_nh2_plus_n2h4_to_n2h3_plus_nh3(self):
+        """NH2 + N2H4 <=> N2H3 + NH3 (reversed product order)"""
+        r_1 = ARCSpecies(label='NH2', smiles='[NH2]', xyz=self.nh2_xyz)
+        r_2 = ARCSpecies(label='N2H4', smiles='NN', xyz=self.n2h4_xyz)
+        p_1 = ARCSpecies(label='NH3', smiles='N', xyz=self.nh3_xyz)
+        p_2 = ARCSpecies(label='N2H3', smiles='N[NH]', xyz=self.n2h3_xyz)
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_2, p_1])
         atom_map = rxn.atom_map
         self.assertEqual(atom_map[0], 5)
@@ -540,48 +596,24 @@ class TestMappingDriver(unittest.TestCase):
         self.assertTrue(any(atom_map[r_index] in [6, 7, 8] for r_index in [5, 6, 7, 8]))
         self.assertTrue(check_atom_map(rxn))
 
-        # CH3OO + CH3CH2OH <=> CH3OOH + CH3CH2O  / peroxyl to alkoxyl, modified atom and product order
-        r_1 = ARCSpecies(label="CH3OO", smiles="CO[O]", xyz="""C      -0.41690000    0.03757000    0.00590000
-                                                               O       0.83973000    0.69383000   -0.05239000
-                                                               O       1.79663000   -0.33527000   -0.02406000
-                                                               H      -0.54204000   -0.62249000   -0.85805000
-                                                               H      -1.20487000    0.79501000   -0.01439000
-                                                               H      -0.50439000   -0.53527000    0.93431000""")
-        r_2 = ARCSpecies(label='CH3CH2OH', smiles='CCO', xyz="""C      -0.97459464    0.29181710    0.10303882
-                                                                C       0.39565894   -0.35143697    0.10221676
-                                                                H      -1.68942501   -0.32359616    0.65926091
-                                                                H      -0.93861751    1.28685508    0.55523033
-                                                                H      -1.35943743    0.38135479   -0.91822428
-                                                                H       0.76858330   -0.46187184    1.12485643
-                                                                H       1.10301149    0.25256708   -0.47388355
-                                                                O       0.30253309   -1.63748710   -0.49196889
-                                                                H       1.19485981   -2.02360458   -0.47786539""")
-        p_1 = ARCSpecies(label='CH3OOH', smiles='COO', xyz="""C      -0.76039072    0.01483858   -0.00903344
-                                                              H      -1.56632337    0.61401630   -0.44251282
-                                                              H      -1.02943316   -0.30449156    1.00193709
-                                                              O       0.16024511    1.92327904    0.86381800
-                                                              H      -0.60052507   -0.86954495   -0.63086438
-                                                              O       0.44475333    0.76952102    0.02291303
-                                                              H       0.30391344    2.59629139    0.17435159""")
-        p_2 = ARCSpecies(label='CH3CH2O', smiles='CC[O]', xyz="""C       0.79799272   -0.01511040    0.00517437
-                                                                 H      -1.13881231   -0.99286049    0.06963185
-                                                                 O       1.17260343   -0.72227959   -1.04851579
-                                                                 H      -1.14162013    0.59700303    0.84092854
-                                                                 H      -1.13266865    0.46233725   -0.93283228
-                                                                 C      -0.74046271    0.02568566   -0.00568694
-                                                                 H       1.11374677    1.03794239    0.06905096
-                                                                 H       1.06944350   -0.38306117    1.00698657""")
+    def test_map_abstractions_peroxyl_to_alkoxyl(self):
+        """CH3OO + CH3CH2OH <=> CH3OOH + CH3CH2O (peroxyl-to-alkoxyl, modified atom and product order)"""
+        r_1 = ARCSpecies(label='CH3OO', smiles='CO[O]', xyz=self.ch3oo_xyz)
+        r_2 = ARCSpecies(label='CH3CH2OH', smiles='CCO', xyz=self.ch3ch2oh_xyz)
+        p_1 = ARCSpecies(label='CH3OOH', smiles='COO', xyz=self.ch3ooh_xyz)
+        p_2 = ARCSpecies(label='CH3CH2O', smiles='CC[O]', xyz=self.ch3ch2o_xyz)
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_1, p_2])
         atom_map = rxn.atom_map
-        self.assertEqual([0,5,3],atom_map[0:3])
+        self.assertEqual([0, 5, 3], atom_map[0:3])
         self.assertIn(tuple(atom_map[3:6]), list(permutations([1, 2, 4])))
         self.assertEqual([12, 7], atom_map[6:8])
-        self.assertIn(tuple(atom_map[8:11]),list(permutations([8, 10, 11])))
-        self.assertIn(tuple(atom_map[11:13]),list(permutations([13, 14])))
-        self.assertEqual([9,6], atom_map[13:])     
+        self.assertIn(tuple(atom_map[8:11]), list(permutations([8, 10, 11])))
+        self.assertIn(tuple(atom_map[11:13]), list(permutations([13, 14])))
+        self.assertEqual([9, 6], atom_map[13:])
         self.assertTrue(check_atom_map(rxn))
 
-        # C3H6O + OH <=> C3H5O + H2O
+    def test_map_abstractions_c3h6o_plus_oh(self):
+        """C3H6O + OH <=> C3H5O + H2O"""
         r_1 = ARCSpecies(label='C3H6O', smiles='CCC=O', xyz=self.c3h6o_xyz)
         r_2 = ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)
         p_1 = ARCSpecies(label='C3H5O', smiles='C[CH]C=O', xyz=self.c3h5o_xyz)
@@ -589,14 +621,15 @@ class TestMappingDriver(unittest.TestCase):
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_1, p_2])
         atom_map = rxn.atom_map
         self.assertEqual(atom_map[:4], [0, 1, 3, 4])
-        self.assertIn(atom_map[4], [5,6, 7])
+        self.assertIn(atom_map[4], [5, 6, 7])
         self.assertIn(atom_map[5], [5, 6, 7])
         self.assertIn(atom_map[6], [5, 6, 7])
         self.assertIn(atom_map[7], [2, 11])
         self.assertIn(atom_map[8], [2, 11])
         self.assertEqual(atom_map[9:], [8, 9, 10])
 
-        # C4H10O + OH <=> C4H9O + H2O
+    def test_map_abstractions_c4h10o_plus_oh(self):
+        """C4H10O + OH <=> C4H9O + H2O"""
         r_1 = ARCSpecies(label='C4H10O', smiles='CC(C)CO', xyz=self.c4h10o_xyz)
         r_2 = ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)
         p_1 = ARCSpecies(label='C4H9O', smiles='[CH2]C(C)CO', xyz=self.c4h9o_xyz)
@@ -606,17 +639,18 @@ class TestMappingDriver(unittest.TestCase):
         self.assertEqual(atom_map[:5], [0, 3, 4, 5, 6])
         for index in [5, 6, 7]:
             self.assertIn(atom_map[index], [1, 2, 15, 16])
-        self.assertEqual(atom_map[8],7)
+        self.assertEqual(atom_map[8], 7)
         for i in atom_map[9:12]:
-            self.assertIn(i,[8,9,10])
+            self.assertIn(i, [8, 9, 10])
         for i in atom_map[12:14]:
-            self.assertIn(i,[11,12])
-        self.assertEqual(atom_map[14],13)
-        self.assertEqual(atom_map[15],14)
+            self.assertIn(i, [11, 12])
+        self.assertEqual(atom_map[14], 13)
+        self.assertEqual(atom_map[15], 14)
         self.assertIn(atom_map[16], [15, 16])
         self.assertTrue(check_atom_map(rxn))
 
-        # C3H6O + C4H9O <=> C3H5O + C4H10O
+    def test_map_abstractions_c3h6o_plus_c4h9o(self):
+        """C3H6O + C4H9O <=> C3H5O + C4H10O"""
         r_1 = ARCSpecies(label='C3H6O', smiles='CCC=O', xyz=self.c3h6o_xyz)
         r_2 = ARCSpecies(label='C4H9O', smiles='[CH2]C(C)CO', xyz=self.c4h9o_xyz)
         p_1 = ARCSpecies(label='C3H5O', smiles='C[CH]C=O', xyz=self.c3h5o_xyz)
@@ -624,26 +658,26 @@ class TestMappingDriver(unittest.TestCase):
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p_1, p_2])
         atom_map = rxn.atom_map
         self.assertEqual(atom_map[0:4], [0, 1, 3, 4])
-        self.assertIn(atom_map[4], [5,6, 7])
-        self.assertIn(atom_map[5], [5,6, 7])
-        self.assertIn(atom_map[6], [5,6, 7])
+        self.assertIn(atom_map[4], [5, 6, 7])
+        self.assertIn(atom_map[5], [5, 6, 7])
+        self.assertIn(atom_map[6], [5, 6, 7])
         self.assertIn(atom_map[7], [2, 14, 15, 16, 18, 19, 20])
         self.assertIn(atom_map[8], [2, 14, 15, 16, 18, 19, 20])
         self.assertIn(2, atom_map[7:9])
         self.assertEqual(atom_map[9], 8)
-        self.assertIn(atom_map[10], [9,11])
-        self.assertIn(atom_map[11], [14, 15, 16,18,19,20])
-        self.assertIn(atom_map[12], [14, 15, 16,18,19,20])
-        self.assertEqual(atom_map[13],10)
-        self.assertIn(atom_map[14], [9,11])
-        self.assertEqual(atom_map[15:17], [12,13])
-        self.assertEqual(atom_map[17],17)
-        self.assertIn(atom_map[18], [14, 15, 16,18,19,20])
-        self.assertIn(atom_map[19], [14, 15, 16,18,19,20])
-        self.assertIn(atom_map[20], [14, 15, 16,18,19,20])
-        self.assertIn(atom_map[21], [21,22])
-        self.assertIn(atom_map[22], [21,22])
-        self.assertEqual(atom_map[23],23)
+        self.assertIn(atom_map[10], [9, 11])
+        self.assertIn(atom_map[11], [14, 15, 16, 18, 19, 20])
+        self.assertIn(atom_map[12], [14, 15, 16, 18, 19, 20])
+        self.assertEqual(atom_map[13], 10)
+        self.assertIn(atom_map[14], [9, 11])
+        self.assertEqual(atom_map[15:17], [12, 13])
+        self.assertEqual(atom_map[17], 17)
+        self.assertIn(atom_map[18], [14, 15, 16, 18, 19, 20])
+        self.assertIn(atom_map[19], [14, 15, 16, 18, 19, 20])
+        self.assertIn(atom_map[20], [14, 15, 16, 18, 19, 20])
+        self.assertIn(atom_map[21], [21, 22])
+        self.assertIn(atom_map[22], [21, 22])
+        self.assertEqual(atom_map[23], 23)
         self.assertTrue(check_atom_map(rxn))
     
     def test_map_ho2_elimination_from_peroxy_radical(self):


### PR DESCRIPTION
Splits the catch-all `test_map_abstractions` and heuristics tests into one test per reaction case, so failures point at a specific scenario instead of one giant test. Shared XYZ fixtures live on `setUpClass`. No production-code changes.