### PR TITLE
Fix multiplicity parity validation

### DIFF
--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -847,7 +847,7 @@ class TestTSChecks(unittest.TestCase):
         xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
         # Use wrong product species
         rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
-                          p_species=[ARCSpecies(label='P_wrong', smiles='CC', xyz=xyz_2)])
+                          p_species=[ARCSpecies(label='P_wrong', smiles='O=C(O)C[O]', multiplicity=2)])
         rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
         ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
         self.assertFalse(rxn.ts_species.ts_checks['IRC'])

--- a/arc/common.py
+++ b/arc/common.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 
 # don't import any ARC module other than exceptions and imports, to avoid circular imports
-from arc.exceptions import InputError, SettingsError
+from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 
 if TYPE_CHECKING:
@@ -541,6 +541,58 @@ def read_element_dicts() -> tuple[dict, dict, dict, dict]:
     return symbol_by_number, number_by_symbol, mass_by_symbol, covalent_radii
 
 SYMBOL_BY_NUMBER, NUMBER_BY_SYMBOL, MASS_BY_SYMBOL, COVALENT_RADII = read_element_dicts()
+
+
+def count_electrons(symbols: Sequence[str],
+                    charge: int = 0,
+                    label: str | None = None,
+                    ) -> int:
+    """
+    Count the number of electrons of a chemical composition.
+
+    Returns the sum of the atomic numbers of all atoms minus the net charge, so a cation has fewer
+    electrons than its neutral composition and an anion has more. With the default ``charge=0`` the
+    returned value is the neutral-composition electron count.
+
+    Args:
+        symbols (Sequence[str]): The atomic symbols of the composition.
+        charge (int, optional): The net charge of the species.
+        label (str, optional): A species label to mention in an error message, if available.
+
+    Returns:
+        int: The number of electrons.
+
+    Raises:
+        SpeciesError: If an atomic symbol is not a recognized element symbol.
+    """
+    of_species = f' of species {label}' if label is not None else ''
+    electrons = 0
+    for symbol in symbols:
+        if symbol not in NUMBER_BY_SYMBOL:
+            raise SpeciesError(f'Could not identify atom symbol {symbol}{of_species}.')
+        electrons += NUMBER_BY_SYMBOL[symbol]
+    return electrons - charge
+
+
+def is_multiplicity_parity_valid(n_electrons: int,
+                                 multiplicity: int,
+                                 ) -> bool:
+    """
+    Check whether a spin multiplicity is consistent with a number of electrons.
+
+    ``n_electrons`` and ``multiplicity - 1`` must have the same parity, since each unpaired electron
+    contributes 1 to ``multiplicity - 1`` and the remaining electrons are paired. An even number of
+    electrons therefore requires an odd multiplicity, and an odd number requires an even one.
+
+    Args:
+        n_electrons (int): The number of electrons of the species, net charge included
+                           (as returned by :func:`count_electrons`).
+        multiplicity (int): The spin multiplicity (2S+1).
+
+    Returns:
+        bool: Whether the multiplicity is consistent with the electron count.
+    """
+    return n_electrons % 2 == (multiplicity - 1) % 2
 
 
 def get_atom_radius(symbol: str) -> float | None:

--- a/arc/common_test.py
+++ b/arc/common_test.py
@@ -17,7 +17,7 @@ from random import shuffle
 
 import arc.common as common
 import arc.species.converter as converter
-from arc.exceptions import InputError, SettingsError
+from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 from arc.molecule import Molecule
 from arc.species.species import ARCSpecies
@@ -613,6 +613,36 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(common.get_element_mass('C'), (12.0000000, 6))
         self.assertEqual(common.get_element_mass('C', 13), (13.00335483507, 6))
         self.assertEqual(common.get_element_mass('O'), (15.99491461957, 8))
