### PR TITLE
Make the IRC verdict meaningful, enforce it, and never publish a rate silently from an IRC-invalid TS

### DIFF
--- a/arc/checks/common.py
+++ b/arc/checks/common.py
@@ -4,8 +4,13 @@ contains helper functions for Scheduler.
 """
 
 import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arc.species.species import ARCSpecies
 
 CONFORMER_JOB_TYPES = ('conf_opt', 'conf_sp')
+TS_IRC_FAILED_MARKER = 'INVALID TS (failed IRC validation)'
 
 
 def is_conformer_job(job_name: str) -> bool:
@@ -56,3 +61,55 @@ def get_i_from_job_name(job_name: str) -> int | None:
     if job_name.startswith('tsg'):
         i = int(job_name[3:])
     return i
+
+
+def is_ts_check_exempt(check: str,
+                       ts_checks: dict,
+                       ) -> bool:
+    """
+    Determine whether a failed TS check is exempt, i.e., does not count as a TS validation failure.
+
+    The only exemption is 'e_elect': the electronic-energy barrier check is superseded by the
+    zero-point-corrected 'E0' check, so a failed 'e_elect' is excused once 'E0' passed.
+    'E0' is looked up with ``dict.get()``, so a ``ts_checks`` dictionary that has no 'E0' key
+    yields ``False`` (not exempt) instead of raising a ``KeyError``.
+
+    Args:
+        check (str): The key of the ``ts_checks`` entry being evaluated.
+        ts_checks (dict): The ``ts_checks`` dictionary of the TS species.
+
+    Returns:
+        bool: Whether a failed ``check`` is exempt.
+    """
+    return check == 'e_elect' and bool(ts_checks.get('E0'))
+
+
+def get_ts_validation_comment(ts_species: 'ARCSpecies | None') -> str | None:
+    """
+    Get a human-readable marker describing a positively-failed TS validation.
+
+    Only a ``ts_checks['IRC']`` value of ``False`` (checked and failed) produces a marker.
+    A value of ``None`` means the IRC check was not performed (e.g., IRC was not requested,
+    or the reaction connectivity was unavailable) and is treated as unknown, not as a failure.
+
+    The marker names any other TS check that also failed, applying the same exemption as
+    ``ts.ts_passed_checks()``: a ``False`` 'e_elect' is not reported once 'E0' passed.
+
+    Args:
+        ts_species (ARCSpecies, optional): The TS species of the reaction the rate was computed for.
+
+    Returns:
+        str | None: The marker, or ``None`` if the TS did not positively fail the IRC check.
+    """
+    ts_checks = getattr(ts_species, 'ts_checks', None) or dict()
+    if ts_checks.get('IRC', None) is not False:
+        return None
+    comment = f'{TS_IRC_FAILED_MARKER}: the optimized IRC endpoints of this TS do not correspond to the ' \
+              f'reactants and products of this reaction, therefore this rate coefficient does not describe ' \
+              f'this reaction and must not be used.'
+    other_failed_checks = sorted(key for key, val in ts_checks.items()
+                                 if key not in ['IRC', 'warnings'] and val is False
+                                 and not is_ts_check_exempt(key, ts_checks))
+    if other_failed_checks:
+        comment += f' Additional TS checks that failed: {", ".join(other_failed_checks)}.'
+    return comment

--- a/arc/checks/common_test.py
+++ b/arc/checks/common_test.py
@@ -9,6 +9,7 @@ import datetime
 import unittest
 
 import arc.checks.common as common
+from arc.species import ARCSpecies
 
 
 class TestChecks(unittest.TestCase):
@@ -40,6 +41,45 @@ class TestChecks(unittest.TestCase):
         self.assertEqual(common.get_i_from_job_name('conf_opt_33'), 33)
         self.assertEqual(common.get_i_from_job_name('conf_opt_3355'), 3355)
         self.assertEqual(common.get_i_from_job_name('tsg2'), 2)
+
+    def test_is_ts_check_exempt(self):
+        """
+        Test the is_ts_check_exempt() function.
+        """
+        self.assertFalse(common.is_ts_check_exempt('NMD', {'NMD': False, 'E0': True}))
+        self.assertFalse(common.is_ts_check_exempt('E0', {'e_elect': False, 'E0': True}))
+        self.assertTrue(common.is_ts_check_exempt('e_elect', {'e_elect': False, 'E0': True}))
+        self.assertFalse(common.is_ts_check_exempt('e_elect', {'e_elect': False, 'E0': False}))
+        self.assertFalse(common.is_ts_check_exempt('e_elect', {'e_elect': False, 'E0': None}))
+        self.assertFalse(common.is_ts_check_exempt('e_elect', dict()))
+
+    def test_get_ts_validation_comment(self):
+        """
+        Test the get_ts_validation_comment() function.
+        """
+        self.assertIsNone(common.get_ts_validation_comment(None))
+        ts = ARCSpecies(label='TS0', is_ts=True)
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = True
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = None
+        ts.ts_checks['NMD'] = False
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = False
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn(common.TS_IRC_FAILED_MARKER, comment)
+        self.assertIn('NMD', comment)
+        ts.ts_checks['NMD'] = True
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn(common.TS_IRC_FAILED_MARKER, comment)
+        self.assertNotIn('NMD', comment)
+        ts.ts_checks['e_elect'] = False
+        ts.ts_checks['E0'] = True
+        self.assertNotIn('e_elect', common.get_ts_validation_comment(ts))
+        ts.ts_checks['E0'] = False
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn('e_elect', comment)
+        self.assertIn('E0', comment)
 
 
 if __name__ == '__main__':

--- a/arc/checks/ts.py
+++ b/arc/checks/ts.py
@@ -9,6 +9,7 @@ import numpy as np
 from typing import TYPE_CHECKING
 
 from arc.parser import parser
+from arc.checks.common import is_ts_check_exempt
 from arc.checks.nmd import analyze_ts_normal_mode_displacement
 from arc.common import (ARC_PATH,
                         convert_list_index_0_to_1,
@@ -52,10 +53,8 @@ def check_ts(reaction: ARCReaction,
     """
     Check the TS in terms of energy, normal mode displacement, and IRC.
     Populates the ``TS.ts_checks`` dictionary.
