### PR TITLE
Report piped species as converged when their sp/freq jobs succeed

### DIFF
--- a/arc/job/pipe/pipe_coordinator.py
+++ b/arc/job/pipe/pipe_coordinator.py
@@ -12,10 +12,15 @@ import os
 import time
 from typing import TYPE_CHECKING
 
+import arc.parser.parser as parser
 from arc.common import get_logger
 from arc.imports import settings
+from arc.level import Level
 
-from arc.job.pipe.pipe_run import PipeRun, ingest_completed_task
+from arc.job.pipe.pipe_run import (
+    PipeRun, check_ess_convergence, find_output_file, get_task_attempt_dir,
+    ingest_completed_task,
+)
 from arc.job.pipe.pipe_state import (
     TASK_FAMILY_TO_JOB_TYPE, PipeRunState, TaskState, TaskSpec,
     TaskStateRecord, read_task_state,
@@ -27,6 +32,31 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 pipe_settings = settings['pipe_settings']
+
+SPECIES_LEAF_FAMILIES = ('species_sp', 'species_freq')
+
+
+class PipedJobView:
+    """
+    A minimal job-like view of a completed pipe task.
+
+    ``Scheduler.post_freq_actions()`` and the checks it calls read only
+    ``local_path_to_output_file`` from the job they are handed, so a piped task can be validated
+    by the very same code path as an individually submitted job without materializing a full
+    ``JobAdapter``. ``level`` and ``job_status`` are provided so the view stays usable if those
+    checks grow to consult them. Job-resubmitting troubleshooting is not reachable through this
+    view, which is why ``post_freq_actions()`` and not ``check_freq_job()`` is the shared entry
+    point: the former is the whole success path, the latter also owns the failure path.
+
+    Args:
+        output_file (str): Path to the task's canonical output file.
+        level (Level, optional): The level of theory the task ran at.
+    """
+
+    def __init__(self, output_file: str, level: Level | None = None):
+        self.local_path_to_output_file = output_file
+        self.level = level
+        self.job_status = ['done', {'status': 'done'}]
 
 
 class PipeCoordinator:
@@ -276,6 +306,8 @@ class PipeCoordinator:
             if state.status == TaskState.COMPLETED.value:
                 ingest_completed_task(pipe.run_id, pipe.pipe_root, spec, state,
                                       self.sched.species_dict, self.sched.output)
+                if spec.task_family in SPECIES_LEAF_FAMILIES:
+                    self._finalize_species_leaf_task(pipe, spec, state)
             elif state.status == TaskState.FAILED_ESS.value:
                 self._eject_to_scheduler(pipe, spec, state)
                 ejected_count += 1
@@ -292,6 +324,64 @@ class PipeCoordinator:
         else:
             self._post_ingest_pipe_run(pipe)
 
+    def _finalize_species_leaf_task(self, pipe: PipeRun, spec: TaskSpec, state: TaskStateRecord) -> None:
+        """
+        Run the Scheduler's post-job checks for a completed ``species_sp`` / ``species_freq`` task.
+
+        Per-task ingestion records the parsed results, but the ``output[label]['job_types']``
+        success flags are owned by the Scheduler's post-job logic, which also performs the QA that
+        those flags stand for and produces the artifacts that other parts of ARC then read: for a
+        freq job the imaginary-frequency check (exactly zero for a stable species, exactly one for
+        a TS), ``species.freqs``, the ``freq.out`` copy in the species output folder, the
+        polarizability and the TS normal mode displacement check; for an sp job the T1 diagnostic,
+        the solvation-scheme follow-ups and the reaction-E0 check. Routing piped tasks through the
+        same methods keeps piped and individually submitted jobs judged identically and equally
+        well equipped, instead of duplicating any of it here where the two could drift apart.
+
+        This runs per task rather than in ``_post_ingest_pipe_run`` because a cross-species batch
+        carries one species per task, and because ``_post_ingest_pipe_run`` is skipped entirely
+        when any sibling task is ejected for troubleshooting.
+
+        A task can reach ``COMPLETED`` and still hold a non-converged ESS output, so the same
+        convergence gate the ingestion helpers apply is repeated here before any success flag
+        can be set.
+
+        Args:
+            pipe (PipeRun): The owning pipe run.
+            spec (TaskSpec): The completed task's specification.
+            state (TaskStateRecord): The completed task's state record.
+        """
+        label = spec.owner_key
+        if not label or label not in self.sched.species_dict:
+            logger.warning(f'Pipe run {pipe.run_id}, task {spec.task_id}: '
+                           f'species "{label}" not in species_dict, not finalizing.')
+            return
+        attempt_dir = get_task_attempt_dir(pipe.pipe_root, spec.task_id, state.attempt_index)
+        try:
+            output_file = find_output_file(attempt_dir, spec.engine, spec.task_id)
+        except Exception as e:
+            logger.error(f'Pipe run {pipe.run_id}, task {spec.task_id}: '
+                         f'output lookup failed while finalizing: {type(e).__name__}: {e}')
+            return
+        if output_file is None:
+            logger.warning(f'Pipe run {pipe.run_id}, task {spec.task_id}: '
+                           f'no output file found, not finalizing {spec.task_family} for {label}.')
+            return
+        if not check_ess_convergence(pipe.run_id, spec, output_file, label):
+            return
+        level = Level(repr=spec.level) if spec.level else None
+        try:
+            if spec.task_family == 'species_sp':
+                self.sched.post_sp_actions(label=label, sp_path=output_file, level=level)
+            elif spec.task_family == 'species_freq':
+                vibfreqs = parser.parse_frequencies(log_file_path=str(output_file))
+                self.sched.post_freq_actions(label=label,
+                                             job=PipedJobView(output_file, level),
+                                             vibfreqs=vibfreqs)
+        except Exception as e:
+            logger.error(f'Pipe run {pipe.run_id}, task {spec.task_id}: '
+                         f'could not finalize {spec.task_family} for {label}: {type(e).__name__}: {e}')
+
     def _post_ingest_pipe_run(self, pipe: PipeRun) -> None:
         """
         Trigger family-specific post-processing after all tasks in a pipe run
@@ -303,7 +393,9 @@ class PipeCoordinator:
           - conf_sp: determine most stable conformer (sp_flag), then run opt job
 
         Other families (species_sp, species_freq, irc, rotor_scan_1d) are
-        leaf jobs with no batch-level post-processing.
+        leaf jobs with no batch-level post-processing. The species_sp and
+        species_freq families are finalized per task instead, in
+        ``_finalize_species_leaf_task``.
         """
         if not pipe.tasks:
             return

--- a/arc/job/pipe/pipe_coordinator_test.py
+++ b/arc/job/pipe/pipe_coordinator_test.py
@@ -5,6 +5,8 @@
 This module contains unit tests for the arc.job.pipe.pipe_coordinator module
 """
 
+import functools
+import json
 import os
 import shutil
 import tempfile
@@ -13,13 +15,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from arc.job.pipe.pipe_coordinator import PipeCoordinator
-from arc.job.pipe.pipe_run import PipeRun
+from arc.job.pipe.pipe_run import PipeRun, get_task_attempt_dir
 from arc.job.pipe.pipe_state import (
     PipeRunState,
     TaskState,
     TaskSpec,
     update_task_state,
 )
+from arc.level import Level
+from arc.scheduler import Scheduler
 from arc.species import ARCSpecies
 
 
@@ -273,6 +277,178 @@ class TestIngestPipeResults(unittest.TestCase):
         # Remove state.json to simulate corruption
         os.remove(os.path.join(pipe.pipe_root, 'tasks', 't_missing', 'state.json'))
         self.coord.ingest_pipe_results(pipe)  # should not raise
+
+
+class TestFinalizeSpeciesLeafTask(unittest.TestCase):
+    """
+    Tests that piped species_sp / species_freq tasks are routed through the Scheduler's own
+    post-job checks, which own the ``output[label]['job_types']`` success flags. Without this,
+    a piped job computes correctly and is ingested, yet the species is reported as failed.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='pipe_coord_finalize_')
+        self.sched = _make_mock_sched(self.tmpdir)
+        self.coord = PipeCoordinator(self.sched)
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        convergence_patch = patch('arc.job.pipe.pipe_coordinator.check_ess_convergence',
+                                  return_value=True)
+        self.mock_convergence = convergence_patch.start()
+        self.addCleanup(convergence_patch.stop)
+
+    def _stage_completed(self, task_id, task_family):
+        """Stage a single-task pipe run, complete it, and give it a canonical output file."""
+        task = _make_spec(task_id, task_family=task_family)
+        pipe = self.coord.submit_pipe_run(f'run_{task_id}', [task])
+        _complete_task(pipe.pipe_root, task_id)
+        attempt_dir = get_task_attempt_dir(pipe.pipe_root, task_id, 0)
+        os.makedirs(attempt_dir, exist_ok=True)
+        output_file = os.path.join(attempt_dir, 'output.out')
+        with open(output_file, 'w') as f:
+            f.write('mock output\n')
+        with open(os.path.join(attempt_dir, 'result.json'), 'w') as f:
+            json.dump({'canonical_output_path': output_file}, f)
+        return pipe, output_file
+
+    def test_species_sp_is_finalized(self):
+        """A completed species_sp task runs post_sp_actions, which sets job_types['sp']."""
+        pipe, output_file = self._stage_completed('t_sp', 'species_sp')
+        self.coord.ingest_pipe_results(pipe)
+        self.sched.post_sp_actions.assert_called_once()
+        kwargs = self.sched.post_sp_actions.call_args.kwargs
+        self.assertEqual(kwargs['label'], 'H2O')
+        self.assertEqual(kwargs['sp_path'], output_file)
+
+    def test_species_freq_is_finalized(self):
+        """A completed species_freq task runs post_freq_actions, which sets job_types['freq']."""
+        pipe, output_file = self._stage_completed('t_freq', 'species_freq')
+        with patch('arc.job.pipe.pipe_coordinator.parser.parse_frequencies',
+                   return_value=[1500.0, 3000.0]):
+            self.coord.ingest_pipe_results(pipe)
+        self.sched.post_freq_actions.assert_called_once()
+        kwargs = self.sched.post_freq_actions.call_args.kwargs
+        self.assertEqual(kwargs['label'], 'H2O')
+        self.assertEqual(kwargs['vibfreqs'], [1500.0, 3000.0])
+        self.assertEqual(kwargs['job'].local_path_to_output_file, output_file)
+
+    def test_other_families_are_not_finalized(self):
+        """conf_opt has its own post-ingestion handler and must not be finalized here."""
+        pipe, _ = self._stage_completed('t_conf', 'conf_opt')
+        self.coord.ingest_pipe_results(pipe)
+        self.sched.post_sp_actions.assert_not_called()
+        self.sched.post_freq_actions.assert_not_called()
+
+    def test_unknown_species_is_skipped(self):
+        """An owner_key absent from species_dict is skipped rather than raising."""
+        pipe, _ = self._stage_completed('t_unknown', 'species_sp')
+        self.sched.species_dict.pop('H2O')
+        self.coord.ingest_pipe_results(pipe)
+        self.sched.post_sp_actions.assert_not_called()
+
+    def test_non_converged_ess_is_not_finalized(self):
+        """A task can be COMPLETED yet hold a non-converged output; it must not be flagged."""
+        pipe, _ = self._stage_completed('t_unconverged', 'species_sp')
+        self.mock_convergence.return_value = False
+        self.coord.ingest_pipe_results(pipe)
+        self.sched.post_sp_actions.assert_not_called()
+
+    def test_missing_output_file_is_skipped(self):
+        """A completed task with no locatable output does not reach the Scheduler checks."""
+        task = _make_spec('t_no_out', task_family='species_sp')
+        pipe = self.coord.submit_pipe_run('run_no_out', [task])
+        _complete_task(pipe.pipe_root, 't_no_out')
+        self.coord.ingest_pipe_results(pipe)
+        self.sched.post_sp_actions.assert_not_called()
+
+
+class _RealMethodSchedulerStub:
+    """
+    A Scheduler stand-in that runs the Scheduler's real post-job methods over stub state.
+
+    Every attribute that is not stub state falls through to the Scheduler class, so whichever
+    post-job method the coordinator reaches for is the production implementation, bound to this
+    object. Tests can therefore observe what a piped task actually leaves behind, rather than
+    only that some method was called on a mock.
+    """
+
+    def __init__(self, project_directory, species):
+        self.project_directory = project_directory
+        self.server_job_ids = list()
+        self.species_dict = {species.label: species}
+        self.output = {species.label: {'paths': {'sp': '', 'composite': '', 'freq': ''},
+                                       'job_types': dict(),
+                                       'warnings': '',
+                                       'info': ''}}
+        self.testing = True
+        self.trsh_ess_jobs = False
+        self.skip_nmd = False
+        self.rxn_dict = dict()
+        self.rxn_list = list()
+        self.freq_level = Level(repr='wb97xd/def2tzvp')
+
+    def __getattr__(self, name):
+        return functools.partial(getattr(Scheduler, name), self)
+
+
+class TestPipedFreqArtifacts(unittest.TestCase):
+    """
+    Tests that a piped species_freq task leaves behind everything a converged freq job is
+    expected to leave behind, not merely the ``job_types['freq']`` success flag.
+
+    Marking a species converged while ``species.freqs`` is unset and no ``freq.out`` sits in its
+    output folder would trade a loud failure for a quiet one: ``compute_rxn_e0()`` abandons the
+    reaction E0 check when that file is missing for any participant, and the frequencies would
+    never reach the restart or output files.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='pipe_coord_freq_artifacts_')
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.species = ARCSpecies(label='H2O', smiles='O')
+        self.sched = _RealMethodSchedulerStub(self.tmpdir, self.species)
+        self.coord = PipeCoordinator(self.sched)
+        self.freq_out = os.path.join(self.tmpdir, 'output', 'Species', 'H2O', 'geometry', 'freq.out')
+        convergence_patch = patch('arc.job.pipe.pipe_coordinator.check_ess_convergence', return_value=True)
+        convergence_patch.start()
+        self.addCleanup(convergence_patch.stop)
+        ingest_patch = patch('arc.job.pipe.pipe_coordinator.ingest_completed_task')
+        ingest_patch.start()
+        self.addCleanup(ingest_patch.stop)
+
+    def _ingest_freq_task(self, task_id, vibfreqs):
+        """Stage, complete and ingest a single species_freq task yielding ``vibfreqs``."""
+        task = _make_spec(task_id, task_family='species_freq')
+        pipe = self.coord.submit_pipe_run(f'run_{task_id}', [task])
+        _complete_task(pipe.pipe_root, task_id)
+        attempt_dir = get_task_attempt_dir(pipe.pipe_root, task_id, 0)
+        os.makedirs(attempt_dir, exist_ok=True)
+        output_file = os.path.join(attempt_dir, 'output.out')
+        with open(output_file, 'w') as f:
+            f.write('mock freq output\n')
+        with open(os.path.join(attempt_dir, 'result.json'), 'w') as f:
+            json.dump({'canonical_output_path': output_file}, f)
+        with patch('arc.job.pipe.pipe_coordinator.parser.parse_frequencies', return_value=vibfreqs):
+            self.coord.ingest_pipe_results(pipe)
+
+    def test_converged_freq_sets_freqs_and_writes_freq_out(self):
+        """A piped freq task that passes the check must populate species.freqs and freq.out."""
+        self._ingest_freq_task('t_freq_ok', [1500.0, 3000.0, 3700.0])
+        self.assertTrue(self.sched.output['H2O']['job_types']['freq'])
+        self.assertEqual(self.species.freqs, [1500.0, 3000.0, 3700.0])
+        self.assertTrue(os.path.isfile(self.freq_out),
+                        f'Expected the freq output to be copied to {self.freq_out}')
+        with open(self.freq_out, 'r') as f:
+            self.assertIn('mock freq output', f.read())
+
+    def test_imaginary_freq_leaves_no_artifacts(self):
+        """
+        A stable species carrying an imaginary frequency must fail the check, and must not be
+        credited with any of the artifacts a converged freq job produces.
+        """
+        self._ingest_freq_task('t_freq_imag', [-800.0, 1500.0, 3000.0])
+        self.assertFalse(self.sched.output['H2O']['job_types'].get('freq', False))
+        self.assertIsNone(self.species.freqs)
+        self.assertFalse(os.path.isfile(self.freq_out))
 
 
 class TestComputePipeRoot(unittest.TestCase):

--- a/arc/job/pipe/pipe_run.py
+++ b/arc/job/pipe/pipe_run.py
@@ -500,7 +500,7 @@ def find_output_file(attempt_dir: str, engine: str, task_id: str = '') -> str | 
     return None
 
 
-def _check_ess_convergence(pipe_run_id: str, spec: TaskSpec, output_file: str, label: str) -> bool:
+def check_ess_convergence(pipe_run_id: str, spec: TaskSpec, output_file: str, label: str) -> bool:
     """
     Check whether an ESS job converged by inspecting the output file.
 
