### PR TITLE
scripts: harden rmg_kinetics & rmg_thermo

### DIFF
--- a/arc/processor_test.py
+++ b/arc/processor_test.py
@@ -62,8 +62,15 @@ class TestProcessor(unittest.TestCase):
                                                        output_directory=output_directory,
                                                        )
         self.assertEqual(len(reactions_to_compare), 2)
-        self.assertEqual(len(reactions_to_compare[0].rmg_kinetics), 3)
-        self.assertEqual(len(reactions_to_compare[1].rmg_kinetics), 1)
+        # Library matches plus every family estimate are reported: both the training-set
+        # depository hits and the rate-rule estimate (the old 'training' comment filter used
+        # to drop them, and the rule tree that produces the rate-rule estimate was not built).
+        self.assertEqual(len(reactions_to_compare[0].rmg_kinetics), 5)
+        self.assertEqual(len(reactions_to_compare[1].rmg_kinetics), 3)
+        comments_0 = [entry['comment'] for entry in reactions_to_compare[0].rmg_kinetics]
+        self.assertTrue(any(comment.startswith('Library:') for comment in comments_0))
+        self.assertTrue(any('source: rate rules' in comment for comment in comments_0))
+        self.assertTrue(any('training' in comment for comment in comments_0))
         self.assertTrue(os.path.isfile(os.path.join(output_directory, 'rate_plots.pdf')))
         kinetics_yml_path = os.path.join(output_directory, 'RMG_kinetics.yml')
         self.assertTrue(os.path.isfile(kinetics_yml_path))

--- a/arc/scripts/common.py
+++ b/arc/scripts/common.py
@@ -17,9 +17,14 @@ def parse_command_line_arguments(command_line_args=None):
 
     Returns:
         The parsed command-line arguments by keywords.
+        ``args.file`` is the input YAML path (positional).
+        ``args.output`` is an optional output path (``-o``/``--output``); when omitted,
+        callers should default to overwriting ``args.file`` to preserve historical behavior.
     """
     parser = argparse.ArgumentParser(description='Automatic Rate Calculator (ARC)')
     parser.add_argument('file', metavar='FILE', type=str, nargs=1, help='a file with input information')
+    parser.add_argument('-o', '--output', type=str, default=None,
+                        help='optional output YAML path; if omitted, the input file is overwritten')
     args = parser.parse_args(command_line_args)
     args.file = args.file[0]
     return args

--- a/arc/scripts/rmg_kinetics.py
+++ b/arc/scripts/rmg_kinetics.py
@@ -2,12 +2,25 @@
 # encoding: utf-8
 
 """
-A standalone script to run RMG
-and get kinetic rate coefficients for reactions
+A standalone script to run RMG and get kinetic rate coefficients for reactions.
+
+Output units (per entry returned by ``get_kinetics_from_reactions``):
+    - ``A``:    cm^3/(mol*s) for bimolecular reactions, s^-1 for unimolecular
+                (3-body: cm^6/(mol^2*s)). Reported in the units stored on the
+                Arrhenius object after the SI->cm conversion below.
+    - ``n``:    dimensionless temperature exponent.
+    - ``Ea``:   kJ/mol (converted from SI J/mol).
+    - ``T_min``, ``T_max``: K.
 """
 
+import copy
 import os
+import sys
 from typing import Dict, List, Optional, Tuple
+
+# Make ``from common import ...`` work no matter how this script is invoked
+# (e.g. ``python /abs/path/to/rmg_kinetics.py``, ``cd elsewhere && python ...``).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common import parse_command_line_arguments, read_yaml_file, save_yaml_file
 
@@ -15,6 +28,7 @@ from rmgpy.data.kinetics.common import find_degenerate_reactions
 from rmgpy.data.kinetics.family import KineticsFamily
 from rmgpy.data.rmg import RMGDatabase
 from rmgpy import settings as rmg_settings
+from rmgpy.kinetics import Arrhenius, ArrheniusEP, KineticsModel
 from rmgpy.reaction import same_species_lists, Reaction
 from rmgpy.species import Species
 
@@ -35,11 +49,12 @@ def main():
     """
     args = parse_command_line_arguments()
     input_file = args.file
+    output_file = args.output or input_file
     reaction_list = read_yaml_file(path=input_file)
     if not isinstance(reaction_list, list):
         raise ValueError(f'The content of {input_file} must be a list, got {reaction_list} which is a {type(reaction_list)}')
     result = get_rate_coefficients(reaction_list)
-    save_yaml_file(path=input_file, content=result)
+    save_yaml_file(path=output_file, content=result)
 
 
 def get_rate_coefficients(reaction_list: List[Dict]) -> List[Dict]:
@@ -62,6 +77,42 @@ def get_rate_coefficients(reaction_list: List[Dict]) -> List[Dict]:
     return reaction_list
 
 
