### PR TITLE
Fix NameError from TYPE_CHECKING annotations evaluated at runtime

### DIFF
--- a/arc/parser/parser.py
+++ b/arc/parser/parser.py
@@ -4,7 +4,7 @@ A module for parsing information from various files.
 
 import os
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
 import numpy as np
@@ -15,6 +15,8 @@ from arc.exceptions import InputError, ParserError
 from arc.parser.factory import ess_factory
 from arc.species.converter import str_to_xyz
 
+if TYPE_CHECKING:
+    from arc.species.species import ARCSpecies
 
 logger = get_logger()
 
@@ -533,7 +535,7 @@ def process_conformers_file(conformers_path: str) -> tuple[list[dict[str, tuple]
     return xyzs, energies
 
 
-def parse_active_space(sp_path: str, species: ARCSpecies) -> dict[str, list[int] | tuple[int, int]] | None:
+def parse_active_space(sp_path: str, species: 'ARCSpecies') -> dict[str, list[int] | tuple[int, int]] | None:
     """
     Parse the active space (electrons and orbitals) from a Molpro CCSD output file.
 


### PR DESCRIPTION
### What

`arc/parser/parser.py` defined `parse_active_space(sp_path: str, species: ARCSpecies)`, but `ARCSpecies` was never imported in the module — not even under `TYPE_CHECKING`. It was therefore an undefined name in the annotation: unresolvable to type checkers, and a `NameError` on any interpreter (or tool) that evaluates the annotation.

### Fix

- Add the missing type-only import: `if TYPE_CHECKING: from arc.species.species import ARCSpecies`.
- Quote the annotation (`species: 'ARCSpecies'`) so its evaluation is deferred, keeping the module import-safe on Python ≤ 3.13 (eager annotations) as well as on the 3.14 target.

### Scope

This PR is intentionally limited to the single genuine defect in `arc/parser/parser.py` (see the earlier scope-reduction commit). The broader idea of adding `from __future__ import annotations` across all modules was dropped: ARC targets Python 3.14 (`environment.yml`), where PEP 649 makes annotations lazy by default, so the remaining `TYPE_CHECKING`-only annotations do not raise on import. Those modules already carry correct `TYPE_CHECKING` guards for their type-only names.