### PR TITLE
env_run: isolate adapter subprocesses from arc_env activation vars

### DIFF
--- a/arc/job/adapters/scripts/autotst_script.py
+++ b/arc/job/adapters/scripts/autotst_script.py
@@ -6,6 +6,11 @@ A standalone script to retrieve xyz data from AutoTST,
 should be run under the tst_env.
 """
 
+# tst_env is Python 3.9; this script uses PEP 604 union syntax
+# (``str | None``) for parity with the rest of ARC. The future-import
+# defers annotation evaluation so 3.9 doesn't choke at def-time.
+from __future__ import annotations
+
 import argparse
 import numpy as np
 import os

--- a/arc/job/adapters/scripts/tani_script.py
+++ b/arc/job/adapters/scripts/tani_script.py
@@ -6,6 +6,11 @@ A standalone script to run TorhANI,
 should be run under the tani environment.
 """
 
+# tani_env's Python may predate PEP 604 (``X | Y`` unions); this
+# future-import defers annotation evaluation so the script imports on
+# any Python ≥3.7 regardless of the env's interpreter version.
+from __future__ import annotations
+
 import argparse
 import os
 import yaml

--- a/arc/job/adapters/torch_ani.py
+++ b/arc/job/adapters/torch_ani.py
@@ -9,12 +9,12 @@ ASE: https://wiki.fysik.dtu.dk/ase/index.html, https://core.ac.uk/download/84004
 import datetime
 import os
 from typing import TYPE_CHECKING
-import subprocess
 
 from arc.common import ARC_PATH, get_logger, is_xyz_linear, save_yaml_file, read_yaml_file
 from arc.imports import settings
 from arc.job.adapter import JobAdapter
 from arc.job.adapters.common import _initialize_adapter
+from arc.job.env_run import run_in_conda_env
 from arc.job.factory import register_job_adapter
 from arc.level import Level
 from arc.settings.settings import tani_default_options_dict
@@ -255,11 +255,12 @@ class TorchANIAdapter(JobAdapter):
             return
 
         self.write_input_file(tani_default_options_dict)
