### PR TITLE
Dockerfile: drop redundant install_pyrdl.sh step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN micromamba create -y -v -n arc_env python=3.14 -c conda-forge -c danagroup -
     micromamba clean --all -f -y
 
 RUN micromamba run -n arc_env bash -euxo pipefail -c \
-      "make compile && bash ./devtools/install_pyrdl.sh" && \
+      "make compile" && \
     micromamba clean --all --yes
 
 # Stage 2: Final image


### PR DESCRIPTION
## Summary
- `py-rdl` is now resolved via `environment.yml` (`danagroup::py-rdl`), so the explicit `bash ./devtools/install_pyrdl.sh` invocation during the arc_env build stage is redundant.
- Removes the chained call from line 63 of the Dockerfile while preserving `make compile` and the `bash -euxo pipefail` safety wrapper.

## Test plan
- [x] Docker image builds successfully (`docker build .`)
- [x] `arc_env` contains a working `py_rdl` import after build