### PR TITLE
Write an hourly running jobs status into a separate YAML

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -315,7 +315,9 @@ class Scheduler(object):
         self.initialize_output_dict()
 
         self.restart_path = os.path.join(self.project_directory, 'restart.yml')
+        self.running_jobs_snapshot_path = os.path.join(self.project_directory, 'running_jobs.yml')
         self.report_time = time.time()  # init time for reporting status every 1 hr
+        self._last_status_payload: dict | None = None
         self.servers = list()
         self.composite_method = composite_method
         self.conformer_opt_level = conformer_opt_level
@@ -843,13 +845,32 @@ class Scheduler(object):
             t = time.time() - self.report_time
             if t > 3600 and (self.running_jobs or self.active_pipes):
                 self.report_time = time.time()
-                if self.running_jobs:
-                    logger.info(f'Currently running jobs:\n{pprint.pformat(self.running_jobs)}')
-                if self.active_pipes:
-                    logger.info(f'Active pipe runs: {list(self.active_pipes.keys())}')
+                self.report_running_jobs_snapshot()
 
         # Generate a TS report:
         self.generate_final_ts_guess_report()
+
+    def report_running_jobs_snapshot(self) -> None:
+        """
+        Overwrite ``<project>/running_jobs.yml`` with a timestamped snapshot of
+        the currently running jobs and active pipes. If the payload is identical
+        to the previous snapshot, the file is left untouched and only a one-line
+        heartbeat is logged to ARC.log.
+        """
+        payload = {'running_jobs': {label: list(job_names) for label, job_names in self.running_jobs.items()},
+                   'active_pipes': list(self.active_pipes.keys())}
+        n_species = len(self.running_jobs)
+        n_jobs = sum(len(v) for v in self.running_jobs.values())
+        n_pipes = len(self.active_pipes)
+        summary = f'{n_species} species / {n_jobs} jobs / {n_pipes} active pipes'
+        if payload == self._last_status_payload:
+            logger.info(f'Status unchanged: {summary}.')
+            return
+        snapshot = {'timestamp': datetime.datetime.now().isoformat(timespec='seconds'),
+                    **payload}
+        save_yaml_file(path=self.running_jobs_snapshot_path, content=snapshot)
+        logger.info(f'Status changed: {summary}; snapshot written to running_jobs.yml.')
+        self._last_status_payload = payload
 
     def run_job(self,
                 job_type: str,

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import os
 import shutil
 
+
 import arc.parser.parser as parser
 from arc.checks.ts import check_ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords_lists, initialize_job_types, read_yaml_file
@@ -1183,6 +1184,37 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertEqual(kwargs['scan_trsh'], [])
         self.assertEqual(kwargs['trsh'], {'scan_res': 4.0})
         self.assertEqual(kwargs['rotor_index'], 0)
+
+    def test_report_running_jobs_snapshot(self):
+        """The snapshot file is overwritten on change and left untouched (heartbeat only) on no change."""
+        path = self.sched1.running_jobs_snapshot_path
+        if os.path.isfile(path):
+            os.remove(path)
+        self.sched1._last_status_payload = None
+        self.sched1.running_jobs = {'spcA': ['opt_a1234']}
+        self.sched1.active_pipes = {}
+
+        # First call: file doesn't exist, snapshot must be written.
+        self.sched1.report_running_jobs_snapshot()
+        snapshot = read_yaml_file(path)
+        self.assertIn('timestamp', snapshot)
+        self.assertEqual(snapshot['running_jobs'], {'spcA': ['opt_a1234']})
+
+        # Second call with identical payload: file must be left untouched.
+        first_mtime = os.path.getmtime(path)
+        self.sched1.report_running_jobs_snapshot()
+        self.assertEqual(os.path.getmtime(path), first_mtime)
+
+        # Mutating the live running_jobs lists must not alias the stored payload.
+        self.sched1.running_jobs['spcA'].append('sp_b5678')
+        self.assertNotEqual(self.sched1._last_status_payload['running_jobs'], self.sched1.running_jobs)
+
+        # Third call after a change: the file must be overwritten with the new snapshot only.
+        self.sched1.report_running_jobs_snapshot()
+        snapshot = read_yaml_file(path)
+        self.assertEqual(snapshot['running_jobs'], {'spcA': ['opt_a1234', 'sp_b5678']})
+
+        os.remove(path)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
don't spam the ARC.log if the report repeats it self and ARC is idle. outsource the running jobs report into a separate YAML, only update it when needed, and drop a heartbeat line into ARC's log file.

addresses #694