@@ -575,7 +575,7 @@ def _ingest_conf_opt(run_id, pipe_root, spec, state, species_dict, label, confor
         output_file = find_output_file(attempt_dir, spec.engine, spec.task_id)
         if output_file is None:
             return
-        if not _check_ess_convergence(run_id, spec, output_file, label):
+        if not check_ess_convergence(run_id, spec, output_file, label):
             return
         xyz = parser.parse_geometry(log_file_path=output_file)
         e_elect = parser.parse_e_elect(log_file_path=output_file)
@@ -597,7 +597,7 @@ def _ingest_conf_sp(run_id, pipe_root, spec, state, species_dict, label, conform
         output_file = find_output_file(attempt_dir, spec.engine, spec.task_id)
         if output_file is None:
             return
-        if not _check_ess_convergence(run_id, spec, output_file, label):
+        if not check_ess_convergence(run_id, spec, output_file, label):
             return
         e_elect = parser.parse_e_elect(log_file_path=output_file)
     except Exception as e:
@@ -647,7 +647,7 @@ def _ingest_ts_opt(run_id, pipe_root, spec, state, species_dict, label):
         output_file = find_output_file(attempt_dir, spec.engine, spec.task_id)
         if output_file is None:
             return
-        if not _check_ess_convergence(run_id, spec, output_file, label):
+        if not check_ess_convergence(run_id, spec, output_file, label):
             return
         xyz = parser.parse_geometry(log_file_path=output_file)
         e_elect = parser.parse_e_elect(log_file_path=output_file)
@@ -679,7 +679,7 @@ def _ingest_species_sp(run_id, pipe_root, spec, state, species_dict, label):
         output_file = find_output_file(attempt_dir, spec.engine, spec.task_id)
         if output_file is None:
             return
-        if not _check_ess_convergence(run_id, spec, output_file, label):
+        if not check_ess_convergence(run_id, spec, output_file, label):
             return
         e_elect = parser.parse_e_elect(log_file_path=output_file)
     except Exception as e:
@@ -702,7 +702,7 @@ def _ingest_species_freq(run_id, pipe_root, spec, state, species_dict, label, ou
         logger.error(f'Pipe run {run_id}, task {spec.task_id}: '
                      f'output lookup failed: {type(e).__name__}: {e}')
         return
-    if output_file is not None and _check_ess_convergence(run_id, spec, output_file, label):
+    if output_file is not None and check_ess_convergence(run_id, spec, output_file, label):
         if label not in output:
             output[label] = {'paths': {}}
         elif 'paths' not in output[label]:
@@ -722,7 +722,7 @@ def _ingest_irc(run_id, pipe_root, spec, state, species_dict, label, output):
         logger.error(f'Pipe run {run_id}, task {spec.task_id}: '
                      f'output lookup failed: {type(e).__name__}: {e}')
         return
-    if output_file is not None and _check_ess_convergence(run_id, spec, output_file, label):
+    if output_file is not None and check_ess_convergence(run_id, spec, output_file, label):
         if label not in output:
             output[label] = {'paths': {'irc': []}}
         elif 'paths' not in output[label]:
@@ -746,7 +746,7 @@ def _ingest_rotor_scan_1d(run_id, pipe_root, spec, state, species_dict, label):
         return
     if output_file is None:
         return
-    if not _check_ess_convergence(run_id, spec, output_file, label):
+    if not check_ess_convergence(run_id, spec, output_file, label):
         return
     meta = spec.ingestion_metadata or {}
     rotor_index = meta.get('rotor_index')

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -78,6 +78,8 @@ LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ, default_job_settings, \
     settings['default_job_types'], settings['ts_adapters'], settings['max_ess_trsh'], settings['max_rotor_trsh'], \
     settings['rotor_scan_resolution'], settings['servers']
 
+WRONG_FREQ_MESSAGE = 'wrong number of negative frequencies; '
+
 
 class Scheduler(object):
     """
@@ -535,6 +537,29 @@ class Scheduler(object):
         if not self.testing:
             self.schedule_jobs()
 
+    def has_pending_pipe_work(self, label: str) -> bool:
+        """
+        Whether a species still has work queued for, or running in, a pipe run.
+
+        A species whose jobs were routed to pipe mode holds no entries in ``running_jobs``, so an
+        empty entry does not mean that species is finished. It must be kept until its pipe work
+        terminates: dropping it leaves ``check_all_done()`` unreachable for that species, because
+        the main loop only reaches it through ``running_jobs``. The species would then never be
+        marked as converged even once every one of its piped jobs had succeeded.
+
+        Args:
+            label (str): The species label.
+
+        Returns:
+            bool: ``True`` if any pending batch or active pipe run still holds this species.
+        """
+        return (label in self._pending_pipe_sp
+                or label in self._pending_pipe_freq
+                or any(lbl == label for lbl, _ in self._pending_pipe_irc)
+                or label in self._pending_pipe_conf_sp
+                or any(label in {t.owner_key for t in p.tasks}
+                       for p in self.active_pipes.values()))
+
     def flush_pending_pipe_batches(self) -> None:
         """
         Attempt to submit accumulated deferred pipe batches for SP, freq, IRC, and conf_sp.
@@ -821,17 +846,8 @@ class Scheduler(object):
                             self.timer = False
                             break
 
-                if not len(job_list):
-                    has_pending_pipe_work = (
-                        label in self._pending_pipe_sp
-                        or label in self._pending_pipe_freq
-                        or any(lbl == label for lbl, _ in self._pending_pipe_irc)
-                        or label in self._pending_pipe_conf_sp
-                        or any(label in {t.owner_key for t in p.tasks}
-                               for p in self.active_pipes.values())
-                    )
-                    if not has_pending_pipe_work:
-                        self.check_all_done(label)
+                if not len(job_list) and not self.has_pending_pipe_work(label):
+                    self.check_all_done(label)
                     if not self.running_jobs[label]:
                         # Delete the label only if it represents an empty entry.
                         del self.running_jobs[label]
@@ -2630,55 +2646,88 @@ class Scheduler(object):
             label (str): The species label.
             job (JobAdapter): The frequency job object instance.
         """
-        freq_ok, switch_ts = False, False
-        wrong_freq_message = 'wrong number of negative frequencies; '
+        freq_ok = False
         if job.job_status[1]['status'] == 'done':
             if not os.path.isfile(job.local_path_to_output_file):
                 raise SchedulerError('Called check_freq_job with no output file')
             vibfreqs = parser.parse_frequencies(log_file_path=str(job.local_path_to_output_file))
-            freq_ok = self.check_negative_freq(label=label, job=job, vibfreqs=vibfreqs)
-            if freq_ok and vibfreqs is not None:
-                self.species_dict[label].freqs = [float(f) for f in vibfreqs]
-            if freq_ok:
-                # Copy the frequency file to the species / TS output folder.
-                folder_name = 'rxns' if self.species_dict[label].is_ts else 'Species'
-                freq_path = os.path.join(self.project_directory, 'output', folder_name, label, 'geometry', 'freq.out')
-                safe_copy_file(source=job.local_path_to_output_file, destination=freq_path)
-                # Set species.polarizability.
-                polarizability = parser.parse_polarizability(job.local_path_to_output_file)
-                if polarizability is not None:
-                    self.species_dict[label].transport_data.polarizability = (polarizability, str('angstroms^3'))
-                    if self.species_dict[label].transport_data.comment:
-                        self.species_dict[label].transport_data.comment += \
-                            str(f'\nPolarizability calculated at the {self.freq_level.simple()} level of theory')
-                    else:
-                        self.species_dict[label].transport_data.comment = \
-                            str(f'Polarizability calculated at the {self.freq_level.simple()} level of theory')
-                if self.species_dict[label].is_ts:
-                    if self.species_dict[label].rxn_index in self.rxn_dict.keys():
-                        check_ts(reaction=self.rxn_dict[self.species_dict[label].rxn_index],
-                                 job=job,
-                                 checks=['NMD'],
-                                 skip_nmd=self.skip_nmd,
-                                 )
-                    if self.species_dict[label].ts_checks['NMD'] is False:
-                        logger.info(f'TS {label} did not pass the normal mode displacement check. '
-                                    f'Status is:\n{self.species_dict[label].ts_checks}\n'
-                                    f'Searching for a better TS conformer...')
-                        self.switch_ts(label)
-                        switch_ts = True
-                if wrong_freq_message in self.output[label]['warnings']:
-                    self.output[label]['warnings'] = ''.join(self.output[label]['warnings'].split(wrong_freq_message))
-            elif not self.species_dict[label].is_ts and self.trsh_ess_jobs:
-                # Only trsh neg freq here for non TS species, trsh TS species is done in check_negative_freq().
-                self.troubleshoot_negative_freq(label=label, job=job)
+            freq_ok, _ = self.post_freq_actions(label=label, job=job, vibfreqs=vibfreqs)
             if not freq_ok:
-                self.output[label]['warnings'] += wrong_freq_message
+                if not self.species_dict[label].is_ts and self.trsh_ess_jobs:
+                    # Only trsh neg freq here for non TS species, trsh TS species is done in check_negative_freq().
+                    self.troubleshoot_negative_freq(label=label, job=job)
+                self.output[label]['warnings'] += WRONG_FREQ_MESSAGE
         if job.job_status[1]['status'] != 'done' or (not freq_ok and not self.species_dict[label].is_ts):
             self.troubleshoot_ess(label=label, job=job, level_of_theory=job.level)
-        if (job.job_status[1]['status'] == 'done' and freq_ok and not switch_ts
-                and species_has_sp(self.output[label], self.species_dict[label].yml_path)):
+
+    def post_freq_actions(self,
+                          label: str,
+                          job: JobAdapter,
+                          vibfreqs: list | np.ndarray | None,
+                          ) -> tuple[bool, bool]:
+        """
+        Run the imaginary frequency QA and, if it passes, perform every action a converged freq job
+        is expected to leave behind.
+
+        Pipe mode computes a batch of freq tasks outside the Scheduler's job machinery and hands the
+        results back to be checked, so it is a second caller of this method. Both routes share it so
+        that a species cannot be reported as converged while missing the artifacts its consumers
+        read: ``species.freqs``, which carries the frequencies into the restart and output files, and
+        the ``freq.out`` copy under the species output folder, whose absence makes
+        ``compute_rxn_e0()`` give up on the reaction E0 check. For a TS this is also where the normal
+        mode displacement check runs, so skipping it would leave the TS permanently un-validated.
+
+        Troubleshooting a failed check is deliberately not done here: it resubmits jobs and therefore
+        needs a real job object, which only a Scheduler-submitted job has.
+
+        Args:
+            label (str): The species label.
+            job (JobAdapter): The frequency job object instance.
+            vibfreqs (list | np.ndarray | None): The vibrational frequencies,
+                                                 or ``None`` if they could not be parsed.
+
+        Returns:
+            tuple[bool, bool]: Whether the frequencies passed the check,
+                               and whether a different TS guess was selected as a result.
+        """
+        switch_ts = False
+        if not self.check_negative_freq(label=label, job=job, vibfreqs=vibfreqs):
+            return False, False
+        if vibfreqs is not None:
+            self.species_dict[label].freqs = [float(f) for f in vibfreqs]
+        # Copy the frequency file to the species / TS output folder.
+        folder_name = 'rxns' if self.species_dict[label].is_ts else 'Species'
+        freq_path = os.path.join(self.project_directory, 'output', folder_name, label, 'geometry', 'freq.out')
+        os.makedirs(os.path.dirname(freq_path), exist_ok=True)
+        safe_copy_file(source=job.local_path_to_output_file, destination=freq_path)
+        # Set species.polarizability.
+        polarizability = parser.parse_polarizability(job.local_path_to_output_file)
+        if polarizability is not None:
+            self.species_dict[label].transport_data.polarizability = (polarizability, str('angstroms^3'))
+            if self.species_dict[label].transport_data.comment:
+                self.species_dict[label].transport_data.comment += \
+                    str(f'\nPolarizability calculated at the {self.freq_level.simple()} level of theory')
+            else:
+                self.species_dict[label].transport_data.comment = \
+                    str(f'Polarizability calculated at the {self.freq_level.simple()} level of theory')
+        if self.species_dict[label].is_ts:
+            if self.species_dict[label].rxn_index in self.rxn_dict.keys():
+                check_ts(reaction=self.rxn_dict[self.species_dict[label].rxn_index],
+                         job=job,
+                         checks=['NMD'],
+                         skip_nmd=self.skip_nmd,
+                         )
+            if self.species_dict[label].ts_checks['NMD'] is False:
+                logger.info(f'TS {label} did not pass the normal mode displacement check. '
+                            f'Status is:\n{self.species_dict[label].ts_checks}\n'
+                            f'Searching for a better TS conformer...')
+                self.switch_ts(label)
+                switch_ts = True
+        if WRONG_FREQ_MESSAGE in self.output[label]['warnings']:
+            self.output[label]['warnings'] = ''.join(self.output[label]['warnings'].split(WRONG_FREQ_MESSAGE))
+        if not switch_ts and species_has_sp(self.output[label], self.species_dict[label].yml_path):
             self.check_rxn_e0_by_spc(label)
+        return True, switch_ts
 
     def check_negative_freq(self,
                             label: str,

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -29,6 +29,47 @@ from arc.species.species import ARCSpecies, TSGuess
 default_levels_of_theory = settings['default_levels_of_theory']
 
 
+class TestHasPendingPipeWork(unittest.TestCase):
+    """Tests for Scheduler.has_pending_pipe_work()."""
+
+    def test_has_pending_pipe_work(self):
+        """
+        A species routed to pipe mode holds no running_jobs entries, so it must be reported as
+        still busy until every pending batch and active pipe run has released it. Otherwise the
+        main loop drops its label and check_all_done() never runs for it.
+        """
+        label = 'spc_under_test'
+        sched = MagicMock()
+        sched._pending_pipe_sp = set()
+        sched._pending_pipe_freq = set()
+        sched._pending_pipe_irc = list()
+        sched._pending_pipe_conf_sp = dict()
+        sched.active_pipes = dict()
+        self.assertFalse(Scheduler.has_pending_pipe_work(sched, label))
+
+        sched._pending_pipe_sp.add(label)
+        self.assertTrue(Scheduler.has_pending_pipe_work(sched, label))
+        sched._pending_pipe_sp.clear()
+
+        sched._pending_pipe_freq.add(label)
+        self.assertTrue(Scheduler.has_pending_pipe_work(sched, label))
+        sched._pending_pipe_freq.clear()
+
+        sched._pending_pipe_irc.append((label, 'forward'))
+        self.assertTrue(Scheduler.has_pending_pipe_work(sched, label))
+        sched._pending_pipe_irc.clear()
+
+        sched._pending_pipe_conf_sp[label] = {0, 1}
+        self.assertTrue(Scheduler.has_pending_pipe_work(sched, label))
+        sched._pending_pipe_conf_sp.clear()
+
+        pipe = MagicMock()
+        pipe.tasks = [MagicMock(owner_key=label)]
+        sched.active_pipes['run_0'] = pipe
+        self.assertTrue(Scheduler.has_pending_pipe_work(sched, label))
+        self.assertFalse(Scheduler.has_pending_pipe_work(sched, 'a_label_no_pipe_holds'))
+
+
 class TestScheduler(unittest.TestCase):
     """
     Contains unit tests for the Scheduler class
@@ -209,6 +250,43 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=None))
         # An empty freqs list for a polyatomic non-TS species must not sneak through as successful.
         self.assertFalse(self.sched1.check_negative_freq(label=label, job=self.job3, vibfreqs=list()))
+
+    def test_post_freq_actions(self):
+        """
+        Test the post_freq_actions() method.
+
+        This is the whole success path of a freq job, shared by check_freq_job() and by pipe mode.
+        Passing the imaginary frequency check is not on its own enough to call a freq job done:
+        species.freqs and the freq.out copy under the species output folder must exist too, or
+        consumers such as compute_rxn_e0() have nothing to read.
+        """
+        label = 'C2H6'
+        self.job3.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'C2H6_freq_QChem.out')
+        self.job3.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
+        freq_path = os.path.join(self.project_directory, 'output', 'Species', label, 'geometry', 'freq.out')
+        if os.path.isfile(freq_path):
+            os.remove(freq_path)
+        self.sched1.species_dict[label].freqs = None
+
+        vibfreqs = parser.parse_frequencies(log_file_path=self.job3.local_path_to_output_file)
+        freq_ok, switch_ts = self.sched1.post_freq_actions(label=label, job=self.job3, vibfreqs=vibfreqs)
+        self.assertTrue(freq_ok)
+        self.assertFalse(switch_ts)
+        self.assertTrue(self.sched1.output[label]['job_types']['freq'])
+        self.assertEqual(self.sched1.species_dict[label].freqs, [float(f) for f in vibfreqs])
+        self.assertTrue(os.path.isfile(freq_path))
+
+        # A failed check must leave none of the above behind.
+        os.remove(freq_path)
+        self.sched1.species_dict[label].freqs = None
+        self.sched1.output[label]['job_types']['freq'] = False
+        freq_ok, switch_ts = self.sched1.post_freq_actions(label=label, job=self.job3,
+                                                           vibfreqs=[-500.0] + list(vibfreqs))
+        self.assertFalse(freq_ok)
+        self.assertFalse(switch_ts)
+        self.assertFalse(self.sched1.output[label]['job_types']['freq'])
+        self.assertIsNone(self.sched1.species_dict[label].freqs)
+        self.assertFalse(os.path.isfile(freq_path))
 
     def test_determine_adaptive_level(self):
         """Test the determine_adaptive_level() method"""


