### PR TITLE
Fix orca ess status

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -207,6 +207,17 @@ class JobAdapter(ABC):
         """
         pass
 
+    @property
+    def ess_software(self) -> str:
+        """
+        The electronic-structure software whose output format this adapter's log follows.
+
+        Defaults to the adapter's own name, which is correct for adapters that ARE an ESS.
+        An adapter that wraps an ESS (e.g. a TS-search adapter driving Orca) must override
+        this so that the ESS log parsers, which dispatch on the software name, recognize it.
+        """
+        return self.job_adapter
+
     def execute(self):
         """
         Execute a job.
@@ -847,7 +858,7 @@ class JobAdapter(ABC):
                                                                  species_label=self.species_label,
                                                                  job_type=self.job_type,
                                                                  job_log=self.additional_job_info,
-                                                                 software=self.job_adapter,
+                                                                 software=self.ess_software,
                                                                  )
             if status != 'done' and self.final_time is not None \
                     and datetime.datetime.now() - self.final_time < datetime.timedelta(seconds=30):
@@ -857,7 +868,7 @@ class JobAdapter(ABC):
                                                                      species_label=self.species_label,
                                                                      job_type=self.job_type,
                                                                      job_log=self.additional_job_info,
-                                                                     software=self.job_adapter,
+                                                                     software=self.ess_software,
                                                                      )
         else:
             status, keywords, error, line = '', '', '', ''

--- a/arc/job/adapters/ts/orca_neb.py
+++ b/arc/job/adapters/ts/orca_neb.py
@@ -209,6 +209,11 @@ class OrcaNEBAdapter(OrcaAdapter):
         self.local_path_to_output_file = os.path.join(self.local_path, output_filenames[self.job_adapter])
         self.execution_type = execution_type or 'queue'
 
+    @property
+    def ess_software(self) -> str:
+        """Orca NEB is a TS-search adapter, but its output is an Orca log."""
+        return 'orca'
+
     def write_input_file(self) -> None:
         """
         Write the input file to execute the job on the server.

--- a/arc/job/adapters/ts/orca_neb_test.py
+++ b/arc/job/adapters/ts/orca_neb_test.py
@@ -168,6 +168,43 @@ class TestOrcaNEB(unittest.TestCase):
         # C -1.406738 -0.055989 0.104836
         self.assertAlmostEqual(tsg.initial_xyz['coords'][0][0], -1.406738, places=5)
 
+    def test_task_3_ess_status_of_a_normally_terminated_neb_log(self):
+        """
+        Task 3: Orca NEB keeps its adapter identity while using Orca's ESS status classification,
+        so that a normally terminated run is marked 'done' and its guesses may be ingested.
+        """
+        # This test owns its fixture: a private project directory and a private adapter instance, so it
+        # neither races the shared class-level project directory under xdist nor depends on the state
+        # (initial_time / final_time / job_status) that the other tests in this class mutate in place.
+        project_directory = os.path.join(ARC_TESTING_PATH, 'test_OrcaNEBAdapter_ess_status')
+        if os.path.exists(project_directory):
+            shutil.rmtree(project_directory, ignore_errors=True)
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        job = OrcaNEBAdapter(project='test_orca_neb_ess_status',
+                             job_type='tsg',
+                             project_directory=project_directory,
+                             reactions=[ARCReaction(r_species=[ARCSpecies(label='i-C3H7', smiles='C[CH]C')],
+                                                    p_species=[ARCSpecies(label='n-C3H7', smiles='CC[CH2]')])],
+                             level=self.level,
+                             server='local')
+
+        log_path = os.path.join(ARC_TESTING_PATH, 'neb', 'neb_res.out')
+        output_path = job.local_path_to_output_file
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        shutil.copy(log_path, output_path)
+
+        job.initial_time = datetime.datetime(2026, 2, 16, 10, 0, 0)
+        job.final_time = datetime.datetime(2026, 2, 16, 10, 15, 42)
+        with unittest.mock.patch.object(OrcaNEBAdapter, '_get_additional_job_info', return_value=None):
+            job._check_job_ess_status()
+
+        self.assertEqual(job.job_adapter, 'orca_neb')
+        self.assertEqual(job.ess_software, 'orca')
+        self.assertEqual(job.job_status[1]['status'], 'done')
+        self.assertEqual(job.job_status[1]['keywords'], list())
+        self.assertEqual(job.job_status[1]['error'], '')
+        self.assertEqual(job.job_status[1]['line'], '')
+
     @classmethod
     def tearDownClass(cls):
         """