-    Note that the 'freq' check is done in Scheduler.check_negative_freq() and not here.
-
-    Todo:
-        check IRC
+    Note that the 'freq' check is done in Scheduler.check_negative_freq() and not here,
+    and that the 'IRC' check is done in check_irc_species_and_rxn() and not here.
 
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
@@ -97,7 +96,7 @@ def check_ts(reaction: ARCReaction,
             logger.warning(f'Skipping failed normal mode displacement check for TS {reaction.ts_species.label}')
             reaction.ts_species.ts_checks['NMD'] = True
 
-    if 'rotors' in checks or (ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings', 'IRC'])
+    if 'rotors' in checks or (ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings'])
                               and job is not None):
         invalidate_rotors_with_both_pivots_in_a_reactive_zone(reaction, job,
                                                               rxn_zone_atom_indices=rxn_zone_atom_indices)
@@ -110,6 +109,13 @@ def ts_passed_checks(species: ARCSpecies,
     """
     Check whether the TS species passes all checks other than ones specified in ``exemptions``.
 
+    The 'IRC' check is three-valued: ``True`` means the IRC endpoints correspond to the requested wells,
+    ``False`` means they positively do not, and ``None`` means the check was not performed
+    (e.g., IRC jobs were not requested). Only a ``False`` IRC verdict is considered a failure here.
+
+    A failed 'e_elect' check is excused once 'E0' passed, as determined by
+    ``checks.common.is_ts_check_exempt()``.
+
     Args:
         species (ARCSpecies): The TS species.
         exemptions (list[str], optional): Keys of the TS.ts_checks dict to pass.
@@ -120,7 +126,9 @@ def ts_passed_checks(species: ARCSpecies,
     """
     exemptions = exemptions or list()
     for check, value in species.ts_checks.items():
-        if check not in exemptions and not value and not (check == 'e_elect' and species.ts_checks['E0']):
+        if check in exemptions or (check == 'IRC' and value is None):
+            continue
+        if not value and not is_ts_check_exempt(check, species.ts_checks):
             if verbose:
                 logger.warning(f'TS {species.label} did not pass the all checks, status is:\n{species.ts_checks}')
             return False
@@ -507,6 +515,20 @@ def check_irc_species_and_rxn(xyz_1: dict,
     bond-list comparison if perception fails for either endpoint or if the expected
     reactant/product ``Molecule`` objects are unavailable.
 
+    Sets ``rxn.ts_species.ts_checks['IRC']`` to ``True`` if the endpoints match the reactants
+    and products, to ``False`` only if a comparison was actually performed and the endpoints
+    did not match, and leaves it as ``None`` (unknown) if no comparison could be performed
+    (e.g., the expected connectivity of the reaction is unavailable). ``False`` means
+    "checked and failed", never "could not check".
+
+    A negative isomorphism result alone does not set ``False``: it is treated as inconclusive
+    and the bond-list comparison decides. The verdict remains ``None`` if that comparison
+    cannot be carried out.
+
+    The bond-list comparison perceives bonds without assuming that an endpoint is a single
+    connected molecule, so a dissociated fragment stays dissociated instead of being bonded
+    to its nearest neighbour regardless of distance.
+
     Args:
         xyz_1 (dict): The coordinates of IRC species 1.
         xyz_2 (dict): The coordinates of IRC species 2.
@@ -514,7 +536,7 @@ def check_irc_species_and_rxn(xyz_1: dict,
     """
     if rxn is None:
         return None
-    rxn.ts_species.ts_checks['IRC'] = False
+    rxn.ts_species.ts_checks['IRC'] = None
     xyz_1, xyz_2 = check_xyz_dict(xyz_1), check_xyz_dict(xyz_2)
 
     # Primary check: molecular graph isomorphism
@@ -541,15 +563,19 @@ def check_irc_species_and_rxn(xyz_1: dict,
     # Fallback: bond-list connectivity comparison
     try:
         r_bonds, p_bonds = rxn.get_bonds()
-    except Exception:
-        logger.debug('Could not get reaction bonds for IRC fallback check.')
+    except Exception as e:
+        logger.warning(f'Could not get the reaction bonds of {rxn} for the IRC fallback check, '
+                       f'got:\n{e.__class__.__name__}: {e}\n'
+                       f'The IRC check of {rxn.ts_species.label} is therefore left undetermined.')
         return
     dmat_1, dmat_2 = xyz_to_dmat(xyz_1), xyz_to_dmat(xyz_2)
-    dmat_bonds_1 = get_bonds_from_dmat(dmat=dmat_1, elements=xyz_1['symbols'])
-    dmat_bonds_2 = get_bonds_from_dmat(dmat=dmat_2, elements=xyz_2['symbols'])
+    dmat_bonds_1 = get_bonds_from_dmat(dmat=dmat_1, elements=xyz_1['symbols'], n_fragments=0)
+    dmat_bonds_2 = get_bonds_from_dmat(dmat=dmat_2, elements=xyz_2['symbols'], n_fragments=0)
     if _check_equal_bonds_list(dmat_bonds_1, r_bonds) and _check_equal_bonds_list(dmat_bonds_2, p_bonds) \
             or _check_equal_bonds_list(dmat_bonds_2, r_bonds) and _check_equal_bonds_list(dmat_bonds_1, p_bonds):
         rxn.ts_species.ts_checks['IRC'] = True
+    else:
+        rxn.ts_species.ts_checks['IRC'] = False
 
 
 def _perceive_irc_fragments(xyz: dict,

--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -8,11 +8,13 @@ This module contains unit tests for the arc.checks.ts module
 import unittest
 import os
 import shutil
+from unittest.mock import patch
 
 import numpy as np
 
 import arc.checks.ts as ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_lists
+from arc.exceptions import ReactionError
 from arc.job.factory import job_factory
 from arc.level import Level
 from arc.parser.parser import parse_normal_mode_displacement, parse_geometry
@@ -271,6 +273,23 @@ class TestTSChecks(unittest.TestCase):
         self.assertFalse(ts.ts_passed_checks(spc))
         self.assertTrue(ts.ts_passed_checks(spc, exemptions=['NMD', 'warnings']))
         spc.ts_checks['e_elect'] = False
+
+    def test_ts_passed_checks_irc(self):
+        """Test that ts_passed_checks() treats the three-valued IRC check correctly."""
+        spc = ARCSpecies(label='TS', is_ts=True)
+        spc.populate_ts_checks()
+        for key in ['E0', 'e_elect', 'freq', 'NMD']:
+            spc.ts_checks[key] = True
+
+        spc.ts_checks['IRC'] = True
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings']))
+
+        spc.ts_checks['IRC'] = None
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings']))
+
+        spc.ts_checks['IRC'] = False
+        self.assertFalse(ts.ts_passed_checks(spc, exemptions=['warnings']))
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings', 'IRC']))
 
     def test_check_rxn_e_elect(self):
         """Test the check_rxn_e_elect() function."""
@@ -850,7 +869,82 @@ class TestTSChecks(unittest.TestCase):
                           p_species=[ARCSpecies(label='P_wrong', smiles='O=C(O)C[O]', multiplicity=2)])
         rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
         ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
-        self.assertFalse(rxn.ts_species.ts_checks['IRC'])
+        self.assertIs(rxn.ts_species.ts_checks['IRC'], False)
+
+    def test_check_irc_bond_list_tier_does_not_bond_a_dissociated_atom(self):
+        """
+        Test that the bond-list tier does not bond a dissociated fragment to its nearest neighbor.
+
+        The bond-list tier is the only tier allowed to reject a TS, so it must perceive bonds
+        without assuming a single connected molecule. Otherwise a bare H in an endpoint is bonded
+        to whatever atom happens to be closest, no matter how far away, and correct IRC endpoints
+        are rejected. Both reactions below reach the bond-list tier because the triplet atom is
+        not perceived as a triplet, so the isomorphism tier cannot match it.
+        """
+        for r_smiles, r_multiplicity, p_smiles, symbols, coords_r, coords_p in [
+                ('[O]', 3, '[OH]', ('O', 'H', 'H'),
+                 ((0.0, 0.0, 0.0), (5.0, 0.0, 0.0), (5.0, 0.0, 0.74)),
+                 ((0.0, 0.0, 0.0), (3.2, 0.0, 0.0), (0.0, 0.0, 0.97))),
+                ('[S]', 3, '[SH]', ('S', 'H', 'H'),
+                 ((0.0, 0.0, 0.0), (5.0, 0.0, 0.0), (5.0, 0.0, 0.74)),
+                 ((0.0, 0.0, 0.0), (4.0, 0.0, 0.0), (0.0, 0.0, 1.34)))]:
+            with self.subTest(r_smiles=r_smiles):
+                rxn = ARCReaction(r_species=[ARCSpecies(label='X', smiles=r_smiles, multiplicity=r_multiplicity),
+                                             ARCSpecies(label='H2', smiles='[H][H]')],
+                                  p_species=[ARCSpecies(label='XH', smiles=p_smiles),
+                                             ARCSpecies(label='H', smiles='[H]')])
+                rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+                xyz_1 = xyz_from_data(coords=coords_r, symbols=symbols)
+                xyz_2 = xyz_from_data(coords=coords_p, symbols=symbols)
+                ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
+                self.assertIs(rxn.ts_species.ts_checks['IRC'], True)
+
+    def test_check_irc_identical_endpoints(self):
+        """
+        Test that two identical IRC endpoints are a positive IRC failure (False, not None).
+
+        Both endpoints re-perceive as the product, i.e., the "TS" connects P <=> P.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=xyz_2, xyz_2=xyz_2, rxn=rxn)
+        self.assertIs(rxn.ts_species.ts_checks['IRC'], False)
+
+    def test_check_irc_unknown_if_no_comparison_was_performed(self):
+        """
+        Test that the IRC check is None (unknown), not False, if no comparison could be performed.
+
+        Neither the isomorphism check nor the bond-list fallback can be carried out here.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        with patch.object(ts, '_perceive_irc_fragments', return_value=None), \
+                patch.object(rxn, 'get_bonds', side_effect=ReactionError('Cannot get bonds without an atom map.')):
+            ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
+        self.assertIsNone(rxn.ts_species.ts_checks['IRC'])
+
+    def test_check_irc_isomorphism_mismatch_alone_is_not_a_failure(self):
+        """
+        Test that a negative isomorphism result alone leaves the IRC check undetermined.
+
+        The isomorphism check is only the first tier, and the code falls back to the bond-list
+        comparison whenever it does not match. If that fallback cannot run, nothing was
+        conclusively compared, so the verdict must stay None rather than reject the TS.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        with patch.object(rxn, 'get_bonds', side_effect=ReactionError('Cannot get bonds without an atom map.')):
+            ts.check_irc_species_and_rxn(xyz_1=xyz_2, xyz_2=xyz_2, rxn=rxn)
+        self.assertIsNone(rxn.ts_species.ts_checks['IRC'])
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -31,6 +31,7 @@ from arc.common import (NUMBER_BY_SYMBOL,
                         save_yaml_file,
                         sort_two_lists_by_the_first,
                         )
+from arc.checks.common import TS_IRC_FAILED_MARKER, get_ts_validation_comment
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.parser.parser import parse_trajectory
@@ -555,7 +556,10 @@ def draw_kinetics_plots(rxn_list: list,
                                                                             T=T,
                                                                             )
                                        for T in temperatures]})
-            _draw_kinetics_plots(rxn.label, arc_k, temperatures, rmg_rxns, units, pp)
+            rxn_plot_label = rxn.label
+            if get_ts_validation_comment(rxn.ts_species) is not None:
+                rxn_plot_label = f'{rxn.label}\n{TS_IRC_FAILED_MARKER}'
+            _draw_kinetics_plots(rxn_plot_label, arc_k, temperatures, rmg_rxns, units, pp)
 
     if path is not None:
         pp.close()
@@ -883,11 +887,18 @@ longDesc = \"\"\"\n{lib_long_desc}\n\"\"\"\n
                     f'TS optical isomers: {rxn.ts_species.optical_isomers}\n\n' \
                     f'Optimized TS geometry:\n{xyz_to_str(rxn.ts_species.final_xyz)}\n\n' \
                     f'{rxn.ts_species.long_thermo_description}'
+        ts_validation = get_ts_validation_comment(rxn.ts_species)
+        arrhenius_comment = ''
+        if ts_validation is not None:
+            long_desc = f'{ts_validation}\n\n{long_desc}'
+            arrhenius_comment = f",\n                         comment=\"{ts_validation}\""
+            logger.error(f'Saving a rate coefficient for reaction {rxn.label} in the kinetics library although its '
+                         f'TS failed the IRC check. {ts_validation}')
         rxn_txt = f"""entry(
     index = {i},
     label = "{rxn.label}",
     kinetics = Arrhenius(A=({rxn.kinetics['A'][0]:.2e}, '{rxn.kinetics['A'][1]}'), n={rxn.kinetics['n']:.2f}, Ea=({rxn.kinetics['Ea'][0]:.2f}, '{rxn.kinetics['Ea'][1]}'),
-                         T0=(1, 'K'), Tmin=({T_min}, 'K'), Tmax=({T_max}, 'K')),
+                         T0=(1, 'K'), Tmin=({T_min}, 'K'), Tmax=({T_max}, 'K'){arrhenius_comment}),
     longDesc = 
 \"\"\"
 {long_desc}

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -6,6 +6,7 @@ import os
 import shutil
 
 import arc.plotter as plotter
+from arc.checks.common import get_ts_validation_comment
 from arc.common import ARC_PATH, get_logger, read_yaml_file, save_yaml_file
 from arc.imports import settings
 from arc.level import Level
@@ -297,14 +298,21 @@ def compare_rates(rxns_for_kinetics_lib: list,
     """
     reactions_to_compare = list()  # reactions for which a rate was both calculated and estimated.
     reactions_kinetics_path = os.path.join(output_directory, 'RMG_kinetics.yml')
-    save_yaml_file(path=reactions_kinetics_path,
-                   content=[{'label': rxn.label,
-                             'reactants': [spc.mol.to_adjacency_list() for spc in rxn.r_species],
-                             'products': [spc.mol.to_adjacency_list() for spc in rxn.p_species],
-                             'dh_rxn298': rxn.dh_rxn298,
-                             'family': rxn.family,
-                             } for rxn in rxns_for_kinetics_lib],
-                   )
+    content = list()
+    for rxn in rxns_for_kinetics_lib:
+        rxn_content = {'label': rxn.label,
+                       'reactants': [spc.mol.to_adjacency_list() for spc in rxn.r_species],
+                       'products': [spc.mol.to_adjacency_list() for spc in rxn.p_species],
+                       'dh_rxn298': rxn.dh_rxn298,
+                       'family': rxn.family,
+                       }
+        ts_validation = get_ts_validation_comment(rxn.ts_species)
+        if ts_validation is not None:
+            rxn_content['ts_validation'] = ts_validation
+            logger.error(f'Reporting a rate coefficient for reaction {rxn.label} although its TS failed the IRC '
+                         f'check. {ts_validation}')
+        content.append(rxn_content)
+    save_yaml_file(path=reactions_kinetics_path, content=content)
     rmg_db_path = settings.get('RMG_DB_PATH') or ""
     log_suffix = ' > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
     shell_script = rmg_env_command(py_args=[KINETICS_SCRIPT_PATH, reactions_kinetics_path],

--- a/arc/processor_test.py
+++ b/arc/processor_test.py
@@ -10,7 +10,8 @@ import shutil
 import unittest
 
 import arc.processor as processor
-from arc.common import ARC_TESTING_PATH
+from arc.checks.common import TS_IRC_FAILED_MARKER
+from arc.common import ARC_TESTING_PATH, read_yaml_file
 from arc.reaction import ARCReaction
 from arc.species import ARCSpecies
 
@@ -49,10 +50,13 @@ class TestProcessor(unittest.TestCase):
                                        ARCSpecies(label='H2', smiles='[H][H]')],
                             kinetics={'A': 4.79e+05, 'n': 2.5, 'Ea': 40.12},
                             )