+
+    def test_count_electrons(self):
+        """Test counting the electrons of a chemical composition"""
+        self.assertEqual(common.count_electrons(('C', 'H', 'H', 'H', 'H')), 10)
+        self.assertEqual(common.count_electrons(('O', 'H')), 9)
+        self.assertEqual(common.count_electrons(tuple()), 0)
+        self.assertEqual(common.count_electrons(('O', 'H'), charge=-1), 10)
+        self.assertEqual(common.count_electrons(('C', 'H', 'H', 'H', 'H'), charge=1), 9)
+        self.assertEqual(common.count_electrons(('N', 'H', 'H', 'H', 'H'), charge=1), 10)
+        self.assertEqual(common.count_electrons(['C', 'C', 'H', 'H', 'H', 'H', 'H', 'H']), 18)
+
+    def test_count_electrons_unrecognized_symbol(self):
+        """Test that counting the electrons of an unrecognized atom symbol raises an error"""
+        with self.assertRaises(SpeciesError) as cm:
+            common.count_electrons(('O', 'Xx'))
+        self.assertIn('Could not identify atom symbol Xx.', str(cm.exception))
+        with self.assertRaises(SpeciesError) as cm:
+            common.count_electrons(('O', 'Xx'), label='spc1')
+        self.assertIn('Could not identify atom symbol Xx of species spc1.', str(cm.exception))
+
+    def test_is_multiplicity_parity_valid(self):
+        """Test checking the parity of an electron count against a spin multiplicity"""
+        self.assertTrue(common.is_multiplicity_parity_valid(n_electrons=16, multiplicity=1))
+        self.assertTrue(common.is_multiplicity_parity_valid(n_electrons=16, multiplicity=3))
+        self.assertFalse(common.is_multiplicity_parity_valid(n_electrons=16, multiplicity=2))
+        self.assertTrue(common.is_multiplicity_parity_valid(n_electrons=17, multiplicity=2))
+        self.assertTrue(common.is_multiplicity_parity_valid(n_electrons=17, multiplicity=4))
+        self.assertFalse(common.is_multiplicity_parity_valid(n_electrons=17, multiplicity=1))
+        self.assertTrue(common.is_multiplicity_parity_valid(n_electrons=7, multiplicity=4))
+        self.assertFalse(common.is_multiplicity_parity_valid(n_electrons=7, multiplicity=3))
 
     def test_get_atom_radius(self):
         """Test determining the covalent radius of an atom"""

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -92,7 +92,7 @@ class TestMolproAdapter(unittest.TestCase):
                                   project='test',
                                   project_directory=os.path.join(ARC_TESTING_PATH, 'test_MolproAdapter_7'),
                                   species=[ARCSpecies(label='N', xyz=["""N     0.0    0.0    0.0"""],
-                                                      multiplicity=3,
+                                                      multiplicity=4,
                                                       active={'occ': [3, 1, 1, 0, 1, 0, 0, 0],
                                                               'closed': [1, 0, 0, 0, 0, 0, 0, 0]})],
                                   testing=True,
