### PR TITLE
Add PySCF as a local in-core ESS adapter (sp + opt + freq)

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -69,7 +69,6 @@ class JobEnum(str, Enum):
     Consider adding the following adapters:
         - ESS:
             - cosmo
-            - PySCF (https://pyscf.org/user/geomopt.html)
             - TS opt via pysisyphus (https://pysisyphus.readthedocs.io/en/dev/tsoptimization.html)
             - onedmin
             - openbabel
@@ -99,6 +98,7 @@ class JobEnum(str, Enum):
     molpro = 'molpro'
     orca = 'orca'
     psi4 = 'psi4'
+    pyscf = 'pyscf'
     qchem = 'qchem'
     terachem = 'terachem'
     torchani = 'torchani'

--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -767,6 +767,9 @@ class JobAdapter(ABC):
         """
         content = ''
         cluster_soft = servers[self.server]['cluster_soft'].lower()
+        if cluster_soft == 'local':
+            # No queueing system, so there are no scheduler stdout/stderr files to collect.
+            return
         if cluster_soft in ['oge', 'sge', 'slurm', 'pbs', 'htcondor']:
             local_file_path_1 = os.path.join(self.local_path, 'out.txt')
             local_file_path_2 = os.path.join(self.local_path, 'err.txt')

--- a/arc/job/adapters/__init__.py
+++ b/arc/job/adapters/__init__.py
@@ -7,6 +7,7 @@ import arc.job.adapters.molpro
 import arc.job.adapters.obabel
 import arc.job.adapters.orca
 import arc.job.adapters.psi_4
+import arc.job.adapters.pyscf_adapter
 import arc.job.adapters.qchem
 import arc.job.adapters.terachem
 import arc.job.adapters.torch_ani

--- a/arc/job/adapters/pyscf_adapter.py
+++ b/arc/job/adapters/pyscf_adapter.py
@@ -1,0 +1,287 @@
+"""
+An adapter for executing PySCF jobs locally (a local in-core ESS, no PBS/queue round-trip).
+
+PySCF runs DFT (sp, opt, freq, optfreq) on the workstation and hands off an ``output.yml`` in
+ARC's internal format, which ARC's ``YAMLParser`` re-parses (the YAML-handoff pattern, mirroring
+``ase_adapter.py``). The engine script runs inside the dedicated ``pyscf_env`` conda environment
+via ``run_in_conda_env`` so ARC's activation variables do not leak into the child process.
+
+Scope: sp + opt + freq (closed- and open-shell, RKS/UKS). IRC and scans/rotors are out of scope.
+"""
+
+import datetime
+import os
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+from arc.common import ARC_PATH, get_logger, read_yaml_file, save_yaml_file
+from arc.job.adapter import JobAdapter
+from arc.job.adapters.common import _initialize_adapter
+from arc.job.env_run import run_in_conda_env
+from arc.job.factory import register_job_adapter
+from arc.settings.settings import PYSCF_PYTHON
+
+if TYPE_CHECKING:
+    from arc.level import Level
+    from arc.reaction import ARCReaction
+    from arc.species.species import ARCSpecies
+
+logger = get_logger()
+
+PYSCF_SCRIPT_PATH = os.path.join(ARC_PATH, 'arc', 'job', 'adapters', 'scripts', 'pyscf_script.py')
+
+
+class PySCFAdapter(JobAdapter):
+    """
+    A class for executing PySCF jobs.
+
+    Args:
+        project (str): The project's name. Used for setting the remote path.
+        project_directory (str): The path to the local project directory.
+        job_type (list, str): The job's type, validated against ``JobTypeEnum``.
+        args (dict, optional): Methods (e.g., troubleshooting) to be used in input files.
+        bath_gas (str, optional): A bath gas.
+        checkfile (str, optional): The path to a previous Gaussian checkfile to be used in the job.
+        conformer (int, optional): Conformer number if optimizing conformers.
+        constraints (list, optional): A list of constraints to use during an optimization or scan.
+        cpu_cores (int, optional): The total number of cpu cores requested for a job.
+        dihedral_increment (float, optional): The degrees increment to use when scanning dihedrals.
+        dihedrals (list, optional): The dihedral angles of a directed scan job.
+        directed_scan_type (str, optional): The type of the directed scan.
+        ess_settings (dict, optional): A dictionary of available ESS and a corresponding server list.
+        ess_trsh_methods (list, optional): A list of troubleshooting methods already tried out.
+        execution_type (str, optional): The execution type, 'incore', 'queue', or 'pipe'.
+        fine (bool, optional): Whether to use fine geometry optimization parameters. Default: ``False``.
+        initial_time (datetime.datetime or str, optional): The time at which this job was initiated.
+        irc_direction (str, optional): The direction of the IRC job (`forward` or `reverse`).
+        job_id (int, optional): The job's ID determined by the server.
+        job_memory_gb (int, optional): The total job allocated memory in GB (14 by default).
+        job_name (str, optional): The job's name (e.g., 'opt_a103').
+        job_num (int, optional): Used as the entry number in the database, as well as in ``job_name``.
+        job_server_name (str, optional): Job's name on the server (e.g., 'a103').
+        job_status (list, optional): The job's server and ESS statuses.
+        level (Level, optional): The level of theory to use.
+        max_job_time (float, optional): The maximal allowed job time on the server in hours.
+        run_multi_species (bool, optional): Whether to run a job for multiple species in the same input file.
+        reactions (list, optional): Entries are ARCReaction instances, used for TS search methods.
+        rotor_index (int, optional): The 0-indexed rotor number (key) in the species.rotors_dict dictionary.
+        server (str, optional): The server to run on.
+        server_nodes (list, optional): The nodes this job was previously submitted to.
+        species (list, optional): Entries are ARCSpecies instances.
+                                  Either ``reactions`` or ``species`` must be given.
+        testing (bool, optional): Whether the object is generated for testing purposes, ``True`` if it is.
+        times_rerun (int, optional): Number of times this job was re-run with the same arguments.
+        torsions (list, optional): The 0-indexed atom indices of the torsion(s).
+        tsg (int, optional): TSGuess number if optimizing TS guesses.
+        xyz (dict, optional): The 3D coordinates to use in the job.
+    """
+
+    def __init__(self,
+                 project: str,
+                 project_directory: str,
+                 job_type: Union[List[str], str],
+                 args: Optional[dict] = None,
+                 bath_gas: Optional[str] = None,
+                 checkfile: Optional[str] = None,
+                 conformer: Optional[int] = None,
+                 constraints: Optional[List[Tuple[List[int], float]]] = None,
+                 cpu_cores: Optional[str] = None,
+                 dihedral_increment: Optional[float] = None,
+                 dihedrals: Optional[List[float]] = None,
+                 directed_scan_type: Optional[str] = None,
+                 ess_settings: Optional[dict] = None,
+                 ess_trsh_methods: Optional[List[str]] = None,
+                 execution_type: Optional[str] = None,
+                 fine: bool = False,
+                 initial_time: Optional[Union[datetime.datetime, str]] = None,
+                 irc_direction: Optional[str] = None,
+                 job_id: Optional[int] = None,
+                 job_memory_gb: float = 14.0,
+                 job_name: Optional[str] = None,
+                 job_num: Optional[int] = None,
+                 job_server_name: Optional[str] = None,
+                 job_status: Optional[List[Union[dict, str]]] = None,
+                 level: Optional['Level'] = None,
+                 max_job_time: Optional[float] = None,
+                 run_multi_species: bool = False,
+                 reactions: Optional[List['ARCReaction']] = None,
+                 rotor_index: Optional[int] = None,
+                 server: Optional[str] = None,
+                 server_nodes: Optional[list] = None,
+                 queue: Optional[str] = None,
+                 attempted_queues: Optional[List[str]] = None,
+                 species: Optional[List['ARCSpecies']] = None,
+                 testing: bool = False,
+                 times_rerun: int = 0,
+                 torsions: Optional[List[List[int]]] = None,
+                 tsg: Optional[int] = None,
+                 xyz: Optional[dict] = None,
+                 ):
+
+        self.job_adapter = 'pyscf'
+        self.execution_type = execution_type or 'incore'
+        self.incore_capacity = 100
+        self.command = None
+        self.url = 'https://pyscf.org/'
+
+        self.sp = None
+        self.opt_xyz = None
+        self.freqs = None
+
+        self.script_path = PYSCF_SCRIPT_PATH
+
+        _initialize_adapter(obj=self,
+                            is_ts=False,
+                            project=project,
+                            project_directory=project_directory,
+                            job_type=job_type,
+                            args=args,
+                            bath_gas=bath_gas,
+                            checkfile=checkfile,
+                            conformer=conformer,
+                            constraints=constraints,
+                            cpu_cores=cpu_cores,
+                            dihedral_increment=dihedral_increment,
+                            dihedrals=dihedrals,
+                            directed_scan_type=directed_scan_type,
+                            ess_settings=ess_settings,
+                            ess_trsh_methods=ess_trsh_methods,
+                            fine=fine,
+                            initial_time=initial_time,
+                            irc_direction=irc_direction,
+                            job_id=job_id,
+                            job_memory_gb=job_memory_gb,
+                            job_name=job_name,
+                            job_num=job_num,
+                            job_server_name=job_server_name,
+                            job_status=job_status,
+                            level=level,
+                            max_job_time=max_job_time,
+                            run_multi_species=run_multi_species,
+                            reactions=reactions,
+                            rotor_index=rotor_index,
+                            server=server,
+                            server_nodes=server_nodes,
+                            queue=queue,
+                            attempted_queues=attempted_queues,
+                            species=species,
+                            testing=testing,
+                            times_rerun=times_rerun,
+                            torsions=torsions,
+                            tsg=tsg,
+                            xyz=xyz,
+                            )
+
+    def determine_settings(self) -> dict:
+        """
+        Build the ``settings`` block passed to pyscf_script.py: the level's method (the xc
+        functional) and basis set, the job memory, the ``fine`` flag and cpu core count (which
+        pins PySCF's thread count), plus any user ``args['keyword']`` knobs.
+
+        Returns:
+            dict: The resolved PySCF run settings.
+        """
+        settings_dict = dict((self.args or dict()).get('keyword', dict()))
+        if self.level is not None:
+            for key, level_value in (('method', self.level.method), ('basis', self.level.basis)):
+                if key in settings_dict and settings_dict[key] != level_value:
+                    logger.warning(f"PySCF job {self.job_name}: ignoring args['keyword']['{key}']="
+                                   f"{settings_dict[key]!r}; using the job's level of theory "
+                                   f"{key}={level_value!r} so the computed result matches the level "
+                                   f"ARC records.")
+                settings_dict[key] = level_value
+        settings_dict.setdefault('memory_mb', int(self.job_memory_gb * 1024))
+        settings_dict.setdefault('fine', self.fine)
+        if self.cpu_cores:
+            settings_dict.setdefault('cpu_cores', self.cpu_cores)
+        return settings_dict
+
+    def write_input_file(self) -> None:
+        """
+        Write the input file (input.yml) for pyscf_script.py.
+        """
+        input_dict = {
+            'job_type': self.job_type,
+            'xyz': self.xyz,
+            'charge': self.charge,
+            'multiplicity': self.multiplicity,
+            'is_ts': self.species[0].is_ts if self.species else False,
+            'constraints': self.constraints,
+            'settings': self.determine_settings(),
+        }
+        save_yaml_file(os.path.join(self.local_path, 'input.yml'), input_dict)
+
+    def execute_incore(self):
+        """
+        Execute a job incore: run pyscf_script.py inside pyscf_env, then parse output.yml.
+        """
+        self._log_job_execution()
+        self.write_input_file()
+        output = run_in_conda_env(PYSCF_PYTHON, self.script_path, '--yml_path', self.local_path)
+        if output.returncode:
+            logger.warning(f'PySCF subprocess for {self.job_name} returned a non-zero code.\n'
+                           f'Got return code: {output.returncode}\n'
+                           f'stdout: {output.stdout}\nstderr: {output.stderr}')
+        self.parse_results()
+
+    def execute_queue(self):
+        """
+        PySCF is a local in-core ESS; fall back to incore execution when queued.
+
+        ``execution_type`` is updated to reflect what actually happened, so that downstream
+        status handling (e.g., ``determine_job_status()``) does not query a queueing system
+        for a job that never reached one.
+        """
+        logger.debug('Queue execution is not supported for PySCF in ARC; running incore instead.')
+        self.execution_type = 'incore'
+        self.execute_incore()
+
+    def parse_results(self) -> None:
+        """
+        Read output.yml written by pyscf_script.py into the job-object attributes.
+
+        Note: these attributes are dead-end writes; the authoritative contract is the on-disk
+        output.yml, which ARC re-parses via ``YAMLParser``.
+        """
+        out_path = os.path.join(self.local_path, 'output.yml')
+        if os.path.isfile(out_path):
+            results = read_yaml_file(out_path)
+            self.sp = results.get('sp')
+            self.opt_xyz = results.get('opt_xyz') or results.get('xyz')
+            self.freqs = results.get('freqs')
+        else:
+            logger.error(f'PySCF job {self.job_name} did not generate an output.yml file.')
+
+    def set_files(self) -> None:
+        """
+        Set files to be uploaded and downloaded.
+        """
+        if self.execution_type != 'incore':
+            self.files_to_upload.append(self.get_file_property_dictionary(file_name='submit.sh'))
+            self.files_to_upload.append(self.get_file_property_dictionary(file_name='input.yml'))
+            self.files_to_upload.append(self.get_file_property_dictionary(file_name='pyscf_script.py',
+                                                                          local=self.script_path))
+        self.files_to_download.append(self.get_file_property_dictionary(file_name='output.yml'))
+
+    def set_additional_file_paths(self) -> None:
+        """
+        Set additional file paths specific for the adapter.
+        """
+        pass
+
+    def set_input_file_memory(self) -> None:
+        """
+        Set the input_file_memory attribute.
+        """
+        pass
+
+    def write_submit_script(self) -> None:
+        """
+        Write the submission script (for the queue fallback path).
+        """
+        command = f"{PYSCF_PYTHON} {self.script_path} --yml_path {self.remote_path}"
+        content = f"#!/bin/bash\n\n{command}\n"
+        with open(os.path.join(self.local_path, 'submit.sh'), 'w') as f:
+            f.write(content)
+
+
+register_job_adapter('pyscf', PySCFAdapter)

--- a/arc/job/adapters/pyscf_adapter.py
+++ b/arc/job/adapters/pyscf_adapter.py
@@ -18,7 +18,7 @@ from arc.job.adapter import JobAdapter
 from arc.job.adapters.common import _initialize_adapter
 from arc.job.env_run import run_in_conda_env
 from arc.job.factory import register_job_adapter
-from arc.settings.settings import PYSCF_PYTHON
+from arc.settings.settings import PYSCF_DEVICE, PYSCF_PYTHON
 
 if TYPE_CHECKING:
     from arc.level import Level
@@ -191,6 +191,7 @@ class PySCFAdapter(JobAdapter):
                 settings_dict[key] = level_value
         settings_dict.setdefault('memory_mb', int(self.job_memory_gb * 1024))
         settings_dict.setdefault('fine', self.fine)
+        settings_dict.setdefault('device', PYSCF_DEVICE)
         if self.cpu_cores:
             settings_dict.setdefault('cpu_cores', self.cpu_cores)
         return settings_dict

--- a/arc/job/adapters/pyscf_test.py
+++ b/arc/job/adapters/pyscf_test.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+This module contains unit tests for the arc.job.adapters.pyscf_adapter module.
+
+The adapter tests verify IO and logic without executing PySCF (the engine runs in the separate
+``pyscf_env`` conda environment, which is absent from ARC's CI env). Tests that import the engine
+script (``pyscf_script.py``) are skipped unless PySCF is importable.
+"""
+
+import importlib.util
+import os
+import shutil
+import unittest
+from unittest.mock import patch
+
+from arc.common import ARC_TESTING_PATH, read_yaml_file, save_yaml_file
+from arc.job.adapters.pyscf_adapter import PySCFAdapter
+from arc.level import Level
+from arc.parser.adapters.yaml import YAMLParser
+from arc.species.species import ARCSpecies
+
+HAS_PYSCF = importlib.util.find_spec('pyscf') is not None
+
+
+class TestPySCFAdapter(unittest.TestCase):
+    """
+    Contains unit tests for the PySCFAdapter class.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.maxDiff = None
+        cls.project_directory = os.path.join(ARC_TESTING_PATH, 'test_PySCFAdapter')
+        if not os.path.exists(cls.project_directory):
+            os.makedirs(cls.project_directory)
+
+        water_xyz = {'symbols': ('O', 'H', 'H'),
+                     'isotopes': (16, 1, 1),
+                     'coords': ((0.0, 0.0, 0.1173),
+                                (0.0, 0.7572, -0.4692),
+                                (0.0, -0.7572, -0.4692))}
+        oh_xyz = {'symbols': ('O', 'H'),
+                  'isotopes': (16, 1),
+                  'coords': ((0.0, 0.0, 0.0),
+                             (0.0, 0.0, 0.9738))}
+
+        cls.job_1 = PySCFAdapter(execution_type='incore',
+                                 job_type='sp',
+                                 project='test_1',
+                                 project_directory=os.path.join(cls.project_directory, 'test_1'),
+                                 level=Level(repr='wb97m-v/def2tzvp'),
+                                 species=[ARCSpecies(label='H2O', xyz=water_xyz)],
+                                 testing=True)
+
+        cls.job_2 = PySCFAdapter(execution_type='queue',
+                                 job_type='optfreq',
+                                 project='test_2',
+                                 project_directory=os.path.join(cls.project_directory, 'test_2'),
+                                 level=Level(repr='wb97m-v/def2tzvp'),
+                                 species=[ARCSpecies(label='OH', xyz=oh_xyz, multiplicity=2)],
+                                 testing=True)
+
+        cls.job_1.local_path = os.path.join(cls.project_directory, 'test_1')
+        cls.job_2.local_path = os.path.join(cls.project_directory, 'test_2')
+        cls.job_2.remote_path = '/path/to/remote'
+        os.makedirs(cls.job_1.local_path, exist_ok=True)
+        os.makedirs(cls.job_2.local_path, exist_ok=True)
+
+    def test_determine_settings(self):
+        """Test resolving the method (xc functional) and basis from the level."""
+        settings = self.job_1.determine_settings()
+        self.assertEqual(settings['method'], 'wb97m-v')
+        self.assertEqual(settings['basis'], 'def2tzvp')
+        self.assertIn('memory_mb', settings)
+
+    def test_level_takes_precedence_over_conflicting_keyword(self):
+        """Test that the job's level, not a conflicting args keyword, sets method/basis.
+
+        A user keyword must never silently override the level of theory: PySCF would then compute
+        one method while ARC's level object (and restart.yml) records another. The level wins and a
+        warning is logged naming the dropped keyword value.
+        """
+        water_xyz = {'symbols': ('O', 'H', 'H'), 'isotopes': (16, 1, 1),
+                     'coords': ((0.0, 0.0, 0.1173), (0.0, 0.7572, -0.4692), (0.0, -0.7572, -0.4692))}
+        job = PySCFAdapter(execution_type='incore',
+                           job_type='sp',
+                           project='test_conflict',
+                           project_directory=os.path.join(self.project_directory, 'test_conflict'),
+                           level=Level(repr='wb97m-v/def2tzvp'),
+                           species=[ARCSpecies(label='H2O', xyz=water_xyz)],
+                           args={'keyword': {'method': 'pbe', 'basis': 'sto-3g'}},
+                           testing=True)
+        with self.assertLogs('arc', level='WARNING') as cm:
+            settings = job.determine_settings()
+        self.assertEqual(settings['method'], 'wb97m-v')
+        self.assertEqual(settings['basis'], 'def2tzvp')
+        self.assertTrue(any('pbe' in msg for msg in cm.output))
+
+    def test_matching_keyword_does_not_warn(self):
+        """Test that a keyword matching the level is accepted silently (no divergence, no warning)."""
+        water_xyz = {'symbols': ('O', 'H', 'H'), 'isotopes': (16, 1, 1),
+                     'coords': ((0.0, 0.0, 0.1173), (0.0, 0.7572, -0.4692), (0.0, -0.7572, -0.4692))}
+        job = PySCFAdapter(execution_type='incore',
+                           job_type='sp',
+                           project='test_match',
+                           project_directory=os.path.join(self.project_directory, 'test_match'),
+                           level=Level(repr='wb97m-v/def2tzvp'),
+                           species=[ARCSpecies(label='H2O', xyz=water_xyz)],
+                           args={'keyword': {'method': 'wb97m-v'}},
+                           testing=True)
+        with self.assertNoLogs('arc', level='WARNING'):
+            settings = job.determine_settings()
+        self.assertEqual(settings['method'], 'wb97m-v')
+
+    def test_write_input_file(self):
+        """Test writing the YAML input file for the PySCF script."""
+        self.job_2.write_input_file()
+        input_path = os.path.join(self.job_2.local_path, 'input.yml')
+        self.assertTrue(os.path.isfile(input_path))
+        data = read_yaml_file(input_path)
+        self.assertEqual(data['job_type'], 'optfreq')
+        self.assertEqual(data['multiplicity'], 2)
+        self.assertEqual(data['settings']['method'], 'wb97m-v')
+        self.assertEqual(data['settings']['basis'], 'def2tzvp')
+        self.assertEqual(data['xyz']['symbols'], ('O', 'H'))
+
+    def test_write_submit_script(self):
+        """Test writing the submission script for the queue fallback path."""
+        self.job_2.write_submit_script()
+        submit_path = os.path.join(self.job_2.local_path, 'submit.sh')
+        self.assertTrue(os.path.isfile(submit_path))
+        with open(submit_path, 'r') as f:
+            content = f.read()
+        self.assertIn('--yml_path /path/to/remote', content)
+        self.assertIn('pyscf_script.py', content)
+
+    def test_set_files(self):
+        """Test properly assigning upload and download files."""
+        self.job_2.set_files()
+        self.assertTrue(any('submit.sh' in f['local'] for f in self.job_2.files_to_upload))
+        self.assertTrue(any('input.yml' in f['local'] for f in self.job_2.files_to_upload))
+        self.assertTrue(any('pyscf_script.py' in f['local'] for f in self.job_2.files_to_upload))
+        self.assertTrue(any('output.yml' in f['local'] for f in self.job_2.files_to_download))
+
+    def test_parse_results(self):
+        """Test parsing a dummy output YAML back into object attributes."""
+        output_data = {
+            'schema_version': 1, 'adapter': 'pyscf', 'success': True, 'error': None,
+            'sp': -200665.9,
+            'opt_xyz': {'symbols': ('O', 'H', 'H'),
+                        'isotopes': (16, 1, 1),
+                        'coords': ((0.0, 0.0, 0.116), (0.0, 0.763, -0.469), (0.0, -0.763, -0.469))},
+            'freqs': [1617.5, 3823.7, 3927.5],
+            'modes': [[[0.0, 0.0, 0.1]]],
+            'zpe': 56.0,
+        }
+        save_yaml_file(os.path.join(self.job_1.local_path, 'output.yml'), output_data)
+        self.job_1.parse_results()
+        self.assertEqual(self.job_1.sp, -200665.9)
+        self.assertEqual(self.job_1.freqs, [1617.5, 3823.7, 3927.5])
+        self.assertIsNotNone(self.job_1.opt_xyz)
+        self.assertAlmostEqual(self.job_1.opt_xyz['coords'][1][1], 0.763)
+
+    def test_output_yaml_round_trips_through_yaml_parser(self):
+        """Test that a PySCF output.yml round-trips through YAMLParser (energy, geom, freqs, zpe)."""
+        output_data = {
+            'schema_version': 1, 'adapter': 'pyscf', 'success': True, 'error': None,
+            'sp': -200665.87676,
+            'opt_xyz': {'symbols': ('O', 'H', 'H'),
+                        'isotopes': (16, 1, 1),
+                        'coords': ((0.0, 0.0, 0.116), (0.0, 0.763, -0.469), (0.0, -0.763, -0.469))},
+            'freqs': [1617.5, 3823.7, 3927.5],
+            'modes': [[[0.0, 0.0, 0.1], [0.0, 0.4, 0.5], [0.0, -0.4, 0.5]]],
+            'zpe': 56.04,
+            'dipole': 2.07,
+        }
+        out_path = os.path.join(self.job_1.local_path, 'output_rt.yml')
+        save_yaml_file(out_path, output_data)
+        parser = YAMLParser(log_file_path=out_path)
+        self.assertAlmostEqual(parser.parse_e_elect(), -200665.87676, places=3)
+        self.assertEqual(parser.parse_geometry()['symbols'], ('O', 'H', 'H'))
+        self.assertAlmostEqual(parser.parse_frequencies()[0], 1617.5, places=1)
+        self.assertAlmostEqual(parser.parse_zpe_correction(), 56.04, places=2)
+        self.assertAlmostEqual(parser.parse_dipole_moment(), 2.07, places=2)
+        self.assertIsNone(parser.logfile_contains_errors())
+
+    def test_failed_job_is_surfaced_by_yaml_parser(self):
+        """Test that a failed in-core job (success: false) is surfaced by logfile_contains_errors."""
+        out_path = os.path.join(self.job_1.local_path, 'output_fail.yml')
+        save_yaml_file(out_path, {'schema_version': 1, 'adapter': 'pyscf',
+                                  'success': False, 'error': 'SCF did not converge'})
+        parser = YAMLParser(log_file_path=out_path)
+        self.assertEqual(parser.logfile_contains_errors(), 'SCF did not converge')
+
+    def test_execute_queue_reports_incore_execution(self):
+        """Test that a queued PySCF job runs incore and updates its execution type accordingly.
+
+        ARC only skips the queue status check when ``execution_type == 'incore'``, so leaving it
+        as 'queue' makes ARC query a queueing system for a job that never reached one.
+        """
+        job = PySCFAdapter(execution_type='queue',
+                           job_type='sp',
+                           project='test_queue_fallback',
+                           project_directory=os.path.join(self.project_directory, 'test_queue_fallback'),
+                           level=Level(repr='wb97m-v/def2tzvp'),
+                           species=[ARCSpecies(label='OH',
+                                               xyz={'symbols': ('O', 'H'),
+                                                    'isotopes': (16, 1),
+                                                    'coords': ((0.0, 0.0, 0.0),
+                                                               (0.0, 0.0, 0.9738))},
+                                               multiplicity=2)],
+                           testing=True)
+        with patch.object(PySCFAdapter, 'execute_incore') as mock_execute_incore:
+            job.execute_queue()
+        mock_execute_incore.assert_called_once()
+        self.assertEqual(job.execution_type, 'incore')
+
+    @unittest.skipUnless(HAS_PYSCF, 'PySCF is not installed in this environment')
+    def test_normalize_basis(self):
+        """Test the basis-set normalization helper in pyscf_script."""
+        from arc.job.adapters.scripts.pyscf_script import normalize_basis
+        self.assertEqual(normalize_basis('def2tzvp'), 'def2-tzvp')
+        self.assertEqual(normalize_basis('def2SVP'), 'def2-svp')
+        self.assertEqual(normalize_basis('cc-pvtz'), 'cc-pvtz')
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        A function that is run ONCE after all unit tests in this class.
+        Delete all project directories created during these unit tests.
+        """
+        shutil.rmtree(cls.project_directory, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/job/adapters/pyscf_test.py
+++ b/arc/job/adapters/pyscf_test.py
@@ -77,6 +77,20 @@ class TestPySCFAdapter(unittest.TestCase):
         self.assertEqual(settings['method'], 'wb97m-v')
         self.assertEqual(settings['basis'], 'def2tzvp')
         self.assertIn('memory_mb', settings)
+        self.assertIn('device', settings)
+        self.assertIn('fine', settings)
+
+    def test_device_can_be_requested_per_job(self):
+        """Test that an explicit device keyword overrides the default device."""
+        job = PySCFAdapter(execution_type='incore',
+                           job_type='sp',
+                           project='test_gpu',
+                           project_directory=os.path.join(self.project_directory, 'test_gpu'),
+                           level=Level(repr='wb97m-v/def2tzvp'),
+                           species=[ARCSpecies(label='H2O', xyz=self.job_1.xyz)],
+                           args={'keyword': {'device': 'gpu'}},
+                           testing=True)
+        self.assertEqual(job.determine_settings()['device'], 'gpu')
 
     def test_level_takes_precedence_over_conflicting_keyword(self):
         """Test that the job's level, not a conflicting args keyword, sets method/basis.

--- a/arc/job/adapters/scripts/pyscf_script.py
+++ b/arc/job/adapters/scripts/pyscf_script.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+A standalone script to run PySCF electronic-structure jobs (sp, opt, freq, optfreq).
+
+Executed inside the dedicated ``pyscf_env`` conda environment (isolated from ARC's env).
+Reads an ``input.yml`` in ARC's internal format and writes an ``output.yml`` in the
+in-core ESS schema (v1) that ARC's ``YAMLParser`` re-parses.
+
+Level of theory is taken from the input (ARC routes wb97m-v/def2-tzvp here). Closed-shell
+species use RKS with an analytic Hessian for frequencies; open-shell species use UKS with a
+numerical Hessian (central finite difference of analytic gradients), because PySCF has no
+analytic Hessian for NLC (VV10) functionals in the unrestricted case.
+"""
+
+import argparse
+import os
+
+import numpy as np
+import yaml
+
+from pyscf import dft, gto, lib
+from pyscf.geomopt.geometric_solver import optimize
+from pyscf.hessian import thermo
+
+# Physical constants (CODATA 2018), hard-coded so this script needs no ARC imports.
+HARTREE2KJMOL = 2625.4996394798254
+BOHR2ANG = 0.52917721090380
+CM2KJMOL = 0.0119626565  # kJ/mol per cm^-1 (= h*c*N_A*100/1000)
+
+# Numerical Hessian finite-difference step (Angstrom), used for open-shell (UKS) freqs.
+NUM_HESS_DISP_ANG = 0.005
+
+# XC grid level for a "fine" job: the closest PySCF match to Gaussian's UltraFine grid.
+FINE_GRIDS_LEVEL = 4
+
+
+def read_yaml_file(path):
+    """
+    Read a YAML file.
+
+    Args:
+        path (str): The file path.
+
+    Returns:
+        The parsed content.
+    """
+    with open(path, 'r') as f:
+        return yaml.load(stream=f, Loader=yaml.FullLoader)
+
+
+def save_yaml_file(path, content):
+    """
+    Save a dictionary as a YAML file.
+
+    Args:
+        path (str): The file path.
+        content (dict): The content to dump.
+    """
+    with open(path, 'w') as f:
+        f.write(yaml.dump(data=content, default_flow_style=False))
+
+
+def normalize_basis(basis):
+    """
+    Normalize an ARC basis-set string to a name PySCF recognizes.
+
+    ARC stores def2 basis sets without a hyphen (e.g. ``def2tzvp``) while PySCF expects
+    ``def2-tzvp``. Unknown names are passed through lower-cased.
+
+    Args:
+        basis (str): The ARC basis-set string.
+
+    Returns:
+        str: A PySCF-compatible basis-set string.
+    """
+    if not basis:
+        return 'def2-tzvp'
+    b = basis.lower().strip()
+    mapping = {'def2svp': 'def2-svp', 'def2svpd': 'def2-svpd',
+               'def2tzvp': 'def2-tzvp', 'def2tzvpp': 'def2-tzvpp', 'def2tzvpd': 'def2-tzvpd',
+               'def2qzvp': 'def2-qzvp', 'def2qzvpp': 'def2-qzvpp'}
+    return mapping.get(b, b)
+
+
+def build_mol(xyz, charge, multiplicity, basis, memory_mb=None):
+    """
+    Build a PySCF ``Mole`` from an ARC xyz dictionary.
+
+    Args:
+        xyz (dict): ARC xyz dict with ``symbols`` and ``coords`` (Angstrom).
+        charge (int): The net molecular charge.
+        multiplicity (int): The spin multiplicity (2S+1).
+        basis (str): The basis-set name.
+        memory_mb (int, optional): Max memory in MB.
+
+    Returns:
+        gto.Mole: The built molecule.
+    """
+    atoms = [[sym, tuple(coord)] for sym, coord in zip(xyz['symbols'], xyz['coords'])]
+    mol = gto.Mole()
+    mol.atom = atoms
+    mol.unit = 'Angstrom'
+    mol.charge = int(charge)
+    mol.spin = int(multiplicity) - 1  # number of unpaired electrons (2S)
+    mol.basis = normalize_basis(basis)
+    if memory_mb:
+        mol.max_memory = float(memory_mb)
+    mol.verbose = 0
+    mol.build()
+    return mol
+
+
+def make_mf(mol, xc, multiplicity, settings=None):
+    """
+    Construct a DFT mean-field object (RKS for closed-shell, UKS for open-shell).
+
+    Numerical knobs (integration-grid levels, SCF convergence) default to PySCF's own defaults
+    and are only overridden when explicitly requested, so results stay reproducible.
+
+    A ``fine`` job raises the XC grid to level 4, the closest PySCF analogue of the
+    ``integral=(grid=ultrafine)`` grid ARC's Gaussian adapter requests for fine jobs:
+    level 4 is (90, 590) radial x angular points for a second-row atom vs. Gaussian
+    UltraFine's (99, 590), while PySCF's own default level 3 is (75, 302), matching
+    Gaussian's plain FineGrid. Level 5 would overshoot UltraFine by ~1.5x in grid points.
+    The NLC (VV10) grid is left at PySCF's default level 3, since the nonlocal correlation
+    kernel is smooth and conventionally integrated on a coarser grid than the XC term.
+
+    Args:
+        mol (gto.Mole): The molecule.
+        xc (str): The exchange-correlation functional.
+        multiplicity (int): The spin multiplicity.
+        settings (dict, optional): Optional numerical settings (``fine``, ``grids_level``,
+                                   ``nlcgrids_level``, ``conv_tol``, ``max_cycle``).
+
+    Returns:
+        The configured PySCF mean-field object.
+    """
+    settings = settings or dict()
+    mf = dft.UKS(mol) if int(multiplicity) > 1 else dft.RKS(mol)
+    mf.xc = xc.lower()
+    mf.verbose = 0
+    fine = bool(settings.get('fine', False))
+    grids_level = settings.get('grids_level', FINE_GRIDS_LEVEL if fine else None)
+    nlcgrids_level = settings.get('nlcgrids_level')
+    if grids_level is not None:
+        mf.grids.level = int(grids_level)
+    if nlcgrids_level is not None and mf.do_nlc():
+        mf.nlcgrids.level = int(nlcgrids_level)
+    if settings.get('conv_tol') is not None:
+        mf.conv_tol = float(settings['conv_tol'])
+    if settings.get('max_cycle') is not None:
+        mf.max_cycle = int(settings['max_cycle'])
+    return mf
+
+
+def mol_to_xyz_dict(mol, xyz_in):
+    """
+    Convert an optimized ``Mole`` geometry to an ARC xyz dict, preserving isotopes.
+
+    Args:
+        mol (gto.Mole): The molecule (geometry in Bohr internally).
+        xyz_in (dict): The input ARC xyz dict (for symbols and isotopes).
+
+    Returns:
+        dict: An ARC xyz dict with Angstrom coordinates.
+    """
+    coords = mol.atom_coords(unit='ANG')
+    symbols = tuple(xyz_in['symbols'])
+    isotopes = tuple(xyz_in.get('isotopes')) if xyz_in.get('isotopes') else tuple([None] * len(symbols))
+    return {'symbols': symbols,
+            'isotopes': isotopes,
+            'coords': tuple(tuple(float(x) for x in row) for row in coords)}
+
+
+def get_dipole_debye(mf):
+    """
+    Compute the dipole-moment magnitude in Debye.
+
+    Args:
+        mf: A converged mean-field object.
+
+    Returns:
+        float: The dipole magnitude in Debye.
+    """
+    dip = mf.dip_moment(unit='Debye', verbose=0)
+    return float(np.linalg.norm(np.asarray(dip, dtype=float)))
+
+
+def write_geometric_constraints(constraints, path):
+    """
+    Write ARC internal-coordinate constraints to a geomeTRIC ``$set`` constraints file.
+
+    ARC constraints are (indices, value) tuples with 1-indexed atoms; a 2/3/4-atom index list
+    denotes a bond (Angstrom) / angle (degrees) / dihedral (degrees). geomeTRIC atom indices
+    are 1-indexed, matching ARC.
+
+    Args:
+        constraints (list): The ARC constraints.
+        path (str): The output constraints-file path.
+
+    Returns:
+        str: The constraints-file path.
+    """
+    lines = ['$set']
+    for indices, value in constraints:
+        atoms = ' '.join(str(int(i)) for i in indices)
+        kind = {2: 'distance', 3: 'angle', 4: 'dihedral'}[len(indices)]
+        lines.append(f'{kind} {atoms} {float(value)}')
+    with open(path, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+    return path
+
+
+def run_opt(mf, xyz_in, multiplicity, is_ts=False, constraints=None, work_dir='.', settings=None):
+    """
+    Run a geomeTRIC geometry optimization and return a fresh converged mean-field.
+
+    Transition-state searches use tightened trust radii, which are more robust for saddle-point
+    optimization than geomeTRIC's minimization defaults.
+
+    Args:
+        mf: The starting mean-field object.
+        xyz_in (dict): The input ARC xyz dict.
+        multiplicity (int): The spin multiplicity.
+        is_ts (bool): Whether to search for a first-order saddle point (TS).
+        constraints (list, optional): ARC internal-coordinate constraints.
+        work_dir (str): Directory for the geomeTRIC constraints file.
+        settings (dict, optional): Numerical settings forwarded to the mean-field builder.
+
+    Returns:
+        tuple: (mf_opt, opt_xyz_dict) where mf_opt is converged at the optimized geometry.
+    """
+    settings = settings or dict()
+    params = {}
+    if is_ts:
+        params.update({'transition': True, 'trust': 0.02, 'tmax': 0.06})
+    if constraints:
+        params['constraints'] = write_geometric_constraints(
+            constraints, os.path.join(work_dir, 'constraints.txt'))
+    mol_eq = optimize(mf, maxsteps=int(settings.get('maxsteps', 250)), **params)
+    mf_opt = make_mf(mol_eq, mf.xc, multiplicity, settings=settings)
+    mf_opt.kernel()
+    return mf_opt, mol_to_xyz_dict(mol_eq, xyz_in)
+
+
+def numerical_hessian(mf, disp_ang=NUM_HESS_DISP_ANG, settings=None):
+    """
+    Compute a numerical Hessian by central finite difference of analytic nuclear gradients.
+
+    Used for open-shell (UKS) NLC functionals, for which PySCF has no analytic Hessian.
+
+    Args:
+        mf: A converged mean-field object.
+        disp_ang (float): The displacement step in Angstrom.
+        settings (dict, optional): Numerical settings forwarded to the mean-field builder.
+
+    Returns:
+        np.ndarray: The Hessian, shape (natm, natm, 3, 3), in Hartree/Bohr^2.
+    """
+    settings = settings or dict()
+    mol = mf.mol
+    natm = mol.natm
+    coords0 = mol.atom_coords()  # Bohr
+    d = disp_ang / BOHR2ANG
+    hess = np.zeros((natm, natm, 3, 3))
+    for a in range(natm):
+        for x in range(3):
+            grads = {}
+            for sign in (1, -1):
+                c = coords0.copy()
+                c[a, x] += sign * d
+                m = mol.copy()
+                m.set_geom_(c, unit='Bohr')
+                m.build(False, False)
+                mf_d = make_mf(m, mf.xc, mol.spin + 1, settings=settings)
+                mf_d.kernel()
+                grads[sign] = mf_d.nuc_grad_method().kernel()
+            hess[a, :, x, :] = (grads[1] - grads[-1]) / (2 * d)
+    return 0.5 * (hess + hess.transpose(1, 0, 3, 2))
+
+
+def run_freq(mf, multiplicity, settings=None):
+    """
+    Compute harmonic frequencies, normal modes, and ZPE at the current geometry.
+
+    Closed-shell species use the analytic Hessian; open-shell species use a numerical Hessian.
+    Imaginary frequencies are returned as negative reals (ARC convention).
+
+    Args:
+        mf: A converged mean-field object.
+        multiplicity (int): The spin multiplicity.
+        settings (dict, optional): Numerical settings forwarded to the mean-field builder.
+
+    Returns:
+        dict: Keys ``freqs`` (cm^-1), ``modes``, and ``zpe`` (kJ/mol).
+    """
+    if int(multiplicity) > 1:
+        hess = numerical_hessian(mf, settings=settings)
+    else:
+        hess = mf.Hessian().kernel()
+    results = thermo.harmonic_analysis(mf.mol, hess)
+    raw = np.asarray(results['freq_wavenumber'], dtype=complex)
+    freqs = [float(f.real) if abs(f.imag) < 1e-6 else -float(abs(f.imag)) for f in raw]
+    modes = np.asarray(results['norm_mode'], dtype=float).tolist()
+    zpe = 0.5 * sum(f for f in freqs if f > 0) * CM2KJMOL
+    return {'freqs': freqs, 'modes': modes, 'zpe': float(zpe)}
+
+
+def run_job(input_dict, work_dir):
+    """
+    Run the requested PySCF job and assemble the output dictionary.
+
+    Args:
+        input_dict (dict): The parsed ``input.yml`` content.
+        work_dir (str): The working directory (for scratch files).
+
+    Returns:
+        dict: The schema-v1 output dictionary.
+    """
+    job_type = input_dict.get('job_type')
+    xyz = input_dict.get('xyz')
+    charge = input_dict.get('charge', 0)
+    multiplicity = input_dict.get('multiplicity', 1)
+    is_ts = input_dict.get('is_ts', False)
+    constraints = input_dict.get('constraints') or list()
+    settings = input_dict.get('settings') or dict()
+    xc = settings.get('method', 'wb97m-v')
+    basis = settings.get('basis', 'def2-tzvp')
+    memory_mb = settings.get('memory_mb')
+
+    output = {'schema_version': 1, 'adapter': 'pyscf', 'success': True, 'error': None}
+
+    # Pin the thread count so concurrent local PySCF jobs cannot each grab every core.
+    if settings.get('cpu_cores'):
+        lib.num_threads(int(settings['cpu_cores']))
+
+    mol = build_mol(xyz, charge, multiplicity, basis, memory_mb=memory_mb)
+    mf = make_mf(mol, xc, multiplicity, settings=settings)
+    mf.kernel()
+    if not mf.converged:
+        # Stop here: an optimization or Hessian built on an unconverged wavefunction costs as much as
+        # a valid one and yields numbers that only look like results.
+        output['success'] = False
+        output['error'] = 'SCF did not converge'
+        output['xyz'] = mol_to_xyz_dict(mol, xyz)
+        return output
+
+    do_opt = job_type in ('opt', 'conf_opt', 'optfreq')
+    do_freq = job_type in ('freq', 'optfreq')
+
+    if do_opt:
+        mf, opt_xyz = run_opt(mf, xyz, multiplicity, is_ts=is_ts,
+                              constraints=constraints, work_dir=work_dir, settings=settings)
+        output['opt_xyz'] = opt_xyz
+    else:
+        output['xyz'] = mol_to_xyz_dict(mol, xyz)
+
+    output['sp'] = float(mf.e_tot) * HARTREE2KJMOL
+    output['dipole'] = get_dipole_debye(mf)
+
+    if do_freq:
+        output.update(run_freq(mf, multiplicity, settings=settings))
+
+    return output
+
+
+def main():
+    """
+    Parse the input path, run the job, and write ``output.yml`` (always, even on failure).
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--yml_path', type=str, default='input.yml')
+    args = parser.parse_args()
+
+    input_path = os.path.abspath(args.yml_path)
+    if os.path.isdir(input_path):
+        input_path = os.path.join(input_path, 'input.yml')
+    work_dir = os.path.dirname(input_path)
+
+    try:
+        input_dict = read_yaml_file(input_path)
+        output = run_job(input_dict, work_dir)
+    except Exception as exc:
+        output = {'schema_version': 1, 'adapter': 'pyscf', 'success': False,
+                  'error': f'{type(exc).__name__}: {exc}'}
+
+    save_yaml_file(os.path.join(work_dir, 'output.yml'), output)
+
+
+if __name__ == '__main__':
+    main()

--- a/arc/job/adapters/scripts/pyscf_script.py
+++ b/arc/job/adapters/scripts/pyscf_script.py
@@ -12,6 +12,11 @@ Level of theory is taken from the input (ARC routes wb97m-v/def2-tzvp here). Clo
 species use RKS with an analytic Hessian for frequencies; open-shell species use UKS with a
 numerical Hessian (central finite difference of analytic gradients), because PySCF has no
 analytic Hessian for NLC (VV10) functionals in the unrestricted case.
+
+Setting ``device: gpu`` runs the SCF, the gradients and the geometry optimization on an NVIDIA
+GPU through gpu4pyscf. Closed-shell analytic Hessians always fall back to the CPU, since
+gpu4pyscf's Hessian is currently broken (it is not NLC-specific: plain hybrids fail too).
+Open-shell numerical Hessians stay on the GPU, as they only need SCF energies and gradients.
 """
 
 import argparse
@@ -23,6 +28,11 @@ import yaml
 from pyscf import dft, gto, lib
 from pyscf.geomopt.geometric_solver import optimize
 from pyscf.hessian import thermo
+
+try:
+    from gpu4pyscf import dft as gpu_dft
+except ImportError:
+    gpu_dft = None
 
 # Physical constants (CODATA 2018), hard-coded so this script needs no ARC imports.
 HARTREE2KJMOL = 2625.4996394798254
@@ -60,6 +70,19 @@ def save_yaml_file(path, content):
     """
     with open(path, 'w') as f:
         f.write(yaml.dump(data=content, default_flow_style=False))
+
+
+def to_numpy(array):
+    """
+    Return a NumPy view of an array that may live on the GPU.
+
+    Args:
+        array: A NumPy or CuPy array.
+
+    Returns:
+        np.ndarray: The array as a NumPy array.
+    """
+    return np.asarray(array.get() if hasattr(array, 'get') else array)
 
 
 def normalize_basis(basis):
@@ -138,7 +161,13 @@ def make_mf(mol, xc, multiplicity, settings=None):
         The configured PySCF mean-field object.
     """
     settings = settings or dict()
-    mf = dft.UKS(mol) if int(multiplicity) > 1 else dft.RKS(mol)
+    module = dft
+    if str(settings.get('device', 'cpu')).lower() in ('gpu', 'cuda'):
+        if gpu_dft is not None:
+            module = gpu_dft
+        else:
+            print('Requested device "gpu" but gpu4pyscf is not installed; falling back to the CPU.')
+    mf = module.UKS(mol) if int(multiplicity) > 1 else module.RKS(mol)
     mf.xc = xc.lower()
     mf.verbose = 0
     fine = bool(settings.get('fine', False))
@@ -184,7 +213,7 @@ def get_dipole_debye(mf):
     Returns:
         float: The dipole magnitude in Debye.
     """
-    dip = mf.dip_moment(unit='Debye', verbose=0)
+    dip = to_numpy(mf.dip_moment(unit='Debye', verbose=0))
     return float(np.linalg.norm(np.asarray(dip, dtype=float)))
 
 
@@ -276,7 +305,7 @@ def numerical_hessian(mf, disp_ang=NUM_HESS_DISP_ANG, settings=None):
                 m.build(False, False)
                 mf_d = make_mf(m, mf.xc, mol.spin + 1, settings=settings)
                 mf_d.kernel()
-                grads[sign] = mf_d.nuc_grad_method().kernel()
+                grads[sign] = to_numpy(mf_d.nuc_grad_method().kernel())
             hess[a, :, x, :] = (grads[1] - grads[-1]) / (2 * d)
     return 0.5 * (hess + hess.transpose(1, 0, 3, 2))
 
@@ -288,6 +317,10 @@ def run_freq(mf, multiplicity, settings=None):
     Closed-shell species use the analytic Hessian; open-shell species use a numerical Hessian.
     Imaginary frequencies are returned as negative reals (ARC convention).
 
+    The analytic Hessian always runs on the CPU: gpu4pyscf's Hessian raises an assertion error
+    for both NLC functionals and plain hybrids. The numerical Hessian only needs SCF energies
+    and gradients, so it stays on whichever device was requested.
+
     Args:
         mf: A converged mean-field object.
         multiplicity (int): The spin multiplicity.
@@ -296,10 +329,15 @@ def run_freq(mf, multiplicity, settings=None):
     Returns:
         dict: Keys ``freqs`` (cm^-1), ``modes``, and ``zpe`` (kJ/mol).
     """
+    settings = settings or dict()
     if int(multiplicity) > 1:
         hess = numerical_hessian(mf, settings=settings)
     else:
-        hess = mf.Hessian().kernel()
+        cpu_settings = dict(settings, device='cpu')
+        mf_cpu = make_mf(mf.mol, mf.xc, multiplicity, settings=cpu_settings)
+        mf_cpu.kernel()
+        hess = mf_cpu.Hessian().kernel()
+    hess = to_numpy(hess)
     results = thermo.harmonic_analysis(mf.mol, hess)
     raw = np.asarray(results['freq_wavenumber'], dtype=complex)
     freqs = [float(f.real) if abs(f.imag) < 1e-6 else -float(abs(f.imag)) for f in raw]

--- a/arc/job/local.py
+++ b/arc/job/local.py
@@ -182,6 +182,10 @@ def check_running_jobs_ids() -> list[str]:
         list[str]: List of job IDs.
     """
     cluster_soft = servers['local']['cluster_soft'].lower()
+    if cluster_soft == 'local':
+        # This machine has no queueing system, so there are no queue job IDs to report.
+        # Jobs here run in-core (e.g., PySCF) or as a local pipe worker pool.
+        return list()
     if cluster_soft not in ['slurm', 'oge', 'sge', 'pbs', 'htcondor']:
         raise ValueError(f"Server cluster software {servers['local']['cluster_soft']} is not supported.")
     cmd = check_status_command[servers['local']['cluster_soft']]

--- a/arc/job/local_test.py
+++ b/arc/job/local_test.py
@@ -107,6 +107,20 @@ class TestLocal(unittest.TestCase):
                     local.submit_job(path='.', cluster_soft='pbs', submit_cmd='qsub', submit_filename='submit.sh')
         self.assertIn('compute node', str(cm.exception))
 
+    def test_check_running_jobs_ids_without_a_queueing_system(self):
+        """Test that a machine with no queueing system reports no queue job IDs"""
+        for cluster_soft in ['local', 'Local']:
+            with patch.dict(local.servers, {'local': {'cluster_soft': cluster_soft}}):
+                with patch('arc.job.local.execute_command') as mock_execute:
+                    self.assertEqual(local.check_running_jobs_ids(), list())
+                mock_execute.assert_not_called()
+
+    def test_check_running_jobs_ids_unsupported_cluster_software(self):
+        """Test that an unrecognized cluster software is still rejected"""
+        with patch.dict(local.servers, {'local': {'cluster_soft': 'no_such_scheduler'}}):
+            with self.assertRaises(ValueError):
+                local.check_running_jobs_ids()
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/job/pipe/pipe_run.py
+++ b/arc/job/pipe/pipe_run.py
@@ -15,8 +15,14 @@ All QA, troubleshooting, and downstream branching remain in mother ARC.
 import json
 import os
 import stat
+import subprocess
 import sys
 import time
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 import arc.parser.parser as parser
 from arc.common import get_logger
@@ -196,6 +202,8 @@ class PipeRun:
         cpus = self.tasks[0].required_cores if self.tasks else 1
         memory_mb = self.tasks[0].required_memory_mb if self.tasks else 4096
         array_size = min(self.max_workers, len(self.tasks)) if self.tasks else self.max_workers
+        if self.cluster_software == 'local':
+            array_size = min(array_size, local_worker_limit(cpus, memory_mb))
         return cpus, memory_mb, array_size
 
     def _build_env_preamble(self) -> str:
@@ -226,9 +234,13 @@ class PipeRun:
             lines.append(engine_setup)
         scratch_base = pipe_settings.get('scratch_base', '')
         if scratch_base:
-            lines.append(
-                f'export TMPDIR="{scratch_base}/${{PBS_JOBID%%[*}}/$PBS_ARRAY_INDEX"\nmkdir -p "$TMPDIR"'
-            )
+            # Each worker needs its own scratch directory. Without a queueing system there is no
+            # job id to key it on, so fall back to the run id and the worker id.
+            if self.cluster_software == 'local':
+                subdir = f'{self.run_id}/$WORKER_ID'
+            else:
+                subdir = '${PBS_JOBID%%[*}/$PBS_ARRAY_INDEX'
+            lines.append(f'export TMPDIR="{scratch_base}/{subdir}"\nmkdir -p "$TMPDIR"')
         return '\n'.join(lines)
 
     def write_submit_script(self) -> str:
@@ -284,6 +296,8 @@ class PipeRun:
             Tuple[str, str]: ``(job_status, job_id)`` — ``'submitted'`` on
                 success, ``'errored'`` on failure.
         """
+        if self.cluster_software == 'local':
+            return self.submit_locally()
         import shutil as _shutil
         from arc.imports import settings as _settings
         submit_command = _settings['submit_command']
@@ -305,6 +319,35 @@ class PipeRun:
             submit_filename=filename,
         )
         return job_status, job_id
+
+    def submit_locally(self):
+        """
+        Launch the worker pool locally, without a queueing system.
+
+        Runs the generated ``submit.sh`` in a detached session so the pool keeps running
+        independently of ARC's own process. Completion is detected the same way as for a
+        queued pipe run, by reconciling the per-task state files under ``pipe_root``, so
+        the returned identifier is only used for bookkeeping.
+
+        Returns:
+            Tuple[str, str]: ``(job_status, job_id)`` — ``('running', <pid>)`` on success,
+                ``('errored', None)`` on failure.
+        """
+        submit_path = os.path.join(self.pipe_root, 'submit.sh')
+        if not os.path.isfile(submit_path):
+            logger.error(f'Cannot launch a local pipe run, {submit_path} does not exist.')
+            return 'errored', None
+        try:
+            process = subprocess.Popen(['bash', submit_path],
+                                       stdout=subprocess.DEVNULL,
+                                       stderr=subprocess.DEVNULL,
+                                       cwd=self.pipe_root,
+                                       start_new_session=True)
+        except Exception as e:
+            logger.error(f'Could not launch the local pipe worker pool: {e}')
+            return 'errored', None
+        logger.info(f'Launched a local pipe worker pool for {self.run_id} (pid {process.pid}).')
+        return 'running', str(process.pid)
 
     def reconcile(self) -> dict[str, int]:
         """
@@ -770,15 +813,46 @@ def _ingest_rotor_scan_1d(run_id, pipe_root, spec, state, species_dict, label):
 # ===========================================================================
 
 
+def local_worker_limit(cpus_per_worker: int, memory_mb_per_worker: int) -> int:
+    """
+    Determine how many pipe workers may run concurrently on this machine.
+
+    Without a queueing system nothing else throttles the pool, so the worker count is bounded
+    by both the core count and the available memory. ``pipe_settings['local_max_workers']``
+    overrides the derived value when set.
+
+    Args:
+        cpus_per_worker (int): Cores each worker is allowed to use.
+        memory_mb_per_worker (int): Memory each worker is expected to need, in MB.
+
+    Returns:
+        int: The maximum number of concurrent local workers (at least 1).
+    """
+    configured = (settings.get('pipe_settings') or dict()).get('local_max_workers')
+    if configured:
+        return max(1, int(configured))
+    by_cores = (os.cpu_count() or 1) // max(1, int(cpus_per_worker))
+    limit = by_cores
+    if memory_mb_per_worker and psutil is not None:
+        by_memory = int(psutil.virtual_memory().available / (1024 ** 2) // memory_mb_per_worker)
+        limit = min(limit, by_memory)
+    return max(1, limit)
+
+
 def derive_cluster_software(ess_settings: dict, job_adapter: str) -> str:
     """
     Heuristic: derive cluster software from the first server configured
     for this engine in ess_settings. Mirrors how run_job() picks its server.
 
     Returns a lowercase identifier matching the ``pipe_submit`` template keys
-    (e.g., ``'slurm'``, ``'pbs'``, ``'sge'``, ``'htcondor'``).
+    (e.g., ``'slurm'``, ``'pbs'``, ``'sge'``, ``'htcondor'``, ``'local'``).
     Maps ``'oge'`` to ``'sge'`` for template compatibility.
+
+    ``pipe_settings['run_locally']`` forces the ``'local'`` backend, which runs the array as a
+    pool of background worker processes on this machine instead of submitting it to a queue.
     """
+    if (settings.get('pipe_settings') or dict()).get('run_locally'):
+        return 'local'
     cs_alias = {'oge': 'sge'}
     for server_name in ess_settings.get(job_adapter, []):
         if server_name in servers_dict and 'cluster_soft' in servers_dict[server_name]:

--- a/arc/job/pipe/pipe_run.py
+++ b/arc/job/pipe/pipe_run.py
@@ -203,6 +203,10 @@ class PipeRun:
         memory_mb = self.tasks[0].required_memory_mb if self.tasks else 4096
         array_size = min(self.max_workers, len(self.tasks)) if self.tasks else self.max_workers
         if self.cluster_software == 'local':
+            # Cap each worker's cores at the local CPU budget so a single worker cannot exceed it
+            # (the submit script exports these as OMP/MKL/OPENBLAS_NUM_THREADS and ARC_PIPE_LOCAL_CPUS),
+            # then size the pool from the capped value so workers x cores stays within the budget.
+            cpus = max(1, min(cpus, local_cpu_budget()))
             array_size = min(array_size, local_worker_limit(cpus, memory_mb))
         return cpus, memory_mb, array_size
 
@@ -813,13 +817,77 @@ def _ingest_rotor_scan_1d(run_id, pipe_root, spec, state, species_dict, label):
 # ===========================================================================
 
 
+def local_cpu_budget() -> int:
+    """
+    Determine the total number of CPU cores ARC may use for local (queueless) execution.
+
+    This is the single global CPU limit for a machine with no queueing system: the ``cpus`` field
+    of the local server. It is the same ceiling the in-core ESS path already applies per job (see
+    ``JobAdapter.set_cpu_and_mem``), so one number bounds both the in-core jobs and the local worker
+    pool. The server named ``'local'`` is preferred (matching how the submit script resolves it);
+    otherwise the first server whose ``cluster_soft`` is ``'local'`` is used. When no such server is
+    configured, or its ``cpus`` is missing or not a positive integer, fall back to the machine's
+    physical core count.
+
+    Returns:
+        int: The core budget for local execution (at least 1).
+    """
+    def _is_local(server: dict) -> bool:
+        return isinstance(server, dict) and str(server.get('cluster_soft', '')).strip().lower() == 'local'
+
+    server = servers_dict.get('local')
+    if not _is_local(server):
+        server = next((s for s in servers_dict.values() if _is_local(s)), None)
+    if isinstance(server, dict):
+        try:
+            cpus = int(server.get('cpus'))
+        except (TypeError, ValueError):
+            cpus = 0
+        if cpus > 0:
+            return cpus
+    return max(1, os.cpu_count() or 1)
+
+
+def worker_cpu_cores(env: dict | None = None) -> int | None:
+    """
+    Resolve the CPU-core count a local pipe worker should pin its reconstructed job to.
+
+    The local submit script exports the budget-capped per-worker cores (see ``_submission_resources``)
+    as ``ARC_PIPE_LOCAL_CPUS``. A worker reconstructs its in-core job in a fresh process with no server
+    context, so ``set_cpu_and_mem`` would otherwise fall back to the default ``job_cpu_cores`` and an
+    engine that pins its own threads (e.g. PySCF's ``lib.num_threads``) could exceed the local CPU
+    budget. Reading the capped value back from the environment carries it into the reconstructed job,
+    so the same one number bounds the worker's actual thread count.
+
+    A dedicated variable is used rather than ``OMP_NUM_THREADS`` so that only local pipe workers are
+    affected: queue submit templates do not set it, so a queued worker keeps ARC's default allocation
+    and never picks up an ambient ``OMP_NUM_THREADS`` from the login shell.
+
+    Args:
+        env (dict, optional): Environment mapping to read (defaults to ``os.environ``).
+
+    Returns:
+        int | None: The capped core count, or ``None`` if unset/unparseable (the caller then falls
+        back to ARC's default core allocation).
+    """
+    env = os.environ if env is None else env
+    raw = env.get('ARC_PIPE_LOCAL_CPUS')
+    if not raw:
+        return None
+    try:
+        cores = int(str(raw).split(',')[0])
+    except (ValueError, IndexError):
+        return None
+    return cores if cores > 0 else None
+
+
 def local_worker_limit(cpus_per_worker: int, memory_mb_per_worker: int) -> int:
     """
     Determine how many pipe workers may run concurrently on this machine.
 
-    Without a queueing system nothing else throttles the pool, so the worker count is bounded
-    by both the core count and the available memory. ``pipe_settings['local_max_workers']``
-    overrides the derived value when set.
+    Without a queueing system nothing else throttles the pool, so the worker count is bounded by
+    both the CPU budget (see ``local_cpu_budget``) and the available memory.
+    ``pipe_settings['local_max_workers']`` overrides the derived value when set.
 
     Args:
         cpus_per_worker (int): Cores each worker is allowed to use.
@@ -831,7 +899,7 @@ def local_worker_limit(cpus_per_worker: int, memory_mb_per_worker: int) -> int:
     configured = (settings.get('pipe_settings') or dict()).get('local_max_workers')
     if configured:
         return max(1, int(configured))
-    by_cores = (os.cpu_count() or 1) // max(1, int(cpus_per_worker))
+    by_cores = local_cpu_budget() // max(1, int(cpus_per_worker))
     limit = by_cores
     if memory_mb_per_worker and psutil is not None:
         by_memory = int(psutil.virtual_memory().available / (1024 ** 2) // memory_mb_per_worker)

--- a/arc/job/pipe/pipe_run_test.py
+++ b/arc/job/pipe/pipe_run_test.py
@@ -14,7 +14,7 @@ import unittest
 
 from arc.job.adapters.mockter import MockAdapter
 from arc.job.pipe.pipe_state import TaskState, PipeRunState, TaskSpec, read_task_state, update_task_state
-from arc.job.pipe.pipe_run import PipeRun
+from arc.job.pipe.pipe_run import PipeRun, local_worker_limit
 from arc.level import Level
 from arc.species import ARCSpecies
 
@@ -169,6 +169,28 @@ class TestPipeRunWriteSubmitScript(unittest.TestCase):
         with open(path) as f:
             content = f.read()
         self.assertIn('queue 12', content)
+
+    def test_local_content(self):
+        """A local pipe run renders a plain background worker pool, with no queue directives."""
+        run = self._make_run('local', max_workers=4, n_tasks=4)
+        path = run.write_submit_script()
+        self.assertEqual(os.path.basename(path), 'submit.sh')
+        with open(path) as f:
+            content = f.read()
+        self.assertIn('-m arc.scripts.pipe_worker', content)
+        self.assertIn('for WORKER_ID in $(seq 1', content)
+        self.assertIn('wait', content)
+        self.assertIn('export OMP_NUM_THREADS=', content)
+        self.assertNotIn('#SBATCH', content)
+        self.assertNotIn('#PBS', content)
+
+    def test_local_worker_count_is_capped_by_machine(self):
+        """The local pool never exceeds what the machine can run concurrently."""
+        run = self._make_run('local', max_workers=1000, n_tasks=1000)
+        _, _, array_size = run._submission_resources()
+        self.assertLessEqual(array_size, local_worker_limit(run.tasks[0].required_cores,
+                                                            run.tasks[0].required_memory_mb))
+        self.assertGreaterEqual(array_size, 1)
 
     def test_overwrite_is_safe(self):
         run = self._make_run('slurm')

--- a/arc/job/pipe/pipe_run_test.py
+++ b/arc/job/pipe/pipe_run_test.py
@@ -11,16 +11,18 @@ import shutil
 import tempfile
 import time
 import unittest
+from unittest import mock
 
+import arc.job.pipe.pipe_run as pipe_run_module
 from arc.job.adapters.mockter import MockAdapter
 from arc.job.pipe.pipe_state import TaskState, PipeRunState, TaskSpec, read_task_state, update_task_state
-from arc.job.pipe.pipe_run import PipeRun, local_worker_limit
+from arc.job.pipe.pipe_run import PipeRun, local_cpu_budget, local_worker_limit, worker_cpu_cores
 from arc.level import Level
 from arc.species import ARCSpecies
 
 
 def _make_spec(task_id, label='H2O', smiles='O', task_family='conf_opt',
-               engine='mockter', level=None):
+               engine='mockter', level=None, required_cores=1, required_memory_mb=512):
     """Helper to create a TaskSpec for testing."""
     spc = ARCSpecies(label=label, smiles=smiles)
     return TaskSpec(
@@ -31,8 +33,8 @@ def _make_spec(task_id, label='H2O', smiles='O', task_family='conf_opt',
         input_fingerprint=f'{task_id}_fp',
         engine=engine,
         level=level or {'method': 'mock', 'basis': 'mock'},
-        required_cores=1,
-        required_memory_mb=512,
+        required_cores=required_cores,
+        required_memory_mb=required_memory_mb,
         input_payload={'species_dicts': [spc.as_dict()]},
         ingestion_metadata={'conformer_index': 0},
     )
@@ -181,8 +183,19 @@ class TestPipeRunWriteSubmitScript(unittest.TestCase):
         self.assertIn('for WORKER_ID in $(seq 1', content)
         self.assertIn('wait', content)
         self.assertIn('export OMP_NUM_THREADS=', content)
+        self.assertIn('export ARC_PIPE_LOCAL_CPUS=', content)  # carries the capped budget to the worker
         self.assertNotIn('#SBATCH', content)
         self.assertNotIn('#PBS', content)
+
+    def test_queue_scripts_do_not_export_local_worker_cpus(self):
+        """Only the local template sets ARC_PIPE_LOCAL_CPUS, so queued workers keep ARC's default cores."""
+        for soft in ('slurm', 'pbs', 'sge', 'htcondor'):
+            tasks = [_make_spec(f't_{i}') for i in range(4)]
+            run = PipeRun(project_directory=self.tmpdir, run_id=f'sub_{soft}',
+                          tasks=tasks, cluster_software=soft, max_workers=4)
+            run.stage()
+            with open(run.write_submit_script()) as f:
+                self.assertNotIn('ARC_PIPE_LOCAL_CPUS', f.read())
 
     def test_local_worker_count_is_capped_by_machine(self):
         """The local pool never exceeds what the machine can run concurrently."""
@@ -191,6 +204,23 @@ class TestPipeRunWriteSubmitScript(unittest.TestCase):
         self.assertLessEqual(array_size, local_worker_limit(run.tasks[0].required_cores,
                                                             run.tasks[0].required_memory_mb))
         self.assertGreaterEqual(array_size, 1)
+
+    def test_local_per_worker_cores_capped_by_cpu_budget(self):
+        """A worker asking for more cores than the local CPU budget is capped at the budget.
+
+        Otherwise a single worker's OMP/MKL/OPENBLAS thread exports would exceed the budget.
+        """
+        tasks = [_make_spec(f't{i}', required_cores=8) for i in range(4)]
+        run = PipeRun(project_directory=self.tmpdir, run_id='budget_cap',
+                      tasks=tasks, cluster_software='local', max_workers=4)
+        run.stage()
+        servers = {'local': {'cluster_soft': 'local', 'cpus': 4}}
+        pipe = {'local_max_workers': None}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers), \
+                mock.patch.dict(pipe_run_module.settings, {'pipe_settings': pipe, 'servers': servers}):
+            cpus, _, array_size = run._submission_resources()
+        self.assertEqual(cpus, 4)                  # capped from 8 down to the 4-core budget
+        self.assertLessEqual(cpus * array_size, 4)  # workers x cores stays within the budget
 
     def test_overwrite_is_safe(self):
         run = self._make_run('slurm')
@@ -599,6 +629,80 @@ class TestPipeRunHomogeneity(unittest.TestCase):
         restored = PipeRun.from_dir(run.pipe_root)
         self.assertEqual(len(restored.tasks), 2)
         self.assertEqual(restored.tasks[0].task_family, 'rotor_scan_1d')
+
+
+class TestLocalCpuBudget(unittest.TestCase):
+    """Unit tests for the single global local CPU budget and how it sizes the local worker pool."""
+
+    def test_local_cpu_budget_reads_local_server_cpus(self):
+        """The budget is the 'cpus' of the server whose cluster_soft is 'local'."""
+        servers = {'local': {'cluster_soft': 'local', 'cpus': 12, 'memory': 32}}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+            self.assertEqual(local_cpu_budget(), 12)
+
+    def test_local_cpu_budget_falls_back_to_machine_cores(self):
+        """Without a local server 'cpus', the budget falls back to the physical core count."""
+        servers = {'zeus': {'cluster_soft': 'pbs', 'cpus': 24}}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+            self.assertEqual(local_cpu_budget(), max(1, os.cpu_count() or 1))
+
+    def test_local_cpu_budget_prefers_server_named_local(self):
+        """When several servers are 'local', the one named 'local' wins (matches the submit script)."""
+        servers = {'workstation': {'cluster_soft': 'local', 'cpus': 64},
+                   'local': {'cluster_soft': 'local', 'cpus': 12}}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+            self.assertEqual(local_cpu_budget(), 12)
+
+    def test_local_cpu_budget_uses_first_local_when_none_named_local(self):
+        """If no server is named 'local', the first server with cluster_soft 'local' is used."""
+        servers = {'workstation': {'cluster_soft': 'local', 'cpus': 16}}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+            self.assertEqual(local_cpu_budget(), 16)
+
+    def test_local_cpu_budget_tolerates_whitespace_and_case(self):
+        """'cluster_soft' matching ignores surrounding whitespace and case."""
+        servers = {'local': {'cluster_soft': '  Local ', 'cpus': 8}}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+            self.assertEqual(local_cpu_budget(), 8)
+
+    def test_local_cpu_budget_rejects_invalid_cpus(self):
+        """A non-positive or non-numeric 'cpus' fails safe to the machine core count, not a crash."""
+        fallback = max(1, os.cpu_count() or 1)
+        for bad in (0, None, -8, 'local'):
+            servers = {'local': {'cluster_soft': 'local', 'cpus': bad}}
+            with mock.patch.object(pipe_run_module, 'servers_dict', servers):
+                self.assertEqual(local_cpu_budget(), fallback)
+
+    def test_local_worker_limit_bounded_by_cpu_budget(self):
+        """The derived worker count is the CPU budget divided by the cores each worker needs."""
+        servers = {'local': {'cluster_soft': 'local', 'cpus': 12}}
+        pipe = {'local_max_workers': None}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers), \
+                mock.patch.dict(pipe_run_module.settings, {'pipe_settings': pipe, 'servers': servers}):
+            self.assertEqual(local_worker_limit(cpus_per_worker=1, memory_mb_per_worker=0), 12)
+            self.assertEqual(local_worker_limit(cpus_per_worker=4, memory_mb_per_worker=0), 3)
+
+    def test_local_max_workers_overrides_cpu_budget(self):
+        """An explicit local_max_workers wins over the derived CPU budget."""
+        servers = {'local': {'cluster_soft': 'local', 'cpus': 12}}
+        pipe = {'local_max_workers': 4}
+        with mock.patch.object(pipe_run_module, 'servers_dict', servers), \
+                mock.patch.dict(pipe_run_module.settings, {'pipe_settings': pipe, 'servers': servers}):
+            self.assertEqual(local_worker_limit(cpus_per_worker=1, memory_mb_per_worker=0), 4)
+
+    def test_worker_cpu_cores_reads_dedicated_env(self):
+        """A local worker pins its job to the budget-capped cores exported as ARC_PIPE_LOCAL_CPUS."""
+        self.assertEqual(worker_cpu_cores({'ARC_PIPE_LOCAL_CPUS': '4'}), 4)
+        self.assertEqual(worker_cpu_cores({'ARC_PIPE_LOCAL_CPUS': '4,1'}), 4)
+
+    def test_worker_cpu_cores_ignores_ambient_omp(self):
+        """A queued worker (no ARC_PIPE_LOCAL_CPUS) never picks up an ambient OMP_NUM_THREADS."""
+        self.assertIsNone(worker_cpu_cores({'OMP_NUM_THREADS': '64'}))
+
+    def test_worker_cpu_cores_falls_back_to_none(self):
+        """Unset or unparseable value yields None, so the caller uses ARC's default allocation."""
+        for env in ({}, {'ARC_PIPE_LOCAL_CPUS': ''}, {'ARC_PIPE_LOCAL_CPUS': '0'}, {'ARC_PIPE_LOCAL_CPUS': 'abc'}):
+            self.assertIsNone(worker_cpu_cores(env))
 
 
 if __name__ == '__main__':

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -16,7 +16,8 @@ from arc.common import (check_torsion_change,
                         get_number_with_ordinal_indicator,
                         is_same_pivot,
                         is_same_sequence_sublist,
-                        is_str_float
+                        is_str_float,
+                        read_yaml_file
                         )
 from arc.exceptions import InputError, SpeciesError, TrshError
 from arc.imports import settings
@@ -75,6 +76,9 @@ def determine_ess_status(output_path: str,
 
     if software is None:
         software = determine_ess(log_file_path=output_path)
+
+    if output_path.endswith('.yml'):
+        return determine_ess_status_from_yaml(output_path=output_path)
 
     keywords, error, = list(), ''
     with open(output_path, 'r') as f:
@@ -482,6 +486,42 @@ def determine_ess_status(output_path: str,
             return 'errored', keywords, error, line
 
     return '', list(), '', ''
+
+
+def determine_ess_status_from_yaml(output_path: str) -> tuple[str, list[str], str, str]:
+    """
+    Determine the status of a job run by an in-core ESS adapter that reports results via YAML.
+
+    In-core adapters (e.g., 'ase', 'pyscf', 'torchani') hand off results in ARC's internal schema
+    rather than writing a text log, so the textual error signatures used for the queue-based ESS
+    software do not apply.
+
+    Two conventions are supported. An adapter that reports an explicit ``success`` key (e.g., 'pyscf')
+    is taken at its word. The older adapters ('ase', 'torchani', 'openbabel') omit ``success`` and
+    write an ``error`` key only when something goes wrong, so for those the absence of an error means
+    the job is done -- treating a missing ``success`` as failure would mark every one of their
+    successful jobs as errored.
+
+    Args:
+        output_path (str): The path to the adapter's output.yml file.
+
+    Returns: tuple[str, list[str], str, str]
+        - The status, either 'done' or 'errored'.
+        - The standardized error keywords.
+        - A description of the error.
+        - The parsed line indicating the error (always empty for a YAML output).
+    """
+    content = read_yaml_file(path=output_path)
+    if not isinstance(content, dict):
+        return 'errored', ['NoOutput'], f'Could not read {output_path}', ''
+    error = content.get('error')
+    if 'success' in content:
+        if content['success']:
+            return 'done', list(), '', ''
+        return 'errored', ['Unknown'], error or 'The in-core ESS job did not report success.', ''
+    if error:
+        return 'errored', ['Unknown'], error, ''
+    return 'done', list(), '', ''
 
 
 def determine_job_log_memory_issues(job_log: str | None = None) -> tuple[list[str], str, str]:

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -6,11 +6,13 @@ This module contains unit tests of the arc.job.trsh module
 """
 
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch
 
 import arc.job.trsh as trsh
-from arc.common import ARC_TESTING_PATH
+from arc.common import ARC_TESTING_PATH, save_yaml_file
 from arc.exceptions import TrshError
 from arc.imports import settings
 from arc.parser.parser import parse_1d_scan_energies
@@ -1087,6 +1089,47 @@ class TestTrsh(unittest.TestCase):
         self.assertIn('maytal_q', result.keys())
         self.assertIn('48:00:00', result.values())
         self.assertTrue(success)
+
+    def test_determine_ess_status_of_a_yaml_output(self):
+        """Test determining the status of an in-core adapter that reports results via YAML.
+
+        These adapters write ARC's internal schema rather than a text log, so the per-software
+        textual error signatures do not apply and the job's own ``success`` key is authoritative.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp_dir, 'output.yml')
+
+            save_yaml_file(path=path, content={'schema_version': 1, 'adapter': 'pyscf',
+                                               'success': True, 'sp': -397940.79})
+            status, keywords, error, line = trsh.determine_ess_status(
+                output_path=path, species_label='H2O2', job_type='opt', software='pyscf')
+            self.assertEqual(status, 'done')
+            self.assertEqual(keywords, list())
+            self.assertEqual(error, '')
+
+            save_yaml_file(path=path, content={'schema_version': 1, 'adapter': 'pyscf',
+                                               'success': False, 'error': 'SCF did not converge'})
+            status, keywords, error, line = trsh.determine_ess_status(
+                output_path=path, species_label='H2O2', job_type='opt', software='pyscf')
+            self.assertEqual(status, 'errored')
+            self.assertEqual(error, 'SCF did not converge')
+
+            # Adapters predating the ``success`` key (ase, torchani, openbabel) write an ``error``
+            # key only on failure, so a missing ``success`` must not be read as a failure.
+            save_yaml_file(path=path, content={'xyz': {'symbols': ('O', 'O')}, 'energy': -1.5})
+            status, keywords, error, line = trsh.determine_ess_status(
+                output_path=path, species_label='H2O2', job_type='opt', software='ase')
+            self.assertEqual(status, 'done')
+            self.assertEqual(error, '')
+
+            save_yaml_file(path=path, content={'error': 'Optimization failed: boom'})
+            status, keywords, error, line = trsh.determine_ess_status(
+                output_path=path, species_label='H2O2', job_type='opt', software='ase')
+            self.assertEqual(status, 'errored')
+            self.assertEqual(error, 'Optimization failed: boom')
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -87,6 +87,7 @@ class TestARC(unittest.TestCase):
                                           'openbabel': ['local'],
                                           'orca': ['local'],
                                           'orca_neb': ['local'],
+                                          'pyscf': ['local'],
                                           'qchem': ['server1'],
                                           'rits': ['local'],
                                           'terachem': ['server1'],

--- a/arc/parser/adapters/yaml.py
+++ b/arc/parser/adapters/yaml.py
@@ -26,12 +26,17 @@ class YAMLParser(ESSAdapter, ABC):
 
     def logfile_contains_errors(self) -> str | None:
         """
-        Check if the TeraChem log file contains any errors.
+        Check if the YAML output file reports a failed in-core ESS job.
+
+        In-core adapters (e.g. PySCF) set ``success: false`` and populate ``error`` when the
+        local job crashes, so a failed run is not silently treated as done. Producers that do
+        not emit ``success`` (e.g. legacy ASE/TorchANI output) are unaffected.
 
         Returns: str | None
-            None if no errors, else error message string.
+            None if no errors, else the error message string.
         """
-        # YAML files don't contain runtime errors like ESS logs.
+        if self.data.get('success') is False:
+            return self.data.get('error') or 'The in-core ESS job reported a failure.'
         return None
 
     def parse_geometry(self) -> dict[str, tuple] | None:

--- a/arc/scripts/pipe_worker.py
+++ b/arc/scripts/pipe_worker.py
@@ -21,6 +21,7 @@ import time
 
 from arc.imports import settings
 from arc.job.factory import job_factory
+from arc.job.pipe.pipe_run import worker_cpu_cores
 from arc.job.pipe.pipe_state import (
     TASK_FAMILY_TO_JOB_TYPE,
     TaskState,
@@ -338,6 +339,7 @@ def _run_adapter(spec: TaskSpec, scratch_dir: str, job_type: str, **extra_kwargs
         xyz=xyz,
         conformer=conformer,
         tsg=tsg,
+        cpu_cores=worker_cpu_cores(),
         testing=False,
         **extra_kwargs,
     )

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -68,6 +68,10 @@ servers = {
     # in-core (e.g., 'pyscf'), since ARC validates every ESS's server against this dictionary.
     # Set 'cluster_soft' to 'local' on a workstation with no queueing system: jobs then run
     # in-core or as a local pipe worker pool rather than being submitted to a queue.
+    # When 'cluster_soft' is 'local', 'cpus' is the single machine-wide CPU budget: it both caps
+    # the cores any one in-core job may use and bounds the local worker pool (workers x cores/worker
+    # <= cpus). Set it below the physical core count to leave headroom (e.g., 'cpus': 12 on a
+    # 16-core box). 'pipe_settings['local_max_workers']' can override the derived worker count.
     'local': {
         'cluster_soft': 'HTCondor',  # or 'Slurm'/'PBS'/'OGE'/'SGE', or 'local' if there is no queue
         'un': '<username>',
@@ -353,8 +357,10 @@ pipe_settings = {
     'run_locally': False,      # Run the pipe array as a local pool of worker processes instead of
                                # submitting it to a queue. Use on a workstation with no queueing
                                # system (e.g., to parallelize local PySCF jobs).
-    'local_max_workers': None, # Concurrent local workers. None derives a limit from the available
-                               # cores and memory; set an int to override.
+    'local_max_workers': None, # Concurrent local workers. None derives a limit from the local CPU
+                               # budget (the 'local' server's 'cpus') and available memory. Set an
+                               # int to override; note an explicit value wins outright and can exceed
+                               # the CPU budget, so total cores may pass servers['local']['cpus'].
     'max_attempts': 3,         # Retry budget per task before terminal failure.
     'lease_duration_hrs': 1,   # Worker lease duration in hours (default 1h).
     'env_setup': {},           # Engine-specific shell setup commands, e.g.,

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -64,8 +64,12 @@ servers = {
         'un': '<username>',
         'key': 'path_to_rsa_key',
     },
+    # The machine ARC itself runs on. A 'local' server entry is required for any ESS that runs
+    # in-core (e.g., 'pyscf'), since ARC validates every ESS's server against this dictionary.
+    # Set 'cluster_soft' to 'local' on a workstation with no queueing system: jobs then run
+    # in-core or as a local pipe worker pool rather than being submitted to a queue.
     'local': {
-        'cluster_soft': 'HTCondor',
+        'cluster_soft': 'HTCondor',  # or 'Slurm'/'PBS'/'OGE'/'SGE', or 'local' if there is no queue
         'un': '<username>',
         'cpus': 48,
         'queues': {'':''},  # {'queue_name':'HH:MM:SS'}
@@ -346,6 +350,11 @@ pipe_settings = {
     'enabled': False,          # Set to True to enable pipe mode (it is off by default, use it for large compute campaigns).
     'min_tasks': 10,           # Minimum batch size to trigger pipe mode.
     'max_workers': 100,        # Upper bound on array worker slots per PipeRun.
+    'run_locally': False,      # Run the pipe array as a local pool of worker processes instead of
+                               # submitting it to a queue. Use on a workstation with no queueing
+                               # system (e.g., to parallelize local PySCF jobs).
+    'local_max_workers': None, # Concurrent local workers. None derives a limit from the available
+                               # cores and memory; set an int to override.
     'max_attempts': 3,         # Retry budget per task before terminal failure.
     'lease_duration_hrs': 1,   # Worker lease duration in hours (default 1h).
     'env_setup': {},           # Engine-specific shell setup commands, e.g.,

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -93,10 +93,11 @@ global_ess_settings = {
     'openbabel': 'local',
     'orca_neb': 'local',
     'ase': 'local',
+    'pyscf': 'local',
 }
 
 # Electronic structure software ARC may access (use lowercase):
-supported_ess = ['cfour', 'gaussian', 'mockter', 'molpro', 'orca', 'qchem', 'terachem', 'onedmin', 'xtb', 'torchani', 'openbabel', 'ase']
+supported_ess = ['cfour', 'gaussian', 'mockter', 'molpro', 'orca', 'qchem', 'terachem', 'onedmin', 'xtb', 'torchani', 'openbabel', 'ase', 'pyscf']
 
 # TS methods to try when appropriate for a reaction (other than user guesses which are always allowed):
 # Note: 'goflow' and 'rits' are intentionally NOT in the default — their envs
@@ -132,6 +133,9 @@ levels_ess = {
     'xtb': ['xtb', 'gfn'],
     'torchani': ['torchani'],
     'openbabel': ['mmff94s', 'mmff94', 'gaff', 'uff', 'ghemical'],
+    # Note: 'pyscf' is deliberately not listed here. Adding a phrase such as 'wb97m-v' would
+    # silently re-route levels that currently run on QChem/Gaussian to the local PySCF adapter.
+    # PySCF is opt-in: request it explicitly (e.g. Level(..., software='pyscf')).
 }
 
 check_status_command = {'OGE': 'export SGE_ROOT=/opt/sge; /opt/sge/bin/lx24-amd64/qstat -u $USER',
@@ -181,6 +185,7 @@ input_filenames = {'ase': 'input.yml',
                    'qchem': 'input.in',
                    'terachem': 'input.in',
                    'xtb': 'input.sh',
+                   'pyscf': 'input.yml',
                    }
 
 output_filenames = {'ase': 'output.yml',
@@ -199,6 +204,7 @@ output_filenames = {'ase': 'output.yml',
                     'torchani': 'output.yml',
                     'xtb': 'output.out',
                     'openbabel':'output.yml',
+                    'pyscf': 'output.yml',
                     }
 
 default_levels_of_theory = {'conformer': 'wb97xd/def2svp',  # it's recommended to choose a method with dispersion
@@ -426,6 +432,7 @@ GOFLOW_PYTHON = find_executable('goflow_env')
 RITS_PYTHON = find_executable('rits_env')
 ARC_PYTHON = find_executable('arc_env')
 XTB_PYTHON = find_executable('xtb_env')
+PYSCF_PYTHON = find_executable('pyscf_env')
 RMG_ENV_NAME = 'rmg_env'
 RMG_PYTHON = find_executable('rmg_env')
 XTB = find_executable('xtb_env', 'xtb')

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -433,6 +433,9 @@ RITS_PYTHON = find_executable('rits_env')
 ARC_PYTHON = find_executable('arc_env')
 XTB_PYTHON = find_executable('xtb_env')
 PYSCF_PYTHON = find_executable('pyscf_env')
+# Device PySCF runs on: 'cpu', or 'gpu' to use an NVIDIA GPU via gpu4pyscf (which must be
+# installed in pyscf_env). Closed-shell analytic Hessians always fall back to the CPU.
+PYSCF_DEVICE = 'cpu'
 RMG_ENV_NAME = 'rmg_env'
 RMG_PYTHON = find_executable('rmg_env')
 XTB = find_executable('xtb_env', 'xtb')

--- a/arc/settings/submit.py
+++ b/arc/settings/submit.py
@@ -115,6 +115,7 @@ export OPENBLAS_NUM_THREADS={cpus}
 for WORKER_ID in $(seq 1 {max_task_num}); do
     (
 {env_setup}
+        export ARC_PIPE_LOCAL_CPUS={cpus}
         {python_exe} -m arc.scripts.pipe_worker --pipe_root {pipe_root} --worker_id $WORKER_ID
     ) > {pipe_root}/out_$WORKER_ID.txt 2> {pipe_root}/err_$WORKER_ID.txt &
 done

--- a/arc/settings/submit.py
+++ b/arc/settings/submit.py
@@ -102,6 +102,25 @@ error = {pipe_root}/err_$(Process).txt
 log = {pipe_root}/condor.log
 queue {max_task_num}
 """,
+    # No queueing system: run the array locally as a pool of background worker processes.
+    # Pipe workers claim tasks from the shared pipe root themselves, so plain concurrent
+    # workers reproduce array semantics without a scheduler. Each worker is pinned to
+    # {cpus} threads so the pool cannot oversubscribe the machine.
+    'local': """#!/bin/bash
+
+export OMP_NUM_THREADS={cpus}
+export MKL_NUM_THREADS={cpus}
+export OPENBLAS_NUM_THREADS={cpus}
+
+for WORKER_ID in $(seq 1 {max_task_num}); do
+    (
+{env_setup}
+        {python_exe} -m arc.scripts.pipe_worker --pipe_root {pipe_root} --worker_id $WORKER_ID
+    ) > {pipe_root}/out_$WORKER_ID.txt 2> {pipe_root}/err_$WORKER_ID.txt &
+done
+
+wait
+""",
 }
 
 

--- a/devtools/install_all.sh
+++ b/devtools/install_all.sh
@@ -105,6 +105,7 @@ if [[ $SKIP_EXT == false ]]; then
         [TorchANI]=install_torchani.sh
         [GoFlow]=install_goflow.sh
         [RitS]=install_rits.sh
+        [PySCF]=install_pyscf.sh
     )
 
     # Optionally drop GoFlow — used by `make install-ci` since CI runs GoFlow in its own lane
@@ -125,6 +126,7 @@ if [[ $SKIP_EXT == false ]]; then
        [install_autotst.sh]="--conda"
        [install_goflow.sh]="--cpu --no-ckpt-check"
        [install_rits.sh]="--cpu --no-ckpt-check"
+       [install_pyscf.sh]="--cuda --gpu"
         # add more later, e.g.  [install_xtb.sh]="--cuda --prefix"
     )
 

--- a/devtools/install_pyscf.sh
+++ b/devtools/install_pyscf.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# install_pyscf.sh - Set up the 'pyscf_env' environment for ARC's PySCF ESS adapter.
+#
+# PySCF is a Python quantum-chemistry package that ARC runs as a local, in-core ESS (no external
+# scheduler), shelling out to a dedicated 'pyscf_env' conda environment from arc_env. This script
+# wraps every step needed to get PySCF working:
+#
+#   1. Create the 'pyscf_env' conda env from devtools/pyscf_environment.yml (CPU baseline: the
+#      pyscf and pyscf-dispersion PyPI wheels installed via the yml's pip: block).
+#   2. With --cuda/--gpu, additionally install the GPU stack (gpu4pyscf-cuda12x) on top.
+#   3. Verify the pyscf (and, for GPU, gpu4pyscf) imports the adapter relies on.
+#
+# The CPU baseline is wired into devtools/install_all.sh, so a plain `make install` yields a
+# working CPU pyscf_env. The GPU stack is opt-in (a CUDA 12.x toolkit + NVIDIA GPU are required):
+#
+# Usage:
+#   bash devtools/install_pyscf.sh                 # install + verify the CPU baseline (default)
+#   bash devtools/install_pyscf.sh --cuda          # also install the gpu4pyscf-cuda12x GPU stack
+#   bash devtools/install_pyscf.sh --gpu           # alias for --cuda
+#
+# Re-running is safe: an existing 'pyscf_env' is updated in place.
+
+set -eo pipefail
+
+# gpu4pyscf-cuda12x pin for the optional GPU stack (CUDA 12.x wheels; see gpu4pyscf docs).
+GPU4PYSCF_PKG="gpu4pyscf-cuda12x==1.7.6"
+
+DEVICE="cpu"
+for arg in "$@"; do
+    case "$arg" in
+        --cpu) DEVICE="cpu" ;;
+        --cuda|--gpu) DEVICE="gpu" ;;
+        -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# Resolve repo paths from this script's location (no hard-coded paths).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_YAML="$SCRIPT_DIR/pyscf_environment.yml"
+ENV_NAME="$(grep -E '^ *name:' "$ENV_YAML" | head -1 | awk '{print $2}')"
+
+# 1) Pick a conda front-end and initialize shell integration.
+if command -v micromamba &>/dev/null; then
+    COMMAND_PKG=micromamba
+    eval "$(micromamba shell hook --shell=bash)"
+elif command -v mamba &>/dev/null; then
+    COMMAND_PKG=mamba
+    BASE=$(conda info --base); source "$BASE/etc/profile.d/conda.sh"
+elif command -v conda &>/dev/null; then
+    COMMAND_PKG=conda
+    BASE=$(conda info --base); source "$BASE/etc/profile.d/conda.sh"
+else
+    echo "❌  No micromamba/mamba/conda found in PATH." >&2
+    exit 1
+fi
+echo "✔️  Using $COMMAND_PKG"
+
+# 2) Create or update the CPU environment (pyscf + pyscf-dispersion via the yml's pip: block).
+if $COMMAND_PKG env list | grep -qE "^\s*${ENV_NAME}\s"; then
+    echo ">>> Updating existing '$ENV_NAME' from $ENV_YAML"
+    $COMMAND_PKG env update -n "$ENV_NAME" -f "$ENV_YAML" --prune
+else
+    echo ">>> Creating '$ENV_NAME' from $ENV_YAML"
+    $COMMAND_PKG env create -n "$ENV_NAME" -f "$ENV_YAML" -y
+fi
+
+# 3) Optionally layer the GPU stack on top.
+if [ "$DEVICE" = "gpu" ]; then
+    echo ">>> Installing the GPU stack ($GPU4PYSCF_PKG) into '$ENV_NAME'"
+    $COMMAND_PKG run -n "$ENV_NAME" pip install "$GPU4PYSCF_PKG"
+fi
+
+# 4) Verify the imports the PySCF adapter / pyscf_script.py depend on.
+echo ">>> Verifying pyscf imports in '$ENV_NAME'"
+$COMMAND_PKG run -n "$ENV_NAME" python - "$DEVICE" <<'PYCODE'
+import sys
+import pyscf
+print("pyscf", pyscf.__version__, "imports OK")
+if sys.argv[1] == "gpu":
+    import gpu4pyscf
+    print("gpu4pyscf", gpu4pyscf.__version__, "imports OK")
+PYCODE
+
+echo ""
+echo "✅  '$ENV_NAME' is ready. ARC discovers it via find_executable('$ENV_NAME')."
+if [ "$DEVICE" = "cpu" ]; then
+    echo "    Installed the CPU baseline; re-run with --cuda to add the gpu4pyscf GPU stack."
+fi
+echo "✅  PySCF setup script finished."

--- a/devtools/pyscf_environment.yml
+++ b/devtools/pyscf_environment.yml
@@ -1,0 +1,12 @@
+name: pyscf_env
+channels:
+  - conda-forge
+dependencies:
+  - python =3.11
+  - numpy
+  - pyyaml
+  - setuptools
+  - pip
+  - pip:
+      - pyscf==2.14.0
+      - pyscf-dispersion==1.5.0

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -125,6 +125,51 @@ submitted using the configured scheduler and submit template.
        'xtb': 'local',
    }
 
+Run PySCF In-Core (Queueless)
+-----------------------------
+
+PySCF is supported as a local, **in-core** ESS: ARC calls it in-process on the machine ARC runs
+on, with no external scheduler. This is aimed at workstations that have no queueing system.
+
+Install PySCF into its dedicated ``pyscf_env`` environment with the bundled script (also wired
+into ``devtools/install_all.sh``). ARC discovers the environment via ``find_executable('pyscf_env')``:
+
+.. code-block:: bash
+
+   bash devtools/install_pyscf.sh            # CPU baseline
+   bash devtools/install_pyscf.sh --cuda     # additionally install the gpu4pyscf GPU stack
+
+To run PySCF jobs, set the reserved ``local`` server's ``cluster_soft`` to ``'local'`` (no queue)
+and route ``pyscf`` to it. When ``cluster_soft`` is ``'local'``, the server's ``cpus`` is a single
+machine-wide CPU budget: it caps the cores any one in-core job may use and bounds the local worker
+pool. Set it below the physical core count to leave headroom:
+
+.. code-block:: python
+
+   servers = {
+       'local': {
+           'cluster_soft': 'local',   # no queueing system
+           'un': 'my_user',
+           'cpus': 12,                # machine-wide CPU budget (e.g. on a 16-core box)
+       },
+   }
+
+   global_ess_settings = {
+       'pyscf': 'local',
+   }
+
+Supported job types are single-point energy (``sp``), geometry optimization (``opt``), and
+frequencies (``freq``). A few things to know:
+
+* **GPU**: after installing with ``--cuda``, select the GPU globally by setting
+  ``PYSCF_DEVICE = 'gpu'`` in ``settings.py``, or per job via the ``args`` keyword
+  ``{'keyword': {'device': 'gpu'}}``. The GPU stack (gpu4pyscf) is pinned to a version that avoids
+  a known upstream Hessian regression, so GPU ``freq`` jobs are supported.
+* **Method and basis** always come from the job's level of theory. If an ``args`` keyword tries to
+  set a conflicting ``method`` or ``basis``, it is ignored (with a warning) so the computed result
+  matches the level ARC records.
+* If a PySCF job is ever routed to a queue, it transparently falls back to in-core execution.
+
 Run over SSH
 ------------
 


### PR DESCRIPTION
## Summary

Adds **PySCF as a local (in-core) electronic-structure adapter** so ARC can run DFT on the
workstation with **no PBS/zeus round-trip**. Uses the **YAML-handoff** in-core pattern (mirroring
`ase_adapter.py`): the engine script runs PySCF in a dedicated `pyscf_env` conda env, writes an
`output.yml` in ARC's internal schema, and ARC's `YAMLParser` re-parses it (the on-disk
`output.yml` is the entire contract).

**Scope: exactly `sp` + `opt` + `freq` (+`optfreq`), closed- and open-shell (RKS/UKS).**
IRC (no native PySCF path — needs Sella) and scans/rotors are **out of scope**, deferred.

## Level of theory & frequency method

- **ωB97M-V / def2-TZVP** — native VV10 nonlocal dispersion, no external dispersion package.
  (ωB97X-D3, the originally-requested level, is **not available in PySCF** — `wb97x_d3` is
  black-listed in `pyscf/scf/dispersion.py` and raises `NotImplementedError`. ωB97M-V was chosen
  as the replacement.)
- **Closed-shell (RKS): analytic Hessian** (VV10 second derivative is implemented).
- **Open-shell (UKS): numerical Hessian** (central finite difference of analytic gradients),
  because PySCF raises `NotImplementedError: UKS Hessian for NLC functional` — there is no analytic
  Hessian for NLC functionals in the unrestricted case.

## Validation (raw PySCF 2.14.0, ωB97M-V/def2-TZVP, before wiring the adapter)

| species | job | result |
|---|---|---|
| H₂O (RKS) | sp+opt+**analytic** Hess | E=−76.42960 Ha; r(O–H)=0.9611 Å; freqs [1617.5, 3823.7, 3927.5] cm⁻¹ (all real); ZPE 56.04 kJ/mol; |μ|=2.07 D |
| OH· (UKS) | sp+opt+**numerical** Hess | E=−75.74005 Ha; r(O–H)=0.9738 Å; freq 3728.6 cm⁻¹ (real) |

## End-to-end round-trip (through the full ARC adapter path, local, no zeus)

A real `optfreq` on H₂O via `PySCFAdapter.execute_incore()` → `output.yml` → `YAMLParser`:
`e_elect=−200665.877 kJ/mol`, geometry, freqs `[1617.5, 3823.7, 3927.5]`, ZPE `56.038 kJ/mol`,
dipole `2.0657 D`, normal modes `(3,3,3)` — all ingest cleanly.

## Schema decisions (output.yml, schema v1)

- **Energy units:** `sp` and `zpe` in **kJ/mol** (matching what `YAMLParser` consumes); scan
  `energies` would be Hartree — documented, but scans are out of scope here.
- **Geometry:** always emitted as an ARC xyz **dict** under `opt_xyz` (opt jobs) / `xyz` (sp/freq),
  never a string — addressing the geometry key/format drift.
- **Frequencies:** emitted as `freqs` (cm⁻¹, imaginary as negative reals) + `modes` + `zpe`, i.e.
  exactly the keys `YAMLParser` already ingests. **`hessian`/`reduced_masses`/`force_constants` are
  deliberately NOT emitted** since `YAMLParser` drops them (no written-but-dropped fields). Ingesting
  the analytic Hessian into Arkane is a follow-up (see below).
- **Error surfacing:** on failure the script writes `success: false` + `error`, and
  `YAMLParser.logfile_contains_errors()` now returns that error (previously always `None`), so a
  crashed local job isn't silently treated as done. Producers that don't emit `success` are unaffected.

## Files

- `arc/job/adapters/scripts/pyscf_script.py` — engine script (RKS/UKS sp/opt/freq via geomeTRIC +
  analytic/numerical Hessian; emits schema-v1 `output.yml`). Runs in `pyscf_env`.
- `arc/job/adapters/pyscf_adapter.py` — the `JobAdapter` (YAML in/out; launches the script via
  `run_in_conda_env` to isolate `pyscf_env`).
- `arc/job/adapters/pyscf_test.py` — unit tests (IO/logic mocked for CI; engine test skipped unless
  PySCF is importable). 7 passed, 1 skipped locally.
- `arc/parser/adapters/yaml.py` — error-surfacing fix (above).
- Registration: `supported_ess`, `global_ess_settings`, `levels_ess` (`wb97m-v`),
  `input_filenames`, `output_filenames`, `PYSCF_PYTHON` (settings.py); `JobEnum.pyscf` (adapter.py);
  adapter import (`adapters/__init__.py`); `register_job_adapter('pyscf', ...)`.

## Reviewer notes / follow-ups

- **Auto-routing:** `levels_ess['pyscf'] = ['wb97m-v']` routes wb97m-v jobs to PySCF. A local
  `~/.arc/settings.py` (if present) overrides `levels_ess`/`supported_ess`, so add `pyscf` there too
  to exercise routing on a machine that uses a local settings override.
- **Environment:** needs a `pyscf_env` conda env with `pyscf`, `geometric`, `pyyaml`.
- **Deferred:** IRC, scans/rotors; ingesting the (closed-shell) analytic Hessian into Arkane
  (`YAMLParser` currently reads freqs+modes+zpe, not the full Hessian).
- **TS opt** (`is_ts`) attempts a geomeTRIC saddle search (`transition=True`); validated here only
  for minimization.