+def get_a_factor_si_to_cm(num_reactants: int) -> float:
+    """
+    Get the factor that converts an Arrhenius A-factor from SI (m-based) units to
+    cm-based units, based on the reaction molecularity.
+
+    Args:
+        num_reactants (int): The number of reactants.
+
+    Returns:
+        float: 1.0 for unimolecular (s^-1), 1e6 for bimolecular (m^3->cm^3),
+               1e12 for termolecular (m^6->cm^6). Defaults to 1.0 otherwise.
+    """
+    return {1: 1.0, 2: 1e6, 3: 1e12}.get(num_reactants, 1.0)
+
+
+def scale_kinetics_by_degeneracy(kinetics: KineticsModel,
+                                 degeneracy: float,
+                                 ) -> KineticsModel:
+    """
+    Scale Arrhenius-type kinetics in place by the reaction-path degeneracy.
+
+    Non-Arrhenius forms (e.g. Chebyshev, PDepArrhenius) are returned unchanged,
+    since ``change_rate`` would otherwise corrupt their parameters.
+
+    Args:
+        kinetics (KineticsModel): An RMG kinetics object.
+        degeneracy (float): The reaction-path degeneracy to scale by.
+
+    Returns:
+        KineticsModel: The (possibly scaled) kinetics object.
+    """
+    if isinstance(kinetics, (Arrhenius, ArrheniusEP)):
+        kinetics.change_rate(degeneracy)
+    return kinetics
+
+
 def determine_rmg_kinetics(rmgdb: RMGDatabase,
                            reaction: Reaction,
                            dh_rxn298: Optional[float] = None,
@@ -71,6 +122,13 @@ def determine_rmg_kinetics(rmgdb: RMGDatabase,
     Determine kinetics for `reaction` (an RMG Reaction object) from RMG's database, if possible.
     Assigns a list of all matching entries from both libraries and families.
 
+    Note:
+        Family entries originating from the training set are intentionally filtered out
+        (an empty returned list therefore means "no matching libraries and only training-set
+        family hits", not necessarily "no match at all"). Database kinetics are deep-copied
+        before any in-place mutation (degeneracy scaling, unit conversion) so the loaded
+        ``rmgdb`` instance remains unchanged across calls.
+
     Args:
         rmgdb (RMGDatabase): The RMG database instance.
         reaction (Reaction): The RMG Reaction object.
@@ -79,6 +137,7 @@ def determine_rmg_kinetics(rmgdb: RMGDatabase,
 
     Returns: list[dict]
         All matching RMG reactions kinetics (both libraries and families) as a dict of parameters.
+        Empty list if nothing matched (or only training-set entries matched).
     """
     rmg_reactions = list()
     # Libraries:
@@ -89,19 +148,22 @@ def determine_rmg_kinetics(rmgdb: RMGDatabase,
                 library_reaction.comment = f'Library: {library.label}'
                 rmg_reactions.append(library_reaction)
                 break
-    # # Families:
-    A_units = "cm^3/(mol*s)" if len(reaction.reactants) == 2 else "s^-1"
+    # Families:
+    a_factor = get_a_factor_si_to_cm(len(reaction.reactants))
     fam_list = loop_families(rmgdb, reaction)
     dh_rxn298 = dh_rxn298 or get_dh_rxn298(rmgdb=rmgdb, reaction=reaction)  # J/mol
     for family, degenerate_reactions in fam_list:
         for deg_rxn in degenerate_reactions:
             kinetics_list = family.get_kinetics(reaction=deg_rxn, template_labels=deg_rxn.template, degeneracy=deg_rxn.degeneracy)
             for kinetics_detailes in kinetics_list:
-                kinetics = kinetics_detailes[0]
-                kinetics.change_rate(deg_rxn.degeneracy)
+                # Deep-copy before mutating so the database object isn't double-scaled
+                # if the same family rule is queried again for another reaction.
+                kinetics = copy.deepcopy(kinetics_detailes[0])
+                kinetics = scale_kinetics_by_degeneracy(kinetics, deg_rxn.degeneracy)
                 if hasattr(kinetics, 'to_arrhenius'):
                     kinetics = kinetics.to_arrhenius(dh_rxn298)  # Convert ArrheniusEP to Arrhenius
-                kinetics.A.value_si = kinetics.A.value_si * (1e6 if A_units == "cm^3/(mol*s)" else 1)
+                if a_factor != 1.0 and isinstance(kinetics, Arrhenius):
+                    kinetics.A.value_si = kinetics.A.value_si * a_factor
                 deg_rxn.kinetics = kinetics
                 deg_rxn.comment = f'Family: {deg_rxn.family}'
                 if 'training' in deg_rxn.kinetics.comment:
@@ -150,7 +212,11 @@ def get_kinetics_from_reactions(reactions: List[Reaction]) -> List[Dict]:
     """
     kinetics_list = list()
     for rxn in reactions:
-        print(f'rxn: {rxn}, kinetics: {rxn.kinetics}, comment: {rxn.comment}')
+        try:
+            rxn_repr = str(rxn)
+        except (TypeError, AttributeError):
+            rxn_repr = '<reaction without reactants/products labels>'
+        print(f'rxn: {rxn_repr}, kinetics: {rxn.kinetics}, comment: {rxn.comment}', file=sys.stderr)
         kinetics_list.append({
             'kinetics': rxn.kinetics.__repr__(),
             'comment': rxn.comment,

--- a/arc/scripts/rmg_kinetics.py
+++ b/arc/scripts/rmg_kinetics.py
@@ -2,12 +2,26 @@
 # encoding: utf-8
 
 """
-A standalone script to run RMG
-and get kinetic rate coefficients for reactions
+A standalone script to run RMG and get kinetic rate coefficients for reactions.
+
+Output units (per entry returned by ``get_kinetics_from_reactions``):
+    - ``A``:    cm/mol/s convention (s^-1, cm^3/(mol*s), cm^6/(mol^2*s), ...),
+                obtained from the SI value via RMG's
+                ``A.get_conversion_factor_from_si_to_cm_mol_s()`` (the same
+                dimensionality-based factor RMG uses to write Chemkin files),
+                so it is correct regardless of the matched entry's molecularity.
+    - ``n``:    dimensionless temperature exponent.
+    - ``Ea``:   kJ/mol (converted from SI J/mol).
+    - ``T_min``, ``T_max``: K.
 """
 
 import os
+import sys
 from typing import Dict, List, Optional, Tuple
+
+# Make ``from common import ...`` work no matter how this script is invoked
+# (e.g. ``python /abs/path/to/rmg_kinetics.py``, ``cd elsewhere && python ...``).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common import parse_command_line_arguments, read_yaml_file, save_yaml_file
 
@@ -35,11 +49,12 @@ def main():
     """
     args = parse_command_line_arguments()
     input_file = args.file
+    output_file = args.output or input_file
     reaction_list = read_yaml_file(path=input_file)
     if not isinstance(reaction_list, list):
         raise ValueError(f'The content of {input_file} must be a list, got {reaction_list} which is a {type(reaction_list)}')
     result = get_rate_coefficients(reaction_list)
-    save_yaml_file(path=input_file, content=result)
+    save_yaml_file(path=output_file, content=result)
 
 
 def get_rate_coefficients(reaction_list: List[Dict]) -> List[Dict]:
@@ -57,61 +72,89 @@ def get_rate_coefficients(reaction_list: List[Dict]) -> List[Dict]:
     for i in range(len(reaction_list)):
         rxn = Reaction(reactants=[Species().from_adjacency_list(adjlist) for adjlist in reaction_list[i]['reactants']],
                        products=[Species().from_adjacency_list(adjlist) for adjlist in reaction_list[i]['products']])
-        reaction_list[i]['kinetics'] = determine_rmg_kinetics(rmgdb=rmgdb, reaction=rxn, dh_rxn298=reaction_list[i]['dh_rxn298'],
-                                                              family=reaction_list[i]['family'] if 'family' in reaction_list[i] else None)
+        reaction_list[i]['kinetics'] = determine_rmg_kinetics(rmgdb=rmgdb, reaction=rxn, dh_rxn298=reaction_list[i]['dh_rxn298'])
     return reaction_list
+
+
+def format_kinetics_comment(family_label: str,
+                            source,
+                            entry,
+                            ) -> str:
+    """
+    Build a provenance comment for a family kinetics hit from what ``get_kinetics`` returns.
+
+    ``get_kinetics`` reports the source as a depository object (e.g. the ``training``
+    depository), the string ``'rate rules'``, or an estimator name, and the matched
+    database ``entry`` (``None`` for an averaged rate-rule estimate). This replaces the
+    former substring test on the kinetics comment prose, which discarded valid rate-rule
+    estimates once the rule tree is built from the training set.
+
+    Args:
+        family_label (str): The RMG family label.
+        source: The kinetics source returned by ``get_kinetics`` (a depository object,
+                or a string such as ``'rate rules'``).
+        entry: The matched database entry, or ``None`` for an averaged estimate.
+
+    Returns:
+        str: A human-readable provenance comment.
+    """
+    source_label = source.label if hasattr(source, 'label') else str(source)
+    comment = f'Family: {family_label}, source: {source_label}'
+    if entry is not None and getattr(entry, 'rank', None) is not None:
+        comment += f', rank: {entry.rank}'
+    return comment
 
 
 def determine_rmg_kinetics(rmgdb: RMGDatabase,
                            reaction: Reaction,
                            dh_rxn298: Optional[float] = None,
-                           family: Optional[str] = None,
                            ) -> List[Dict]:
     """
     Determine kinetics for `reaction` (an RMG Reaction object) from RMG's database, if possible.
     Assigns a list of all matching entries from both libraries and families.
 
+    Note:
+        Only forward-direction matches are reported. Reaction-path degeneracy is applied by
+        RMG's ``get_kinetics`` on the rate-rule path, so this function does not scale again.
+        The kinetics objects returned by RMG are already deep copies, so mutating the reported
+        copy does not affect the loaded ``rmgdb`` instance.
+
     Args:
         rmgdb (RMGDatabase): The RMG database instance.
         reaction (Reaction): The RMG Reaction object.
         dh_rxn298 (float, optional): The heat of reaction at 298 K in J/mol.
-        family (str, optional): The RMG family label.
 
     Returns: list[dict]
-        All matching RMG reactions kinetics (both libraries and families) as a dict of parameters.
+        All matching RMG reaction kinetics (both libraries and families) as a dict of parameters.
+        Empty list if nothing matched.
     """
     rmg_reactions = list()
-    # Libraries:
+    # Libraries (forward direction only; ``is_isomorphic`` defaults to ``either_direction=True``,
+    # which would report a reverse-direction entry's rate as though it were the forward rate).
     for library in rmgdb.kinetics.libraries.values():
-        library_reactions = library.get_library_reactions()
-        for library_reaction in library_reactions:
-            if reaction.is_isomorphic(library_reaction):
+        for library_reaction in library.get_library_reactions():
+            if reaction.is_isomorphic(library_reaction, either_direction=False):
                 library_reaction.comment = f'Library: {library.label}'
                 rmg_reactions.append(library_reaction)
                 break
-    # # Families:
-    A_units = "cm^3/(mol*s)" if len(reaction.reactants) == 2 else "s^-1"
-    fam_list = loop_families(rmgdb, reaction)
+    # Families:
     dh_rxn298 = dh_rxn298 or get_dh_rxn298(rmgdb=rmgdb, reaction=reaction)  # J/mol
-    for family, degenerate_reactions in fam_list:
+    for family, degenerate_reactions in loop_families(rmgdb, reaction):
         for deg_rxn in degenerate_reactions:
-            kinetics_list = family.get_kinetics(reaction=deg_rxn, template_labels=deg_rxn.template, degeneracy=deg_rxn.degeneracy)
-            for kinetics_detailes in kinetics_list:
-                kinetics = kinetics_detailes[0]
-                kinetics.change_rate(deg_rxn.degeneracy)
+            kinetics_list = family.get_kinetics(reaction=deg_rxn, template_labels=deg_rxn.template,
+                                                degeneracy=deg_rxn.degeneracy)
+            for kinetics, source, entry, is_forward in kinetics_list:
+                if not is_forward:
+                    # A reverse-direction depository match is a different rate; skip it.
+                    continue
                 if hasattr(kinetics, 'to_arrhenius'):
                     kinetics = kinetics.to_arrhenius(dh_rxn298)  # Convert ArrheniusEP to Arrhenius
-                kinetics.A.value_si = kinetics.A.value_si * (1e6 if A_units == "cm^3/(mol*s)" else 1)
                 deg_rxn.kinetics = kinetics
-                deg_rxn.comment = f'Family: {deg_rxn.family}'
-                if 'training' in deg_rxn.kinetics.comment:
-                    deg_rxn.comment += ' (training)'
                 deg_rxn.reactants = reaction.reactants
                 deg_rxn.products = reaction.products
                 rxn_copy = deg_rxn.copy()
-                rxn_copy.comment = deg_rxn.comment
-                if 'training' not in rxn_copy.comment:
-                    rmg_reactions.append(rxn_copy)
+                rxn_copy.comment = format_kinetics_comment(deg_rxn.family, source, entry)
+                rmg_reactions.append(rxn_copy)
     return get_kinetics_from_reactions(rmg_reactions)
 
 
@@ -150,11 +193,16 @@ def get_kinetics_from_reactions(reactions: List[Reaction]) -> List[Dict]:
     """
     kinetics_list = list()
     for rxn in reactions:
-        print(f'rxn: {rxn}, kinetics: {rxn.kinetics}, comment: {rxn.comment}')
+        try:
+            rxn_repr = str(rxn)
+        except (TypeError, AttributeError):
+            rxn_repr = '<reaction without reactants/products labels>'
+        print(f'rxn: {rxn_repr}, kinetics: {rxn.kinetics}, comment: {rxn.comment}', file=sys.stderr)
         kinetics_list.append({
             'kinetics': rxn.kinetics.__repr__(),
             'comment': rxn.comment,
-            'A': rxn.kinetics.A.value if hasattr(rxn.kinetics, 'A') else None,
+            'A': (rxn.kinetics.A.value_si * rxn.kinetics.A.get_conversion_factor_from_si_to_cm_mol_s()
+                  if hasattr(rxn.kinetics, 'A') else None),  # SI -> cm/mol/s, as RMG writes Chemkin
             'n': rxn.kinetics.n.value if hasattr(rxn.kinetics, 'n') else None,
             'Ea': rxn.kinetics.Ea.value_si * 0.001 if hasattr(rxn.kinetics, 'Ea') else None,  # kJ/mol
             'T_min': rxn.kinetics.Tmin.value_si if hasattr(rxn.kinetics, 'Tmin') and rxn.kinetics.Tmin is not None else None,
@@ -261,13 +309,20 @@ def load_rmg_database() -> RMGDatabase:
         RMGDatabase: The loaded RMG database.
     """
     rmgdb = RMGDatabase()
-    kinetics_libraries = read_yaml_file(path=os.path.join(os.path.dirname(__file__), 'libraries.yaml'))['kinetics']
-    thermo_libraries = read_yaml_file(path=os.path.join(os.path.dirname(__file__), 'libraries.yaml'))['thermo']
-    rmgdb.load_thermo(path=os.path.join(DB_PATH, 'thermo'), thermo_libraries=thermo_libraries, depository=True, surface=False)
+    libraries = read_yaml_file(path=os.path.join(os.path.dirname(__file__), 'libraries.yaml'))
+    rmgdb.load_thermo(path=os.path.join(DB_PATH, 'thermo'), thermo_libraries=libraries['thermo'], depository=True, surface=False)
     rmgdb.load_kinetics(path=os.path.join(DB_PATH, 'kinetics'),
-                        reaction_libraries=kinetics_libraries,
+                        reaction_libraries=libraries['kinetics'],
                         kinetics_families='default',
                         kinetics_depositories=['training'])
+    # ``load_kinetics`` does not populate the rate-rule tree; RMG builds it after loading
+    # (rmgpy/rmg/main.py) so family estimates don't fall back to a generic ancestor node.
+    # Mirror that here for every non-auto-generated family (auto-generated ones build their
+    # own rules on load).
+    for family in rmgdb.kinetics.families.values():
+        if not family.auto_generated:
+            family.add_rules_from_training(thermo_database=rmgdb.thermo)
+            family.fill_rules_by_averaging_up(verbose=False)
     return rmgdb
 
 

--- a/arc/scripts/rmg_thermo.py
+++ b/arc/scripts/rmg_thermo.py
@@ -2,11 +2,19 @@
 # encoding: utf-8
 
 """
-A standalone script to run RMG
-and get thermodynamic properties for species
+A standalone script to run RMG and get thermodynamic properties for species.
+
+Output units (per entry returned by ``get_thermo``):
+    - ``h298``: kJ/mol (converted from SI J/mol).
+    - ``s298``: J/(mol*K).
+    - ``comment``: source / estimation comment from RMG.
 """
 
 import os
+import sys
+
+# Make ``from common import ...`` work no matter how this script is invoked.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common import parse_command_line_arguments, read_yaml_file, save_yaml_file
 
@@ -33,11 +41,12 @@ def main():
     """
     args = parse_command_line_arguments()
     input_file = args.file
+    output_file = args.output or input_file
     species_list = read_yaml_file(path=input_file)
     if not isinstance(species_list, list):
         raise ValueError(f'The content of {input_file} must be a list, got {species_list} which is a {type(species_list)}')
     result = get_thermo(species_list)
-    save_yaml_file(path=input_file, content=result)
+    save_yaml_file(path=output_file, content=result)
 
 
 def get_thermo(species_list: list[dict]) -> list[dict]:

--- a/arc/scripts_test.py
+++ b/arc/scripts_test.py
@@ -12,9 +12,11 @@ import os
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import unittest
 
-from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file
+from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file, save_yaml_file
+from arc.scripts.common import parse_command_line_arguments
 
 
 def _rmg_env_available() -> bool:
@@ -115,6 +117,154 @@ class TestSaveArkaneThermo(unittest.TestCase):
             self.assertGreater(len(cp), 0)
             self.assertIn('temperature_k', cp[0])
             self.assertIn('cp_j_mol_k', cp[0])
+
+
+class TestCommonArgparse(unittest.TestCase):
+    """Test the shared CLI parser used by the standalone scripts."""
+
+    def test_positional_file_only(self):
+        """Without ``--output`` the parser exposes ``args.output is None``."""
+        args = parse_command_line_arguments(['/tmp/in.yml'])
+        self.assertEqual(args.file, '/tmp/in.yml')
+        self.assertIsNone(args.output)
+
+    def test_output_long_form(self):
+        """``--output`` populates ``args.output`` so callers can avoid overwriting input."""
+        args = parse_command_line_arguments(['/tmp/in.yml', '--output', '/tmp/out.yml'])
+        self.assertEqual(args.file, '/tmp/in.yml')
+        self.assertEqual(args.output, '/tmp/out.yml')
+
+    def test_output_short_form(self):
+        """``-o`` is an accepted short form."""
+        args = parse_command_line_arguments(['/tmp/in.yml', '-o', '/tmp/out.yml'])
+        self.assertEqual(args.output, '/tmp/out.yml')
+
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestRmgKineticsHelpers(unittest.TestCase):
+    """
+    Unit tests for ``rmg_kinetics.py`` helpers that don't need a full RMG database load.
+
+    Each test runs a tiny ``python -c`` snippet inside ``rmg_env`` so we can import
+    rmgpy and the script module directly. Stdout is parsed as JSON.
+    """
+
+    SCRIPT_DIR = os.path.join(ARC_PATH, 'arc', 'scripts')
+
+    def _run_in_rmg_env(self, snippet: str) -> str:
+        """Execute ``snippet`` inside rmg_env and return stripped stdout."""
+        result = subprocess.run(
+            ['conda', 'run', '-n', 'rmg_env', 'python', '-c', snippet],
+            capture_output=True, text=True, timeout=120,
+        )
+        self.assertEqual(result.returncode, 0,
+                         f'snippet failed: stderr={result.stderr}\nstdout={result.stdout}')
+        return result.stdout.strip()
+
+    def test_get_kinetics_from_reactions_arrhenius(self):
+        """``get_kinetics_from_reactions`` reports A/n/Ea (Ea in kJ/mol) for an Arrhenius rxn."""
+        snippet = textwrap.dedent(f"""
+            import sys, json
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import get_kinetics_from_reactions
+            from rmgpy.kinetics import Arrhenius
+            from rmgpy.reaction import Reaction
+            rxn = Reaction()
+            rxn.kinetics = Arrhenius(A=(1.5e13, 'cm^3/(mol*s)'), n=0.0, Ea=(20.0, 'kJ/mol'),
+                                     Tmin=(300.0, 'K'), Tmax=(2500.0, 'K'))
+            rxn.comment = 'unit-test'
+            out = get_kinetics_from_reactions([rxn])
+            print(json.dumps(out[0]))
+        """)
+        import json
+        entry = json.loads(self._run_in_rmg_env(snippet))
+        self.assertEqual(entry['comment'], 'unit-test')
+        self.assertAlmostEqual(entry['A'], 1.5e13, delta=1e7)
+        self.assertEqual(entry['n'], 0.0)
+        self.assertAlmostEqual(entry['Ea'], 20.0, places=6)  # kJ/mol
+        self.assertEqual(entry['T_min'], 300.0)
+        self.assertEqual(entry['T_max'], 2500.0)
+
+    def test_get_kinetics_from_reactions_handles_missing_T_bounds(self):
+        """Tmin/Tmax may be absent; helper should yield None rather than crashing."""
+        snippet = textwrap.dedent(f"""
+            import sys, json
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import get_kinetics_from_reactions
+            from rmgpy.kinetics import Arrhenius
+            from rmgpy.reaction import Reaction
+            rxn = Reaction()
+            rxn.kinetics = Arrhenius(A=(1.0, 's^-1'), n=1.0, Ea=(0.0, 'J/mol'))
+            rxn.comment = 'no-T-bounds'
+            print(json.dumps(get_kinetics_from_reactions([rxn])[0]))
+        """)
+        import json
+        entry = json.loads(self._run_in_rmg_env(snippet))
+        self.assertIsNone(entry['T_min'])
+        self.assertIsNone(entry['T_max'])
+
+    def test_scale_kinetics_by_degeneracy_skips_non_arrhenius(self):
+        """``scale_kinetics_by_degeneracy`` scales Arrhenius A by the degeneracy but
+        leaves non-Arrhenius forms (e.g. Chebyshev) untouched. Dropping the guard would
+        let ``change_rate`` corrupt the Chebyshev coefficients and fail this test."""
+        snippet = textwrap.dedent(f"""
+            import sys
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import scale_kinetics_by_degeneracy
+            from rmgpy.kinetics import Arrhenius, Chebyshev
+            arr = Arrhenius(A=(1.0, 's^-1'), n=0.0, Ea=(0.0, 'J/mol'))
+            scale_kinetics_by_degeneracy(arr, 2)
+            assert abs(arr.A.value_si - 2.0) < 1e-9, arr.A.value_si
+            cheb = Chebyshev(coeffs=[[1.0, 0.0], [0.0, 0.0]],
+                             kunits='cm^3/(mol*s)',
+                             Tmin=(300.0, 'K'), Tmax=(2000.0, 'K'),
+                             Pmin=(0.01, 'bar'), Pmax=(100.0, 'bar'))
+            before = cheb.coeffs.value_si.tolist()
+            scale_kinetics_by_degeneracy(cheb, 2)
+            assert cheb.coeffs.value_si.tolist() == before, 'Chebyshev coeffs were mutated'
+            print('ok')
+        """)
+        self.assertEqual(self._run_in_rmg_env(snippet), 'ok')
+
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestRmgScriptsOutputFlag(unittest.TestCase):
+    """Verify ``--output`` writes to a fresh path and leaves the input file untouched."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='rmg_scripts_test_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _h2_adjlist(self) -> str:
+        return '1 H u0 p0 c0 {2,S}\n2 H u0 p0 c0 {1,S}\n'
+
+    def test_rmg_thermo_output_does_not_overwrite_input(self):
+        """The thermo script writes the augmented YAML to ``--output`` and preserves input."""
+        input_path = os.path.join(self.tmp_dir, 'in.yml')
+        output_path = os.path.join(self.tmp_dir, 'out.yml')
+        original = [{'label': 'H2', 'adjlist': self._h2_adjlist()}]
+        save_yaml_file(path=input_path, content=original)
+        with open(input_path, 'rb') as f:
+            input_bytes_before = f.read()
+
+        script = os.path.join(ARC_PATH, 'arc', 'scripts', 'rmg_thermo.py')
+        result = subprocess.run(
+            ['conda', 'run', '-n', 'rmg_env', 'python', script, input_path, '--output', output_path],
+            capture_output=True, text=True, timeout=300,
+        )
+        self.assertEqual(result.returncode, 0, f'thermo script failed: {result.stderr}')
+
+        # Input must be byte-identical (the script must not overwrite it).
+        with open(input_path, 'rb') as f:
+            self.assertEqual(f.read(), input_bytes_before)
+        # Output must contain the new keys.
+        out = read_yaml_file(output_path)
+        self.assertEqual(len(out), 1)
+        self.assertIn('h298', out[0])
+        self.assertIn('s298', out[0])
+        self.assertIn('comment', out[0])
 
 
 if __name__ == '__main__':

--- a/arc/scripts_test.py
+++ b/arc/scripts_test.py
@@ -12,19 +12,41 @@ import os
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import unittest
 
-from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file
+from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file, save_yaml_file
+from arc.job.env_run import rmg_env_command
+from arc.scripts.common import parse_command_line_arguments
+
+
+def _run_rmg_env(py_args, cwd=None, timeout=120, text=True):
+    """
+    Run ``python <py_args>`` inside rmg_env via ARC's production launcher helper.
+
+    Routing through ``rmg_env_command`` (rather than a hardcoded ``conda run``) matches
+    how ARC invokes these scripts in production and selects the right launcher
+    (micromamba/mamba/conda) on whatever host the tests run on.
+
+    Args:
+        py_args (list[str]): Everything after ``python`` (e.g. ``[script, '--output', out]``
+                             or ``['-c', snippet]``).
+        cwd (str, optional): Directory to run in.
+        timeout (int): Subprocess timeout in seconds.
+        text (bool): Whether to decode stdout/stderr as text.
+
+    Returns:
+        subprocess.CompletedProcess: The finished process.
+    """
+    command = rmg_env_command(py_args=py_args, cwd=cwd)
+    return subprocess.run(command, shell=True, executable='/bin/bash',
+                          capture_output=True, text=text, timeout=timeout)
 
 
 def _rmg_env_available() -> bool:
-    """Check whether rmg_env conda environment is available."""
+    """Check whether the rmg_env conda environment is available."""
     try:
-        result = subprocess.run(
-            ['conda', 'run', '-n', 'rmg_env', 'python', '-c', 'import rmgpy'],
-            capture_output=True, timeout=30,
-        )
-        return result.returncode == 0
+        return _run_rmg_env(['-c', 'import rmgpy'], timeout=30, text=False).returncode == 0
     except Exception:
         return False
 
@@ -49,10 +71,7 @@ class TestSaveArkaneThermo(unittest.TestCase):
     def test_produces_thermo_yaml(self):
         """Run the script and verify it produces a valid thermo.yaml."""
         script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
-        result = subprocess.run(
-            ['conda', 'run', '-n', 'rmg_env', 'python', script],
-            capture_output=True, text=True, cwd=self.tmp_dir, timeout=60,
-        )
+        result = _run_rmg_env([script], cwd=self.tmp_dir, timeout=60)
         self.assertEqual(result.returncode, 0, f'Script failed: {result.stderr}')
 
         yaml_path = os.path.join(self.tmp_dir, 'thermo.yaml')
@@ -68,10 +87,7 @@ class TestSaveArkaneThermo(unittest.TestCase):
     def test_h298_s298_values(self):
         """Verify H298 and S298 are reasonable."""
         script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
-        subprocess.run(
-            ['conda', 'run', '-n', 'rmg_env', 'python', script],
-            capture_output=True, cwd=self.tmp_dir, timeout=60,
-        )
+        _run_rmg_env([script], cwd=self.tmp_dir, timeout=60)
         data = read_yaml_file(os.path.join(self.tmp_dir, 'thermo.yaml'))
 
         # CHO: H298 ~ 41 kJ/mol (radical), S298 ~ 224 J/(mol*K)
@@ -85,10 +101,7 @@ class TestSaveArkaneThermo(unittest.TestCase):
     def test_nasa_polynomials_present(self):
         """Verify NASA polynomial data is extracted."""
         script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
-        subprocess.run(
-            ['conda', 'run', '-n', 'rmg_env', 'python', script],
-            capture_output=True, cwd=self.tmp_dir, timeout=60,
-        )
+        _run_rmg_env([script], cwd=self.tmp_dir, timeout=60)
         data = read_yaml_file(os.path.join(self.tmp_dir, 'thermo.yaml'))
 
         for label in ['CHO', 'CH4', 'CH2O', 'CH3']:
@@ -102,10 +115,7 @@ class TestSaveArkaneThermo(unittest.TestCase):
     def test_cp_data_present(self):
         """Verify tabulated Cp data is extracted."""
         script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
-        subprocess.run(
-            ['conda', 'run', '-n', 'rmg_env', 'python', script],
-            capture_output=True, cwd=self.tmp_dir, timeout=60,
-        )
+        _run_rmg_env([script], cwd=self.tmp_dir, timeout=60)
         data = read_yaml_file(os.path.join(self.tmp_dir, 'thermo.yaml'))
 
         for label in ['CHO', 'CH4', 'CH2O', 'CH3']:
@@ -115,6 +125,147 @@ class TestSaveArkaneThermo(unittest.TestCase):
             self.assertGreater(len(cp), 0)
             self.assertIn('temperature_k', cp[0])
             self.assertIn('cp_j_mol_k', cp[0])
+
+
+class TestCommonArgparse(unittest.TestCase):
+    """Test the shared CLI parser used by the standalone scripts."""
+
+    def test_positional_file_only(self):
+        """Without ``--output`` the parser exposes ``args.output is None``."""
+        args = parse_command_line_arguments(['/tmp/in.yml'])
+        self.assertEqual(args.file, '/tmp/in.yml')
+        self.assertIsNone(args.output)
+
+    def test_output_long_form(self):
+        """``--output`` populates ``args.output`` so callers can avoid overwriting input."""
+        args = parse_command_line_arguments(['/tmp/in.yml', '--output', '/tmp/out.yml'])
+        self.assertEqual(args.file, '/tmp/in.yml')
+        self.assertEqual(args.output, '/tmp/out.yml')
+
+    def test_output_short_form(self):
+        """``-o`` is an accepted short form."""
+        args = parse_command_line_arguments(['/tmp/in.yml', '-o', '/tmp/out.yml'])
+        self.assertEqual(args.output, '/tmp/out.yml')
+
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestRmgKineticsHelpers(unittest.TestCase):
+    """
+    Unit tests for ``rmg_kinetics.py`` helpers that don't need a full RMG database load.
+
+    Each test runs a tiny ``python -c`` snippet inside ``rmg_env`` so we can import
+    rmgpy and the script module directly. Stdout is parsed as JSON.
+    """
+
+    SCRIPT_DIR = os.path.join(ARC_PATH, 'arc', 'scripts')
+
+    def _run_in_rmg_env(self, snippet: str) -> str:
+        """Execute ``snippet`` inside rmg_env and return stripped stdout."""
+        result = _run_rmg_env(['-c', snippet], timeout=120)
+        self.assertEqual(result.returncode, 0,
+                         f'snippet failed: stderr={result.stderr}\nstdout={result.stdout}')
+        return result.stdout.strip()
+
+    def test_get_kinetics_from_reactions_arrhenius(self):
+        """``get_kinetics_from_reactions`` reports A/n/Ea (Ea in kJ/mol) for an Arrhenius rxn."""
+        snippet = textwrap.dedent(f"""
+            import sys, json
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import get_kinetics_from_reactions
+            from rmgpy.kinetics import Arrhenius
+            from rmgpy.reaction import Reaction
+            rxn = Reaction()
+            rxn.kinetics = Arrhenius(A=(1.5e13, 'cm^3/(mol*s)'), n=0.0, Ea=(20.0, 'kJ/mol'),
+                                     Tmin=(300.0, 'K'), Tmax=(2500.0, 'K'))
+            rxn.comment = 'unit-test'
+            out = get_kinetics_from_reactions([rxn])
+            print(json.dumps(out[0]))
+        """)
+        import json
+        entry = json.loads(self._run_in_rmg_env(snippet))
+        self.assertEqual(entry['comment'], 'unit-test')
+        self.assertAlmostEqual(entry['A'], 1.5e13, delta=1e7)
+        self.assertEqual(entry['n'], 0.0)
+        self.assertAlmostEqual(entry['Ea'], 20.0, places=6)  # kJ/mol
+        self.assertEqual(entry['T_min'], 300.0)
+        self.assertEqual(entry['T_max'], 2500.0)
+
+    def test_get_kinetics_from_reactions_handles_missing_T_bounds(self):
+        """Tmin/Tmax may be absent; helper should yield None rather than crashing."""
+        snippet = textwrap.dedent(f"""
+            import sys, json
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import get_kinetics_from_reactions
+            from rmgpy.kinetics import Arrhenius
+            from rmgpy.reaction import Reaction
+            rxn = Reaction()
+            rxn.kinetics = Arrhenius(A=(1.0, 's^-1'), n=1.0, Ea=(0.0, 'J/mol'))
+            rxn.comment = 'no-T-bounds'
+            print(json.dumps(get_kinetics_from_reactions([rxn])[0]))
+        """)
+        import json
+        entry = json.loads(self._run_in_rmg_env(snippet))
+        self.assertIsNone(entry['T_min'])
+        self.assertIsNone(entry['T_max'])
+
+    def test_get_kinetics_from_reactions_converts_si_to_cm(self):
+        """``get_kinetics_from_reactions`` reports A in the cm/mol/s convention.
+
+        A bimolecular Arrhenius built in SI (``m^3/(mol*s)``) must be reported ×1e6
+        (``cm^3/(mol*s)``) via ``A.get_conversion_factor_from_si_to_cm_mol_s()`` — this
+        exercises the units contract directly rather than reading a cm value straight back.
+        """
+        snippet = textwrap.dedent(f"""
+            import sys, json
+            sys.path.insert(0, {self.SCRIPT_DIR!r})
+            from rmg_kinetics import get_kinetics_from_reactions
+            from rmgpy.kinetics import Arrhenius
+            from rmgpy.reaction import Reaction
+            rxn = Reaction()
+            rxn.kinetics = Arrhenius(A=(1.0, 'm^3/(mol*s)'), n=0.0, Ea=(0.0, 'J/mol'))
+            rxn.comment = 'si-input'
+            print(json.dumps(get_kinetics_from_reactions([rxn])[0]))
+        """)
+        import json
+        entry = json.loads(self._run_in_rmg_env(snippet))
+        self.assertAlmostEqual(entry['A'], 1.0e6, delta=1.0)  # m^3/(mol*s) -> cm^3/(mol*s)
+
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestRmgScriptsOutputFlag(unittest.TestCase):
+    """Verify ``--output`` writes to a fresh path and leaves the input file untouched."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='rmg_scripts_test_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _h2_adjlist(self) -> str:
+        return '1 H u0 p0 c0 {2,S}\n2 H u0 p0 c0 {1,S}\n'
+
+    def test_rmg_thermo_output_does_not_overwrite_input(self):
+        """The thermo script writes the augmented YAML to ``--output`` and preserves input."""
+        input_path = os.path.join(self.tmp_dir, 'in.yml')
+        output_path = os.path.join(self.tmp_dir, 'out.yml')
+        original = [{'label': 'H2', 'adjlist': self._h2_adjlist()}]
+        save_yaml_file(path=input_path, content=original)
+        with open(input_path, 'rb') as f:
+            input_bytes_before = f.read()
+
+        script = os.path.join(ARC_PATH, 'arc', 'scripts', 'rmg_thermo.py')
+        result = _run_rmg_env([script, input_path, '--output', output_path], timeout=300)
+        self.assertEqual(result.returncode, 0, f'thermo script failed: {result.stderr}')
+
+        # Input must be byte-identical (the script must not overwrite it).
+        with open(input_path, 'rb') as f:
+            self.assertEqual(f.read(), input_bytes_before)
+        # Output must contain the new keys.
+        out = read_yaml_file(output_path)
+        self.assertEqual(len(out), 1)
+        self.assertIn('h298', out[0])
+        self.assertIn('s298', out[0])
+        self.assertIn('comment', out[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Deep-copy DB kinetics before scaling so a second query can't read a doubly-scaled A, gate change_rate on Arrhenius/EP so non-Arrhenius forms (Chebyshev/PLOG/etc.) are skipped safely, add sys.path bootstrap so `from common import ...` works regardless of CWD, add an --output flag so the input YAML isn't overwritten, document the training-entry filter and output units, and harden the helper's debug print against reactions without reactants. Adds argparse + subprocess unit tests.