### PR TITLE
Add a first-class validated input schema for ARC (pydantic, mirroring T3)

### DIFF
--- a/ARC.py
+++ b/ARC.py
@@ -8,9 +8,13 @@ ARC - Automatic Rate Calculator
 import argparse
 import logging
 import os
+import sys
+
+from pydantic import ValidationError
 
 from arc.common import read_yaml_file
 from arc.main import ARC
+from arc.schema import validate_input_dict
 
 
 def parse_command_line_arguments(command_line_args=None):
@@ -48,7 +52,11 @@ def main():
     input_file = args.file
     project_directory = os.path.abspath(os.path.dirname(args.file))
     input_dict = read_yaml_file(path=input_file, project_directory=project_directory)
-    if 'project' not in list(input_dict.keys()):
+    if not isinstance(input_dict, dict):
+        print(f'Invalid ARC input file "{input_file}": expected a top-level mapping of ARC '
+              f'options, got {type(input_dict).__name__}.', file=sys.stderr)
+        sys.exit(1)
+    if 'project' not in input_dict:
         raise ValueError('A project name must be provided!')
 
     verbose = logging.INFO
@@ -59,7 +67,12 @@ def main():
     input_dict['verbose'] = input_dict['verbose'] if 'verbose' in input_dict else verbose
     if 'project_directory' not in input_dict or not input_dict['project_directory']:
         input_dict['project_directory'] = project_directory
-    arc_object = ARC(**input_dict)
+    try:
+        validated_input_dict = validate_input_dict(input_dict)
+    except (ValidationError, TypeError) as e:
+        print(f'Invalid ARC input file "{input_file}":\n{e}', file=sys.stderr)
+        sys.exit(1)
+    arc_object = ARC(**validated_input_dict)
     arc_object.execute()
 
 

--- a/arc/common.py
+++ b/arc/common.py
@@ -49,6 +49,10 @@ ARC_TESTING_PATH = os.path.join(ARC_PATH, 'arc', 'testing')
 
 VERSION = '1.1.0'
 
+# The input/restart file schema version. Bumped only when the input/restart contract changes,
+# NOT with ARC releases.
+ARC_INPUT_SCHEMA_VERSION = 1
+
 R = 8.31446261815324  # J/(mol*K)
 EA_UNIT_CONVERSION = {'J/mol': 1, 'kJ/mol': 1e+3, 'cal/mol': 4.184, 'kcal/mol': 4.184e+3}
 FULL_CIRCLE = 360.0