+        rxn_1.ts_species = ARCSpecies(label='TS1', is_ts=True)
+        rxn_1.ts_species.ts_checks['IRC'] = False
         rxn_2 = ARCReaction(r_species=[ARCSpecies(label='nC3H7', smiles='[CH2]CC')],
                             p_species=[ARCSpecies(label='iC3H7', smiles='C[CH]C')],
                             kinetics={'A': 7.18e5, 'n': 2.05, 'Ea': 151.88},
                             )
+        rxn_2.ts_species = ARCSpecies(label='TS2', is_ts=True)
         output_directory = os.path.join(ARC_TESTING_PATH, 'process_kinetics')
         reactions_to_compare = processor.compare_rates(rxns_for_kinetics_lib=[rxn_1, rxn_2],
                                                        output_directory=output_directory,
@@ -61,7 +65,11 @@ class TestProcessor(unittest.TestCase):
         self.assertEqual(len(reactions_to_compare[0].rmg_kinetics), 3)
         self.assertEqual(len(reactions_to_compare[1].rmg_kinetics), 1)
         self.assertTrue(os.path.isfile(os.path.join(output_directory, 'rate_plots.pdf')))
-        self.assertTrue(os.path.isfile(os.path.join(output_directory, 'RMG_kinetics.yml')))
+        kinetics_yml_path = os.path.join(output_directory, 'RMG_kinetics.yml')
+        self.assertTrue(os.path.isfile(kinetics_yml_path))
+        content = read_yaml_file(path=kinetics_yml_path)
+        self.assertIn(TS_IRC_FAILED_MARKER, content[0]['ts_validation'])
+        self.assertNotIn('ts_validation', content[1])
 
 
     @classmethod

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -875,7 +875,7 @@ class Scheduler(object):
 
                 if not len(job_list) and not self.has_pending_pipe_work(label):
                     self.check_all_done(label)
-                    if not self.running_jobs[label]:
+                    if label in self.running_jobs and not self.running_jobs[label]:
                         # Delete the label only if it represents an empty entry.
                         del self.running_jobs[label]
 
@@ -3161,7 +3161,8 @@ class Scheduler(object):
 
     def check_irc_species(self, label: str):
         """
-        Check that the optimized geometry of the two species created from a TS IRC runs makes sense
+        Check that the optimized geometry of the two species created from a TS IRC runs makes sense.
+        A TS for which the IRC check positively failed is rejected, and a different TS guess is sought.
 
         Args:
             label (str): The label of one of the optimized IRC-resulting species.
@@ -3170,10 +3171,53 @@ class Scheduler(object):
         if len(self.output[ts_label]['paths']['irc']) == 2:
             irc_species_labels = self.species_dict[ts_label].irc_label.split()
             if all(self.output[irc_label]['paths']['geo'] for irc_label in irc_species_labels):
+                rxn = self.rxn_dict.get(self.species_dict[ts_label].rxn_index, None)
                 check_irc_species_and_rxn(xyz_1=self.output[irc_species_labels[0]]['paths']['geo'],
                                           xyz_2=self.output[irc_species_labels[1]]['paths']['geo'],
-                                          rxn=self.rxn_dict.get(self.species_dict[ts_label].rxn_index, None),
+                                          rxn=rxn,
                                           )
+                self.process_irc_verdict(ts_label=ts_label, rxn=rxn)
+
+    def process_irc_verdict(self,
+                            ts_label: str,
+                            rxn: ARCReaction | None,
+                            ):
+        """
+        Act on the verdict of the IRC check of a TS species.
+
+        The verdict is three-valued: ``True`` means the optimized IRC endpoints correspond to the
+        requested wells, ``False`` means they positively do not, and ``None`` means the check was not
+        performed or its result could not be determined (e.g., IRC jobs were not requested).
+        Only a ``False`` verdict rejects the TS, in which case a different TS guess is sought.
+        Once every guess was tried, the TS is marked unconverged and the verdict is restored.
+
+        Args:
+            ts_label (str): The label of the TS species the IRC check was performed for.
+            rxn (ARCReaction, optional): The reaction the TS species belongs to.
+        """
+        ts_species = self.species_dict.get(ts_label, None)
+        ts_checks = getattr(ts_species, 'ts_checks', None)
+        verdict = ts_checks.get('IRC', None) if isinstance(ts_checks, dict) else None
+        rxn_label = getattr(rxn, 'label', None) or 'unknown reaction'
+        if verdict is True:
+            logger.info(f'The optimized IRC endpoints of TS {ts_label} correspond to the reactants and products '
+                        f'of reaction {rxn_label}.')
+            return
+        if verdict is not False:
+            logger.debug(f'The IRC check for TS {ts_label} of reaction {rxn_label} was not performed, '
+                         f'or its result could not be determined.')
+            return
+        logger.error(f'The optimized IRC endpoints of TS {ts_label} do NOT correspond to the reactants and '
+                     f'products of reaction {rxn_label}. This TS does not connect the requested wells, '
+                     f'therefore any rate coefficient computed from it does not describe this reaction.\n'
+                     f'Status is:\n{ts_checks}\n'
+                     f'Searching for a better TS conformer...')
+        self.switch_ts(ts_label)
+        if ts_species.ts_guesses_exhausted or ts_species.chosen_ts is None:
+            logger.error(f'Could not find a TS conformer for {ts_label} of reaction {rxn_label} '
+                         f'that passes the IRC check. Marking as unconverged.')
+            self.output[ts_label]['convergence'] = False
+            ts_species.ts_checks['IRC'] = False
 
     def check_scan_job(self,
                        label: str,
@@ -3418,9 +3462,10 @@ class Scheduler(object):
         """
         all_converged = True
         if label in self.output and not self.output[label]['convergence']:
-            # A TS that failed the E0 check should stay unconverged even if all jobs succeeded.
+            # A TS that failed the E0 or the IRC check should stay unconverged even if all jobs succeeded.
             if self.species_dict[label].is_ts \
-                    and getattr(self.species_dict[label], 'ts_checks', {}).get('E0') is False \
+                    and any(getattr(self.species_dict[label], 'ts_checks', {}).get(check) is False
+                            for check in ['E0', 'IRC']) \
                     and (self.species_dict[label].ts_guesses_exhausted
                          or self.species_dict[label].chosen_ts is None):
                 all_converged = False

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -1460,6 +1460,197 @@ H      -1.82570782    0.42754384   -0.56130718"""
             self.assertIsNone(tsg.opt_xyz)
         self.assertEqual([tsg.index for tsg in sched.species_dict[ts_label].ts_guesses], [5, 2])
 
+    def make_irc_scheduler(self,
+                           ts_label: str,
+                           project_directory_name: str,
+                           num_guesses: int = 2,
+                           chosen_ts_list: list | None = None,
+                           ) -> Scheduler:
+        """
+        A helper for generating a Scheduler instance with a single TS species that has several TS guesses,
+        simulating the state right after the first chosen guess completed its opt/freq/sp jobs.
+
+        Args:
+            ts_label (str): The TS species label.
+            project_directory_name (str): The name of the testing project directory.
+            num_guesses (int, optional): The number of TS guesses to generate.
+            chosen_ts_list (list, optional): The indices of the TS guesses that were already tried.
+
+        Returns:
+            Scheduler: The Scheduler instance.
+        """
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        chosen_ts_list = chosen_ts_list if chosen_ts_list is not None else [0]
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=i, method='heuristics', success=True, energy=100.0 + 10 * i,
+                                     xyz=ts_xyz, execution_time='0:00:01')
+                             for i in range(num_guesses)]
+        for tsg in ts_spc.ts_guesses:
+            tsg.opt_xyz = ts_xyz
+            tsg.imaginary_freqs = [-500.0]
+        ts_spc.chosen_ts = chosen_ts_list[-1]
+        ts_spc.chosen_ts_list = list(chosen_ts_list)
+        ts_spc.ts_guesses_exhausted = False
+        project_directory = os.path.join(ARC_PATH, 'Projects', project_directory_name)
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=project_directory_name, ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.output[ts_label]['job_types']['opt'] = True
+        sched.output[ts_label]['job_types']['freq'] = True
+        sched.output[ts_label]['job_types']['sp'] = True
+        sched.output[ts_label]['convergence'] = True
+        sched.job_dict[ts_label] = {'opt': {}, 'freq': {}, 'sp': {}}
+        sched.running_jobs[ts_label] = list()
+        return sched
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_false_switches_ts(self, mock_switch_ts):
+        """Test that a positively failed IRC check rejects the TS and searches for a different TS guess."""
+        ts_label = 'TS_irc_false'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_1')
+        sched.species_dict[ts_label].ts_checks['IRC'] = False
+        with self.assertLogs('arc', level='ERROR') as log_records:
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_called_once_with(ts_label)
+        self.assertTrue(any('do NOT correspond' in record for record in log_records.output))
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_none_does_not_switch_ts(self, mock_switch_ts):
+        """Test that an IRC check which was not performed does not reject the TS."""
+        ts_label = 'TS_irc_none'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_2')
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['IRC'])
+        with self.assertNoLogs('arc', level='ERROR'):
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_not_called()
+        self.assertTrue(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_true_does_not_switch_ts(self, mock_switch_ts):
+        """Test that a passed IRC check does not reject the TS."""
+        ts_label = 'TS_irc_true'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_3')
+        sched.species_dict[ts_label].ts_checks['IRC'] = True
+        with self.assertNoLogs('arc', level='ERROR'):
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_not_called()
+        self.assertTrue(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_process_irc_verdict_false_terminates_when_guesses_are_exhausted(self, mock_run_opt):
+        """Test that rejecting a TS by the IRC check terminates once all TS guesses were tried."""
+        ts_label = 'TS_irc_exhausted'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_4',
+                                        num_guesses=1,
+                                        chosen_ts_list=[0],
+                                        )
+        sched.species_dict[ts_label].ts_checks['IRC'] = False
+        sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_run_opt.assert_not_called()
+        self.assertTrue(sched.species_dict[ts_label].ts_guesses_exhausted
+                        or sched.species_dict[ts_label].chosen_ts is None)
+        self.assertFalse(sched.output[ts_label]['convergence'])
+        self.assertIs(sched.species_dict[ts_label].ts_checks['IRC'], False)
+        for job_type in sched.output[ts_label]['job_types']:
+            sched.output[ts_label]['job_types'][job_type] = True
+        sched.check_all_done(ts_label)
+        self.assertFalse(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.check_irc_species_and_rxn')
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_check_irc_species_rejects_a_ts_with_a_failed_irc(self, mock_run_opt, mock_check_irc_species_and_rxn):
+        """Test that check_irc_species rejects a TS whose IRC endpoints do not match the requested wells."""
+        ts_label = 'TS_irc_reject'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_5',
+                                        num_guesses=2,
+                                        )
+        ts_spc = sched.species_dict[ts_label]
+
+        def fail_irc(**kwargs):
+            """Simulate an IRC check the TS did not pass."""
+            ts_spc.ts_checks['IRC'] = False
+
+        mock_check_irc_species_and_rxn.side_effect = fail_irc
+        irc_label_1, irc_label_2 = f'IRC_{ts_label}_1', f'IRC_{ts_label}_2'
+        for irc_label in [irc_label_1, irc_label_2]:
+            irc_spc = ARCSpecies(label=irc_label, xyz=ts_spc.get_xyz(), compute_thermo=False, irc_label=ts_label)
+            sched.species_dict[irc_label] = irc_spc
+            sched.species_list.append(irc_spc)
+            sched.unique_species_labels.append(irc_label)
+            sched.job_dict[irc_label] = {'opt': {}}
+            sched.running_jobs[irc_label] = list()
+            sched.initialize_output_dict(label=irc_label)
+            sched.output[irc_label]['paths']['geo'] = f'{irc_label}_geo.out'
+        ts_spc.irc_label = f'{irc_label_1} {irc_label_2}'
+        sched.output[ts_label]['paths']['irc'] = ['irc_f.out', 'irc_r.out']
+
+        sched.check_irc_species(label=irc_label_1)
+
+        mock_check_irc_species_and_rxn.assert_called_once()
+        self.assertEqual(sched.species_dict[ts_label].chosen_ts, 1)
+        self.assertIn(1, sched.species_dict[ts_label].chosen_ts_list)
+        self.assertNotIn(irc_label_1, sched.species_dict)
+        self.assertNotIn(irc_label_2, sched.species_dict)
+        self.assertNotIn(irc_label_1, sched.running_jobs)
+        self.assertNotIn(irc_label_2, sched.output)
+        self.assertIsNone(sched.species_dict[ts_label].irc_label)
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['IRC'])
+        mock_run_opt.assert_called_once()
+
+    @patch('arc.scheduler.Scheduler.generate_final_ts_guess_report')
+    @patch('arc.scheduler.Scheduler.spawn_ts_jobs')
+    @patch('arc.scheduler.Scheduler.run_conformer_jobs')
+    def test_schedule_jobs_tolerates_a_label_deleted_while_it_is_iterated(self,
+                                                                         mock_run_conformer_jobs,
+                                                                         mock_spawn_ts_jobs,
+                                                                         mock_generate_report):
+        """
+        Test that the main loop survives a species label being removed from running_jobs mid-iteration.
+
+        Rejecting a TS by its IRC verdict calls switch_ts(), which calls delete_all_species_jobs()
+        on the TS, which in turn deletes the running_jobs entries of the very IRC species labels the
+        main loop is iterating over. The main loop must therefore not assume that a label it started
+        the iteration with is still a key of running_jobs by the time it reaches the cleanup below.
+        """
+        ts_label = 'TS_irc_deleted_label'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_6')
+        irc_label = f'IRC_{ts_label}_1'
+        irc_spc = ARCSpecies(label=irc_label, xyz=sched.species_dict[ts_label].get_xyz(),
+                             compute_thermo=False, irc_label=ts_label)
+        sched.species_dict[irc_label] = irc_spc
+        sched.species_list.append(irc_spc)
+        sched.job_dict[irc_label] = {'opt': {}}
+        sched.initialize_output_dict(label=irc_label)
+        del sched.running_jobs[ts_label]
+        sched.running_jobs[irc_label] = list()
+        sched.unique_species_labels = [irc_label]
+
+        def delete_the_iterated_label(label):
+            """Delete the label being iterated, as delete_all_species_jobs() does for an IRC species."""
+            del sched.running_jobs[label]
+
+        with patch.object(sched, 'check_all_done', side_effect=delete_the_iterated_label) as mock_check_all_done:
+            sched.schedule_jobs()
+        mock_check_all_done.assert_called_once_with(irc_label)
+        self.assertEqual(sched.running_jobs, dict())
+
     @patch('arc.scheduler.Scheduler.run_job')
     def test_run_sp_monoatomic_dlpno(self, mock_run_job):
         """Monoatomic H falls back to HF; heavier atoms (O) keep DLPNO intact."""

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from mako.template import Template
 
 import arc.plotter as plotter
+from arc.checks.common import get_ts_validation_comment
 from arc.common import ARC_PATH, get_logger, read_yaml_file
 from arc.exceptions import AtomTypeError, InputError
 from arc.imports import incore_commands, settings
@@ -254,6 +255,10 @@ class ArkaneAdapter(StatmechAdapter, ABC):
         self.parse_arkane_kinetics_output(statmech_dir)
         for reaction in self.reactions:
             plotter.log_kinetics(reaction.ts_species.label, path=statmech_dir)
+            ts_validation = get_ts_validation_comment(reaction.ts_species)
+            if ts_validation is not None:
+                logger.error(f'The above rate coefficient of reaction {reaction.label} is not validated. '
+                             f'{ts_validation}')
             clean_output_directory(species_path=os.path.join(self.output_directory, 'rxns', reaction.ts_species.label),
                                    is_ts=True)
 
@@ -1325,7 +1330,32 @@ def parse_reaction_kinetics(reaction, output_content: str) -> None:
         if m_dea:
             kinetics['dEa'] = float(m_dea.group(1))
             kinetics['dEa_units'] = m_dea.group(2) or 'kJ/mol'
+    mark_ts_validation_in_kinetics(reaction=reaction, kinetics=kinetics)
     reaction.kinetics = kinetics
+
+
+def mark_ts_validation_in_kinetics(reaction, kinetics: dict) -> None:
+    """
+    Stamp the TS validation verdict onto a parsed kinetics dictionary.
+
+    Adds a ``ts_validation`` key and appends the marker to the Arrhenius ``comment``. The rate
+    coefficient values are not modified. A TS for which the IRC check was not performed
+    (``None``) or was passed (``True``) leaves ``kinetics`` untouched.
+
+    Args:
+        reaction: The reaction object the kinetics were computed for.
+        kinetics (dict): The parsed Arrhenius kinetics dictionary, modified in place.
+    """
+    ts_species = getattr(reaction, 'ts_species', None)
+    marker = get_ts_validation_comment(ts_species)
+    if marker is None:
+        return
+    kinetics['ts_validation'] = marker
+    comment = kinetics.get('comment', None) or ''
+    kinetics['comment'] = f'{comment}\n{marker}' if comment else marker
+    logger.error(f'Computed a rate coefficient for reaction {reaction.label} although its TS '
+                 f'{ts_species.label} failed the IRC check. {marker}\n'
+                 f'TS checks: {ts_species.ts_checks}')
 
 
 def _parse_conformer_statmech(species, content: str) -> None:

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -6,11 +6,14 @@ This module contains unit tests for ARC's statmech.arkane module
 """
 
 import os
+import re
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
-from arc.common import ARC_PATH, ARC_TESTING_PATH
+from arc.checks.common import TS_IRC_FAILED_MARKER
+from arc.common import ARC_TESTING_PATH
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -32,8 +35,14 @@ from arc.statmech.arkane import (
     check_arkane_aec,
     check_arkane_bacs,
     get_arkane_model_chemistry,
+    parse_e0,
+    parse_reaction_kinetics,
+    parse_thermo_data_block,
+    run_arkane,
+    _classify_arkane_stderr,
+    _parse_conformer_statmech,
+    _summarize_arkane_stderr,
 )
-from unittest.mock import patch
 
 
 class TestEnumerationClasses(unittest.TestCase):
@@ -429,9 +438,33 @@ class TestArkaneAdapter(unittest.TestCase):
 class TestArkaneOutputParsing(unittest.TestCase):
     """Tests for parsing functions that read Arkane output.py content."""
 
+    kinetics_output_content = """
+conformer(label='TS0', E0=(50.0, 'kJ/mol'), modes=[], spin_multiplicity=2, optical_isomers=1)
+
+kinetics(
+    label = 'nitroethane <=> ethyl_nitrite',
+    kinetics = Arrhenius(
+        A = (5.0, 's^-1'),
+        n = 1.0,
+        Ea = (20.0, 'kJ/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2000, 'K'),
+        comment = 'Fitted to 10 data points; dA = *|/ 1.1, dn = +|- 0.01, dEa = +|- 0.1 kJ/mol',
+    ),
+)
+"""
+
+    @staticmethod
+    def isomerization_reaction() -> ARCReaction:
+        """Build the real nitroethane <=> ethyl nitrite reaction with a TS species named 'TS0'."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='nitroethane', smiles='CC[N+](=O)[O-]')],
+                          p_species=[ARCSpecies(label='ethyl_nitrite', smiles='CCON=O')])
+        rxn.ts_species = ARCSpecies(label='TS0', is_ts=True)
+        return rxn
+
     def test_parse_e0(self):
         """Test parse_e0 extracts E0 from conformer blocks."""
-        from arc.statmech.arkane import parse_e0
         content = """
 conformer(
     label = 'CH4',
@@ -445,14 +478,11 @@ conformer(
         self.assertIsNone(parse_e0('missing_species', content))
 
     def test_parse_e0_positive(self):
-        from arc.statmech.arkane import parse_e0
         content = "conformer(label='CHO', E0=(44.0971, 'kJ/mol'), modes=[], spin_multiplicity=2, optical_isomers=1)"
         self.assertAlmostEqual(parse_e0('CHO', content), 44.0971)
 
     def test_parse_conformer_statmech(self):
         """Test extraction of external_symmetry and optical_isomers."""
-        from arc.statmech.arkane import _parse_conformer_statmech
-        from unittest.mock import MagicMock
         content = """
 conformer(
     label = 'H2O',
@@ -467,18 +497,13 @@ conformer(
     optical_isomers = 1,
 )
 """
-        spc = MagicMock()
-        spc.label = 'H2O'
-        spc.optical_isomers = None
-        spc.external_symmetry = None
+        spc = ARCSpecies(label='H2O', smiles='O')
         _parse_conformer_statmech(spc, content)
         self.assertEqual(spc.optical_isomers, 1)
         self.assertEqual(spc.external_symmetry, 2)
 
     def test_parse_conformer_statmech_linear(self):
         """Test with LinearRotor."""
-        from arc.statmech.arkane import _parse_conformer_statmech
-        from unittest.mock import MagicMock
         content = """
 conformer(
     label = 'CO2',
@@ -488,23 +513,18 @@ conformer(
     optical_isomers = 1,
 )
 """
-        spc = MagicMock()
-        spc.label = 'CO2'
-        spc.optical_isomers = None
-        spc.external_symmetry = None
+        spc = ARCSpecies(label='CO2', smiles='O=C=O')
         _parse_conformer_statmech(spc, content)
         self.assertEqual(spc.external_symmetry, 2)
         self.assertEqual(spc.optical_isomers, 1)
 
     def test_parse_reaction_kinetics_with_uncertainties(self):
         """Test that dA, dn, dEa, n_data_points are parsed from the comment."""
-        from arc.statmech.arkane import parse_reaction_kinetics
-        from unittest.mock import MagicMock
         content = """
 conformer(label='TS0', E0=(50.0, 'kJ/mol'), modes=[], spin_multiplicity=2, optical_isomers=1)
 
 kinetics(
-    label = 'A + B <=> C + D',
+    label = 'CH4 + OH <=> CH3 + H2O',
     kinetics = Arrhenius(
         A = (1.2e10, 'cm^3/(mol*s)'),
         n = 2.5,
@@ -516,11 +536,11 @@ kinetics(
     ),
 )
 """
-        rxn = MagicMock()
-        rxn.label = 'A + B <=> C + D'
-        rxn.ts_species = MagicMock()
-        rxn.ts_species.label = 'TS0'
-        rxn.ts_species.e0 = None
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        rxn.ts_species = ARCSpecies(label='TS0', is_ts=True)
         parse_reaction_kinetics(rxn, content)
         self.assertIsNotNone(rxn.kinetics)
         self.assertAlmostEqual(rxn.kinetics['A'][0], 1.2e10)
@@ -534,13 +554,11 @@ kinetics(
 
     def test_parse_reaction_kinetics_no_comment(self):
         """Kinetics without a comment should still parse A, n, Ea."""
-        from arc.statmech.arkane import parse_reaction_kinetics
-        from unittest.mock import MagicMock
         content = """
 conformer(label='TS0', E0=(50.0, 'kJ/mol'), modes=[], spin_multiplicity=2, optical_isomers=1)
 
 kinetics(
-    label = 'X <=> Y',
+    label = 'nitroethane <=> ethyl_nitrite',
     kinetics = Arrhenius(
         A = (5.0, 's^-1'),
         n = 1.0,
@@ -551,19 +569,38 @@ kinetics(
     ),
 )
 """
-        rxn = MagicMock()
-        rxn.label = 'X <=> Y'
-        rxn.ts_species = MagicMock()
-        rxn.ts_species.label = 'TS0'
-        rxn.ts_species.e0 = None
+        rxn = self.isomerization_reaction()
         parse_reaction_kinetics(rxn, content)
         self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
         self.assertAlmostEqual(rxn.kinetics['n'], 1.0)
         self.assertNotIn('dA', rxn.kinetics)
 
+    def test_parse_reaction_kinetics_marks_an_irc_invalid_ts(self):
+        """Kinetics of a TS that failed the IRC check are reported, and are labeled as invalid."""
+        content = self.kinetics_output_content
+        rxn = self.isomerization_reaction()
+        rxn.ts_species.ts_checks['IRC'] = False
+        rxn.ts_species.ts_checks['NMD'] = True
+        parse_reaction_kinetics(rxn, content)
+        self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
+        self.assertAlmostEqual(rxn.kinetics['Ea'][0], 20.0)
+        self.assertIn(TS_IRC_FAILED_MARKER, rxn.kinetics['ts_validation'])
+        self.assertIn(TS_IRC_FAILED_MARKER, rxn.kinetics['comment'])
+        self.assertIn('Fitted to 10 data points', rxn.kinetics['comment'])
+
+    def test_parse_reaction_kinetics_does_not_mark_an_unchecked_or_valid_ts(self):
+        """Kinetics of a TS for which the IRC check was not performed or was passed are not labeled."""
+        content = self.kinetics_output_content
+        for irc_value in [None, True]:
+            rxn = self.isomerization_reaction()
+            rxn.ts_species.ts_checks['IRC'] = irc_value
+            parse_reaction_kinetics(rxn, content)
+            self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
+            self.assertNotIn('ts_validation', rxn.kinetics)
+            self.assertNotIn(TS_IRC_FAILED_MARKER, rxn.kinetics['comment'])
+
     def test_parse_thermo_data_block_scalars_are_float(self):
         """Verify Tmin, Tmax, H298, S298 are parsed as floats, not strings."""
-        from arc.statmech.arkane import parse_thermo_data_block
         block = """
             H298 = (-108.9, 'kJ/mol'),
             S298 = (218.4, 'J/(mol*K)'),
@@ -578,7 +615,6 @@ kinetics(
 
     def test_find_scalar_word_boundary(self):
         """The ``n`` parameter must not match ``Tmin`` or substrings in the comment."""
-        import re
         # Simulate find_scalar with word boundary
         arr_block = "A = (1.0, 's^-1'), n = 2.5, Ea = (30.0, 'kJ/mol'), Tmin = (300, 'K')"
         pat = rf"\bn\s*=\s*([-+]?[\d.eE+-]+)"
@@ -708,7 +744,6 @@ class TestRunArkaneOutputPySignal(unittest.TestCase):
     """
 
     def setUp(self):
-        from arc.statmech.arkane import run_arkane
         self._run_arkane = run_arkane
         self.tmp = tempfile.mkdtemp(prefix='arkane-stderr-test-')
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
@@ -789,7 +824,6 @@ class TestRunArkaneOutputPySignal(unittest.TestCase):
         self.assertFalse(self._run_with_stderr([]))
 
     def test_missing_statmech_dir_returns_false_pre_flight(self):
-        from arc.statmech.arkane import run_arkane
         self.assertFalse(run_arkane('/nonexistent/dir'))
 
 
@@ -797,7 +831,6 @@ class TestClassifyArkaneStderr(unittest.TestCase):
     """Direct tests of the stderr-noise filter, independent of run_arkane."""
 
     def setUp(self):
-        from arc.statmech.arkane import _classify_arkane_stderr
         self._classify = _classify_arkane_stderr
 
     def test_empty_input_returns_empty(self):
@@ -826,7 +859,6 @@ class TestSummarizeArkaneStderr(unittest.TestCase):
     """The stderr summarizer condenses a traceback to the salient exception line for arc.log."""
 
     def setUp(self):
-        from arc.statmech.arkane import _summarize_arkane_stderr
         self._summarize = _summarize_arkane_stderr
 
     def test_empty(self):


### PR DESCRIPTION
Make the IRC verdict meaningful, enforce it, and never publish a rate silently from an IRC-invalid TS.

This PR combines what were previously two stacked PRs (#937 and #938). They were never independently reviewed, and splitting them made the story harder to follow than it was worth: the verdict semantics, the enforcement that consumes them, and the labelling of anything that still slips through are one change. #938 is closed in favour of this.

## What went wrong

Benchmark reaction `r3_16` (nitroethane ⇌ ethyl nitrite, `intra_NO2_ONO_conversion`) produced a fitted Arrhenius expression of `Ea = 65.8 kJ/mol`. The correct barrier is ~250 kJ/mol — the published rate coefficient was wrong by **~9 orders of magnitude in k at 1000 K**. For scale, the published rate implies a room-temperature half-life of about 23 ms for nitroethane.

ARC had already determined the TS was invalid: `ts_checks['IRC'] = False`, because both optimized IRC endpoints re-perceive as the *product* (the "TS" is a torsional saddle of ethyl nitrite, connecting product↔product). That verdict was written to `restart.yml` — and then the Arrhenius fit was written to `RMG_kinetics.yml`, `rate_plots.pdf` and the kinetics library **with no indication that validation had failed**.

Arkane is not at fault. Its `E0` values (`R1 −81.43`, `P1 −73.74`, `TS −18.07 kJ/mol`) are self-consistent with the fitted expression: `TS − R1 = 63.36` against the fitted `Ea = 65.84`, a 2.5 kJ/mol gap that is unremarkable for an `n = 0.70` fit with Eckart tunnelling. Arkane correctly computed the rate for the structure it was given; the TS search supplied the wrong structure.

## The saddle is falsifiable without the IRC

Three independent lines of evidence say the rejected structure is a torsional saddle of ethyl nitrite, not the migration TS. The first needs no IRC, no atom map and no energy reference at all.

**1. The imaginary frequency is 3–4× too soft.** ARC's rejected saddle has a single imaginary mode at **−270.3 cm⁻¹**. A nitro→nitrite migration TS is a tight, strained C···O···N three-membered arrangement whose reaction coordinate is a heavy-atom bond reorganisation: literature values are **846i cm⁻¹ (B3LYP)** to **1063i cm⁻¹ (CASSCF)**. An alkyl-nitrite O–N torsional saddle is a soft internal rotation: a literature analogue gives **236i**, and an independent GFN2-xTB Hessian computed on the ethyl nitrite O–N torsional saddle gives a single imaginary mode at **−348 cm⁻¹**. −270.3 is squarely in the torsion class and nowhere near the migration class. A curvature that soft cannot be a C–N/C–O bond exchange.

**2. The geometry is ordinary ethyl nitrite.** C–O is **1.428 Å** — fully formed. C and N are **1-3 neighbours through the ether oxygen**: with d(C–O) = 1.428, d(O–N) = 1.40 and ∠C–O–N = 114.3°, the geminal C···N distance *is* **2.372 Å**. There is no stretched or partially broken C–N bond here; there is no C–N bond at all, and 2.376 Å is simply what 1-3 geminal separation looks like. A genuine migration TS has C–N ~1.9–3.4 Å **while** C–O is also partial at ~1.9–3.7 Å — both bonds in flight. Here C–O is complete. The structure sits in the product well, not between the wells.

**3. The barrier height matches a torsion, not an isomerisation.** Measured from the product well the saddle is a **55.7 kJ/mol** barrier (`TS −18.07` against `P1 −73.74`). The measured syn/anti barrier of ethyl nitrite is **ΔG‡ = 46.0 ± 0.4 kJ/mol** (gas-phase ¹H NMR, Conboy/Chauvel/True 1986); CH₃ONO is 45.3 kJ/mol (Van der Veken/Durig 1990). 55.7 is ~10 kJ/mol above the measured ethyl nitrite value — the right magnitude class for this torsion, and nowhere near the ~250 kJ/mol of a C–N-breaking isomerisation. Measured from the reactant well the same structure gives the 63–66 kJ/mol that was published as the reaction barrier.

A re-run that rejected that guess and found the true saddle gives `Ea = 253.639 kJ/mol`, against the RMG NOx2018 library's `253.8`. Both are ~250 kJ/mol. They are *not* the same quantity and should not be compared to a percentage: they are fitted modified-Arrhenius `Ea` parameters from fits with different `n` (the library's `n = 1`), so the closeness of the two numbers is coincidental. The point is the order of magnitude, which is the point at issue.

## The three changes

### 1. `ts_checks['IRC'] = False` now means only "checked and failed"

`check_irc_species_and_rxn` pessimistically set `False` up front and only wrote `True` on success. An early return — `rxn.get_bonds()` raising in the fallback — left `False` in place **having compared nothing**, so `False` conflated *"checked and failed"* with *"could not check"*, which makes it unusable as a gate. It now starts at `None` and writes `False` only where a comparison actually happened. (A second no-comparison path existed purely *because* of the up-front `False`: if `check_xyz_dict()` or `get_reactants_and_products()` raised, the exception propagated out with a "failed" verdict already recorded.)

A negative result from the **isomorphism tier alone** does not write `False` either. That tier perceives each endpoint's molecular graph from coordinates without the expected species' spin or charge, so it can disagree for a chemically correct endpoint. The code already treated that as inconclusive by falling through to the bond-list comparison; the verdict now follows, and stays `None` when that comparison cannot run.

### 2. The bond-list tier no longer invents connectivity

The bond-list tier is the only tier that can write `False`, so it must not perceive bonds that are not there. It was calling `get_bonds_from_dmat()` with the default `n_fragments=1`, which bonds **every hydrogen to its absolute nearest neighbour with no distance test at all** — `CH4 + H` at 50 Å comes back "bonded". Meanwhile `_perceive_irc_fragments()` — the *inconclusive* tier — already passed `n_fragments=0` for exactly this reason. The tiers were inverted: the tier that cannot reject anything used the safe setting, and the tier with the authority to reject used the lossy one.

Both call sites now pass `n_fragments=0`. Reproduced before and after on this branch:

| reaction | before | after |
|---|---|---|
| `O(3P) + H2 ⇌ OH + H` | `False` | `True` |
| `S(3P) + H2 ⇌ SH + H` | `False` | `True` |

These reach the bond-list tier because the triplet atom is not perceived as a triplet, so the isomorphism tier cannot match it. The `r3_16` true negative, the mismatched-species case and the identical-endpoints case are all unchanged.

**Measured exposure.** Triggering this needed *both* the isomorphism tier to fail *and* a bare atom in an endpoint. Across the 509 benchmark reactions, 4 have a bare H and 9 have a bare O/S/C/N, and **the two sets do not intersect** — so benchmark exposure was zero and no benchmark result changes. The risk was to small-molecule users: `O(3P) + H2` is a top-tier combustion reaction.

### 3. The verdict is enforced, and anything that still slips through is labelled

`ts_checks['IRC']` was previously **computed correctly and read nowhere.** It was explicitly exempted — `ts_passed_checks(species=..., exemptions=['E0', 'warnings', 'IRC'])` — and `check_ts`'s docstring still carried `Todo: check IRC`. By contrast an NMD failure **does** act: it logs and calls `switch_ts` to try another guess. There was no IRC equivalent.

- IRC is un-exempted (`exemptions=['E0', 'warnings']`) and the stale `Todo` is dropped.
- New `Scheduler.process_irc_verdict`: on `IRC is False`, log at ERROR and call `switch_ts`, mirroring the NMD path, with the same E0-style exhaustion fallback (restores the verdict and marks the TS unconverged when no guesses remain).
- `check_all_done`'s "stay unconverged" guard extends from `E0` to `['E0', 'IRC']`.

And when a rate is nonetheless produced from an IRC-invalid TS — on restart, or in a project that does not enforce — every artifact carrying it is marked via the new `common.get_ts_validation_comment()`: the Arrhenius `comment`, the `RMG_kinetics.yml` entry, the kinetics-library `longDesc`, and the `rate_plots.pdf` title, each with an `ERROR` logged naming the reaction.

**The rate is deliberately NOT suppressed** — it is diagnostically valuable, and it is how this bug was found. It is computed, recorded, and clearly labelled.

## Three-valued logic — the trap this had to avoid

`ts_checks` values are `True` / `False` / `None`, and `ts_passed_checks` used `not value`, which treats `None` and `False` identically. **Naively un-exempting IRC would have failed every run that skips IRC** (`job_types: irc: false`). So:

```python
if check in exemptions or (check == 'IRC' and value is None):
    continue
```

Scoped to IRC only; `None` semantics for the other keys are unchanged. `IRC is None` is likewise not marked and not suppressed. Many users skip IRC because it is expensive; they are unaffected.

## Is switching the TS after IRC actually supported? Yes — verified

IRC runs later in the pipeline than NMD, so this needed checking. `switch_ts` → `delete_all_species_jobs` resets `output[ts]['paths']`, all `job_types`, `convergence`, discards pending pipe work, **deletes the IRC species spawned from the rejected guess** and sets `irc_label = None` — so `spawn_post_opt_jobs` re-enqueues the full chain for the new guess. No stale state survives. Termination is bounded by `len(ts_guesses)` via `chosen_ts_list`.

This surfaced one latent bug that only appears once switching is enabled: `check_irc_species` is reached while the main loop iterates the *IRC species'* label; rejecting the TS deletes that label, and the loop then did `del self.running_jobs[label]` unconditionally → `KeyError`. Now guarded — and now covered: the guard was necessary *and* sufficient, but removing it left the entire suite green, so `test_schedule_jobs_tolerates_a_label_deleted_while_it_is_iterated` drives `schedule_jobs()` with a `check_all_done()` that deletes the iterated label the same way `delete_all_species_jobs()` does, and reproduces the `KeyError`.

## Reuse before writing

Searched before adding `is_ts_check_exempt()`: `git grep -n "e_elect.*E0"` and `git grep -n "ts_checks\["` across `arc/`, plus the callers of `ts_passed_checks` via the impact graph. That search is what found the problem — the `e_elect`/`E0` exemption was already implemented **twice**, at `arc/checks/ts.py` and in `common.get_ts_validation_comment()`, and the two had already drifted: one indexes `ts_checks['E0']` (raises `KeyError` when the key is absent), the other uses `.get('E0')`. Rather than leave a second copy, the predicate is extracted once into `arc/common.py` — the module that owns it, and the only direction that does not create a cycle, since `arc/plotter.py` → `arc/checks/ts.py` is a real import cycle via `arc.statmech.factory` → `arc.statmech.arkane` → `arc.plotter`. The shared helper takes the `.get()` semantics, and says so in its docstring.

## Measured impact across the completed benchmark runs

- **Exactly one run changes**: `r3_16` — the invalid TS is rejected, the search continues, and the wrong `Ea = 65.8` is no longer published.
- The four runs with `IRC = None` (`r2_11`, `r2_19`, `r3_01`, `r3_10`) are **unaffected by construction**.
- `IRC = True` runs: behaviour identical, one extra INFO line.
- The `n_fragments` correction changes no benchmark run (see the exposure measurement above).

## Test evidence

All measured on this branch, serially, against a baseline established on `origin/main` (`adf58ad9`) in the same worktree:

| | passed | failed | skipped | subtests |
|---|---|---|---|---|
| baseline, `origin/main` | 2745 | 5 | 36 | 208 |
| this branch | **2760** | 5 | 36 | 210 |

The 5 failures are identical in both: pre-existing `arc/job/adapters/torch_ani_test.py` path failures, unrelated to every module touched here. The five touched test files (`ts_test`, `common_test`, `processor_test`, `arkane_test`, `scheduler_test`) run **192 passed, 2 subtests passed**. Each of the three commits is independently green at the same 5-failure baseline (2749 / 2754 / 2760 passed), so the branch is bisectable.

Each fix is covered by a test that fails without it, verified by reverting the fix in place:

- `test_check_irc_bond_list_tier_does_not_bond_a_dissociated_atom` → `AssertionError: False is not True` on both subtests with `n_fragments` restored to the default.
- `test_schedule_jobs_tolerates_a_label_deleted_while_it_is_iterated` → `KeyError: 'IRC_TS_irc_deleted_label_1'` with the guard removed.

`test_check_irc_wrong_species` asserted with `assertFalse()`, which also passes on `None` — the very conflation this PR removes — and is changed to `assertIs(..., False)`.

## Known limitations (not fixed here)

- **Degenerate reactions get no IRC protection.** Tier 1 short-circuits on a graph match, so for a reaction whose reactants and products are isomorphic — `CH3 + CH4 → CH4 + CH3`, `H + H2 → H2 + H` — the check returns `True` even when *both* endpoints are the reactant. This is pre-existing and permissive rather than newly introduced, but it means symmetric H-abstractions, degenerate H-shifts and self-disproportionations are not protected by this gate.
- `infer_multiplicity`'s triplet-atom table has no O or S, which is why the two reactions in the table above fall through to the bond-list tier at all. Fixing that would make the isomorphism tier succeed for them; it is a separate change.
- The 1.2× bond-length threshold in `get_bonds_from_dmat` misses genuinely long bonds such as N₂O₄'s N–N.
- `check_ts(checks=['IRC'])` is an accepted no-op — the IRC check is performed by `check_irc_species_and_rxn`, not `check_ts`.
- `process_irc_verdict` reads the verdict off `ts_checks` rather than taking a returned value.
- The IRC verdict is **not** exported to `output.yml`: `_rxn_to_dict` uses an explicit kinetics allow-list that excludes `ts_validation` and `comment`, and `ts_checks` appears nowhere in `output.py`. A consumer of `output.yml` still cannot see whether a rate came from a validated TS.
- The TCKDB upload gate is out of scope: `arc/tckdb/` does not exist on `main`.

## Note for review

`except Exception` in the fallback was **kept** (not narrowed) and made loud rather than silent. `get_bonds()` reaches `atom_map` → `map_reaction`, `spc.copy()` and `.index()` lookups, so the raisable surface is genuinely unbounded; narrowing it wrongly would turn a benign "cannot atom-map" into a scheduler crash mid-run.
