### PR TITLE
Fix: detect SCRF polarization charge error and troubleshoot with nosymm

### DIFF
--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -94,6 +94,7 @@ def determine_ess_status(output_path: str,
                     if 'l9999.exe' in line or 'link 9999' in line:
                         cycle_issue = False
                         neg_eigenvalues = False
+                        polarization_error = False
                         for j in range(i, len_reversed_lines):
                             if 'Number of steps exceeded' in reverse_lines[j]:
                                 keywords = ['MaxOptCycles', 'GL9999']
@@ -107,7 +108,13 @@ def determine_ess_status(output_path: str,
                                 neg_eigenvalues = True
                                 line = 'Wrong number of Negative eigenvalues'
                                 break
-                        if not cycle_issue and not neg_eigenvalues:
+                            elif 'Error on total polarization charges' in reverse_lines[j]:
+                                keywords = ['Unconverged', 'GL9999', 'NoSymm']
+                                error = 'Error on total polarization charges (SCRF/SMD convergence failure)'
+                                polarization_error = True
+                                line = 'Error on total polarization charges'
+                                break
+                        if not cycle_issue and not neg_eigenvalues and not polarization_error:
                             keywords = ['Unconverged', 'GL9999']  # GL stand for Gaussian Link
                             error = 'Unconverged'
                     elif 'l101.exe' in line:

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -129,7 +129,16 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(keywords, ["MaxOptCycles", "GL9999",])
         self.assertEqual(error, "Maximum optimization cycles reached.")
         self.assertIn("Number of steps exceeded", line)
-        
+
+        path = os.path.join(self.base_path["gaussian"], "polarization_charges.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="pr2", job_type="opt"
+        )
+        self.assertEqual(status, "errored")
+        self.assertEqual(keywords, ["Unconverged", "GL9999", "NoSymm"])
+        self.assertEqual(error, "Error on total polarization charges (SCRF/SMD convergence failure)")
+        self.assertIn("Error on total polarization charges", line)
+
         path = os.path.join(self.base_path["gaussian"], "inaccurate_quadrature.out")
         status, keywords, error, line = trsh.determine_ess_status(
             output_path=path, species_label="Zr2O4H", job_type="opt"

--- a/arc/testing/trsh/gaussian/polarization_charges.out
+++ b/arc/testing/trsh/gaussian/polarization_charges.out
@@ -1,0 +1,22 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /usr/local/g16/l1.exe "/scratch/g16/Gau-12345.inp" -scrdir="/scratch/g16/"
+ Entering Link 1 = /usr/local/g16/l1.exe PID=     12345.
+
+ Copyright (c) 1988-2019, Gaussian, Inc.  All Rights Reserved.
+
+ #P opt=(cartesian,calcfc,maxcycle=200,tight) SCRF=(smd,Solvent=dimethylsulfoxide) wb97xd/jul-cc-pvtz
+
+ pr2
+
+ 0 1
+ C   0.000000   0.000000   0.000000
+
+ Error on total polarization charges =  0.04304
+ (Enter /usr/local/g16/l9999.exe)
+
+ Error termination request processed by link 9999.
+ Error termination via Lnk1e in /usr/local/g16/l9999.exe at Tue Jun 16 12:39:18 2026.
+ Job cpu time:       1 days 22 hours 50 minutes 16.4 seconds.
+ Elapsed time:       0 days  2 hours 57 minutes 47.6 seconds.
+ File lengths (MBytes):  RWF=    101 Int=      0 D2E=      0 Chk=     11 Scr=      1


### PR DESCRIPTION
Gaussian jobs using SMD/SCRF solvation can fail at l9999 with "Error on total polarization charges", which is a cavity construction issue unrelated to geometry convergence. ARC was classifying this as a generic Unconverged error and never attempting nosymm, which disables symmetry in the cavity and typically resolves the issue. Added detection of this error string in the l9999 block of determine_ess_status so that NoSymm is included in the parsed keywords, triggering the existing trsh_keyword_nosymm troubleshooting path.