### PR DESCRIPTION
## The bug

A `species_sp` or `species_freq` task routed through pipe mode computes correctly, writes valid output, passes `determine_ess_status` and is ingested — and the species is then reported as **failed**, aborting the rate coefficient:

```
Species CH4 failed with status:
{'sp': False, 'conf_opt': True, 'freq': False, 'opt': True}
...
Error: Cannot compute a rate coefficient for CH4 + OH <=> CH3 + H2O.
       Species ['CH4', 'OH', 'CH3', 'H2O'] did not converge.
```

The data is all present. From `restart.yml` of that run: `e_elect: -106300.678` and `paths['freq']: True`, sitting next to `job_types: {'freq': False, 'sp': False}`.

There are two independent causes.

**1. Nothing sets the success flags.** `_ingest_species_sp()` sets `species.e_elect` and `_ingest_species_freq()` sets `output[label]['paths']['freq']`, but neither sets `output[label]['job_types']['sp'|'freq']`. Those are only ever set on the non-piped path in `scheduler.py`. `_ingest_species_sp()` also never sets `paths['sp']`.

**2. The species stops being reachable.** `check_all_done()` is only called from the main loop while iterating `running_jobs`, and a piped species holds no entries there. Its empty entry was deleted on the first iteration after the batch was submitted — even though `has_pending_pipe_work()` had just reported it busy — so when the pipe run finished the label was gone and `convergence` stayed `False`.

