### PR TITLE
Fix Docker build: resolve Julia sys.so not found in install_rms.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,12 +47,18 @@ RUN micromamba create -y -v -n rmg_env python=3.11 -f /home/mambauser/Code/RMG-P
 
 RUN micromamba run -n rmg_env make -C /home/mambauser/Code/RMG-Py -j"$(nproc)"
 
-RUN micromamba run -n rmg_env bash -c "\
+# `~/.juliaup/bin/julia` is the juliaup launcher, not the real Julia binary; pyjuliacall
+# derives sys.so relative to it and looks for a non-existent path, so install_rms.sh fails.
+# Prepend the real Julia BINDIR (resolved via the launcher) so `which julia` finds the actual
+# binary. Single quotes keep `$(...)` from being evaluated by the outer shell before micromamba
+# activates rmg_env, so `julia` resolves inside the environment.
+RUN micromamba run -n rmg_env bash -c '\
+      export PATH=$(julia -e "print(Sys.BINDIR)"):$PATH && \
       cd /home/mambauser/Code/RMG-Py && \
       export RMS_INSTALLER=continuous && \
       export RMS_BRANCH=for_rmg && \
       source install_rms.sh \
-    "
+    '
 
 WORKDIR /home/mambauser/Code/ARC
 RUN micromamba create -y -v -n arc_env python=3.14 -c conda-forge -c danagroup -f environment.yml && \


### PR DESCRIPTION
## Problem

The `Docker Image Build and Push` workflow has been red on every `push`/`pull_request` run since **~2026-06-10** (last green real build: 2026-06-04). Scheduled runs are green only because on a `schedule` event neither build step's `if:` condition matches, so no image is actually built.

The build fails in the `builder` stage at `install_rms.sh`:

```
ERROR: could not load library "/home/mambauser/.juliaup/bin/../lib/julia/sys.so"
/home/mambauser/.juliaup/bin/../lib/julia/sys.so: cannot open shared object file: No such file or directory
```

This is **not** related to PR #907 (Dependabot action bumps) — it reproduces on `main` independently.

## Root cause

`~/.juliaup/bin/julia` is the juliaup **launcher**, not the real Julia binary. `install_rms.sh` sets `PYTHON_JULIAPKG_EXE=$(which julia)`, so pyjuliacall receives the launcher path and derives `sys.so` relative to it — `~/.juliaup/bin/../lib/julia/sys.so`, which does not exist. The real Julia binary (and its `sys.so`) lives under the juliaup depot, reported by `Sys.BINDIR`.

## Fix

Prepend the real Julia `BINDIR` (resolved by running `julia -e "print(Sys.BINDIR)"` through the launcher) to `PATH` before sourcing `install_rms.sh`, so `which julia` resolves to the actual binary. The inner `bash -c` is single-quoted so the `$(...)` is evaluated inside the activated `rmg_env`, not by the outer shell before `micromamba run` activates it.

## Provenance / why this will work

This restores the fix originally proposed in **#901**, which was closed without merging (the closing comment conflated it with an `actions/checkout` bump). #901's own CI log proves the fix reaches `[ Info: RMS loaded successfully!` past this step. The **second** blocker that #901's log then exposed — `ModuleNotFoundError: No module named 'setuptools'` in `make compile` — is already resolved on `main` via #904 (`setuptools` is present in `environment.yml`). With both fixes in place, the build should complete.

Verification is via this PR's Docker build check (the full image build can't be run locally against the RMG toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)