--- a/arc/job/trsh.py
+++ b/arc/job/trsh.py
@@ -270,17 +270,26 @@ def determine_ess_status(output_path: str,
             for i, line in enumerate(reverse_lines):
                 if 'ORCA TERMINATED NORMALLY' in line:
                     scf_energy_initial_iteration = None
+                    scf_energy_last_iteration = None
                     # not done yet, things can still go wrong (e.g., SCF energy might blow up)
                     for j, info in enumerate(forward_lines):
                         if 'Starting incremental Fock matrix formation' in info:
-                            while not is_str_float(forward_lines[j + 1].split()[1]):
-                                j += 1
-                            scf_energy_initial_iteration = float(forward_lines[j + 1].split()[1])
+                            # The first SCF iteration line does not necessarily follow immediately: Orca may
+                            # print a SOSCF (or similar) header in between, and such header lines can hold
+                            # fewer than two whitespace-separated tokens. Scan forward for the first line that
+                            # actually holds an iteration energy, and give up quietly if there is none.
+                            k = j + 1
+                            while k < len_forward_lines:
+                                splits = forward_lines[k].split()
+                                if len(splits) > 1 and is_str_float(splits[1]):
+                                    scf_energy_initial_iteration = float(splits[1])
+                                    break
+                                k += 1
                         if 'TOTAL SCF ENERGY' in info:
                             # this value is very close to the scf energy at last iteration and is easier to parse
                             scf_energy_last_iteration = float(forward_lines[j + 3].split()[3])
                             break
-                    if scf_energy_initial_iteration is not None:
+                    if scf_energy_initial_iteration is not None and scf_energy_last_iteration is not None:
                         # Check if final SCF energy makes sense
                         scf_energy_ratio = scf_energy_last_iteration / scf_energy_initial_iteration
                         scf_energy_ratio_threshold = 2  # it is rare that this ratio > 2
@@ -296,7 +305,10 @@ def determine_ess_status(output_path: str,
                         else:
                             done = True
                         break
-                    if scf_energy_initial_iteration is None:
+                    if scf_energy_initial_iteration is None or scf_energy_last_iteration is None:
+                        # Nothing to compare: either no parseable SCF iteration line, or no
+                        # 'TOTAL SCF ENERGY' block was emitted. The run terminated normally,
+                        # so treat it as done rather than raising on an unassigned energy.
                         done = True
                 elif 'ORCA finished by error termination in SCF' in line:
                     keywords = ['SCF']

--- a/arc/job/trsh_test.py
+++ b/arc/job/trsh_test.py
@@ -207,6 +207,20 @@ class TestTrsh(unittest.TestCase):
         self.assertEqual(error, "")
         self.assertEqual(line, "")
 
+        # test detection of a normally terminated Orca NEB-TS job.
+        # NEB logs switch to SOSCF right after the
+        # ***  Starting incremental Fock matrix formation  ***
+        # line, so the first SCF iteration energy is several lines further down, past a separator line
+        # that holds a single token. The SCF parser must skip such lines rather than fail on them.
+        path = os.path.join(ARC_TESTING_PATH, "neb", "neb_res.out")
+        status, keywords, error, line = trsh.determine_ess_status(
+            output_path=path, species_label="test", job_type="tsg", software="orca"
+        )
+        self.assertEqual(status, "done")
+        self.assertEqual(keywords, list())
+        self.assertEqual(error, "")
+        self.assertEqual(line, "")
+
         # test detection of SCF energy diverge issue
         path = os.path.join(self.base_path["orca"], "orca_scf_blow_up_error.log")
         status, keywords, error, line = trsh.determine_ess_status(
@@ -373,6 +387,37 @@ class TestTrsh(unittest.TestCase):
         )
         self.assertEqual(error, expected_error_msg)
         self.assertIn("This wavefunction IS NOT FULLY CONVERGED!", line)
+
+    def test_determine_ess_status_orca_scf_energies_unavailable(self):
+        """
+        Test that determine_ess_status() reports 'done' for a normally terminated Orca job whose SCF
+        block cannot be mined for the initial/final energy pair used by the divergence heuristic.
+
+        The heuristic needs BOTH energies; whenever either is missing there is nothing to compare and
+        a normally terminated job must simply be reported as done (never raise).
+
+        Both fixtures are real Orca NEB output (arc/testing/neb/neb_res.out) truncated at a point that
+        leaves the SCF block incomplete, so they carry genuine Orca formatting rather than a
+        hand-written approximation. Each pins a different half of the fix:
+
+        - neb_scf_no_iteration_line.out keeps the incremental-Fock marker, the SOSCF header and the
+          column header but no numeric iteration row. It exercises the forward scan, which must run
+          off the end of the file without ever assigning an initial energy instead of indexing past
+          a one-token separator line.
+        - neb_scf_no_total_energy.out keeps a parseable iteration row but stops before the
+          'TOTAL SCF ENERGY' block, so the initial energy is assigned while the final one is not.
+          Before the guard required both energies this read an unassigned local and raised
+          UnboundLocalError out of determine_ess_status, which no caller catches.
+        """
+        for file_name in ('neb_scf_no_iteration_line.out', 'neb_scf_no_total_energy.out'):
+            path = os.path.join(ARC_TESTING_PATH, 'neb', file_name)
+            status, keywords, error, line = trsh.determine_ess_status(
+                output_path=path, species_label="test", job_type="sp", software="orca"
+            )
+            self.assertEqual(status, "done", msg=f'for {file_name}')
+            self.assertEqual(keywords, list(), msg=f'for {file_name}')
+            self.assertEqual(error, "", msg=f'for {file_name}')
+            self.assertEqual(line, "", msg=f'for {file_name}')
 
     def test_trsh_ess_job(self):
         """Test the trsh_ess_job() function"""

--- a/arc/testing/neb/neb_scf_no_iteration_line.out
+++ b/arc/testing/neb/neb_scf_no_iteration_line.out
@@ -1,0 +1,383 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Cooperlake SINGLE_THREADED
+        Core in use  :  Cooperlake
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+NOTE: MaxCore=1792 MB was set to SCF,MP2,MDCI,CIPSI,MRCI and CIS
+      => If you want to overwrite this, your respective input block should be placed after the MaxCore statement
+
+
+***************************************
+The coordinates will be read from file: /home/kaplan.kfir/Code/runs/test_orca_adapter/reactant.xyz
+***************************************
+
+
+Your calculation utilizes a Nudged-Elastic-Band implementation
+ by V.Asgeirsson, C. Riplinger & H. Jonsson
+Please cite in your paper:
+ V. Asgeirsson et al., in prep. (2019)
+   
+
+Warning: RI is on but no J-basis has been assigned. Assigning Def2/J (nothing to worry about!)
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: STO-3G
+   H-Ne       : W. J. Hehre, R. F. Stewart and J. A. Pople, J. Chem. Phys. 2657 (1969).
+   Na-Ar      : W. J. Hehre, R. Ditchfield, R. F. Stewart and J. A. Pople, J. Chem. Phys. 2769 (1970).
+   K,Ca,Ga-Kr : W. J. Pietro, B. A. Levy, W. J. Hehre and R. F. Stewart, J. Am. Chem. Soc. 19, 2225 (1980).
+   Sc-Zn,Y-Cd : W. J. Pietro and W. J. Hehre, J. Comp. Chem. 4, 241 (1983).
+
+----- AuxJ basis set information -----
+Your calculation utilizes the auxiliary basis: def2/J
+   F. Weigend, Phys. Chem. Chem. Phys. 8, 1057 (2006).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> 
+|  2> !uHF b3lyp sto-3g NEB-TS
+|  3> %maxcore 1792
+|  4> %pal nprocs 8 end
+|  5> 
+|  6> %neb 
+|  7>    Interpolation    IDPP
+|  8>    NImages  15
+|  9>    PrintLevel   3
+| 10>    PreOpt           true
+| 11>    NEB_END_XYZFILE "/home/kaplan.kfir/Code/runs/test_orca_adapter/product.xyz"
+| 12> END
+| 13> 
+| 14> * XYZFILE 0 2 /home/kaplan.kfir/Code/runs/test_orca_adapter/reactant.xyz
+| 15> 
+| 16>                          ****END OF INPUT****
+================================================================================
+
+
+--------------------------------------------------------------------------------
+                        Nudged Elastic Band Calculation
+--------------------------------------------------------------------------------
+
+Number of images (incl. end points)     ....  17
+Number of intermediate images           ....  15
+Number of optimized images              ....  15
+Optimization of end points before NEB   ....  YES
+Use existing gbw files for MO input     ....  NO
+Number of atoms                         ....  10
+Number of (active) degrees of freedom   ....  30
+Constrained atoms                       ....  None
+
+
+Before the actual NEB run reactant and product are preoptimized.
+
+---------------------------------------------------------------
+                        REACTANT OPTIMIZATION            
+---------------------------------------------------------------
+
+Geometry optimization settings:
+Update method            Update   .... BFGS
+Choice of coordinates    CoordSys .... (2022) Redundant Internals
+Initial Hessian          InHess   .... Almloef's Model
+Max. no of cycles        MaxIter  .... 50
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+Strict Convergence                .... False
+
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in redundant internal coordinates (2022)
+Making redundant internal coordinates   ...  (2022 redundants) done
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....   10
+The number of degrees of freedom        ....   24
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(C   1,C   0)                  1.4874         0.436819   
+      2. B(C   2,C   1)                  1.4874         0.436819   
+      3. B(H   3,C   0)                  1.0936         0.355309   
+      4. B(H   4,C   0)                  1.0939         0.355039   
+      5. B(H   5,C   0)                  1.0940         0.354789   
+      6. B(H   6,C   1)                  1.0847         0.367157   
+      7. B(H   7,C   2)                  1.0936         0.355309   
+      8. B(H   8,C   2)                  1.0940         0.354789   
+      9. B(H   9,C   2)                  1.0939         0.355039   
+     10. A(H   3,C   0,H   4)          109.0040         0.289585   
+     11. A(C   1,C   0,H   3)          110.4180         0.332060   
+     12. A(C   1,C   0,H   5)          110.0120         0.331980   
+     13. A(H   4,C   0,H   5)          107.9848         0.289518   
+     14. A(C   1,C   0,H   4)          111.0052         0.332018   
+     15. A(H   3,C   0,H   5)          108.3405         0.289553   
+     16. A(C   0,C   1,C   2)          119.7740         0.383479   
+     17. A(C   2,C   1,H   6)          119.2330         0.333872   
+     18. A(C   0,C   1,H   6)          119.2330         0.333872   
+     19. A(H   7,C   2,H   9)          109.0040         0.289585   
+     20. A(C   1,C   2,H   9)          111.0052         0.332018   
+     21. A(H   7,C   2,H   8)          108.3405         0.289553   
+     22. A(C   1,C   2,H   8)          110.0119         0.331980   
+     23. A(H   8,C   2,H   9)          107.9849         0.289518   
+     24. A(C   1,C   2,H   7)          110.4180         0.332060   
+     25. D(C   2,C   1,C   0,H   4)    -46.5024         0.014083   
+     26. D(H   6,C   1,C   0,H   3)    -90.2750         0.014083   
+     27. D(C   2,C   1,C   0,H   3)     74.5039         0.014083   
+     28. D(H   6,C   1,C   0,H   4)    148.7186         0.014083   
+     29. D(C   2,C   1,C   0,H   5)   -165.9641         0.014083   
+     30. D(H   7,C   2,C   1,H   6)     90.2750         0.014083   
+     31. D(H   7,C   2,C   1,C   0)    -74.5039         0.014083   
+     32. D(H   9,C   2,C   1,C   0)     46.5024         0.014083   
+     33. D(H   8,C   2,C   1,H   6)    -29.2570         0.014083   
+     34. D(H   8,C   2,C   1,C   0)    165.9640         0.014083   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 10
+Number of degrees of freedom            .... 34
+
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  10            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.332765   -0.020501    0.164771
+  C      0.049051    0.473498   -0.243411
+  C      1.287701   -0.381464   -0.009159
+  H     -1.500987    0.087106    1.254697
+  H     -1.459459   -1.087448   -0.082490
+  H     -2.123597    0.551490   -0.347375
+  H      0.189687    1.556265   -0.373011
+  H      1.622402   -0.337656    1.046231
+  H      2.128049   -0.038113   -0.634368
+  H      1.087551   -1.439468   -0.245981
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     6.0000    0    12.011   -2.518560   -0.038742    0.311372
+   1 C     6.0000    0    12.011    0.092693    0.894782   -0.459980
+   2 C     6.0000    0    12.011    2.433403   -0.720863   -0.017307
+   3 H     1.0000    0     1.008   -2.836454    0.164607    2.371034
+   4 H     1.0000    0     1.008   -2.757979   -2.054979   -0.155884
+   5 H     1.0000    0     1.008   -4.013017    1.042165   -0.656443
+   6 H     1.0000    0     1.008    0.358457    2.940915   -0.704889
+   7 H     1.0000    0     1.008    3.065896   -0.638077    1.977089
+   8 H     1.0000    0     1.008    4.021429   -0.072024   -1.198782
+   9 H     1.0000    0     1.008    2.055174   -2.720200   -0.464836
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.523175073640     0.00000000     0.00000000
+ C      2   1   0     1.523183991924   120.96226545     0.00000000
+ H      1   2   3     1.108069242934   111.70472065    78.15242973
+ H      1   2   3     1.102526422832   110.97774231   318.47471732
+ H      1   2   3     1.102217414936   110.98243349   197.87821642
+ H      2   1   3     1.099526508417   117.83980657   201.16276673
+ H      3   2   1     1.108057033254   111.71099985   281.49100245
+ H      3   2   1     1.102252449363   110.97117894   161.77422667
+ H      3   2   1     1.102504575450   110.97616840    41.19024623
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.878383743195     0.00000000     0.00000000
+ C      2   1   0     2.878400596310   120.96226545     0.00000000
+ H      1   2   3     2.093947406567   111.70472065    78.15242973
+ H      1   2   3     2.083472994564   110.97774231   318.47471732
+ H      1   2   3     2.082889054268   110.98243349   197.87821642
+ H      2   1   3     2.077803977895   117.83980657   201.16276673
+ H      3   2   1     2.093924333614   111.71099985   281.49100245
+ H      3   2   1     2.082955259739   110.97117894   161.77422667
+ H      3   2   1     2.083431708995   110.97616840    41.19024623
+
+
+           ************************************************************
+           *        Program running with 8 parallel MPI-processes     *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 15 minutes 42 seconds 419 msec

--- a/arc/testing/neb/neb_scf_no_total_energy.out
+++ b/arc/testing/neb/neb_scf_no_total_energy.out
@@ -1,0 +1,404 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Cooperlake SINGLE_THREADED
+        Core in use  :  Cooperlake
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+NOTE: MaxCore=1792 MB was set to SCF,MP2,MDCI,CIPSI,MRCI and CIS
+      => If you want to overwrite this, your respective input block should be placed after the MaxCore statement
+
+
+***************************************
+The coordinates will be read from file: /home/kaplan.kfir/Code/runs/test_orca_adapter/reactant.xyz
+***************************************
+
+
+Your calculation utilizes a Nudged-Elastic-Band implementation
+ by V.Asgeirsson, C. Riplinger & H. Jonsson
+Please cite in your paper:
+ V. Asgeirsson et al., in prep. (2019)
+   
+
+Warning: RI is on but no J-basis has been assigned. Assigning Def2/J (nothing to worry about!)
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: STO-3G
+   H-Ne       : W. J. Hehre, R. F. Stewart and J. A. Pople, J. Chem. Phys. 2657 (1969).
+   Na-Ar      : W. J. Hehre, R. Ditchfield, R. F. Stewart and J. A. Pople, J. Chem. Phys. 2769 (1970).
+   K,Ca,Ga-Kr : W. J. Pietro, B. A. Levy, W. J. Hehre and R. F. Stewart, J. Am. Chem. Soc. 19, 2225 (1980).
+   Sc-Zn,Y-Cd : W. J. Pietro and W. J. Hehre, J. Comp. Chem. 4, 241 (1983).
+
+----- AuxJ basis set information -----
+Your calculation utilizes the auxiliary basis: def2/J
+   F. Weigend, Phys. Chem. Chem. Phys. 8, 1057 (2006).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> 
+|  2> !uHF b3lyp sto-3g NEB-TS
+|  3> %maxcore 1792
+|  4> %pal nprocs 8 end
+|  5> 
+|  6> %neb 
+|  7>    Interpolation    IDPP
+|  8>    NImages  15
+|  9>    PrintLevel   3
+| 10>    PreOpt           true
+| 11>    NEB_END_XYZFILE "/home/kaplan.kfir/Code/runs/test_orca_adapter/product.xyz"
+| 12> END
+| 13> 
+| 14> * XYZFILE 0 2 /home/kaplan.kfir/Code/runs/test_orca_adapter/reactant.xyz
+| 15> 
+| 16>                          ****END OF INPUT****
+================================================================================
+
+
+--------------------------------------------------------------------------------
+                        Nudged Elastic Band Calculation
+--------------------------------------------------------------------------------
+
+Number of images (incl. end points)     ....  17
+Number of intermediate images           ....  15
+Number of optimized images              ....  15
+Optimization of end points before NEB   ....  YES
+Use existing gbw files for MO input     ....  NO
+Number of atoms                         ....  10
+Number of (active) degrees of freedom   ....  30
+Constrained atoms                       ....  None
+
+
+Before the actual NEB run reactant and product are preoptimized.
+
+---------------------------------------------------------------
+                        REACTANT OPTIMIZATION            
+---------------------------------------------------------------
+
+Geometry optimization settings:
+Update method            Update   .... BFGS
+Choice of coordinates    CoordSys .... (2022) Redundant Internals
+Initial Hessian          InHess   .... Almloef's Model
+Max. no of cycles        MaxIter  .... 50
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+Strict Convergence                .... False
+
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in redundant internal coordinates (2022)
+Making redundant internal coordinates   ...  (2022 redundants) done
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....   10
+The number of degrees of freedom        ....   24
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(C   1,C   0)                  1.4874         0.436819   
+      2. B(C   2,C   1)                  1.4874         0.436819   
+      3. B(H   3,C   0)                  1.0936         0.355309   
+      4. B(H   4,C   0)                  1.0939         0.355039   
+      5. B(H   5,C   0)                  1.0940         0.354789   
+      6. B(H   6,C   1)                  1.0847         0.367157   
+      7. B(H   7,C   2)                  1.0936         0.355309   
+      8. B(H   8,C   2)                  1.0940         0.354789   
+      9. B(H   9,C   2)                  1.0939         0.355039   
+     10. A(H   3,C   0,H   4)          109.0040         0.289585   
+     11. A(C   1,C   0,H   3)          110.4180         0.332060   
+     12. A(C   1,C   0,H   5)          110.0120         0.331980   
+     13. A(H   4,C   0,H   5)          107.9848         0.289518   
+     14. A(C   1,C   0,H   4)          111.0052         0.332018   
+     15. A(H   3,C   0,H   5)          108.3405         0.289553   
+     16. A(C   0,C   1,C   2)          119.7740         0.383479   
+     17. A(C   2,C   1,H   6)          119.2330         0.333872   
+     18. A(C   0,C   1,H   6)          119.2330         0.333872   
+     19. A(H   7,C   2,H   9)          109.0040         0.289585   
+     20. A(C   1,C   2,H   9)          111.0052         0.332018   
+     21. A(H   7,C   2,H   8)          108.3405         0.289553   
+     22. A(C   1,C   2,H   8)          110.0119         0.331980   
+     23. A(H   8,C   2,H   9)          107.9849         0.289518   
+     24. A(C   1,C   2,H   7)          110.4180         0.332060   
+     25. D(C   2,C   1,C   0,H   4)    -46.5024         0.014083   
+     26. D(H   6,C   1,C   0,H   3)    -90.2750         0.014083   
+     27. D(C   2,C   1,C   0,H   3)     74.5039         0.014083   
+     28. D(H   6,C   1,C   0,H   4)    148.7186         0.014083   
+     29. D(C   2,C   1,C   0,H   5)   -165.9641         0.014083   
+     30. D(H   7,C   2,C   1,H   6)     90.2750         0.014083   
+     31. D(H   7,C   2,C   1,C   0)    -74.5039         0.014083   
+     32. D(H   9,C   2,C   1,C   0)     46.5024         0.014083   
+     33. D(H   8,C   2,C   1,H   6)    -29.2570         0.014083   
+     34. D(H   8,C   2,C   1,C   0)    165.9640         0.014083   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 10
+Number of degrees of freedom            .... 34
+
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE  10            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  C     -1.332765   -0.020501    0.164771
+  C      0.049051    0.473498   -0.243411
+  C      1.287701   -0.381464   -0.009159
+  H     -1.500987    0.087106    1.254697
+  H     -1.459459   -1.087448   -0.082490
+  H     -2.123597    0.551490   -0.347375
+  H      0.189687    1.556265   -0.373011
+  H      1.622402   -0.337656    1.046231
+  H      2.128049   -0.038113   -0.634368
+  H      1.087551   -1.439468   -0.245981
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 C     6.0000    0    12.011   -2.518560   -0.038742    0.311372
+   1 C     6.0000    0    12.011    0.092693    0.894782   -0.459980
+   2 C     6.0000    0    12.011    2.433403   -0.720863   -0.017307
+   3 H     1.0000    0     1.008   -2.836454    0.164607    2.371034
+   4 H     1.0000    0     1.008   -2.757979   -2.054979   -0.155884
+   5 H     1.0000    0     1.008   -4.013017    1.042165   -0.656443
+   6 H     1.0000    0     1.008    0.358457    2.940915   -0.704889
+   7 H     1.0000    0     1.008    3.065896   -0.638077    1.977089
+   8 H     1.0000    0     1.008    4.021429   -0.072024   -1.198782
+   9 H     1.0000    0     1.008    2.055174   -2.720200   -0.464836
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.523175073640     0.00000000     0.00000000
+ C      2   1   0     1.523183991924   120.96226545     0.00000000
+ H      1   2   3     1.108069242934   111.70472065    78.15242973
+ H      1   2   3     1.102526422832   110.97774231   318.47471732
+ H      1   2   3     1.102217414936   110.98243349   197.87821642
+ H      2   1   3     1.099526508417   117.83980657   201.16276673
+ H      3   2   1     1.108057033254   111.71099985   281.49100245
+ H      3   2   1     1.102252449363   110.97117894   161.77422667
+ H      3   2   1     1.102504575450   110.97616840    41.19024623
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ C      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.878383743195     0.00000000     0.00000000
+ C      2   1   0     2.878400596310   120.96226545     0.00000000
+ H      1   2   3     2.093947406567   111.70472065    78.15242973
+ H      1   2   3     2.083472994564   110.97774231   318.47471732
+ H      1   2   3     2.082889054268   110.98243349   197.87821642
+ H      2   1   3     2.077803977895   117.83980657   201.16276673
+ H      3   2   1     2.093924333614   111.71099985   281.49100245
+ H      3   2   1     2.082955259739   110.97117894   161.77422667
+ H      3   2   1     2.083431708995   110.97616840    41.19024623
+
+
+           ************************************************************
+           *        Program running with 8 parallel MPI-processes     *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -116.9662711301396314     0.00e+00  2.36e-04  1.29e-03  3.15e-04     0.2
+               *** Restarting incremental Fock matrix formation ***
+    2    -116.9662893922658782    -1.83e-05  1.15e-04  7.34e-04  4.10e-04     0.1
+    3    -116.9662918221983432    -2.43e-06  2.36e-05  1.53e-04  7.95e-05     0.1
+    4    -116.9662918983407849    -7.61e-08  3.78e-06  3.46e-05  1.02e-05     0.1
+    5    -116.9662919006144648    -2.27e-09  7.34e-07  3.39e-06  2.27e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   5 CYCLES          *
+               *****************************************************
+
+Recomputing exchange energy using gridx3       ... done (    0.097 sec)
+Old exchange energy                            :     -3.614409188 Eh
+New exchange energy                            :     -3.614460377 Eh
+Exchange energy change after final integration :     -0.000051189 Eh
+Total energy after final integration           :   -116.966343090 Eh
+             **** ENERGY FILE WAS UPDATED (input_reactant.en.tmp) ****
+
+----------------
+
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 15 minutes 42 seconds 419 msec


### PR DESCRIPTION
This pull request improves how the code determines and handles the electronic-structure software (ESS) identity for job adapters, especially for cases where an adapter wraps another ESS (like Orca NEB using Orca logs). It also makes the Orca SCF energy parsing logic more robust and adds comprehensive tests to cover tricky log file formats and edge cases.

**Job Adapter and ESS Software Identity:**

* Added a new `ess_software` property to the base `JobAdapter` class, defaulting to the adapter's own name, and overridden in `OrcaNEBAdapter` to return `'orca'`, ensuring correct dispatch to ESS log parsers. [[1]](diffhunk://#diff-fed07595795e09f36c1c30059b2a3eecaae5b64b5b2dbfd3a8c73cf3c99bfe31R208-R218) [[2]](diffhunk://#diff-bc83e23e489b648c53d1a08e15ef42813c2cda2903dd3de1e995db337b0c50c5R212-R216)
* Updated internal calls in `_check_job_ess_status` to use `ess_software` instead of `job_adapter`, so that status checks use the correct ESS name even for adapters that wrap another ESS. [[1]](diffhunk://#diff-fed07595795e09f36c1c30059b2a3eecaae5b64b5b2dbfd3a8c73cf3c99bfe31L845-R856) [[2]](diffhunk://#diff-fed07595795e09f36c1c30059b2a3eecaae5b64b5b2dbfd3a8c73cf3c99bfe31L855-R866)

**Orca SCF Energy Parsing Improvements:**

* Improved the SCF energy extraction logic in `determine_ess_status` to handle Orca NEB log files where the first SCF iteration line may not immediately follow the expected marker, and to avoid errors if energy lines are missing. Now, if either the initial or final SCF energy is missing but the job terminated normally, the status is still reported as `'done'`. [[1]](diffhunk://#diff-543ab169dfe340e750c06406160a449f8e1b27f63f3bd9a268a8fafd53e5a9b1R268-R287) [[2]](diffhunk://#diff-543ab169dfe340e750c06406160a449f8e1b27f63f3bd9a268a8fafd53e5a9b1L294-R306)

**Testing Enhancements:**

* Added targeted tests in `orca_neb_test.py` to verify that Orca NEB jobs are properly recognized as `'done'` when the underlying Orca log terminates normally, and that the adapter/ESS identity logic is correct.
* Added and extended tests in `trsh_test.py` to cover Orca NEB log edge cases, including incomplete SCF blocks and missing energy lines, ensuring the parser never raises errors in these cases and always returns `'done'` for normal terminations. [[1]](diffhunk://#diff-bdbda1161999a2abc660b7d82f775faa50c532b3c612decb3866096ee8537c80R208-R221) [[2]](diffhunk://#diff-bdbda1161999a2abc660b7d82f775faa50c532b3c612decb3866096ee8537c80R389-R419)