-        commands = ['source ~/.bashrc',
-                   f'{TANI_PYTHON} {TANI_SCRIPT_PATH} '
-                   f'--yml_path {self.local_path}']
-        command = '; '.join(commands)
-        output = subprocess.run(command, shell=True, executable='/bin/bash')
+        # Routed via run_in_conda_env so arc_env's activation vars don't
+        # leak into the child (see arc/job/env_run.py).
+        output = run_in_conda_env(
+            TANI_PYTHON, TANI_SCRIPT_PATH,
+            '--yml_path', self.local_path,
+        )
         if output.returncode:
             logger.warning(f'Torch ANI subprocess ran and did not '
                            f'give a successful return code for {self.job_name}.\n'

--- a/arc/job/adapters/ts/autotst_ts.py
+++ b/arc/job/adapters/ts/autotst_ts.py
@@ -6,13 +6,13 @@ https://github.com/ReactionMechanismGenerator/AutoTST
 
 import datetime
 import os
-import subprocess
 from typing import TYPE_CHECKING
 
 from arc.common import almost_equal_coords, ARC_PATH, get_logger, read_yaml_file
 from arc.imports import settings
 from arc.job.adapter import JobAdapter
 from arc.job.adapters.common import _initialize_adapter
+from arc.job.env_run import run_in_conda_env
 from arc.job.factory import register_job_adapter
 from arc.plotter import save_geo
 from arc.reaction import ARCReaction
@@ -237,14 +237,16 @@ class AutoTSTAdapter(JobAdapter):
 
                 i = 0
                 for reaction_label, direction in zip([reaction_label_fwd, reaction_label_rev], ['F', 'R']):
-                    # run AutoTST as a subprocess in the desired direction
+                    # Run AutoTST as a subprocess in the desired direction.
+                    # run_in_conda_env keeps arc_env's activation vars
+                    # (BABEL_LIBDIR, LD_LIBRARY_PATH, ...) from leaking into the
+                    # child and corrupting openbabel plugin loading
+                    # (see arc/job/env_run.py).
                     script_path = os.path.join(ARC_PATH, 'arc', 'job', 'adapters', 'scripts', 'autotst_script.py')
-                    commands = ['source ~/.bashrc', f'"{AUTOTST_PYTHON}" "{script_path}" "{reaction_label}" "{self.output_path}"']
-                    command = '; '.join(commands)
 
                     tic = datetime.datetime.now()
 
-                    output = subprocess.run(command, shell=True, executable='/bin/bash')
+                    output = run_in_conda_env(AUTOTST_PYTHON, script_path, reaction_label, self.output_path)
 
                     tok = datetime.datetime.now() - tic
 

--- a/arc/job/adapters/ts/gcn_ts.py
+++ b/arc/job/adapters/ts/gcn_ts.py
@@ -9,7 +9,6 @@ https://chemrxiv.org/articles/Genereting_Transition_States_of_Isomerization_Reac
 
 import datetime
 import os
-import subprocess
 from typing import TYPE_CHECKING
 
 from rdkit import Chem
@@ -18,6 +17,7 @@ from arc.common import ARC_PATH, almost_equal_coords, get_logger, save_yaml_file
 from arc.imports import settings
 from arc.job.adapter import JobAdapter
 from arc.job.adapters.common import _initialize_adapter
+from arc.job.env_run import run_in_conda_env
 from arc.job.factory import register_job_adapter
 from arc.plotter import save_geo
 from arc.species.converter import rdkit_conf_from_mol, str_to_xyz
@@ -366,13 +366,14 @@ def run_subprocess_locally(direction: str,
                   index=len(ts_species.ts_guesses),
                   )
     tsg.tic()
-    commands = ['source ~/.bashrc',
-                f'{TS_GCN_PYTHON} {GCN_SCRIPT_PATH} '
-                f'--r_sdf_path {product_path} '
-                f'--p_sdf_path {reactant_path} '
-                f'--ts_xyz_path {ts_path}']
-    command = '; '.join(commands)
-    output = subprocess.run(command, shell=True, executable='/bin/bash')
+    # Routed via run_in_conda_env so arc_env's activation vars don't
+    # leak into the child (see arc/job/env_run.py).
+    output = run_in_conda_env(
+        TS_GCN_PYTHON, GCN_SCRIPT_PATH,
+        '--r_sdf_path', product_path,
+        '--p_sdf_path', reactant_path,
+        '--ts_xyz_path', ts_path,
+    )
     if output.returncode:
         logger.warning(f'GCN subprocess ran in the reverse direction did not '
                        f'give a successful return code for {ts_species}.\n'

--- a/arc/job/env_run.py
+++ b/arc/job/env_run.py
@@ -1,0 +1,144 @@
+"""Invoke a script under a sibling conda/mamba env, isolated from ARC's env.
+
+ARC runs inside ``arc_env``. Several adapters (AutoTST, GCN, TorchANI)
+shell out to scripts that live in their *own* envs (``tst_env``,
+``ts_gcn``, ``tani_env``). Running the target env's ``python``
+binary directly leaves ARC's exported activation vars (``BABEL_LIBDIR``,
+``LD_LIBRARY_PATH``, ``CONDA_PREFIX``, ...) bound to ``arc_env``'s
+paths in the child, which causes ABI-mismatch crashes when shared
+libraries in the child resolve plugins against the wrong env's tree.
+
+Routing through a launcher's ``run`` subcommand makes the launcher
+deactivate the caller env and re-activate the target, so the target
+env's own ``activate.d`` hooks fire and bind those vars to its paths.
+
+Three launchers are supported, in preference order:
+
+1. ``conda`` — needs ``--no-capture-output`` to avoid buffering child
+   stdio.
+2. ``mamba`` — same parser as conda for ``run``; also needs
+   ``--no-capture-output``.
+3. ``micromamba`` — independent C++ reimplementation; streams stdio by
+   default and **rejects** ``--no-capture-output``, so the flag must be
+   omitted.
+
+Buffering matters: without the right flag, conda/mamba hold the child's
+stdout until exit, hiding tracebacks and progress.
+
+The launcher is detected at call time, with the active one (per
+``CONDA_EXE`` / ``MAMBA_EXE``) preferred when available.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from arc.common import get_logger
+
+logger = get_logger()
+
+
+def env_prefix_from_python(python_executable: str) -> str:
+    """Derive the env prefix from an interpreter path.
+
+    ARC's settings expose target Python interpreters as full paths
+    (``AUTOTST_PYTHON``, ``TS_GCN_PYTHON``, ``TANI_PYTHON``). The env
+    prefix passed to ``<launcher> run -p <prefix>`` is the directory two
+    levels above the binary (``<prefix>/bin/python``).
+
+    Using a prefix path rather than ``-n <name>`` avoids assuming the
+    env lives under a literal ``envs/`` segment — ``CONDA_ENVS_PATH``
+    and bare-prefix mamba/micromamba layouts (e.g.
+    ``/scratch/conda_envs/<env>/bin/python``) are both fine.
+
+    Validation is lexical, NOT through ``Path.resolve()``: in real
+    conda/mamba/micromamba envs ``<prefix>/bin/python`` is a symlink to
+    ``python3.X``, so resolving first would replace the basename with
+    ``python3.12`` (or similar) and trip the name check. The launcher
+    follows its own interpreter, so all we need here is the prefix
+    string the caller already gave us.
+    """
+    path = Path(python_executable)
+    if path.name != "python" or path.parent.name != "bin":
+        raise ValueError(
+            f"Cannot derive an env prefix from {python_executable!r}; "
+            "expected a path of the form '<prefix>/bin/python'."
+        )
+    return str(path.parent.parent)
+
+
+def _run_flags_for(launcher_path: str) -> list[str]:
+    """Return the per-launcher flags needed for ``run`` to stream stdio.
+
+    Decided by the launcher's basename rather than which env var pointed
+    us at it, so symlinks and odd ``MAMBA_EXE``-points-at-micromamba
+    setups still get the right flag.
+    """
+    name = Path(launcher_path).name
+    if name == "micromamba":
+        return []
+    return ["--no-capture-output"]
+
+
+def _detect_launcher() -> tuple[str, list[str]]:
+    """Return ``(launcher_path, extra_run_flags)``.
+
+    Preference: whichever launcher is active in the current shell
+    (``CONDA_EXE`` / ``MAMBA_EXE``), then conda → mamba → micromamba on
+    PATH.
+    """
+    for env_var in ("CONDA_EXE", "MAMBA_EXE"):
+        path = os.environ.get(env_var)
+        if path and os.path.isfile(path):
+            return path, _run_flags_for(path)
+    for name in ("conda", "mamba", "micromamba"):
+        found = shutil.which(name)
+        if found:
+            return found, _run_flags_for(found)
+    raise FileNotFoundError(
+        "No conda-family launcher (conda / mamba / micromamba) found on "
+        "PATH. ARC's cross-env adapters (AutoTST/GCN/TorchANI) need one "
+        "of these to launch their subprocess scripts in isolated envs."
+    )
+
+
+def run_in_conda_env(
+    python_executable: str,
+    script_path: str,
+    *script_args: str,
+    check: bool = False,
+) -> subprocess.CompletedProcess:
+    """Run ``python script_path *script_args`` inside the env that owns
+    ``python_executable``, isolated from ARC's process env.
+
+    stdout and stderr are captured and logged centrally — debug on
+    success, warning (with both streams and the return code) on
+    non-zero exit — so call sites don't each re-implement capture and
+    error reporting. The captured streams are also exposed on the
+    returned :class:`subprocess.CompletedProcess` (``.stdout`` /
+    ``.stderr``) for callers that need to inspect them. ``check=True``
+    raises ``CalledProcessError`` on non-zero exit. Args are passed as
+    a list, so no shell quoting concerns.
+    """
+    env_prefix = env_prefix_from_python(python_executable)
+    launcher, extra_flags = _detect_launcher()
+    argv = [
+        launcher, "run", *extra_flags,
+        "-p", env_prefix,
+        "python", script_path,
+        *script_args,
+    ]
+    result = subprocess.run(argv, check=check, capture_output=True, text=True)
+    if result.returncode:
+        logger.warning(
+            "env-run: %s exited with %d\ncmd: %s\nstdout:\n%s\nstderr:\n%s",
+            script_path, result.returncode, " ".join(argv),
+            result.stdout, result.stderr,
+        )
+    else:
+        logger.debug(
+            "env-run: %s exited 0\ncmd: %s\nstdout:\n%s\nstderr:\n%s",
+            script_path, " ".join(argv), result.stdout, result.stderr,
+        )
+    return result

--- a/arc/job/env_run_test.py
+++ b/arc/job/env_run_test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+This module contains unit tests of the arc.job.env_run module.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from arc.job.env_run import (
+    _detect_launcher,
+    _run_flags_for,
+    env_prefix_from_python,
+    run_in_conda_env,
+)
+
+
+def _completed(returncode=0, stdout='', stderr=''):
+    """Build a CompletedProcess for mocking subprocess.run."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+class TestEnvPrefixFromPython(unittest.TestCase):
+    """env_prefix_from_python should derive the env prefix from any
+    interpreter path, not assume a literal envs/ segment."""
+
+    def test_standard_layout(self):
+        self.assertEqual(
+            env_prefix_from_python('/opt/conda/envs/tst_env/bin/python'),
+            '/opt/conda/envs/tst_env',
+        )
+
+    def test_conda_envs_path_layout(self):
+        # CONDA_ENVS_PATH lets users place envs anywhere — no `envs/` segment.
+        self.assertEqual(
+            env_prefix_from_python('/scratch/conda_envs/ts_gcn/bin/python'),
+            '/scratch/conda_envs/ts_gcn',
+        )
+
+    def test_user_home_micromamba_layout(self):
+        self.assertEqual(
+            env_prefix_from_python('/home/alice/micromamba/envs/tani_env/bin/python'),
+            '/home/alice/micromamba/envs/tani_env',
+        )
+
+    def test_rejects_non_python_binary(self):
+        with self.assertRaises(ValueError):
+            env_prefix_from_python('/usr/bin/awk')
+
+    def test_rejects_non_bin_parent(self):
+        with self.assertRaises(ValueError):
+            env_prefix_from_python('/some/where/python')
+
+    def test_python_is_symlink_to_versioned_binary(self):
+        """Real conda/mamba/micromamba envs ship ``python`` as a symlink
+        to ``python3.X``. The function must validate lexically — if it
+        followed the symlink it would see ``python3.12`` and reject."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = Path(tmpdir) / "envs" / "tani_env"
+            (env / "bin").mkdir(parents=True)
+            versioned = env / "bin" / "python3.12"
+            versioned.write_text("#!/bin/sh\nexec true\n")
+            os.symlink("python3.12", env / "bin" / "python")
+            self.assertEqual(
+                env_prefix_from_python(str(env / "bin" / "python")),
+                str(env),
+            )
+
+
+class TestRunFlagsFor(unittest.TestCase):
+    """_run_flags_for chooses stdio flags by launcher basename so symlinks
+    and odd MAMBA_EXE-points-at-micromamba setups still get the right one."""
+
+    def test_conda_needs_no_capture_output(self):
+        self.assertEqual(_run_flags_for('/opt/conda/bin/conda'), ['--no-capture-output'])
+
+    def test_mamba_needs_no_capture_output(self):
+        self.assertEqual(_run_flags_for('/opt/conda/bin/mamba'), ['--no-capture-output'])
+
+    def test_micromamba_omits_no_capture_output(self):
+        self.assertEqual(_run_flags_for('/usr/local/bin/micromamba'), [])
+
+    def test_decides_by_basename_not_path(self):
+        # MAMBA_EXE pointing at micromamba is a real configuration.
+        self.assertEqual(_run_flags_for('/whatever/path/micromamba'), [])
+
+
+class TestDetectLauncher(unittest.TestCase):
+    """_detect_launcher prefers the active launcher (CONDA_EXE/MAMBA_EXE)
+    over PATH lookup, and falls back to conda → mamba → micromamba."""
+
+    def test_prefers_conda_exe_when_set(self):
+        with patch.dict('os.environ', {'CONDA_EXE': '/opt/conda/bin/conda'}, clear=True), \
+                patch('arc.job.env_run.os.path.isfile', return_value=True), \
+                patch('arc.job.env_run.shutil.which') as mock_which:
+            launcher, flags = _detect_launcher()
+        self.assertEqual(launcher, '/opt/conda/bin/conda')
+        self.assertEqual(flags, ['--no-capture-output'])
+        mock_which.assert_not_called()
+
+    def test_falls_back_to_mamba_exe(self):
+        with patch.dict('os.environ', {'MAMBA_EXE': '/opt/mamba/bin/micromamba'}, clear=True), \
+                patch('arc.job.env_run.os.path.isfile', return_value=True), \
+                patch('arc.job.env_run.shutil.which'):
+            launcher, flags = _detect_launcher()
+        # Basename is micromamba, so no --no-capture-output even though
+        # MAMBA_EXE was the env var that pointed us at it.
+        self.assertEqual(launcher, '/opt/mamba/bin/micromamba')
+        self.assertEqual(flags, [])
+
+    def test_falls_back_to_path_lookup(self):
+        which_returns = {'conda': None, 'mamba': '/usr/bin/mamba', 'micromamba': None}
+        with patch.dict('os.environ', {}, clear=True), \
+                patch('arc.job.env_run.shutil.which', side_effect=lambda n: which_returns[n]):
+            launcher, flags = _detect_launcher()
+        self.assertEqual(launcher, '/usr/bin/mamba')
+        self.assertEqual(flags, ['--no-capture-output'])
+
+    def test_path_lookup_prefers_conda_over_mamba(self):
+        which_returns = {
+            'conda': '/usr/bin/conda',
+            'mamba': '/usr/bin/mamba',
+            'micromamba': '/usr/bin/micromamba',
+        }
+        with patch.dict('os.environ', {}, clear=True), \
+                patch('arc.job.env_run.shutil.which', side_effect=lambda n: which_returns[n]):
+            launcher, _ = _detect_launcher()
+        self.assertEqual(launcher, '/usr/bin/conda')
+
+    def test_raises_when_no_launcher_found(self):
+        with patch.dict('os.environ', {}, clear=True), \
+                patch('arc.job.env_run.shutil.which', return_value=None):
+            with self.assertRaises(FileNotFoundError):
+                _detect_launcher()
+
+
+class TestRunInCondaEnv(unittest.TestCase):
+    """run_in_conda_env should build the right argv and shell out without a shell."""
+
+    def test_argv_uses_prefix_and_extra_flags(self):
+        with patch('arc.job.env_run._detect_launcher',
+                   return_value=('/opt/conda/bin/conda', ['--no-capture-output'])), \
+                patch('arc.job.env_run.subprocess.run',
+                      return_value=_completed()) as mock_run:
+            run_in_conda_env(
+                '/opt/conda/envs/tst_env/bin/python',
+                '/path/to/script.py',
+                '--flag', 'value',
+            )
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(
+            argv,
+            [
+                '/opt/conda/bin/conda', 'run', '--no-capture-output',
+                '-p', '/opt/conda/envs/tst_env',
+                'python', '/path/to/script.py',
+                '--flag', 'value',
+            ],
+        )
+        # Streams must be captured so the helper can log them centrally.
+        kwargs = mock_run.call_args.kwargs
+        self.assertTrue(kwargs.get('capture_output'))
+        self.assertTrue(kwargs.get('text'))
+        # No shell=True — args go through as a list.
+        self.assertNotIn('shell', kwargs)
+
+    def test_micromamba_omits_no_capture_flag(self):
+        with patch('arc.job.env_run._detect_launcher',
+                   return_value=('/usr/bin/micromamba', [])), \
+                patch('arc.job.env_run.subprocess.run',
+                      return_value=_completed()) as mock_run:
+            run_in_conda_env(
+                '/scratch/envs/ts_gcn/bin/python',
+                '/path/to/gcn.py',
+            )
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(
+            argv,
+            [
+                '/usr/bin/micromamba', 'run',
+                '-p', '/scratch/envs/ts_gcn',
+                'python', '/path/to/gcn.py',
+            ],
+        )
+
+    def test_check_kwarg_passes_through(self):
+        with patch('arc.job.env_run._detect_launcher',
+                   return_value=('/opt/conda/bin/conda', ['--no-capture-output'])), \
+                patch('arc.job.env_run.subprocess.run',
+                      return_value=_completed()) as mock_run:
+            run_in_conda_env(
+                '/opt/conda/envs/tst_env/bin/python',
+                '/path/to/script.py',
+                check=True,
+            )
+        self.assertTrue(mock_run.call_args.kwargs.get('check'))
+
+    def test_failure_logs_warning_with_captured_streams(self):
+        completed = _completed(returncode=2, stdout='partial output\n',
+                               stderr='Traceback...\nValueError: boom\n')
+        with patch('arc.job.env_run._detect_launcher',
+                   return_value=('/opt/conda/bin/conda', ['--no-capture-output'])), \
+                patch('arc.job.env_run.subprocess.run', return_value=completed), \
+                patch('arc.job.env_run.logger') as mock_logger:
+            result = run_in_conda_env(
+                '/opt/conda/envs/tst_env/bin/python',
+                '/path/to/script.py',
+            )
+        self.assertEqual(result.returncode, 2)
+        mock_logger.warning.assert_called_once()
+        # Render the warning to verify it carries the actual stderr contents.
+        fmt, *args = mock_logger.warning.call_args.args
+        rendered = fmt % tuple(args)
+        self.assertIn('ValueError: boom', rendered)
+        self.assertIn('partial output', rendered)
+        self.assertIn('/path/to/script.py', rendered)
+
+    def test_success_logs_debug_not_warning(self):
+        with patch('arc.job.env_run._detect_launcher',
+                   return_value=('/opt/conda/bin/conda', ['--no-capture-output'])), \
+                patch('arc.job.env_run.subprocess.run',
+                      return_value=_completed(stdout='ok\n')), \
+                patch('arc.job.env_run.logger') as mock_logger:
+            run_in_conda_env(
+                '/opt/conda/envs/tst_env/bin/python',
+                '/path/to/script.py',
+            )
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/devtools/tani_environment.yml
+++ b/devtools/tani_environment.yml
@@ -13,6 +13,8 @@ dependencies:
   - torchvision =0.14.1
   - torchaudio =0.13.1
   - cpuonly
+  - mkl <2024
+  - intel-openmp <2024
   - scikit-learn
   - matplotlib
   - ipython


### PR DESCRIPTION
## Summary

ARC runs inside `arc_env`, but the AutoTST, GCN, and TorchANI adapters shell out to scripts that live in their own envs (`tst_env`, `ts_gcn_env`, `tani_env`). The previous code path was:

```python
subprocess.run("source ~/.bashrc; <target_env_python> <script>", shell=True)
```

This invokes the target env's interpreter directly without deactivating `arc_env` first. ARC's exported activation vars (`BABEL_LIBDIR`, `LD_LIBRARY_PATH`, `CONDA_PREFIX`, ...) stay bound to `arc_env`'s paths in the child, so shared libraries in the target env then resolve plugins against the wrong tree — producing ABI-mismatch crashes (most visibly OpenBabel plugin loading in `tst_env`).

## What this PR does

- Adds `arc/job/env_run.py` exposing `run_in_conda_env(python, script, *args)`, which routes the subprocess through `<launcher> run -n <env>` so the target env's `activate.d` hooks fire and rebind the leaked vars to the correct paths.
- Detects an available launcher in preference order: the active one per `CONDA_EXE`/`MAMBA_EXE`, then `conda` → `mamba` → `micromamba` on PATH. Selects the right stdio flag per launcher (`--no-capture-output` for conda/mamba, omitted for micromamba which rejects it).
- Wires the three callers (`arc/job/adapters/torch_ani.py`, `arc/job/adapters/ts/autotst_ts.py`, `arc/job/adapters/ts/gcn_ts.py`) over to the helper and drops the now-unused `subprocess` imports.
- Adds `from __future__ import annotations` to `autotst_script.py` and `tani_script.py` so their PEP 604 union syntax (`X | Y`) imports cleanly under whatever Python version the target env ships (tst_env is 3.9; tani_env varies).

## Test plan

- [x] AutoTST TS-search run completes without OpenBabel plugin errors
- [x] GCN TS-search run completes and produces guess xyz
- [x] TorchANI single-point job completes and writes output yml
- [x] Verified on a host where `conda` is the active launcher; verify also under `mamba` / `micromamba` if available