### PR TITLE
Enrich running_jobs.yml snapshot with server identifiers

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -871,6 +871,37 @@ class Scheduler(object):
         # Generate a TS report:
         self.generate_final_ts_guess_report()
 
+    def _running_job_snapshot_entry(self, label: str, job_name: str) -> dict:
+        """
+        Resolve a running ``job_name`` (as stored in ``self.running_jobs``, e.g. ``'tsg3'``)
+        back to its Job object and build a snapshot entry that carries the identifiers needed
+        to find the job on the server: ``server_name`` (the queue job name shown by ``qstat``,
+        e.g. ``a3129``), ``job_id`` (the queue's numeric id), the ``adapter`` (software), and the
+        ``server``. Falls back to just ``{'name': job_name}`` if the Job object can't be located
+        (e.g. the job was already popped, or a restart-loaded entry whose stored name doesn't
+        match any live ``job.job_name``). Resolved incore jobs still get an entry, carrying the
+        job number as their ``job_id``, while ``server`` may be ``None``.
+
+        Args:
+            label (str): The species/TS label the job belongs to.
+            job_name (str): The job name as stored in ``self.running_jobs``.
+
+        Returns:
+            dict: A self-describing snapshot entry for the running job.
+        """
+        entry = {'name': job_name}
+        for jobs in self.job_dict.get(label, dict()).values():
+            if not isinstance(jobs, dict):
+                continue
+            for job in jobs.values():
+                if getattr(job, 'job_name', None) == job_name:
+                    entry['server_name'] = job.job_server_name
+                    entry['job_id'] = job.job_id
+                    entry['adapter'] = job.job_adapter
+                    entry['server'] = job.server
+                    return entry
+        return entry
+
     def report_running_jobs_snapshot(self) -> None:
         """
         Overwrite ``<project>/running_jobs.yml`` with a timestamped snapshot of
@@ -878,7 +909,9 @@ class Scheduler(object):
         to the previous snapshot, the file is left untouched and only a one-line
         heartbeat is logged to ARC.log.
         """
-        payload = {'running_jobs': {label: list(job_names) for label, job_names in self.running_jobs.items()},
+        payload = {'running_jobs': {label: [self._running_job_snapshot_entry(label, job_name)
+                                            for job_name in job_names]
+                                    for label, job_names in self.running_jobs.items()},
                    'active_pipes': list(self.active_pipes.keys())}
         n_species = len(self.running_jobs)
         n_jobs = sum(len(v) for v in self.running_jobs.values())

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 import os
 import shutil
+from types import SimpleNamespace
 
 
 import arc.parser.parser as parser
@@ -1277,11 +1278,12 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.sched1.running_jobs = {'spcA': ['opt_a1234']}
         self.sched1.active_pipes = {}
 
-        # First call: file doesn't exist, snapshot must be written.
+        # First call: file doesn't exist, snapshot must be written. An unresolvable job
+        # (no matching Job object in job_dict) falls back to just its name.
         self.sched1.report_running_jobs_snapshot()
         snapshot = read_yaml_file(path)
         self.assertIn('timestamp', snapshot)
-        self.assertEqual(snapshot['running_jobs'], {'spcA': ['opt_a1234']})
+        self.assertEqual(snapshot['running_jobs'], {'spcA': [{'name': 'opt_a1234'}]})
 
         # Second call with identical payload: file must be left untouched.
         first_mtime = os.path.getmtime(path)
@@ -1295,7 +1297,29 @@ H      -1.82570782    0.42754384   -0.56130718"""
         # Third call after a change: the file must be overwritten with the new snapshot only.
         self.sched1.report_running_jobs_snapshot()
         snapshot = read_yaml_file(path)
-        self.assertEqual(snapshot['running_jobs'], {'spcA': ['opt_a1234', 'sp_b5678']})
+        self.assertEqual(snapshot['running_jobs'],
+                         {'spcA': [{'name': 'opt_a1234'}, {'name': 'sp_b5678'}]})
+
+        # A resolvable job carries its server identifiers (server_name/job_id/adapter/server)
+        # into the snapshot, so the file alone tells you what to look for in qstat.
+        job = SimpleNamespace(job_name='tsg3', job_server_name='a3129', job_id='4438988',
+                              job_adapter='orca_neb', server='server1')
+        self.sched1.job_dict['TS0'] = {'tsg': {3: job}}
+        self.sched1.running_jobs = {'TS0': ['tsg3']}
+        self.sched1._last_status_payload = None
+        self.sched1.report_running_jobs_snapshot()
+        snapshot = read_yaml_file(path)
+        self.assertEqual(snapshot['running_jobs']['TS0'][0],
+                         {'name': 'tsg3', 'server_name': 'a3129', 'job_id': '4438988',
+                          'adapter': 'orca_neb', 'server': 'server1'})
+
+        # A label that has jobs in job_dict, none of which match the requested job_name, also
+        # falls back to just the name rather than borrowing another job's identifiers.
+        self.sched1.running_jobs = {'TS0': ['sp_b5678']}
+        self.sched1._last_status_payload = None
+        self.sched1.report_running_jobs_snapshot()
+        snapshot = read_yaml_file(path)
+        self.assertEqual(snapshot['running_jobs'], {'TS0': [{'name': 'sp_b5678'}]})
 
         os.remove(path)
 


### PR DESCRIPTION
## What

ARC's `<project>/running_jobs.yml` status snapshot previously listed only bare job_names (e.g. `tsg3`). To find the job on the cluster you had to cross-reference `arc.log` to learn its qstat name (e.g. `a3129`).

This adds `Scheduler._running_job_snapshot_entry`, which resolves each running `job_name` back to its `Job` object in `job_dict` (matching on `job.job_name`) and emits a self-describing entry: `{name, server_name (the qstat job name), job_id, adapter, server}`. Unresolvable entries fall back to `{'name': job_name}`. `report_running_jobs_snapshot` now builds `running_jobs` as `{label: [entry, ...]}`.

## Why

Surfaced while diagnosing benchmark reaction_22, where the snapshot alone couldn't map `tsg3` to its qstat job `a3129` without arc.log. This is a usability/observability improvement — no behavior change to job scheduling.

## Testing

`arc/scheduler_test.py::test_report_running_jobs_snapshot` updated to expect the new dict shape and to assert a resolvable job carries its server ids. Full `arc/scheduler_test.py` passes (29 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)