## Why the flags aren't just set directly

`job_types['freq']` is not a "job finished" marker. It stands for the imaginary-frequency QA — exactly zero for a stable species, exactly one for a TS, with `switch_ts()` on failure. `job_types['sp']` is set only at the *end* of `post_sp_actions()`, after the T1 diagnostic, solvation-scheme follow-ups and the reaction-E0 check.

Setting the booleans directly would convert a fail-safe bug, where good results are discarded, into a fail-open one where a stable species carrying an imaginary frequency is accepted as converged.

So piped tasks are routed through the same Scheduler methods the individually submitted ones use. This is cheap: `post_sp_actions()` is already path-based and needs no adaptation, and `check_negative_freq()` reads only `local_path_to_output_file` from its job argument, so a minimal `PipedJobView` supplies it.

Finalization runs per task inside the ingestion loop rather than in `_post_ingest_pipe_run()`, because a cross-species batch carries one species per task and because `_post_ingest_pipe_run()` is skipped entirely when any sibling task is ejected for troubleshooting. A task can reach `COMPLETED` while still holding a non-converged ESS output, so the convergence gate is repeated before any flag can be set.

## Why this went unnoticed

The path is only reached when a `species_sp`/`species_freq` batch actually forms, which needs at least `pipe_settings['min_tasks']` (default **10**) homogeneous species-level tasks in a single flush. Ordinary runs have far fewer species, fall through to `run_sp_job()` / `run_freq_job()` per label, and are unaffected. Existing production runs only ever formed `ts_opt` batches, which have their own post-ingestion handler and never consult `job_types`.