--- a/arc/common.py
+++ b/arc/common.py
@@ -95,7 +95,7 @@ def initialize_job_types(job_types: dict | None = None,
     defaults_to_true = ['conf_opt', 'fine', 'freq', 'irc', 'opt', 'rotors', 'sp']
     defaults_to_false = ['conf_sp', 'bde', 'onedmin', 'orbitals']
     if job_types is None:
-        job_types = default_job_types
+        job_types = default_job_types.copy()
         logger.info("Job types were not specified, using ARC's defaults")
     else:
         logger.debug(f'the following job types were specified: {job_types}.')

--- a/arc/common_test.py
+++ b/arc/common_test.py
@@ -428,6 +428,16 @@ class TestCommon(unittest.TestCase):
         job_types_initialized = common.initialize_job_types(job_types)
         self.assertEqual(job_types_expected, job_types_initialized)
 
+    def test_initialize_job_types_does_not_mutate_global(self):
+        """Test that initialize_job_types() does not mutate the module-level default_job_types dict.
+        It used to alias the global when job_types was None and then delete 'fine_grid' from it,
+        corrupting the defaults for every subsequent reader in the process."""
+        default_before = copy.deepcopy(common.default_job_types)
+        common.initialize_job_types(None)
+        common.initialize_job_types(None, specific_job_type='bde')
+        self.assertIn('fine_grid', common.default_job_types)
+        self.assertEqual(default_before, common.default_job_types)
+
     def test_initialize_job_with_specific_job_type(self):
         """Test the initialize_job_types() function"""
         specific_job_type = 'freq'

--- a/arc/job/factory.py
+++ b/arc/job/factory.py
@@ -34,6 +34,16 @@ def register_job_adapter(job_adapter_label: str,
     _registered_job_adapters[JobEnum(job_adapter_label.lower())] = job_adapter_class
 
 
+def get_registered_job_adapters() -> dict:
+    """
+    Get the registry of currently registered job adapters.
+
+    Returns:
+        dict: A mapping of ``JobEnum`` keys to their registered ``JobAdapter`` subclasses.
+    """
+    return _registered_job_adapters
+
+
 def job_factory(job_adapter: str,
                 project: str,
                 project_directory: str,

--- a/arc/job/factory_test.py
+++ b/arc/job/factory_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+This module contains unit tests for the arc.job.factory module
+"""
+
+import unittest
+
+from arc.job.adapter import JobAdapter, JobEnum
+from arc.job.factory import get_registered_job_adapters
+
+
+class TestFactory(unittest.TestCase):
+    """
+    Contains unit tests for the arc.job.factory module
+    """
+
+    def test_get_registered_job_adapters(self):
+        """Test that get_registered_job_adapters returns the live registry populated by
+        importing arc.job.adapters (registration decorators run at import time)"""
+        registered_job_adapters = get_registered_job_adapters()
+        self.assertIsInstance(registered_job_adapters, dict)
+        self.assertIn(JobEnum('gaussian'), registered_job_adapters)
+        for job_adapter_class in registered_job_adapters.values():
+            self.assertTrue(issubclass(job_adapter_class, JobAdapter))
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/main.py
+++ b/arc/main.py
@@ -15,7 +15,8 @@ import shutil
 import time
 from IPython.display import display
 
-from arc.common import (VERSION,
+from arc.common import (ARC_INPUT_SCHEMA_VERSION,
+                        VERSION,
                         ARC_PATH,
                         check_ess_settings,
                         delete_check_files,
@@ -30,7 +31,7 @@ from arc.common import (VERSION,
 from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 from arc.level import Level, assign_frequency_scale_factor
-from arc.job.factory import _registered_job_adapters
+from arc.job.factory import get_registered_job_adapters
 from arc.job.ssh import SSHClient
 from arc.output import write_output_yml
 from arc.processor import process_arc_project, resolve_neb_level
@@ -147,6 +148,10 @@ class ARC(object):
         ts_adapters (list, optional): Entries represent different TS adapters.
         report_e_elect (bool, optional): Whether to report electronic energy. Default is ``False``.
         skip_nmd (bool, optional): Whether to skip normal mode displacement check. Default is ``False``.
+        schema_version (int, optional): The input schema version read from a restart file.
+                                        Accepted for restart compatibility and ignored.
+        arc_version (str, optional): The ARC version that wrote a restart file.
+                                     Accepted for restart compatibility and ignored.
 
     Attributes:
         project (str): The project's name. Used for naming the working directory.
@@ -269,6 +274,8 @@ class ARC(object):
                  verbose=logging.INFO,
                  report_e_elect: bool | None = False,
                  skip_nmd: bool | None = False,
+                 schema_version: int | None = None,
+                 arc_version: str | None = None,
                  ):
 
         if project is None:
@@ -325,8 +332,9 @@ class ARC(object):
         self.ts_adapters = ts_adapters
         self.report_e_elect = report_e_elect
         self.skip_nmd = skip_nmd
+        registered_job_adapters = get_registered_job_adapters()
         for ts_adapter in self.ts_adapters or list():
-            if ts_adapter.lower() not in _registered_job_adapters.keys():
+            if ts_adapter.lower() not in registered_job_adapters.keys():
                 raise InputError(f'Unknown TS adapter: "{ts_adapter}"')
 
         # attributes related to level of theory specifications
@@ -430,6 +438,8 @@ class ARC(object):
         A helper function for dumping this object as a dictionary in a YAML file for restarting ARC.
         """
         restart_dict = dict()
+        restart_dict['schema_version'] = ARC_INPUT_SCHEMA_VERSION
+        restart_dict['arc_version'] = VERSION
         if self.adaptive_levels is not None:
             restart_dict['adaptive_levels'] = [
                 {'atom_range': [atom_range[0], atom_range[1]],

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -5,11 +5,17 @@
 This module contains unit tests for the arc.main module
 """
 
+import io
 import os
 import shutil
 import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
 
-from arc.common import ARC_PATH
+import yaml
+
+import ARC as arc_cli
+from arc.common import ARC_INPUT_SCHEMA_VERSION, ARC_PATH, VERSION
 from arc.exceptions import InputError
 from arc.imports import settings
 from arc.level import Level
@@ -68,7 +74,9 @@ class TestARC(unittest.TestCase):
         self.assertIn("'C-C': 1", long_thermo_description)
         self.assertIn("'C-H': 6", long_thermo_description)
         # mol.atoms are not tested since all id's (including connectivity) changes depending on how the test is run.
-        expected_dict = {'arkane_level_of_theory': {'basis': 'cc-pvdz-f12',
+        expected_dict = {'schema_version': ARC_INPUT_SCHEMA_VERSION,
+                         'arc_version': VERSION,
+                         'arkane_level_of_theory': {'basis': 'cc-pvdz-f12',
                                                     'method': 'ccsd(t)-f12',
                                                     'method_type': 'wavefunction',
                                                     'software': 'molpro'},
@@ -523,6 +531,31 @@ class TestARC(unittest.TestCase):
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestARCCliMain(unittest.TestCase):
+    """
+    Contains unit tests for the ARC.py CLI entry point's input validation seam
+    """
+
+    def test_main_exits_cleanly_on_invalid_input(self):
+        """Test that an invalid input file exits with a formatted pydantic error instead of a
+        raw traceback"""
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_cli_invalid_input_test')
+        os.makedirs(project_directory, exist_ok=True)
+        input_file = os.path.join(project_directory, 'input.yml')
+        try:
+            with open(input_file, 'w') as f:
+                yaml.dump({'project': 'arc_cli_invalid_input_test', 'verbose': 15}, f)
+            stderr = io.StringIO()
+            with patch('sys.argv', ['ARC.py', input_file]):
+                with redirect_stderr(stderr):
+                    with self.assertRaises(SystemExit) as excinfo:
+                        arc_cli.main()
+            self.assertEqual(excinfo.exception.code, 1)
+            self.assertIn('verbose', stderr.getvalue())
+        finally:
+            shutil.rmtree(project_directory, ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -525,7 +525,7 @@ def draw_kinetics_plots(rxn_list: list,
     if T_max is None:
         T_max = (3000, 'K')
     elif isinstance(T_max, (int, float)):
-        T_max = (T_min, 'K')
+        T_max = (T_max, 'K')
     temperatures = np.linspace(T_min[0], T_max[0], T_count)
 
     pp = None

--- a/arc/plotter_test.py
+++ b/arc/plotter_test.py
@@ -8,6 +8,7 @@ This module contains unit tests for the plotter functions
 import os
 import shutil
 import unittest
+from unittest.mock import patch
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file, safe_copy_file
@@ -218,6 +219,12 @@ H      -1.16115119    0.31478894   -0.81506145
         plotter.save_irc_traj_animation(irc_f_path, irc_r_path, out_path)
         self.assertTrue(os.path.isfile(out_path))
 
+    def test_draw_kinetics_plots_bare_scalar_t_max(self):
+        """Regression test: a bare scalar T_max must be used as-is, not silently replaced by T_min
+        (a prior bug normalized T_max to (T_min, 'K') instead of (T_max, 'K'))"""
+        with patch.object(plotter.np, 'linspace') as mock_linspace:
+            plotter.draw_kinetics_plots(rxn_list=[], T_min=500, T_max=3000, T_count=10)
+        mock_linspace.assert_called_once_with(500, 3000, 10)
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/schema.py
+++ b/arc/schema.py
@@ -1,0 +1,480 @@
+"""
+ARC's schema module for input validation.
+
+Validates an ARC input (or restart) dictionary at load time, before instantiating ARC.
+Field names and defaults mirror the ``ARC.__init__`` keyword arguments and the key names
+emitted by ``ARC.as_dict()`` into ``restart.yml``.
+"""
+
+from enum import Enum
+from typing import Annotated
+
+from pydantic import BaseModel, Field, StrictBool, StrictInt, field_serializer, field_validator, model_validator
+
+from arc.common import ARC_INPUT_SCHEMA_VERSION, get_logger
+from arc.job.factory import get_registered_job_adapters
+from arc.settings.settings import default_job_types
+from arc.statmech.adapter import StatmechEnum
+
+
+logger = get_logger()
+
+
+class BACTypeEnum(str, Enum):
+    """
+    The supported bond additivity correction types.
+    'p' for Petersson-type and 'm' for Melius-type BAC.
+    """
+    petersson = 'p'
+    melius = 'm'
+
+
+class TemperatureUnitEnum(str, Enum):
+    """
+    The supported units for a T_min/T_max (value, unit) pair.
+    Only Kelvin is supported: neither ``plotter.py`` nor ``processor.py`` convert the unit
+    before using the value, so any other unit would be silently treated as Kelvin.
+    """
+    kelvin = 'K'
+
+
+class JobTypes(BaseModel):
+    """
+    A class for validating the ``job_types`` argument of an ARC input.
+    """
+    conf_opt: StrictBool = default_job_types['conf_opt']
+    conf_sp: StrictBool = default_job_types['conf_sp']
+    opt: StrictBool = default_job_types['opt']
+    fine_grid: StrictBool = default_job_types['fine_grid']
+    freq: StrictBool = default_job_types['freq']
+    sp: StrictBool = default_job_types['sp']
+    rotors: StrictBool = default_job_types['rotors']
+    irc: StrictBool = default_job_types['irc']
+    orbitals: StrictBool = default_job_types['orbitals']
+    lennard_jones: StrictBool = default_job_types['lennard_jones']
+    bde: StrictBool = default_job_types['bde']
+    fine: StrictBool | None = None
+    onedmin: StrictBool | None = None
+
+    class Config:
+        extra = "forbid"
+
+    @model_validator(mode='after')
+    def check_fine_not_explicit_none(self) -> 'JobTypes':
+        """
+        Reject an explicit null for ``fine`` while still allowing it to be absent.
+
+        ``initialize_job_types`` in ``arc/common.py`` fills ``fine``'s default (``True``) only when
+        the key is missing from ``job_types``. An explicit ``fine: null`` is present, so it skips
+        default-filling and stays ``None``, which is falsy and silently disables the job type. An
+        absent ``fine`` is unaffected and still receives the default. ``onedmin`` is not guarded:
+        it defaults to ``False``, so an explicit ``onedmin: null`` is behaviorally identical to
+        omitting it.
+
+        Returns:
+            JobTypes: This instance, unchanged, once validated.
+        """
+        if 'fine' in self.model_fields_set and self.fine is None:
+            raise ValueError(
+                "job_types.fine was explicitly set to null. ARC only fills the default value for "
+                "'fine' when it is absent from job_types; an explicit null is kept as None "
+                "(falsy), which would silently disable fine-grid optimization. Omit 'fine' "
+                "entirely to use the default, or set it to true/false explicitly.")
+        return self
+
+    @model_validator(mode='after')
+    def check_alias_pairs_not_contradictory(self) -> 'JobTypes':
+        """
+        Reject contradictory values between a legacy/input alias and its ARC-internal counterpart.
+
+        ``initialize_job_types`` in ``arc/common.py`` unconditionally overwrites the internal key
+        (``fine``, ``onedmin``) with the legacy/input key's value (``fine_grid``, ``lennard_jones``)
+        whenever both are present, silently discarding the internal key's value with no warning.
+        Raise instead of allowing that silent data loss when the two explicitly disagree.
+
+        Returns:
+            JobTypes: This instance, unchanged, once validated.
+        """
+        fields_set = self.model_fields_set
+        for input_name, internal_name in (('fine_grid', 'fine'), ('lennard_jones', 'onedmin')):
+            if input_name in fields_set and internal_name in fields_set:
+                input_value = getattr(self, input_name)
+                internal_value = getattr(self, internal_name)
+                if input_value != internal_value:
+                    raise ValueError(
+                        f"Contradictory job_types values: '{input_name}'={input_value} but "
+                        f"'{internal_name}'={internal_value}. '{input_name}' takes precedence over "
+                        f"'{internal_name}' in ARC, so '{internal_name}' would be silently discarded; "
+                        f"set both to the same value or specify only one of them.")
+        return self
+
+
+class Species(BaseModel):
+    """
+    A class for validating a species entry of an ARC input.
+    Mirrors the ``ARCSpecies.__init__`` input surface plus every runtime/restart key that
+    ``ARCSpecies.as_dict()`` writes; unknown keys are rejected.
+    """
+    label: str
+    active: dict | None = None
+    adjlist: str | None = None
+    adaptive_lot_n_heavy: StrictInt | None = None
+    arkane_file: str | None = None
+    bdes: list | None = None
+    bond_corrections: dict | None = None
+    charge: StrictInt | None = None
+    cheap_conformer: dict | str | None = None
+    checkfile: str | None = None
+    chosen_ts: StrictInt | None = None
+    chosen_ts_list: list | None = None
+    chosen_ts_method: str | None = None
+    compute_thermo: StrictBool | None = None
+    conf_is_isomorphic: StrictBool | None = None
+    conformer_energies: list | None = None
+    conformers: list | None = None
+    conformers_before_opt: list | None = None
+    consider_all_diastereomers: StrictBool = True
+    directed_rotors: dict | None = None
+    e0: float | None = None
+    e0_only: StrictBool = False
+    e_elect: float | None = None
+    external_symmetry: Annotated[int, Field(ge=1, strict=True)] | None = None
+    final_xyz: dict | str | None = None
+    force_field: str = 'MMFF94s'
+    fragments: list | None = None
+    freqs: list | None = None
+    inchi: str | None = None
+    include_in_thermo_lib: StrictBool | None = True
+    index: StrictInt | None = None
+    initial_xyz: dict | str | None = None
+    irc_label: str | None = None
+    is_ts: StrictBool = False
+    keep_mol: StrictBool = False
+    long_thermo_description: str | None = None
+    mol: str | dict | None = None
+    mol_list: list | None = None
+    most_stable_conformer: StrictInt | None = None
+    multi_species: str | None = None
+    multiplicity: Annotated[int, Field(ge=1, strict=True)] | None = None
+    neg_freqs_trshed: list | None = None
+    number_of_radicals: Annotated[int, Field(ge=0, strict=True)] | None = None
+    number_of_rotors: StrictInt | None = None
+    opt_level: str | None = None
+    optical_isomers: Annotated[int, Field(ge=1, strict=True)] | None = None
+    original_label: str | None = None
+    preserve_param_in_scan: list | None = None
+    project_directory: str | None = None
+    radius: float | None = None
+    recent_md_conformer: dict | str | None = None
+    rotors_dict: dict | None = None
+    run_time: float | None = None
+    rxn_index: StrictInt | None = None
+    rxn_label: str | None = None
+    rxn_zone_atom_indices: list | None = None
+    smiles: str | None = None
+    successful_methods: list | None = None
+    t1: float | None = None
+    thermo_at_own_level: StrictBool = False
+    ts_checks: dict | None = None
+    ts_conf_spawned: StrictBool | None = None
+    ts_guesses: list | None = None
+    ts_guesses_exhausted: StrictBool | None = None
+    ts_methods: list | None = None
+    ts_number: StrictInt | None = None
+    ts_report: str | None = None
+    tsg_spawned: StrictBool | None = None
+    unsuccessful_methods: list | None = None
+    xyz: list | dict | str | None = None
+    yml_path: str | None = None
+    zmat: dict | None = None
+
+    class Config:
+        extra = "forbid"
+
+    @model_validator(mode='after')
+    def check_structure_specified(self) -> 'Species':
+        """
+        Ensure a non-TS species has at least one structure specification.
+
+        Returns:
+            Species: The validated Species instance.
+        """
+        if not self.is_ts:
+            sources = (self.smiles, self.inchi, self.adjlist, self.xyz, self.mol, self.yml_path,
+                       self.initial_xyz, self.final_xyz, self.conformers, self.cheap_conformer)
+            if not any(sources):
+                raise ValueError(f'A non-TS species must have at least one structure specification '
+                                 f'(SMILES, InChI, adjlist, xyz, mol, or a yml_path). '
+                                 f'Got none for species "{self.label}".')
+        return self
+
+
+class Reaction(BaseModel):
+    """
+    A class for validating a reaction entry of an ARC input.
+    Mirrors the ``ARCReaction.__init__`` input surface plus every runtime/restart key that
+    ``ARCReaction.as_dict()`` writes; unknown keys are rejected.
+    """
+    label: str = ''
+    atom_map: list | None = None
+    charge: StrictInt | None = None
+    done_opt_r_n_p: StrictBool | None = None
+    family: str | None = None
+    family_own_reverse: StrictBool | StrictInt | None = None
+    index: StrictInt | None = None
+    kinetics: dict | None = None
+    long_kinetic_description: str | None = None
+    multiplicity: Annotated[int, Field(ge=1, strict=True)] | None = None
+    p_species: list | None = None
+    preserve_param_in_scan: list | None = None
+    products: list[str] | None = None
+    r_species: list | None = None
+    reactants: list[str] | None = None
+    ts_label: str | None = None
+    ts_methods: list | None = None
+    ts_species: dict | None = None
+    ts_xyz_guess: list | str | None = None
+    xyz: list | str | None = None
+
+    class Config:
+        extra = "forbid"
+
+    @model_validator(mode='after')
+    def check_reaction_identified(self) -> 'Reaction':
+        """
+        Ensure the reaction can be identified via a label, or both reactants and products.
+
+        ``ARCReaction.from_dict`` calls ``set_label_reactants_products`` before it converts the
+        ``r_species``/``p_species`` dicts into species objects, so those dicts alone cannot identify
+        a reaction at load time and ARC would raise. Only a ``label`` or explicit ``reactants`` and
+        ``products`` label lists satisfy ARC.
+
+        Returns:
+            Reaction: The validated Reaction instance.
+        """
+        if not self.label and not (self.reactants and self.products):
+            raise ValueError('A reaction must have either a label, or both reactants and products.')
+        return self
+
+
+class ARCInput(BaseModel):
+    """
+    A class for validating an ARC input (or restart) dictionary.
+    Field names and defaults mirror ``ARC.__init__``; unknown keys are rejected.
+    """
+    project: str
+    adaptive_levels: list | dict | None = None
+    allow_nonisomorphic_2d: StrictBool = False
+    arc_version: str | None = None
+    arkane_level_of_theory: str | dict | None = None
+    bac_type: BACTypeEnum | None = 'p'
+    bath_gas: str | None = None
+    calc_freq_factor: StrictBool = True
+    compare_to_rmg: StrictBool = True
+    composite_method: str | dict | None = None
+    compute_rates: StrictBool = True
+    compute_thermo: StrictBool = True
+    compute_transport: StrictBool = False
+    conformer_level: str | dict | None = None
+    conformer_opt_level: str | dict | None = None
+    conformer_sp_level: str | dict | None = None
+    dont_gen_confs: list[str] | None = None
+    e_confs: Annotated[float, Field(ge=0)] = 5.0
+    ess_settings: dict | None = None
+    freq_level: str | dict | None = None
+    freq_scale_factor: Annotated[float, Field(gt=0)] | None = None
+    irc_level: str | dict | None = None
+    job_memory: Annotated[int, Field(gt=0, strict=True)] | None = None
+    job_types: JobTypes | None = None
+    keep_checks: StrictBool = False
+    kinetics_adapter: StatmechEnum = 'arkane'
+    level_of_theory: str | None = ''
+    max_job_time: Annotated[float, Field(ge=0)] | None = None
+    n_confs: Annotated[int, Field(gt=0, strict=True)] | None = 10
+    opt_level: str | dict | None = None
+    orbitals_level: str | dict | None = None
+    output: dict | None = None
+    output_multi_spc: dict | None = None
+    project_directory: str | None = None
+    reactions: list[Reaction] | None = None
+    report_e_elect: StrictBool | None = False
+    running_jobs: dict | None = None
+    scan_level: str | dict | None = None
+    schema_version: StrictInt | None = None
+    skip_nmd: StrictBool | None = False
+    sp_level: str | dict | None = None
+    species: list[Species] | None = None
+    specific_job_type: str | None = ''
+    T_count: Annotated[int, Field(gt=0, strict=True)] | None = 50
+    T_max: Annotated[float, Field(gt=0)] | tuple[Annotated[float, Field(gt=0)], TemperatureUnitEnum] | None = None
+    T_min: Annotated[float, Field(gt=0)] | tuple[Annotated[float, Field(gt=0)], TemperatureUnitEnum] | None = None
+    thermo_adapter: StatmechEnum = 'arkane'
+    trsh_ess_jobs: StrictBool = True
+    trsh_rotors: StrictBool = True
+    ts_adapters: list[str] | None = None
+    ts_guess_level: str | dict | None = None
+    verbose: Annotated[int, Field(ge=10, le=50, multiple_of=10, strict=True)] = 20
+
+    class Config:
+        extra = "forbid"
+        use_enum_values = True
+
+    @model_validator(mode='after')
+    def check_schema_version(self) -> 'ARCInput':
+        """
+        Validate the ``schema_version`` key of an input/restart file against the running ARC.
+
+        An absent ``schema_version`` is accepted silently (files written before versioning).
+        An explicit null is rejected, a version newer than the running ARC's
+        ``ARC_INPUT_SCHEMA_VERSION`` is rejected, and an older version logs a warning.
+
+        Returns:
+            ARCInput: This instance, unchanged, once validated.
+        """
+        if 'schema_version' in self.model_fields_set:
+            if self.schema_version is None:
+                raise ValueError(
+                    f'schema_version was explicitly set to null. Omit the key entirely, or set it '
+                    f'to the input schema version this ARC writes ({ARC_INPUT_SCHEMA_VERSION}).')
+            if self.schema_version > ARC_INPUT_SCHEMA_VERSION:
+                raise ValueError(
+                    f'schema_version {self.schema_version} is newer than the input schema version '
+                    f'{ARC_INPUT_SCHEMA_VERSION} supported by this ARC. This file was written by a '
+                    f'newer ARC; upgrade ARC to run it.')
+            if self.schema_version < ARC_INPUT_SCHEMA_VERSION:
+                logger.warning(f'schema_version {self.schema_version} is older than the input schema '
+                               f'version {ARC_INPUT_SCHEMA_VERSION} supported by this ARC, '
+                               f'proceeding anyway.')
+        return self
+
+    @field_serializer('T_min', 'T_max')
+    def serialize_temperature_tuple(self, value: float | tuple[float, str] | None) -> float | list | None:
+        """
+        Serialize a (value, unit) temperature tuple as a plain list, leaving a bare scalar as-is.
+
+        Plain ``yaml.dump`` serializes a Python tuple with a ``!!python/tuple`` tag, which
+        corrupts restart.yml round-trips; a plain list dumps as an ordinary YAML sequence. A bare
+        scalar (raw ARC's shorthand for a Kelvin temperature) must round-trip as a scalar, since
+        ``processor.py`` normalizes it downstream and normalizing it here would change the
+        restart file shape.
+
+        Args:
+            value: The validated (value, unit) tuple, a bare scalar, or None.
+
+        Returns:
+            The (value, unit) pair as a list, the bare scalar unchanged, or None.
+        """
+        if isinstance(value, tuple):
+            return list(value)
+        return value
+
+    @field_validator('thermo_adapter', 'kinetics_adapter', 'bac_type', mode='before')
+    @classmethod
+    def lowercase_adapter_and_bac_type(cls, value):
+        """
+        Lowercase a statmech adapter/BAC type name before enum validation, mirroring ARC.__init__
+        (``arc/arkane.py`` compares ``bac_type.lower()`` against single-letter codes).
+
+        Args:
+            value: The raw field value.
+
+        Returns:
+            The lowercased value if it is a string, otherwise the original value.
+        """
+        return value.lower() if isinstance(value, str) else value
+
+    @field_validator('job_memory', 'n_confs', 'T_count', mode='before')
+    @classmethod
+    def coerce_integral_float(cls, value):
+        """
+        Convert an integral float (e.g., ``14.0``) to an int before strict-int validation.
+
+        Raw ARC accepts a float memory/count value, so a previously-working input file must
+        not hard-fail at load merely for spelling an integer as a float. Non-integral floats
+        and strings are left untouched, so they still fail the field's strict-int validation.
+
+        Args:
+            value: The raw field value.
+
+        Returns:
+            The value as an int if it was an integral float, otherwise the original value.
+        """
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return value
+
+    @field_validator('allow_nonisomorphic_2d', 'calc_freq_factor', 'compare_to_rmg', 'compute_rates',
+                     'compute_thermo', 'compute_transport', 'keep_checks', 'report_e_elect',
+                     'skip_nmd', 'trsh_ess_jobs', 'trsh_rotors', mode='before')
+    @classmethod
+    def coerce_int_flag(cls, value):
+        """
+        Convert an integer ``0``/``1`` to a bool before strict-bool validation of a run flag.
+
+        Raw ARC treats these flags with plain truthiness, so a previously-working input file that
+        spells a flag as ``0``/``1`` must not hard-fail at load. Any other value (including a
+        quoted ``"False"`` or an out-of-range int like ``2``) is left untouched, so it still fails
+        the field's strict-bool validation and cannot silently invert the flag.
+
+        Args:
+            value: The raw field value.
+
+        Returns:
+            ``False``/``True`` if the value was ``0``/``1``, otherwise the original value.
+        """
+        if isinstance(value, int) and not isinstance(value, bool) and value in (0, 1):
+            return bool(value)
+        return value
+
+    @field_validator('ts_adapters')
+    @classmethod
+    def check_ts_adapters(cls, value):
+        """
+        ARCInput.ts_adapters validator.
+
+        Args:
+            value: The ts_adapters list to validate.
+
+        Returns:
+            The validated ts_adapters list.
+        """
+        if value is not None:
+            registered_job_adapters = get_registered_job_adapters()
+            for ts_adapter in value:
+                if ts_adapter.lower() not in registered_job_adapters.keys():
+                    raise ValueError(f'Unknown TS adapter: "{ts_adapter}". Registered job adapters are: '
+                                     f'{[adapter.value for adapter in registered_job_adapters.keys()]}')
+        return value
+
+    def as_input_dict(self) -> dict:
+        """
+        Return a plain dict suitable for ARC(**...), enums dumped as their string values.
+
+        Dumps with ``exclude_unset=True`` so the result reproduces exactly the keys the user
+        provided (including explicit ``None`` values, which ARC treats differently from absent
+        keys, e.g. ``bac_type: None`` disables BAC while an absent ``bac_type`` defaults to 'p';
+        ``ARCSpecies.from_dict()`` gates on key presence, so injecting default/None-valued keys
+        would change behavior).
+
+        Strips ``schema_version`` and ``arc_version`` so they never reach ``ARC(**...)``.
+
+        Returns:
+            dict: The dictionary representation of the validated input.
+        """
+        dumped = self.model_dump(exclude_unset=True)
+        dumped.pop('schema_version', None)
+        dumped.pop('arc_version', None)
+        return dumped
+
+
+def validate_input_dict(input_dict: dict) -> dict:
+    """
+    Validate an ARC input/restart dictionary and return kwargs safe for ARC(**...).
+
+    Args:
+        input_dict (dict): The raw ARC input (or restart) dictionary to validate.
+
+    Returns:
+        dict: The validated dictionary, safe to unpack into ``ARC(**...)``.
+    """
+    return ARCInput(**input_dict).as_input_dict()

--- a/arc/schema_test.py
+++ b/arc/schema_test.py
@@ -1,0 +1,843 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+This module contains unit tests for the arc.schema module
+"""
+
+import copy
+import glob
+import inspect
+import logging
+import os
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from arc.common import ARC_INPUT_SCHEMA_VERSION, ARC_PATH, VERSION, get_logger, read_yaml_file
+from arc.main import ARC
+from arc.reaction import ARCReaction
+from arc.schema import ARCInput, BACTypeEnum, JobTypes, Reaction, Species, validate_input_dict
+from arc.settings.settings import default_job_types
+from arc.species.species import ARCSpecies
+
+
+def test_arc_input_minimal():
+    """Test creating a minimal ARCInput instance"""
+    arc_input = ARCInput(project='test_schema')
+    assert arc_input.project == 'test_schema'
+    assert arc_input.verbose == 20
+    assert arc_input.bac_type == 'p'
+    assert arc_input.thermo_adapter == 'arkane'
+    assert arc_input.kinetics_adapter == 'arkane'
+    assert arc_input.n_confs == 10
+    assert arc_input.e_confs == 5.0
+    assert arc_input.T_count == 50
+    assert arc_input.level_of_theory == ''
+    assert arc_input.specific_job_type == ''
+    assert arc_input.species is None
+    assert arc_input.reactions is None
+    assert arc_input.compute_thermo is True
+    assert arc_input.compute_rates is True
+    assert arc_input.compute_transport is False
+    assert arc_input.allow_nonisomorphic_2d is False
+    assert arc_input.trsh_ess_jobs is True
+    assert arc_input.trsh_rotors is True
+
+
+def test_arc_input_requires_project():
+    """Test that a project name is required"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput()
+    assert 'project' in str(excinfo.value)
+
+
+def test_arc_input_bac_type():
+    """Test the bac_type field"""
+    arc_input = ARCInput(project='p', bac_type='m')
+    assert arc_input.bac_type == 'm'
+    arc_input = ARCInput(project='p', bac_type=None)
+    assert arc_input.bac_type is None
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', bac_type='x')
+    assert 'bac_type' in str(excinfo.value)
+    assert [e.value for e in BACTypeEnum] == ['p', 'm']
+
+
+def test_arc_input_bac_type_is_case_insensitive():
+    """Test that bac_type is lowercased before enum validation (arc/arkane.py compares
+    bac_type.lower() == 'm'), but the spelled-out name is still rejected since arc/arkane.py
+    writes the raw value straight into the Arkane input as bondCorrectionType"""
+    arc_input = ARCInput(project='p', bac_type='P')
+    assert arc_input.bac_type == 'p'
+    arc_input = ARCInput(project='p', bac_type='M')
+    assert arc_input.bac_type == 'm'
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', bac_type='petersson')
+    assert 'bac_type' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', bac_type='PETERSSON')
+    assert 'bac_type' in str(excinfo.value)
+
+
+def test_arc_input_statmech_adapters():
+    """Test the thermo_adapter and kinetics_adapter fields"""
+    arc_input = ARCInput(project='p', thermo_adapter='Arkane', kinetics_adapter='Arkane')
+    assert arc_input.thermo_adapter == 'arkane'
+    assert arc_input.kinetics_adapter == 'arkane'
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', thermo_adapter='mess')
+    assert 'thermo_adapter' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', kinetics_adapter='unsupported')
+    assert 'kinetics_adapter' in str(excinfo.value)
+
+
+def test_arc_input_ts_adapters():
+    """Test the ts_adapters field validator"""
+    arc_input = ARCInput(project='p', ts_adapters=['heuristics', 'GCN'])
+    assert arc_input.ts_adapters == ['heuristics', 'GCN']
+    arc_input = ARCInput(project='p', ts_adapters=[])
+    assert arc_input.ts_adapters == list()
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', ts_adapters=['no_such_adapter'])
+    assert 'ts_adapters' in str(excinfo.value)
+
+
+def test_arc_input_numeric_constraints():
+    """Test numeric field constraints"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', n_confs=0)
+    assert 'n_confs' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', e_confs=-1.0)
+    assert 'e_confs' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_count=-5)
+    assert 'T_count' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', max_job_time=-1)
+    assert 'max_job_time' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_memory=-14)
+    assert 'job_memory' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', freq_scale_factor=0)
+    assert 'freq_scale_factor' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', verbose=25)
+    assert 'verbose' in str(excinfo.value)
+    # max_job_time=0 is falsy and treated by ARC as "use the default", so it must be accepted.
+    assert ARCInput(project='p', max_job_time=0).max_job_time == 0
+
+
+def test_arc_input_optional_string_fields_accept_none():
+    """Test that level_of_theory and specific_job_type accept an explicit null, as real restart
+    files and a bare input can carry, rather than only a string"""
+    arc_input = ARCInput(project='p', level_of_theory=None, specific_job_type=None)
+    assert arc_input.level_of_theory is None
+    assert arc_input.specific_job_type is None
+
+
+def test_arc_input_bool_flags_accept_int_0_1():
+    """Test that a run flag spelled as an integer 0/1 (a previously-working raw ARC input) is
+    coerced to a bool, while a quoted string or an out-of-range int still fails strict-bool
+    validation and cannot silently invert the flag"""
+    arc_input = ARCInput(project='p', compute_thermo=1, trsh_rotors=0)
+    assert arc_input.compute_thermo is True
+    assert arc_input.trsh_rotors is False
+    for bad in ('False', 2):
+        with pytest.raises(ValidationError) as excinfo:
+            ARCInput(project='p', compute_thermo=bad)
+        assert 'compute_thermo' in str(excinfo.value)
+
+
+def test_arc_input_integral_float_coercion():
+    """Test that job_memory, n_confs, and T_count accept an integral float (a previously-working
+    raw ARC input value) while still rejecting a non-integral float and a numeric string, so
+    strict-int validation is preserved for genuinely invalid input"""
+    arc_input = ARCInput(project='p', job_memory=14.0, n_confs=14.0, T_count=14.0)
+    assert arc_input.job_memory == 14
+    assert arc_input.n_confs == 14
+    assert arc_input.T_count == 14
+    for field in ('job_memory', 'n_confs', 'T_count'):
+        with pytest.raises(ValidationError) as excinfo:
+            ARCInput(project='p', **{field: 14.7})
+        assert field in str(excinfo.value)
+        with pytest.raises(ValidationError) as excinfo:
+            ARCInput(project='p', **{field: '14'})
+        assert field in str(excinfo.value)
+
+
+def test_arc_input_verbose_accepts_full_logging_level_range():
+    """Test that verbose accepts all standard logging levels, including ERROR/CRITICAL"""
+    for level in (10, 20, 30, 40, 50):
+        arc_input = ARCInput(project='p', verbose=level)
+        assert arc_input.verbose == level
+    for level in (15, 35, 60):
+        with pytest.raises(ValidationError) as excinfo:
+            ARCInput(project='p', verbose=level)
+        assert 'verbose' in str(excinfo.value)
+
+
+def test_arc_input_verbose_rejects_explicit_none_but_allows_absent():
+    """Test that verbose=None raises (logger.setLevel(None) crashes ARC), while an absent
+    verbose still validates and keeps its default"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', verbose=None)
+    assert 'verbose' in str(excinfo.value)
+    arc_input = ARCInput(project='p')
+    assert arc_input.verbose == 20
+    assert 'verbose' not in arc_input.as_input_dict()
+
+
+def test_arc_input_t_min_t_max():
+    """Test the T_min and T_max fields"""
+    arc_input = ARCInput(project='p', T_min=(300, 'K'), T_max=[3000, 'K'])
+    assert arc_input.T_min == (300.0, 'K')
+    assert arc_input.T_max == (3000.0, 'K')
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_min=('K', 300))
+    assert 'T_min' in str(excinfo.value)
+
+
+def test_arc_input_t_min_t_max_dumps_as_plain_list():
+    """Test that T_min/T_max are plain lists (not tuples) after as_input_dict(), for yaml.dump safety"""
+    arc_input = ARCInput(project='p', T_min=[300, 'K'], T_max=[3000, 'K'])
+    dumped = arc_input.as_input_dict()
+    assert isinstance(dumped['T_min'], list)
+    assert isinstance(dumped['T_max'], list)
+    assert dumped['T_min'] == [300.0, 'K']
+    dumped_yaml = yaml.dump({'T_min': dumped['T_min'], 'T_max': dumped['T_max']})
+    assert 'python/tuple' not in dumped_yaml
+
+
+def test_arc_input_t_min_t_max_accept_bare_scalar():
+    """Test that a bare scalar T_min/T_max (raw ARC's shorthand for Kelvin) validates"""
+    arc_input = ARCInput(project='p', T_min=500, T_max=3000)
+    assert arc_input.T_min == 500
+    assert arc_input.T_max == 3000
+    dumped = arc_input.as_input_dict()
+    # A scalar in must stay a scalar out; processor.py normalizes it downstream.
+    assert dumped['T_min'] == 500
+    assert isinstance(dumped['T_min'], float | int)
+    assert dumped['T_max'] == 3000
+    assert isinstance(dumped['T_max'], float | int)
+    dumped_yaml = yaml.dump({'T_min': dumped['T_min'], 'T_max': dumped['T_max']})
+    assert 'python/tuple' not in dumped_yaml
+
+
+def test_arc_input_t_min_t_max_pair_form_still_works():
+    """Regression check: the (value, unit) pair form must still validate and dump as a plain list"""
+    arc_input = ARCInput(project='p', T_min=[300, 'K'], T_max=(3000, 'K'))
+    assert arc_input.T_min == (300.0, 'K')
+    assert arc_input.T_max == (3000.0, 'K')
+    dumped = arc_input.as_input_dict()
+    assert isinstance(dumped['T_min'], list)
+    assert dumped['T_min'] == [300.0, 'K']
+    assert isinstance(dumped['T_max'], list)
+    assert dumped['T_max'] == [3000.0, 'K']
+
+
+def test_arc_input_t_min_t_max_reject_non_kelvin_unit():
+    """Test that a non-Kelvin unit raises, since no consumer ever reads or converts the unit
+    (plotter.py/processor.py silently treat T_min[0]/T_max[0] as Kelvin regardless of the label)"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_min=[300, 'C'])
+    assert 'T_min' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_max=[3000, 'F'])
+    assert 'T_max' in str(excinfo.value)
+    arc_input = ARCInput(project='p', T_min=[300, 'K'])
+    assert arc_input.T_min == (300.0, 'K')
+
+
+def test_arc_input_t_min_t_max_reject_non_positive_temperature():
+    """Test that a non-positive absolute temperature raises, in both scalar and pair form"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_min=-5)
+    assert 'T_min' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_min=0)
+    assert 'T_min' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', T_min=[0, 'K'])
+    assert 'T_min' in str(excinfo.value)
+    arc_input = ARCInput(project='p', T_min=500)
+    assert arc_input.T_min == 500
+    assert arc_input.as_input_dict()['T_min'] == 500
+
+
+def test_arc_input_t_min_t_max_accept_none():
+    """Test that T_min: null / T_max: null still validate, since real restart files have them"""
+    arc_input = ARCInput(project='p', T_min=None, T_max=None)
+    assert arc_input.T_min is None
+    assert arc_input.T_max is None
+
+
+def test_arc_input_species_and_reactions_accept_none():
+    """Test that explicit species: null / reactions: null validate, mirroring ARC.__init__"""
+    arc_input = ARCInput(project='p', species=None, reactions=None)
+    assert arc_input.species is None
+    assert arc_input.reactions is None
+
+
+def test_arc_input_wrong_job_types():
+    """Test that a wrongly-typed job_types raises"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types='rotors')
+    assert 'job_types' in str(excinfo.value)
+
+
+def test_arc_input_extra_keys_forbidden():
+    """Test that an unknown top-level key is rejected with an error citing the key"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', some_unknown_key='value')
+    assert 'some_unknown_key' in str(excinfo.value)
+
+
+def test_arc_input_fields_match_arc_init_kwargs():
+    """Drift guard: ARCInput's modeled fields must exactly mirror ARC.__init__'s kwargs"""
+    init_params = set(inspect.signature(ARC.__init__).parameters) - {'self'}
+    assert set(ARCInput.model_fields) == init_params, \
+        ('ARCInput.model_fields and ARC.__init__ kwargs diverged. Since ARCInput forbids unknown '
+         'top-level keys, adding an ARC.__init__ kwarg without modeling it in arc/schema.py would '
+         'make valid inputs fail validation (and vice versa) — update both together.')
+
+
+def test_job_types_extra_keys_forbidden():
+    """Test that a typo inside job_types is rejected at load rather than silently ignored"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types={'fine_grd': True})
+    assert 'fine_grd' in str(excinfo.value)
+
+
+def test_job_types_covers_all_default_job_types():
+    """Drift guard: every key in settings.default_job_types must be a JobTypes field, so that
+    adding a job type to arc/settings/settings.py cannot silently leave it untyped"""
+    assert set(default_job_types) <= set(JobTypes.model_fields)
+
+
+def test_job_types_schema():
+    """Test creating an instance of JobTypes"""
+    job_types = JobTypes()
+    assert job_types.conf_opt is True
+    assert job_types.conf_sp is False
+    assert job_types.opt is True
+    assert job_types.fine_grid is True
+    assert job_types.freq is True
+    assert job_types.sp is True
+    assert job_types.rotors is True
+    assert job_types.irc is True
+    assert job_types.orbitals is False
+    assert job_types.lennard_jones is False
+    assert job_types.bde is False
+
+    job_types = JobTypes(fine=True, onedmin=False)
+    assert job_types.fine is True
+    assert job_types.onedmin is False
+
+    with pytest.raises(ValidationError) as excinfo:
+        JobTypes(rotors='sometimes')
+    assert 'rotors' in str(excinfo.value)
+
+
+def test_job_types_restart_form_keys_validated():
+    """Test that the restart-form job_types keys (fine, onedmin) are typed and validated"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types={'fine': 'definitely'})
+    assert 'fine' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types={'onedmin': 'maybe'})
+    assert 'onedmin' in str(excinfo.value)
+    arc_input = ARCInput(project='p', job_types={'fine': True, 'onedmin': False})
+    assert arc_input.job_types.fine is True
+    assert arc_input.job_types.onedmin is False
+
+
+def test_job_types_fine_reject_explicit_none_but_allow_absent():
+    """Test that an explicit fine null raises, since initialize_job_types only fills fine's default
+    (True) when the key is absent, so an explicit null would silently disable fine-grid opt. An
+    explicit onedmin null is allowed: onedmin defaults to False, so null is identical to absent"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types={'fine': None})
+    assert 'fine' in str(excinfo.value)
+
+    arc_input = ARCInput(project='p', job_types={'onedmin': None})
+    assert arc_input.job_types.onedmin is None
+
+    arc_input = ARCInput(project='p', job_types={'fine': True})
+    assert arc_input.job_types.fine is True
+
+    arc_input = ARCInput(project='p', job_types={})
+    assert arc_input.job_types.fine is None
+    assert 'fine' not in arc_input.as_input_dict()['job_types']
+
+
+def test_job_types_contradictory_fine_aliases_raise():
+    """Test that contradictory fine_grid/fine values raise, since fine_grid silently wins in
+    ``initialize_job_types`` and the user's explicit ``fine`` value would otherwise be dropped"""
+    with pytest.raises(ValidationError) as excinfo:
+        JobTypes(fine_grid=True, fine=False)
+    assert 'fine_grid' in str(excinfo.value)
+    assert 'fine' in str(excinfo.value)
+
+
+def test_job_types_contradictory_lennard_jones_aliases_raise():
+    """Test that contradictory lennard_jones/onedmin values raise, since lennard_jones silently
+    wins in ``initialize_job_types`` and the user's explicit ``onedmin`` value would otherwise be dropped"""
+    with pytest.raises(ValidationError) as excinfo:
+        JobTypes(lennard_jones=True, onedmin=False)
+    assert 'lennard_jones' in str(excinfo.value)
+    assert 'onedmin' in str(excinfo.value)
+
+
+def test_job_types_agreeing_aliases_allowed():
+    """Test that both aliases of a pair set to the same value is allowed (no information lost)"""
+    job_types = JobTypes(fine_grid=True, fine=True)
+    assert job_types.fine_grid is True
+    assert job_types.fine is True
+    job_types = JobTypes(lennard_jones=False, onedmin=False)
+    assert job_types.lennard_jones is False
+    assert job_types.onedmin is False
+
+
+def test_job_types_single_alias_only_still_allowed():
+    """Test that specifying only one of a pair's aliases still validates unaffected"""
+    job_types = JobTypes(fine_grid=False)
+    assert job_types.fine_grid is False
+    assert job_types.fine is None
+    job_types = JobTypes(fine=False)
+    assert job_types.fine is False
+    job_types = JobTypes(lennard_jones=True)
+    assert job_types.lennard_jones is True
+    assert job_types.onedmin is None
+    job_types = JobTypes(onedmin=True)
+    assert job_types.onedmin is True
+
+
+def test_strict_bool_fields_reject_quoted_strings():
+    """Test that bool fields reject quoted string/int values instead of laxly coercing them"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', compute_thermo='False')
+    assert 'compute_thermo' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', job_types={'rotors': 'False'})
+    assert 'rotors' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', is_ts='False')
+    assert 'is_ts' in str(excinfo.value)
+
+
+def test_strict_bool_fields_accept_unquoted_yaml_bools():
+    """Test that ordinary (unquoted) YAML booleans still validate after strictness is added"""
+    yaml_str = """
+    project: p
+    compute_thermo: false
+    compare_to_rmg: no
+    """
+    data = yaml.safe_load(yaml_str)
+    arc_input = ARCInput(**data)
+    assert arc_input.compute_thermo is False
+    assert arc_input.compare_to_rmg is False
+
+
+def test_species_schema():
+    """Test creating an instance of Species"""
+    spc = Species(label='H2', smiles='[H][H]')
+    assert spc.label == 'H2'
+    assert spc.smiles == '[H][H]'
+    assert spc.is_ts is False
+
+    spc = Species(label='vinoxy', smiles='C=C[O]', multiplicity=2, charge=0,
+                  external_symmetry=1, optical_isomers=1, bdes=[(1, 2), 'all_h'])
+    assert spc.multiplicity == 2
+    assert spc.charge == 0
+
+    with pytest.raises(ValidationError) as excinfo:
+        Species(smiles='CC')
+    assert 'label' in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', multiplicity=0)
+    assert 'multiplicity' in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', external_symmetry=0)
+    assert 'external_symmetry' in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', optical_isomers=-1)
+    assert 'optical_isomers' in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', charge='neutral')
+    assert 'charge' in str(excinfo.value)
+
+
+def test_strict_int_fields_reject_quoted_strings():
+    """Test that int fields reject quoted numeric strings instead of laxly coercing them"""
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', multiplicity='3')
+    assert 'multiplicity' in str(excinfo.value)
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='spc', smiles='CC', charge='0')
+    assert 'charge' in str(excinfo.value)
+    spc = Species(label='spc', smiles='CC', multiplicity=3, charge=0)
+    assert spc.multiplicity == 3
+    assert spc.charge == 0
+
+
+def test_species_structure_check():
+    """Test that a non-TS species with no structure specification raises"""
+    with pytest.raises(ValidationError):
+        Species(label='no_structure')
+    ts = Species(label='TS0', is_ts=True)
+    assert ts.is_ts is True
+    yml_spc = Species(label='from_yml', yml_path='spc.yml')
+    assert yml_spc.yml_path == 'spc.yml'
+    # most_stable_conformer is an index into conformers, not a structure source, so it alone must
+    # not satisfy the structure check.
+    with pytest.raises(ValidationError):
+        Species(label='only_index', most_stable_conformer=0)
+
+
+def test_species_runtime_keys_modeled():
+    """Test that runtime/restart species keys are modeled fields rather than extras"""
+    spc = Species(label='H2', smiles='[H][H]', neg_freqs_trshed=[], ts_methods=None)
+    assert spc.neg_freqs_trshed == list()
+    assert 'neg_freqs_trshed' in Species.model_fields
+    assert 'ts_methods' in Species.model_fields
+
+
+def test_species_typo_key_rejected():
+    """Test that a typo in a species key is rejected instead of being silently swallowed
+    (a swallowed 'mutliplicity' typo previously led to a wrong auto-determined multiplicity)"""
+    with pytest.raises(ValidationError) as excinfo:
+        Species(label='CH2', smiles='[CH2]', mutliplicity=1)
+    assert 'mutliplicity' in str(excinfo.value)
+
+
+def test_reaction_typo_key_rejected():
+    """Test that a typo in a reaction key is rejected instead of being silently swallowed"""
+    with pytest.raises(ValidationError) as excinfo:
+        Reaction(label='H + O2 <=> HO2', ts_xyz_gues=['H 0 0 0'])
+    assert 'ts_xyz_gues' in str(excinfo.value)
+
+
+def test_reaction_identification_requires_label_or_reactants_and_products():
+    """Test that a reaction is identified by a label or by both reactants and products, and that
+    r_species/p_species dicts alone are rejected: ARCReaction.from_dict runs
+    set_label_reactants_products before converting those dicts, so they cannot identify a reaction
+    at load time and ARC would raise"""
+    assert Reaction(label='H + O2 <=> HO2').label == 'H + O2 <=> HO2'
+    assert Reaction(reactants=['H', 'O2'], products=['HO2']).reactants == ['H', 'O2']
+    with pytest.raises(ValidationError):
+        Reaction(r_species=[{'label': 'H', 'smiles': '[H]'}],
+                 p_species=[{'label': 'HO2', 'smiles': 'O[O]'}])
+    with pytest.raises(ValidationError):
+        Reaction(reactants=['H', 'O2'])
+
+
+def test_species_as_dict_keys_are_modeled():
+    """Drift guard: every key ARCSpecies.as_dict() writes must be modeled by Species"""
+    spc = ARCSpecies(label='vinoxy', smiles='C=C[O]')
+    ts = ARCSpecies(label='TS0', is_ts=True, xyz='O 0 0 0\nH 0 0 1\nH 0 1 0')
+    emitted_keys = set(spc.as_dict().keys()) | set(ts.as_dict().keys())
+    assert emitted_keys.issubset(set(Species.model_fields)), \
+        (f'ARC writes a species key the schema does not model — add it to arc/schema.py or '
+         f'restarts will break. Unmodeled: {sorted(emitted_keys - set(Species.model_fields))}')
+
+
+def test_reaction_as_dict_keys_are_modeled():
+    """Drift guard: every key ARCReaction.as_dict() writes must be modeled by Reaction"""
+    rxn = ARCReaction(r_species=[ARCSpecies(label='H', smiles='[H]'),
+                                 ARCSpecies(label='O2', smiles='[O][O]')],
+                      p_species=[ARCSpecies(label='HO2', smiles='O[O]')])
+    emitted_keys = set(rxn.as_dict().keys())
+    assert emitted_keys.issubset(set(Reaction.model_fields)), \
+        (f'ARC writes a reaction key the schema does not model — add it to arc/schema.py or '
+         f'restarts will break. Unmodeled: {sorted(emitted_keys - set(Reaction.model_fields))}')
+
+
+def test_reaction_schema():
+    """Test creating an instance of Reaction"""
+    rxn = Reaction(label='H + O2 <=> HO2')
+    assert rxn.label == 'H + O2 <=> HO2'
+    rxn = Reaction(label='N2H4 + NH <=> N2H3 + NH2', multiplicity=3,
+                   ts_xyz_guess=['N 0 0 0\nH 0 0 1'])
+    assert rxn.multiplicity == 3
+    rxn = Reaction(reactants=['H', 'O2'], products=['HO2'])
+    assert rxn.reactants == ['H', 'O2']
+
+    with pytest.raises(ValidationError) as excinfo:
+        Reaction(label='rxn1', multiplicity=0)
+    assert 'multiplicity' in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        Reaction(label='rxn1', ts_xyz_guess=5)
+    assert 'ts_xyz_guess' in str(excinfo.value)
+
+    with pytest.raises(ValidationError):
+        Reaction(multiplicity=1)
+
+
+def test_all_examples_validate():
+    """Test that all input.yml files under examples/ validate through ARCInput"""
+    example_files = glob.glob(os.path.join(ARC_PATH, 'examples', '**', 'input.yml'), recursive=True)
+    assert len(example_files) >= 8
+    for example_file in example_files:
+        input_dict = read_yaml_file(example_file)
+        arc_input = ARCInput(**input_dict)
+        assert arc_input.project == input_dict['project']
+
+
+def _normalize(value):
+    """
+    Recursively convert tuples to lists for order-insensitive structural comparison.
+
+    Args:
+        value: The value to normalize.
+
+    Returns:
+        The normalized value with all tuples converted to lists.
+    """
+    if isinstance(value, (list, tuple)):
+        return [_normalize(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalize(v) for k, v in value.items()}
+    return value
+
+
+def test_restart_files_round_trip():
+    """Test that real restart.yml files validate and round-trip through ARCInput"""
+    restart_files = glob.glob(os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '**', 'restart.yml'),
+                              recursive=True)
+    assert len(restart_files) >= 4
+    for restart_file in restart_files:
+        restart_dict = read_yaml_file(restart_file)
+        arc_input = ARCInput(**restart_dict)
+        dumped = arc_input.as_input_dict()
+        assert set(dumped.keys()) == set(restart_dict.keys()), restart_file
+        for key, original in restart_dict.items():
+            if key in ('thermo_adapter', 'kinetics_adapter'):
+                # The schema normalizes these to lowercase, mirroring ARC.__init__.
+                assert dumped[key] == original.lower()
+            else:
+                assert _normalize(dumped[key]) == _normalize(original), f'{restart_file}: {key}'
+
+
+def test_restart_thermo_runtime_keys_preserved():
+    """Test that runtime restart keys survive validation as modeled fields"""
+    restart_file = os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '1_restart_thermo', 'restart.yml')
+    restart_dict = read_yaml_file(restart_file)
+    arc_input = ARCInput(**restart_dict)
+    dumped = arc_input.as_input_dict()
+    assert dumped['output'] == restart_dict['output']
+    assert dumped['running_jobs'] == restart_dict['running_jobs']
+    assert dumped['ess_settings'] == restart_dict['ess_settings']
+    assert dumped['job_types'] == restart_dict['job_types']
+    for original_spc, dumped_spc in zip(restart_dict['species'], dumped['species']):
+        assert set(dumped_spc.keys()) == set(original_spc.keys())
+
+
+def test_arc_object_as_dict_round_trip(tmp_path):
+    """Test that an ARC object's as_dict() output validates through ARCInput"""
+    arc_object = ARC(project='arc_schema_test',
+                     project_directory=str(tmp_path),
+                     species=[{'label': 'H2', 'smiles': '[H][H]'}],
+                     )
+    arc_dict = arc_object.as_dict()
+    assert arc_dict['schema_version'] == ARC_INPUT_SCHEMA_VERSION
+    assert arc_dict['arc_version'] == VERSION
+    arc_input = ARCInput(**arc_dict)
+    dumped = arc_input.as_input_dict()
+    assert set(dumped.keys()) == set(arc_dict.keys()) - {'schema_version', 'arc_version'}
+    assert dumped['project'] == 'arc_schema_test'
+    assert dumped['job_types'] == arc_dict['job_types']
+    assert _normalize(dumped['species']) == _normalize(arc_dict['species'])
+
+
+def test_as_input_dict_preserves_explicit_none_and_omits_unset():
+    """Test that as_input_dict reproduces exactly the user-provided keys"""
+    arc_input = ARCInput(project='p', bac_type=None, species=[{'label': 'H2', 'smiles': '[H][H]'}])
+    dumped = arc_input.as_input_dict()
+    assert set(dumped.keys()) == {'project', 'bac_type', 'species'}
+    assert dumped['bac_type'] is None
+    assert dumped['species'] == [{'label': 'H2', 'smiles': '[H][H]'}]
+
+
+# Keys excluded from the ARC.as_dict() equivalence comparison in test_schema_seam_is_behavior_preserving,
+# each with the concrete, investigated reason it is inherently non-deterministic between two separate
+# ARC constructions (as opposed to a real behavioral difference introduced by the schema seam).
+_AS_DICT_EXCLUDED_KEYS = {
+    # Absolute path embedding the per-construction tmp_path, which necessarily differs between
+    # the 'raw' and 'schema' temp directories.
+    'project_directory',
+    # Derived from project_directory (output/, etc.), same reason as above.
+    'output_directory',
+    # Wall-clock timestamp captured at construction time (self.t0 = time.time()); the two
+    # constructions run microseconds apart and will not match.
+    'execution_time',
+}
+
+
+def _normalize_transient_mol_atom_ids(obj):
+    """
+    Recursively renumber RMG ``Molecule`` atom ``id`` fields (and their ``edges`` cross-references)
+    to a 0-based positional index.
+
+    Each ``ARCSpecies``/RMG ``Molecule`` atom is stamped with an ``id`` drawn from a single
+    process-wide auto-incrementing (negative) counter at construction time. Two separate ARC
+    constructions in the same test process therefore get different, but internally consistent,
+    id numbering for otherwise-identical molecules; the ids themselves carry no chemical
+    information, only their consistent use as edge references within one molecule does. This
+    normalizes that transient counter away without touching any other data.
+
+    Args:
+        obj: An arbitrarily nested structure (as produced by ``ARC.as_dict()``) to normalize.
+
+    Returns:
+        A structurally-equal copy of ``obj`` with any molecule atom ``id``/``edges`` fields
+        renumbered to positional indices; other data is left untouched.
+    """
+    if isinstance(obj, dict):
+        if isinstance(obj.get('atoms'), list) and all(isinstance(a, dict) and 'id' in a for a in obj['atoms']):
+            id_map = {atom['id']: i for i, atom in enumerate(obj['atoms'])}
+            new_atoms = []
+            for atom in obj['atoms']:
+                new_atom = dict(atom)
+                new_atom['id'] = id_map[atom['id']]
+                if isinstance(new_atom.get('edges'), dict):
+                    new_atom['edges'] = {id_map.get(k, k): v for k, v in new_atom['edges'].items()}
+                new_atoms.append(_normalize_transient_mol_atom_ids(new_atom))
+            new_obj = {k: (new_atoms if k == 'atoms' else v) for k, v in obj.items()}
+            if isinstance(new_obj.get('atom_order'), list):
+                new_obj['atom_order'] = [id_map.get(x, x) for x in new_obj['atom_order']]
+            return {k: _normalize_transient_mol_atom_ids(v) for k, v in new_obj.items()}
+        return {k: _normalize_transient_mol_atom_ids(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_transient_mol_atom_ids(v) for v in obj]
+    return obj
+
+
+@pytest.mark.parametrize('example_file', [
+    os.path.join(ARC_PATH, 'examples', 'minimal', 'input.yml'),
+    os.path.join(ARC_PATH, 'examples', 'Stationary', 'thermo_demo', 'input.yml'),
+    os.path.join(ARC_PATH, 'examples', 'Reactions', 'rates_demo', 'input.yml'),
+    os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '2_restart_rate', 'restart.yml'),
+    os.path.join(ARC_PATH, 'arc', 'testing', 'restart', '5_TS1', 'restart.yml'),
+])
+def test_schema_seam_is_behavior_preserving(example_file, tmp_path):
+    """Test that constructing ARC through the schema seam is equivalent to constructing it
+    directly from the raw dict, for real example input files"""
+    raw_dict = read_yaml_file(example_file)
+
+    # ARC.__init__ mutates the 'species'/'reactions' lists it is given in place (converting
+    # dicts to ARCSpecies/ARCReaction objects), so each construction needs its own copy of raw_dict.
+    arc_raw = ARC(**copy.deepcopy(raw_dict), project_directory=str(tmp_path / 'raw'))
+    schema_input_dict = ARCInput(**copy.deepcopy(raw_dict)).as_input_dict()
+    schema_input_dict['project_directory'] = str(tmp_path / 'schema')
+    arc_schema = ARC(**schema_input_dict)
+
+    raw_as_dict = arc_raw.as_dict()
+    schema_as_dict = arc_schema.as_dict()
+
+    assert set(raw_as_dict.keys()) == set(schema_as_dict.keys())
+    for key in raw_as_dict:
+        if key in _AS_DICT_EXCLUDED_KEYS:
+            continue
+        raw_value = _normalize_transient_mol_atom_ids(raw_as_dict[key])
+        schema_value = _normalize_transient_mol_atom_ids(schema_as_dict[key])
+        assert raw_value == schema_value, \
+            f'{example_file}: key {key!r} differs: {raw_as_dict[key]!r} != {schema_as_dict[key]!r}'
+
+
+def test_schema_version_absent_accepted():
+    """Test that an input without a schema_version key validates silently"""
+    arc_input = ARCInput(project='p')
+    assert arc_input.schema_version is None
+    assert 'schema_version' not in arc_input.as_input_dict()
+
+
+def test_schema_version_current_accepted():
+    """Test that the current schema version is accepted"""
+    arc_input = ARCInput(project='p', schema_version=ARC_INPUT_SCHEMA_VERSION)
+    assert arc_input.schema_version == ARC_INPUT_SCHEMA_VERSION
+
+
+def test_schema_version_explicit_null_rejected():
+    """Test that an explicit schema_version: null raises"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', schema_version=None)
+    assert 'schema_version' in str(excinfo.value)
+
+
+def test_schema_version_newer_rejected():
+    """Test that a schema_version from a future ARC raises with both versions named"""
+    with pytest.raises(ValidationError) as excinfo:
+        ARCInput(project='p', schema_version=ARC_INPUT_SCHEMA_VERSION + 1)
+    assert 'schema_version' in str(excinfo.value)
+    assert str(ARC_INPUT_SCHEMA_VERSION + 1) in str(excinfo.value)
+    assert str(ARC_INPUT_SCHEMA_VERSION) in str(excinfo.value)
+
+
+def test_schema_version_older_warns_and_proceeds():
+    """Test that an older schema_version logs a warning and still validates"""
+    arc_logger = get_logger()
+    records = list()
+    handler = logging.Handler()
+    handler.emit = records.append
+    arc_logger.addHandler(handler)
+    try:
+        arc_input = ARCInput(project='p', schema_version=0)
+    finally:
+        arc_logger.removeHandler(handler)
+    assert arc_input.schema_version == 0
+    assert any(record.levelno == logging.WARNING and 'schema_version 0' in record.getMessage()
+               and str(ARC_INPUT_SCHEMA_VERSION) in record.getMessage()
+               for record in records)
+
+
+def test_schema_version_and_arc_version_stripped_from_input_dict():
+    """Test that as_input_dict() strips schema_version and arc_version"""
+    arc_input = ARCInput(project='p', schema_version=ARC_INPUT_SCHEMA_VERSION, arc_version=VERSION)
+    dumped = arc_input.as_input_dict()
+    assert 'schema_version' not in dumped
+    assert 'arc_version' not in dumped
+    assert dumped == {'project': 'p'}
+
+
+def test_validate_input_dict_minimal_example(tmp_path):
+    """Test that ARC constructs from validate_input_dict() on a real example input file"""
+    input_dict = read_yaml_file(os.path.join(ARC_PATH, 'examples', 'minimal', 'input.yml'))
+    input_dict['project_directory'] = str(tmp_path)
+    arc_object = ARC(**validate_input_dict(input_dict))
+    assert arc_object.project == input_dict['project']
+
+
+def test_validate_input_dict_versioned_round_trip(tmp_path):
+    """Test a full round trip: construct ARC, as_dict() it (now versioned), validate, reconstruct.
+    Also test that raw ARC(**restart_dict) tolerates the version keys directly"""
+    arc_object = ARC(project='arc_schema_version_round_trip',
+                     project_directory=str(tmp_path / 'first'),
+                     species=[{'label': 'H2', 'smiles': '[H][H]'}],
+                     )
+    restart_dict = arc_object.as_dict()
+    assert restart_dict['schema_version'] == ARC_INPUT_SCHEMA_VERSION
+    assert restart_dict['arc_version'] == VERSION
+
+    validated = validate_input_dict(copy.deepcopy(restart_dict))
+    assert 'schema_version' not in validated
+    assert 'arc_version' not in validated
+    validated['project_directory'] = str(tmp_path / 'second')
+    arc_object_2 = ARC(**validated)
+    assert arc_object_2.project == 'arc_schema_version_round_trip'
+    assert arc_object_2.__version__ == VERSION
+
+    raw_dict = copy.deepcopy(restart_dict)
+    raw_dict['project_directory'] = str(tmp_path / 'third')
+    arc_object_3 = ARC(**raw_dict)
+    assert arc_object_3.project == 'arc_schema_version_round_trip'
+    assert arc_object_3.__version__ == VERSION

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -643,14 +643,12 @@ The above code generates the following input file::
       sp: true
 
     species:
-    - E0: null
-      arkane_file: null
+    - arkane_file: null
       bond_corrections:
         N=O: 1
       charge: 0
       external_symmetry: null
       force_field: MMFF94
-      generate_thermo: true
       is_ts: false
       label: 'NO'
       mol: |
@@ -659,8 +657,7 @@ The above code generates the following input file::
         2 O u0 p2 c0 {1,D}
       multiplicity: 2
       number_of_rotors: 0
-    - E0: null
-      arkane_file: null
+    - arkane_file: null
       bond_corrections:
         C-H: 3
         C-O: 1
@@ -682,7 +679,6 @@ The above code generates the following input file::
         H      -1.28488154    0.84437992   -0.22108130
         H       1.02953840    0.95815005   -0.41011413
       force_field: MMFF94
-      generate_thermo: true
       is_ts: false
       label: vinoxy
       mol: |

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
   - conda-forge::pandas
   - conda-forge::paramiko >=2.6.0
   - conda-forge::py3dmol >=0.8.0
+  - conda-forge::pydantic >=2,<3
   - conda-forge::pydot
   - conda-forge::pytables
   - conda-forge::pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ ffmpeg
 gprof2dot
 graphviz
 h5py
+pydantic>=2,<3
 pydot
 pytables
 sphinx


### PR DESCRIPTION
## Motivation

ARC has no typed, validated input schema today. `ARC.py` reads the input YAML into a raw dict and
hands it straight to `ARC(**input_dict)`, so malformed input fails deep inside object construction —
or, worse, silently misbehaves — instead of failing at load with a clear message. The only
validation that exists is ad-hoc (project name required, a `ts_adapter` membership check,
`StatmechEnum`). T3 already solves this cleanly with a pydantic schema (`t3/schema.py`). This PR
brings the same kind of first-class, validated input schema to ARC.

## What this adds

`arc/schema.py` — a pydantic v2 `ARCInput` model mirroring T3's structure (nested `BaseModel`s,
`Field` constraints, `Enum` controlled vocabularies, `field_validator` / `model_validator`, a
per-model `Config`):

- **`ARCInput`** — the top-level model; field names and defaults mirror the `ARC.__init__` kwargs and
  the keys `ARC.as_dict()` emits into `restart.yml`. Only `project` is required.
- **`Species`** and **`Reaction`** — the full `ARCSpecies` / `ARCReaction` input surfaces.
- **`JobTypes`** — the 11 `default_job_types` keys, plus ARC's internal names.
- **`BACTypeEnum`**, **`TemperatureUnitEnum`**, and the existing `StatmechEnum` (reused, not
  redefined); `ts_adapters` is validated against the live job-adapter registry.

## Integration seam

Validate-then-construct at the single load seam in `ARC.py` `main()`:

```python
try:
    validated_input_dict = validate_input_dict(input_dict)
except ValidationError as e:
    print(f'Invalid ARC input file "{input_file}":\n{e}')
    sys.exit(1)
arc_object = ARC(**validated_input_dict)
```

`ARC.__init__` is otherwise unchanged and still directly callable — the schema is a load-time gate
and normalizer, not a refactor of the constructor. `validate_input_dict()` is public so Python-API
and T3 callers can opt into the same validation without going through the CLI.

`as_input_dict()` uses `model_dump(exclude_unset=True)` rather than `exclude_none=True`, so only the
keys the user actually provided are passed through: `ARCSpecies.from_dict` gates on key *presence*,
and an explicit `bac_type: null` (which disables BAC) must not be silently dropped back to `'p'`.

## Covered vs deferred

**Covered (validated):** top-level ARC options; job types; levels of theory (as `str | dict` — the
`Level` object is deliberately not re-modelled); the full species and reaction input surfaces.

**Deliberately deferred (kept loose and passed through):** `adaptive_levels`, `ess_settings`, and the
restart runtime keys `output`, `output_multi_spc`, `running_jobs`, plus the internals of the runtime
blobs (`rotors_dict`, `ts_guesses`). These are written by ARC's own `as_dict()`, so only a
hand-edited restart file can make them malformed; typing them would turn an *input* schema into a
*serialization* schema.

## Strictness

Every model uses `extra="forbid"`. The two levels are not symmetric, and that asymmetry is the point:

- **Top level** — an unknown key already raised `TypeError` in `ARC.__init__` (it has no `**kwargs`),
  so forbidding only improves the error message.
- **Species / Reaction** — an unknown key was *silently swallowed* by `ARCSpecies`, so a
  `mutliplicity: 1` typo yielded multiplicity 3 with no warning. This is where forbidding actually
  prevents silent corruption, and it required modelling every runtime key ARC's own `as_dict()`
  writes.

To keep that maintainable, guard tests assert that the schema's fields stay a superset of what
`ARC.__init__` accepts, of every key `as_dict()` emits, and of `default_job_types` — so a field added
to ARC without a matching schema field fails CI in the PR that caused it, rather than silently
breaking a user's restart months later.

Bools and ints are strict, because lax coercion changed the science:

- A quoted `"False"` is *truthy* to raw ARC, so lax coercion would have silently inverted
  `compute_thermo`.
- `ARCSpecies` raises on a non-int multiplicity, so the schema must not launder `"3"` into `3`.
- Integral floats (`14.0`) are still accepted for `job_memory`, `n_confs` and `T_count`, since raw
  ARC accepts them; `14.7` and `"14"` are rejected.

## Backward compatibility

The schema validates and normalizes; it does not break existing inputs.

- All 8 `examples/**/input.yml` and all 4 `arc/testing/restart/**/restart.yml` files validate, and a
  test asserts they keep validating.
- Real restart files legitimately carry explicit nulls (`T_min`, `T_max`, `T_count`, `n_confs`,
  `bac_type`, `multiplicity`, `external_symmetry`, `optical_isomers`, ...) — all still accepted.
- `T_min`/`T_max` accept a bare scalar *or* a `(value, unit)` pair, and never serialize as a tuple, so
  `save_yaml_file`'s `yaml.dump` cannot write `!!python/tuple` into `restart.yml`. The unit is
  restricted to Kelvin because it is never read downstream — `[300, 'C']` was silently computed as
  300 K.
- An end-to-end seam test asserts
  `ARC(**raw).as_dict() == ARC(**validate_input_dict(raw)).as_dict()` over the real example inputs
  *and* the `2_restart_rate` / `5_TS1` restart files. It is mutation-tested to confirm it is not
  vacuous (sabotaging `as_input_dict()` to drop `species` makes it fail).

## Schema versioning

`as_dict()` now records `schema_version` and `arc_version` in restart files. `ARC.__init__` accepts
and ignores both, so a raw `ARC(**restart_dict)` keeps working. On read: absent is accepted, an
explicit null is an error, a newer version is an error, an older version warns and proceeds.

To be honest about what this is: with no migration machinery behind it, `schema_version` is a
tripwire that makes a future incompatibility *loud* — it is not, by itself, a compatibility
guarantee.

## Points for the reviewer

- **`arc/plotter.py` is touched in a separate commit** (`6001f419e`) for an unrelated pre-existing
  bug: a bare scalar `T_max` was normalized to `(T_min, 'K')` instead of `(T_max, 'K')`, silently
  replacing `T_max` with `T_min`. It is fixed here because this PR newly blesses a bare scalar
  temperature as a valid input form, which makes the path reachable from a plain input file. Drop
  that commit if you would rather it went separately.
- **`family_own_reverse`** is typed `StrictBool | StrictInt | None` rather than `StrictBool | None`,
  because real restart fixtures carry it as an int `0`/`1`. Pragmatic, but a deviation worth a look.
- **`class Config`** (not `ConfigDict`) is deliberate, mirroring T3's style. It emits a pydantic
  deprecation warning per model; migrating both tools together is a separate change.
- `pydantic >=2` is now declared in `environment.yml`, and a public `get_registered_job_adapters()`
  was added to `arc/job/factory.py` so neither `arc/main.py` nor `arc/schema.py` imports the private
  registry.