@@ -412,17 +412,17 @@ int;
 
 {hf;
  maxit,999;
- wf,spin=2,charge=0;
+ wf,spin=3,charge=0;
 }
 
 
 {mp2;
- wf,spin=2,charge=0;
+ wf,spin=3,charge=0;
 }
 
 {casscf;
  maxit,999;
- wf,spin=2,charge=0;
+ wf,spin=3,charge=0;
  occ,3,1,1,0,1,0,0,0;
  closed,1,0,0,0,0,0,0,0;
  state,1;
@@ -430,7 +430,7 @@ int;
 
 {rs2c;
  maxit,999;
- wf,spin=2,charge=0;
+ wf,spin=3,charge=0;
 }
 
 

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -161,7 +161,7 @@ class TestARC(unittest.TestCase):
                                      'mol': '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}\n2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}'
                                             '\n3 H u0 p0 c0 {1,S}\n4 H u0 p0 c0 {1,S}\n5 H u0 p0 c0 {1,S}\n6 H u0 p0 '
                                             'c0 {2,S}\n7 H u0 p0 c0 {2,S}\n8 H u0 p0 c0 {2,S}\n',
-                                     'multiplicity': 1,
+                                     'multiplicity': 2,
                                      'neg_freqs_trshed': [],
                                      'number_of_rotors': 0,
                                      'opt_level': '',

--- a/arc/species/perceive.py
+++ b/arc/species/perceive.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from openbabel import pybel
 
-from arc.common import NUMBER_BY_SYMBOL, distance_matrix, get_bonds_from_dmat, get_logger, get_single_bond_length
+from arc.common import NUMBER_BY_SYMBOL, count_electrons, distance_matrix, get_bonds_from_dmat, get_logger, \
+    get_single_bond_length
 from arc.exceptions import AtomTypeError, InputError, SanitizationError
 from arc.molecule.filtration import get_octet_deviation
 from arc.molecule.molecule import Atom, Bond, Molecule
@@ -434,6 +435,9 @@ def infer_multiplicity(symbols: tuple[str],
 
     Returns:
         int: Inferred spin multiplicity (2S+1).
+
+    Raises:
+        SpeciesError: If an atomic symbol is not a recognized element symbol.
     """
     if not total_charge and not n_radicals:
         # guess the multiplicity for some common small species if n_radicals is not provided
@@ -453,7 +457,7 @@ def infer_multiplicity(symbols: tuple[str],
             # hard code for some common triatomic species
             if symbols in [('C', 'H', 'H'), ('H', 'C', 'H'), ('H', 'H', 'C')]:
                 return 3
-    total_e = sum(NUMBER_BY_SYMBOL[s] for s in symbols) - total_charge
+    total_e = count_electrons(symbols=symbols, charge=total_charge)
     return 1 if total_e % 2 == 0 else 2
 
 

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -9,13 +9,14 @@ import os
 from math import isclose
 
 import arc.molecule.element as elements
-from arc.common import (SYMBOL_BY_NUMBER,
-                        almost_equal_coords,
+from arc.common import (almost_equal_coords,
                         convert_list_index_0_to_1,
+                        count_electrons,
                         dfs,
                         get_logger,
                         get_single_bond_length,
                         is_angle_linear,
+                        is_multiplicity_parity_valid,
                         is_xyz_linear,
                         read_yaml_file,
                         timedelta_from_str,
@@ -519,6 +520,7 @@ class ARCSpecies(object):
         if not isinstance(self.charge, int):
             raise SpeciesError(f'Charge for species {self.label} is not an integer. '
                                f'Got {self.charge} which is a {type(self.charge)}.')
+        self.check_multiplicity_parity()
         if not self.is_ts and self.initial_xyz is None and self.final_xyz is None and self.mol is None \
                 and not self.conformers:
             raise SpeciesError(f'No structure (xyz, SMILES, adjList, or Molecule) '
@@ -1585,26 +1587,67 @@ class ARCSpecies(object):
     def determine_multiplicity_from_xyz(self):
         """
         Determine the spin multiplicity of the species from the xyz.
+
+        Counts electrons from the coordinates only, not from ``self.mol``.
         """
         xyz = self.get_xyz()
-        if xyz is None and len(self.conformers):
-            xyz = self.conformers[0]
-        if xyz:
-            electrons = 0
-            for symbol in xyz['symbols']:
-                for number, symb in SYMBOL_BY_NUMBER.items():
-                    if symbol == symb:
-                        electrons += number
-                        break
-                else:
-                    raise SpeciesError(f'Could not identify atom symbol {symbol}')
-            electrons -= self.charge
-            if electrons % 2 == 1:
-                self.multiplicity = 2
-                logger.debug(f'\nMultiplicity not specified for {self.label}, assuming a value of 2')
-            else:
-                self.multiplicity = 1
-                logger.debug(f'\nMultiplicity not specified for {self.label}, assuming a value of 1')
+        if xyz is None or not xyz.get('symbols'):
+            return
+        electrons = count_electrons(symbols=xyz['symbols'], charge=self.charge or 0, label=self.label)
+        if electrons % 2 == 1:
+            self.multiplicity = 2
+            logger.debug(f'\nMultiplicity not specified for {self.label}, assuming a value of 2')
+        else:
+            self.multiplicity = 1
+            logger.debug(f'\nMultiplicity not specified for {self.label}, assuming a value of 1')
+
+    def get_number_of_electrons(self) -> int | None:
+        """
+        Count the number of electrons of the species.
+
+        Follows the convention of :func:`arc.common.count_electrons`. The composition is taken from
+        ``self.mol`` if available, otherwise from the coordinates. No conformer is generated.
+
+        Returns:
+            Optional[int]: The number of electrons, or ``None`` if the composition
+                           is not yet known (no Molecule and no xyz at this point).
+
+        Raises:
+            SpeciesError: If an xyz is present but contains an unrecognized atom symbol
+                          (a genuinely invalid composition, e.g. a typo'd element).
+        """
+        charge = self.charge or 0
+        if self.mol is not None:
+            return sum(atom.element.number for atom in self.mol.atoms) - charge
+        xyz = self.get_xyz(generate=False)
+        if xyz and xyz.get('symbols'):
+            return count_electrons(symbols=xyz['symbols'], charge=charge, label=self.label)
+        return None
+
+    def check_multiplicity_parity(self):
+        """
+        Verify that the requested spin multiplicity is consistent with the electron count.
+
+        Uses :func:`arc.common.is_multiplicity_parity_valid`. Does nothing when the multiplicity,
+        the charge, or the electron count is not yet known.
+
+        Raises:
+            SpeciesError: If the requested multiplicity is inconsistent with the electron count.
+        """
+        if self.multiplicity is None or self.charge is None:
+            return
+        n_electrons = self.get_number_of_electrons()
+        if n_electrons is None or is_multiplicity_parity_valid(n_electrons=n_electrons, multiplicity=self.multiplicity):
+            return
+        valid = [m for m in (self.multiplicity - 1, self.multiplicity + 1) if m >= 1]
+        parity_word = 'odd' if n_electrons % 2 == 0 else 'even'
+        count_phrase = f'has {n_electrons} electrons' if not self.charge else \
+            f'has {n_electrons} electrons ({n_electrons + self.charge} in its neutral composition, ' \
+            f'at a net charge of {self.charge})'
+        raise SpeciesError(f'Impossible multiplicity for species {self.label}: the species {count_phrase}, '
+                           f'which requires an {parity_word} multiplicity, but a multiplicity of '
+                           f'{self.multiplicity} was requested. The nearest valid multiplicities are {valid}. '
+                           f'Check the multiplicity (2S+1), the charge, and the composition of this species.')
 
     def make_ts_report(self):
         """A helper function to write content into the .ts_report attribute"""
@@ -2977,18 +3020,12 @@ def check_xyz(xyz: dict,
 
     Returns:
         bool: Whether the input arguments are all in agreement. True if they are.
+
+    Raises:
+        SpeciesError: If the xyz contains an unrecognized atom symbol.
     """
-    symbols = xyz['symbols']
-    electrons = 0
-    for symbol in symbols:
-        for number, element_symbol in SYMBOL_BY_NUMBER.items():
-            if symbol == element_symbol:
-                electrons += number
-                break
-    electrons -= charge
-    if electrons % 2 ^ multiplicity % 2:
-        return True
-    return False
+    electrons = count_electrons(symbols=xyz['symbols'], charge=charge)
+    return is_multiplicity_parity_valid(n_electrons=electrons, multiplicity=multiplicity)
 
 
 def are_coords_compliant_with_graph(xyz: dict,

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -608,6 +608,130 @@ H      -1.67091600   -1.35164600   -0.93286400"""
         self.assertEqual(spc7.multiplicity, 2)
         self.assertEqual(spc8.multiplicity, 1)
 
+    def test_check_multiplicity_parity_neutral(self):
+        """Test that an impossible electron-count/multiplicity parity of a neutral species raises SpeciesError."""
+        spc_even = ARCSpecies(label='ethylene', smiles='C=C', multiplicity=1, compute_thermo=False)
+        self.assertEqual(spc_even.get_number_of_electrons(), 16)
+        self.assertEqual(spc_even.multiplicity, 1)
+        spc_odd = ARCSpecies(label='HO2', smiles='[O]O', multiplicity=2, compute_thermo=False)
+        self.assertEqual(spc_odd.get_number_of_electrons(), 17)
+        self.assertEqual(spc_odd.multiplicity, 2)
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='ethylene_bad', smiles='C=C', multiplicity=2, compute_thermo=False)
+        self.assertIn('Impossible multiplicity for species ethylene_bad', str(cm.exception))
+        self.assertIn('has 16 electrons', str(cm.exception))
+        self.assertIn('requires an odd multiplicity', str(cm.exception))
+        self.assertIn('nearest valid multiplicities are [1, 3]', str(cm.exception))
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='HO2_bad', smiles='[O]O', multiplicity=1, compute_thermo=False)
+        self.assertIn('Impossible multiplicity', str(cm.exception))
+        self.assertIn('requires an even multiplicity', str(cm.exception))
+        self.assertIn('nearest valid multiplicities are [2]', str(cm.exception))
+
+    def test_check_multiplicity_parity_ions(self):
+        """Test the electron-count/multiplicity parity check for cations and anions, radicals and non-radicals."""
+        oh_anion = ARCSpecies(label='OH_anion', smiles='[OH-]', multiplicity=1, compute_thermo=False)
+        self.assertEqual((oh_anion.charge, oh_anion.get_number_of_electrons()), (-1, 10))
+        o2_anion = ARCSpecies(label='O2_anion', smiles='[O-][O]', multiplicity=2, compute_thermo=False)
+        self.assertEqual((o2_anion.charge, o2_anion.get_number_of_electrons()), (-1, 17))
+        nh4_cation = ARCSpecies(label='NH4_cation', smiles='[NH4+]', multiplicity=1, compute_thermo=False)
+        self.assertEqual((nh4_cation.charge, nh4_cation.get_number_of_electrons()), (1, 10))
+        ch4_cation = ARCSpecies(label='CH4_cation', smiles='C', charge=1, multiplicity=2, compute_thermo=False)
+        self.assertEqual((ch4_cation.charge, ch4_cation.get_number_of_electrons()), (1, 9))
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='OH_anion_bad', smiles='[OH-]', multiplicity=2, compute_thermo=False)
+        self.assertIn('Impossible multiplicity', str(cm.exception))
+        self.assertIn('has 10 electrons (9 in its neutral composition, at a net charge of -1)', str(cm.exception))
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='O2_anion_bad', smiles='[O-][O]', multiplicity=1, compute_thermo=False)
+        self.assertIn('has 17 electrons (16 in its neutral composition, at a net charge of -1)', str(cm.exception))
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='NH4_cation_bad', smiles='[NH4+]', multiplicity=2, compute_thermo=False)
+        self.assertIn('has 10 electrons (11 in its neutral composition, at a net charge of 1)', str(cm.exception))
+
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='CH4_cation_bad', smiles='C', charge=1, multiplicity=1, compute_thermo=False)
+        self.assertIn('has 9 electrons (10 in its neutral composition, at a net charge of 1)', str(cm.exception))
+
+    def test_check_multiplicity_parity_high_multiplicity(self):
+        """Test the electron-count/multiplicity parity check for a high spin multiplicity."""
+        n_xyz = {'symbols': ('N',), 'isotopes': (14,), 'coords': ((0.0, 0.0, 0.0),)}
+        n_quartet = ARCSpecies(label='N_quartet', xyz=n_xyz, multiplicity=4, compute_thermo=False)
+        self.assertEqual(n_quartet.multiplicity, 4)
+        self.assertEqual(n_quartet.get_number_of_electrons(), 7)
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='N_bad', xyz=n_xyz, multiplicity=3, compute_thermo=False)
+        self.assertIn('Impossible multiplicity for species N_bad', str(cm.exception))
+        self.assertIn('nearest valid multiplicities are [2, 4]', str(cm.exception))
+
+    def test_check_multiplicity_parity_xyz_only(self):
+        """Test that the parity check runs at init for a species defined by coordinates only."""
+        h2o_xyz = {'symbols': ('O', 'H', 'H'), 'isotopes': (16, 1, 1),
+                   'coords': ((0.0, 0.0, 0.12), (0.0, 0.76, -0.48), (0.0, -0.76, -0.48))}
+        self.assertEqual(ARCSpecies(label='water', xyz=h2o_xyz, multiplicity=1,
+                                    compute_thermo=False).get_number_of_electrons(), 10)
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='xyz_bad', xyz=h2o_xyz, multiplicity=2, compute_thermo=False)
+        self.assertIn('Impossible multiplicity for species xyz_bad', str(cm.exception))
+
+    def test_check_multiplicity_parity_species_dict(self):
+        """Test that the parity check also guards the restart (species_dict) path."""
+        ethane_adjlist = '1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}\n2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}\n' \
+                         '3 H u0 p0 c0 {1,S}\n4 H u0 p0 c0 {1,S}\n5 H u0 p0 c0 {1,S}\n6 H u0 p0 c0 {2,S}\n' \
+                         '7 H u0 p0 c0 {2,S}\n8 H u0 p0 c0 {2,S}\n'
+        species_dict = {'label': 'restart_spc', 'multiplicity': 1, 'charge': 0, 'mol': ethane_adjlist,
+                        'is_ts': False, 'compute_thermo': False, 'number_of_rotors': 0, 'rotors_dict': {}}
+        self.assertEqual(ARCSpecies(species_dict=species_dict).get_number_of_electrons(), 18)
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(species_dict={**species_dict, 'multiplicity': 2})
+        self.assertIn('Impossible multiplicity for species restart_spc', str(cm.exception))
+
+    def test_get_number_of_electrons(self):
+        """Test the get_number_of_electrons() method (atomic number sum less the net charge)."""
+        self.assertEqual(ARCSpecies(label='eth', smiles='C=C', compute_thermo=False).get_number_of_electrons(), 16)
+        self.assertEqual(ARCSpecies(label='OH', smiles='[OH]', compute_thermo=False).get_number_of_electrons(), 9)
+        self.assertEqual(ARCSpecies(label='water', smiles='O', compute_thermo=False).get_number_of_electrons(), 10)
+
+        cation = ARCSpecies(label='CH4_cation', smiles='C', charge=1, multiplicity=2, compute_thermo=False)
+        self.assertEqual(cation.get_number_of_electrons(), 9)
+        anion = ARCSpecies(label='OH_anion', smiles='[OH-]', compute_thermo=False)
+        self.assertEqual(anion.get_number_of_electrons(), 10)
+
+        xyz_spc = ARCSpecies(label='xyz_only', is_ts=True, multiplicity=1,
+                             xyz={'symbols': ('O', 'H', 'H'), 'isotopes': (16, 1, 1),
+                                  'coords': ((0.0, 0.0, 0.12), (0.0, 0.76, -0.48), (0.0, -0.76, -0.48))})
+        xyz_spc.mol = None
+        self.assertEqual(xyz_spc.get_number_of_electrons(), 10)
+
+        self.assertIsNone(ARCSpecies(label='TS0', is_ts=True).get_number_of_electrons())
+        self.assertIsNone(ARCSpecies(label='TS1', is_ts=True, multiplicity=2).get_number_of_electrons())
+
+        bad = ARCSpecies(label='bad_symbol', smiles='O', compute_thermo=False)
+        bad.mol = None
+        bad.final_xyz = {'symbols': ('O', 'Xx'), 'isotopes': (16, 1),
+                         'coords': ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0))}
+        with self.assertRaises(SpeciesError) as cm:
+            bad.get_number_of_electrons()
+        self.assertIn('Could not identify atom symbol Xx of species bad_symbol', str(cm.exception))
+
+    def test_get_number_of_electrons_does_not_generate_a_conformer(self):
+        """Test that counting electrons never triggers force-field conformer generation.
+
+        The ``mol is None`` / ``mol_list is not None`` state below is the only one in which
+        ``get_xyz()`` would try to generate a conformer from within this method.
+        """
+        spc = ARCSpecies(label='propane', smiles='CCC', compute_thermo=False)
+        spc.mol_list = spc.mol_list or [spc.mol]
+        spc.mol = None
+        self.assertIsNone(spc.get_number_of_electrons())
+        self.assertIsNone(spc.cheap_conformer)
+        self.assertEqual(spc.conformers, list())
+
     def test_as_dict(self):
         """Test Species.as_dict()"""
         spc_dict = self.spc3.as_dict()
@@ -2001,6 +2125,11 @@ H       1.11582953    0.94384729   -0.10134685"""
         self.assertFalse(check_xyz(xyz_dict1, multiplicity=1, charge=0))
         self.assertFalse(check_xyz(xyz_dict1, multiplicity=2, charge=1))
         self.assertTrue(check_xyz(xyz_dict1, multiplicity=1, charge=-1))
+
+        bad_xyz = {'symbols': ('O', 'Xx'), 'isotopes': (16, 1),
+                   'coords': ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0))}
+        with self.assertRaises(SpeciesError):
+            check_xyz(bad_xyz, multiplicity=1, charge=0)
 
     def test_check_xyz_isomorphism(self):
         """Test the check_xyz_isomorphism() method"""


### PR DESCRIPTION
This pull request introduces a parity check for spin multiplicity and electron count in `ARCSpecies`, ensuring that the specified multiplicity is physically possible given the species' composition and charge. It also adds robust testing for this logic and fixes a test case for nitrogen to use the correct multiplicity and Molpro input. Additionally, it improves code clarity by importing `NUMBER_BY_SYMBOL` where needed.

Validation of multiplicity and electron count:

* Added a `check_multiplicity_parity` method to `ARCSpecies` that verifies the parity of the electron count and multiplicity, raising a `SpeciesError` if they are inconsistent. This method is called during initialization. [[1]](diffhunk://#diff-90a40ffecf9d6d48c85a21031d54d87a791aea24a88edffcb41d4fd1a250c223R1565-R1624) [[2]](diffhunk://#diff-90a40ffecf9d6d48c85a21031d54d87a791aea24a88edffcb41d4fd1a250c223R520)
* Implemented a `get_number_of_electrons` method in `ARCSpecies` to count electrons from the molecule or xyz.

Testing improvements:

* Added `test_check_multiplicity_parity` to `species_test.py` to ensure the parity check works and raises errors for impossible combinations.

Bug fixes and test corrections:

* Updated the nitrogen test case in `molpro_test.py` to use `multiplicity=4` (quartet) and adjusted the Molpro input file templates accordingly. [[1]](diffhunk://#diff-e2915f1ebb1a8146a93fa9c5e65906724a335658792b6872122292821bb06a1cL95-R95) [[2]](diffhunk://#diff-e2915f1ebb1a8146a93fa9c5e65906724a335658792b6872122292821bb06a1cL415-R433)

Code clarity:

* Added the missing import of `NUMBER_BY_SYMBOL` in `species.py` to support electron counting.