It becomes reachable in large campaigns — which is exactly what pipe mode is for.

Nothing here is engine-specific; the ingestion helpers contain no engine branching.

## Verification

End-to-end A/B on four species (CH4, OH, CH3, H2O), identical input, toggling only `pipe_settings['enabled']`, with `min_tasks: 2` so the batches actually form:

| | verdict |
|---|---|
| pipe off (control) | converged successfully ×4 |
| pipe on, before | failed with status ×4 |
| pipe on, after | converged successfully ×4 |

Confirmed in the log that the batches genuinely formed (`Routing 4 species SP jobs to pipe mode`), not that pipe mode was skipped.

Tests: 6 new for the coordinator (the two positive ones fail without the fix; guard cases cover non-converged ESS, missing output, unknown species, and other families) and 1 for `has_pending_pipe_work()` covering all five branches. `arc/job/pipe/` 149 passed; `arc/scheduler_test.py` 30 passed serially.

Note: `arc/scheduler_test.py` has pre-existing order-dependent failures under xdist (`TestScheduler` shares class-level fixtures and project directories across its tests). Under CI's `-n 6 --dist worksteal`, `main` already fails `test_initialize_output_dict` and `test_check_rxn_e0_by_spc` without any of these changes; all pass with `--dist loadscope` or `-n 0`. The new test is its own `TestCase` to avoid perturbing that class further.

`_check_ess_convergence` is renamed to `check_ess_convergence` now that it has a caller in a sibling module.