### PR TITLE
Enforce the IRC check — reject a TS whose IRC endpoints do not match the wells

### DIFF
--- a/arc/checks/ts.py
+++ b/arc/checks/ts.py
@@ -507,6 +507,16 @@ def check_irc_species_and_rxn(xyz_1: dict,
     bond-list comparison if perception fails for either endpoint or if the expected
     reactant/product ``Molecule`` objects are unavailable.
 
+    Sets ``rxn.ts_species.ts_checks['IRC']`` to ``True`` if the endpoints match the reactants
+    and products, to ``False`` only if a comparison was actually performed and the endpoints
+    did not match, and leaves it as ``None`` (unknown) if no comparison could be performed
+    (e.g., the expected connectivity of the reaction is unavailable). ``False`` means
+    "checked and failed", never "could not check".
+
+    A negative isomorphism result alone does not set ``False``: it is treated as inconclusive
+    and the bond-list comparison decides. The verdict remains ``None`` if that comparison
+    cannot be carried out.
+
     Args:
         xyz_1 (dict): The coordinates of IRC species 1.
         xyz_2 (dict): The coordinates of IRC species 2.
@@ -514,7 +524,7 @@ def check_irc_species_and_rxn(xyz_1: dict,
     """
     if rxn is None:
         return None
-    rxn.ts_species.ts_checks['IRC'] = False
+    rxn.ts_species.ts_checks['IRC'] = None
     xyz_1, xyz_2 = check_xyz_dict(xyz_1), check_xyz_dict(xyz_2)
 
     # Primary check: molecular graph isomorphism
@@ -541,8 +551,10 @@ def check_irc_species_and_rxn(xyz_1: dict,
     # Fallback: bond-list connectivity comparison
     try:
         r_bonds, p_bonds = rxn.get_bonds()
-    except Exception:
-        logger.debug('Could not get reaction bonds for IRC fallback check.')
+    except Exception as e:
+        logger.warning(f'Could not get the reaction bonds of {rxn} for the IRC fallback check, '
+                       f'got:\n{e.__class__.__name__}: {e}\n'
+                       f'The IRC check of {rxn.ts_species.label} is therefore left undetermined.')
         return
     dmat_1, dmat_2 = xyz_to_dmat(xyz_1), xyz_to_dmat(xyz_2)
     dmat_bonds_1 = get_bonds_from_dmat(dmat=dmat_1, elements=xyz_1['symbols'])
@@ -550,6 +562,8 @@ def check_irc_species_and_rxn(xyz_1: dict,
     if _check_equal_bonds_list(dmat_bonds_1, r_bonds) and _check_equal_bonds_list(dmat_bonds_2, p_bonds) \
             or _check_equal_bonds_list(dmat_bonds_2, r_bonds) and _check_equal_bonds_list(dmat_bonds_1, p_bonds):
         rxn.ts_species.ts_checks['IRC'] = True
+    else:
+        rxn.ts_species.ts_checks['IRC'] = False
 
 
 def _perceive_irc_fragments(xyz: dict,

--- a/arc/checks/ts.py
+++ b/arc/checks/ts.py
@@ -52,10 +52,8 @@ def check_ts(reaction: ARCReaction,
     """
     Check the TS in terms of energy, normal mode displacement, and IRC.
     Populates the ``TS.ts_checks`` dictionary.
-    Note that the 'freq' check is done in Scheduler.check_negative_freq() and not here.
-
-    Todo:
-        check IRC
+    Note that the 'freq' check is done in Scheduler.check_negative_freq() and not here,
+    and that the 'IRC' check is done in check_irc_species_and_rxn() and not here.
 
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
@@ -97,7 +95,7 @@ def check_ts(reaction: ARCReaction,
             logger.warning(f'Skipping failed normal mode displacement check for TS {reaction.ts_species.label}')
             reaction.ts_species.ts_checks['NMD'] = True
 
-    if 'rotors' in checks or (ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings', 'IRC'])
+    if 'rotors' in checks or (ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings'])
                               and job is not None):
         invalidate_rotors_with_both_pivots_in_a_reactive_zone(reaction, job,
                                                               rxn_zone_atom_indices=rxn_zone_atom_indices)
@@ -110,6 +108,10 @@ def ts_passed_checks(species: ARCSpecies,
     """
     Check whether the TS species passes all checks other than ones specified in ``exemptions``.
 
+    The 'IRC' check is three-valued: ``True`` means the IRC endpoints correspond to the requested wells,
+    ``False`` means they positively do not, and ``None`` means the check was not performed
+    (e.g., IRC jobs were not requested). Only a ``False`` IRC verdict is considered a failure here.
+
     Args:
         species (ARCSpecies): The TS species.
         exemptions (list[str], optional): Keys of the TS.ts_checks dict to pass.
@@ -120,7 +122,9 @@ def ts_passed_checks(species: ARCSpecies,
     """
     exemptions = exemptions or list()
     for check, value in species.ts_checks.items():
-        if check not in exemptions and not value and not (check == 'e_elect' and species.ts_checks['E0']):
+        if check in exemptions or (check == 'IRC' and value is None):
+            continue
+        if not value and not (check == 'e_elect' and species.ts_checks['E0']):
             if verbose:
                 logger.warning(f'TS {species.label} did not pass the all checks, status is:\n{species.ts_checks}')
             return False

--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -274,6 +274,23 @@ class TestTSChecks(unittest.TestCase):
         self.assertTrue(ts.ts_passed_checks(spc, exemptions=['NMD', 'warnings']))
         spc.ts_checks['e_elect'] = False
 
+    def test_ts_passed_checks_irc(self):
+        """Test that ts_passed_checks() treats the three-valued IRC check correctly."""
+        spc = ARCSpecies(label='TS', is_ts=True)
+        spc.populate_ts_checks()
+        for key in ['E0', 'e_elect', 'freq', 'NMD']:
+            spc.ts_checks[key] = True
+
+        spc.ts_checks['IRC'] = True
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings']))
+
+        spc.ts_checks['IRC'] = None
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings']))
+
+        spc.ts_checks['IRC'] = False
+        self.assertFalse(ts.ts_passed_checks(spc, exemptions=['warnings']))
+        self.assertTrue(ts.ts_passed_checks(spc, exemptions=['warnings', 'IRC']))
+
     def test_check_rxn_e_elect(self):
         """Test the check_rxn_e_elect() function."""
         rxn1 = ARCReaction(r_species=[ARCSpecies(label='s1', smiles='C')], p_species=[ARCSpecies(label='s2', smiles='C')])

--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -8,11 +8,13 @@ This module contains unit tests for the arc.checks.ts module
 import unittest
 import os
 import shutil
+from unittest.mock import patch
 
 import numpy as np
 
 import arc.checks.ts as ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_lists
+from arc.exceptions import ReactionError
 from arc.job.factory import job_factory
 from arc.level import Level
 from arc.parser.parser import parse_normal_mode_displacement, parse_geometry
@@ -851,6 +853,53 @@ class TestTSChecks(unittest.TestCase):
         rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
         ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
         self.assertFalse(rxn.ts_species.ts_checks['IRC'])
+
+    def test_check_irc_identical_endpoints(self):
+        """
+        Test that two identical IRC endpoints are a positive IRC failure (False, not None).
+
+        Both endpoints re-perceive as the product, i.e., the "TS" connects P <=> P.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=xyz_2, xyz_2=xyz_2, rxn=rxn)
+        self.assertIs(rxn.ts_species.ts_checks['IRC'], False)
+
+    def test_check_irc_unknown_if_no_comparison_was_performed(self):
+        """
+        Test that the IRC check is None (unknown), not False, if no comparison could be performed.
+
+        Neither the isomorphism check nor the bond-list fallback can be carried out here.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        with patch.object(ts, '_perceive_irc_fragments', return_value=None), \
+                patch.object(rxn, 'get_bonds', side_effect=ReactionError('Cannot get bonds without an atom map.')):
+            ts.check_irc_species_and_rxn(xyz_1=xyz_1, xyz_2=xyz_2, rxn=rxn)
+        self.assertIsNone(rxn.ts_species.ts_checks['IRC'])
+
+    def test_check_irc_isomorphism_mismatch_alone_is_not_a_failure(self):
+        """
+        Test that a negative isomorphism result alone leaves the IRC check undetermined.
+
+        The isomorphism check is only the first tier, and the code falls back to the bond-list
+        comparison whenever it does not match. If that fallback cannot run, nothing was
+        conclusively compared, so the verdict must stay None rather than reject the TS.
+        """
+        xyz_1 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out'))
+        xyz_2 = parse_geometry(os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_2.out'))
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='O=[C]COO', xyz=xyz_1)],
+                          p_species=[ARCSpecies(label='P', smiles='O=CCO[O]', xyz=xyz_2)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        with patch.object(rxn, 'get_bonds', side_effect=ReactionError('Cannot get bonds without an atom map.')):
+            ts.check_irc_species_and_rxn(xyz_1=xyz_2, xyz_2=xyz_2, rxn=rxn)
+        self.assertIsNone(rxn.ts_species.ts_checks['IRC'])
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/common.py
+++ b/arc/common.py
@@ -54,6 +54,9 @@ EA_UNIT_CONVERSION = {'J/mol': 1, 'kJ/mol': 1e+3, 'cal/mol': 4.184, 'kcal/mol': 
 FULL_CIRCLE = 360.0
 HALF_CIRCLE = 180.0
 
+# A marker stamped onto any reported kinetics of a TS that was checked against its IRC endpoints and failed.
+TS_IRC_FAILED_MARKER = 'INVALID TS (failed IRC validation)'
+
 default_job_types, servers, supported_ess = settings['default_job_types'], settings['servers'], settings['supported_ess']
 
 
@@ -1932,6 +1935,37 @@ def convert_to_hours(time_str:str) -> float:
     """
     h, m, s = map(int, time_str.split(':'))
     return h + m / 60 + s / 3600
+
+
+def get_ts_validation_comment(ts_species: 'ARCSpecies | None') -> str | None:
+    """
+    Get a human-readable marker describing a positively-failed TS validation.
+
+    Only a ``ts_checks['IRC']`` value of ``False`` (checked and failed) produces a marker.
+    A value of ``None`` means the IRC check was not performed (e.g., IRC was not requested,
+    or the reaction connectivity was unavailable) and is treated as unknown, not as a failure.
+
+    The marker names any other TS check that also failed, applying the same exemption as
+    ``ts_passed_checks()``: a ``False`` 'e_elect' is not reported once 'E0' passed.
+
+    Args:
+        ts_species (ARCSpecies, optional): The TS species of the reaction the rate was computed for.
+
+    Returns:
+        str | None: The marker, or ``None`` if the TS did not positively fail the IRC check.
+    """
+    ts_checks = getattr(ts_species, 'ts_checks', None) or dict()
+    if ts_checks.get('IRC', None) is not False:
+        return None
+    comment = f'{TS_IRC_FAILED_MARKER}: the optimized IRC endpoints of this TS do not correspond to the ' \
+              f'reactants and products of this reaction, therefore this rate coefficient does not describe ' \
+              f'this reaction and must not be used.'
+    other_failed_checks = sorted(key for key, val in ts_checks.items()
+                                 if key not in ['IRC', 'warnings'] and val is False
+                                 and not (key == 'e_elect' and ts_checks.get('E0')))
+    if other_failed_checks:
+        comment += f' Additional TS checks that failed: {", ".join(other_failed_checks)}.'
+    return comment
 
 
 def calculate_arrhenius_rate_coefficient(A: int | float | Sequence[float] | np.ndarray,

--- a/arc/common_test.py
+++ b/arc/common_test.py
@@ -1453,6 +1453,34 @@ class TestCommon(unittest.TestCase):
         time_str = '190:40:10'
         self.assertAlmostEqual(common.convert_to_hours(time_str), 190.66944444444442)
 
+    def test_get_ts_validation_comment(self):
+        """
+        Test the get_ts_validation_comment() function.
+        """
+        self.assertIsNone(common.get_ts_validation_comment(None))
+        ts = ARCSpecies(label='TS0', is_ts=True)
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = True
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = None
+        ts.ts_checks['NMD'] = False
+        self.assertIsNone(common.get_ts_validation_comment(ts))
+        ts.ts_checks['IRC'] = False
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn(common.TS_IRC_FAILED_MARKER, comment)
+        self.assertIn('NMD', comment)
+        ts.ts_checks['NMD'] = True
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn(common.TS_IRC_FAILED_MARKER, comment)
+        self.assertNotIn('NMD', comment)
+        ts.ts_checks['e_elect'] = False
+        ts.ts_checks['E0'] = True
+        self.assertNotIn('e_elect', common.get_ts_validation_comment(ts))
+        ts.ts_checks['E0'] = False
+        comment = common.get_ts_validation_comment(ts)
+        self.assertIn('e_elect', comment)
+        self.assertIn('E0', comment)
+
     def test_calculate_arrhenius_rate_coefficient(self):
         """
         Test the calculate_arrhenius_rate() function.

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -20,11 +20,13 @@ import py3Dmol as p3D
 from rdkit import Chem
 
 from arc.common import (NUMBER_BY_SYMBOL,
+                        TS_IRC_FAILED_MARKER,
                         calculate_arrhenius_rate_coefficient,
                         extremum_list,
                         get_angle_in_180_range,
                         get_close_tuple,
                         get_logger,
+                        get_ts_validation_comment,
                         is_notebook,
                         is_str_float,
                         read_yaml_file,
@@ -557,7 +559,10 @@ def draw_kinetics_plots(rxn_list: list,
                                                                             T=T,
                                                                             )
                                        for T in temperatures]})
-            _draw_kinetics_plots(rxn.label, arc_k, temperatures, rmg_rxns, units, pp)
+            rxn_plot_label = rxn.label
+            if get_ts_validation_comment(rxn.ts_species) is not None:
+                rxn_plot_label = f'{rxn.label}\n{TS_IRC_FAILED_MARKER}'
+            _draw_kinetics_plots(rxn_plot_label, arc_k, temperatures, rmg_rxns, units, pp)
 
     if path is not None:
         pp.close()
@@ -885,11 +890,18 @@ longDesc = \"\"\"\n{lib_long_desc}\n\"\"\"\n
                     f'TS optical isomers: {rxn.ts_species.optical_isomers}\n\n' \
                     f'Optimized TS geometry:\n{xyz_to_str(rxn.ts_species.final_xyz)}\n\n' \
                     f'{rxn.ts_species.long_thermo_description}'
+        ts_validation = get_ts_validation_comment(rxn.ts_species)
+        arrhenius_comment = ''
+        if ts_validation is not None:
+            long_desc = f'{ts_validation}\n\n{long_desc}'
+            arrhenius_comment = f",\n                         comment=\"{ts_validation}\""
+            logger.error(f'Saving a rate coefficient for reaction {rxn.label} in the kinetics library although its '
+                         f'TS failed the IRC check. {ts_validation}')
         rxn_txt = f"""entry(
     index = {i},
     label = "{rxn.label}",
     kinetics = Arrhenius(A=({rxn.kinetics['A'][0]:.2e}, '{rxn.kinetics['A'][1]}'), n={rxn.kinetics['n']:.2f}, Ea=({rxn.kinetics['Ea'][0]:.2f}, '{rxn.kinetics['Ea'][1]}'),
-                         T0=(1, 'K'), Tmin=({T_min}, 'K'), Tmax=({T_max}, 'K')),
+                         T0=(1, 'K'), Tmin=({T_min}, 'K'), Tmax=({T_max}, 'K'){arrhenius_comment}),
     longDesc = 
 \"\"\"
 {long_desc}

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -6,7 +6,7 @@ import os
 import shutil
 
 import arc.plotter as plotter
-from arc.common import ARC_PATH, get_logger, read_yaml_file, save_yaml_file
+from arc.common import ARC_PATH, get_logger, get_ts_validation_comment, read_yaml_file, save_yaml_file
 from arc.imports import settings
 from arc.level import Level
 from arc.job.env_run import rmg_env_command
@@ -297,14 +297,21 @@ def compare_rates(rxns_for_kinetics_lib: list,
     """
     reactions_to_compare = list()  # reactions for which a rate was both calculated and estimated.
     reactions_kinetics_path = os.path.join(output_directory, 'RMG_kinetics.yml')
-    save_yaml_file(path=reactions_kinetics_path,
-                   content=[{'label': rxn.label,
-                             'reactants': [spc.mol.to_adjacency_list() for spc in rxn.r_species],
-                             'products': [spc.mol.to_adjacency_list() for spc in rxn.p_species],
-                             'dh_rxn298': rxn.dh_rxn298,
-                             'family': rxn.family,
-                             } for rxn in rxns_for_kinetics_lib],
-                   )
+    content = list()
+    for rxn in rxns_for_kinetics_lib:
+        rxn_content = {'label': rxn.label,
+                       'reactants': [spc.mol.to_adjacency_list() for spc in rxn.r_species],
+                       'products': [spc.mol.to_adjacency_list() for spc in rxn.p_species],
+                       'dh_rxn298': rxn.dh_rxn298,
+                       'family': rxn.family,
+                       }
+        ts_validation = get_ts_validation_comment(rxn.ts_species)
+        if ts_validation is not None:
+            rxn_content['ts_validation'] = ts_validation
+            logger.error(f'Reporting a rate coefficient for reaction {rxn.label} although its TS failed the IRC '
+                         f'check. {ts_validation}')
+        content.append(rxn_content)
+    save_yaml_file(path=reactions_kinetics_path, content=content)
     rmg_db_path = settings.get('RMG_DB_PATH') or ""
     log_suffix = ' > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
     shell_script = rmg_env_command(py_args=[KINETICS_SCRIPT_PATH, reactions_kinetics_path],

--- a/arc/processor_test.py
+++ b/arc/processor_test.py
@@ -10,7 +10,7 @@ import shutil
 import unittest
 
 import arc.processor as processor
-from arc.common import ARC_TESTING_PATH
+from arc.common import ARC_TESTING_PATH, TS_IRC_FAILED_MARKER, read_yaml_file
 from arc.reaction import ARCReaction
 from arc.species import ARCSpecies
 
@@ -49,10 +49,13 @@ class TestProcessor(unittest.TestCase):
                                        ARCSpecies(label='H2', smiles='[H][H]')],
                             kinetics={'A': 4.79e+05, 'n': 2.5, 'Ea': 40.12},
                             )
+        rxn_1.ts_species = ARCSpecies(label='TS1', is_ts=True)
+        rxn_1.ts_species.ts_checks['IRC'] = False
         rxn_2 = ARCReaction(r_species=[ARCSpecies(label='nC3H7', smiles='[CH2]CC')],
                             p_species=[ARCSpecies(label='iC3H7', smiles='C[CH]C')],
                             kinetics={'A': 7.18e5, 'n': 2.05, 'Ea': 151.88},
                             )
+        rxn_2.ts_species = ARCSpecies(label='TS2', is_ts=True)
         output_directory = os.path.join(ARC_TESTING_PATH, 'process_kinetics')
         reactions_to_compare = processor.compare_rates(rxns_for_kinetics_lib=[rxn_1, rxn_2],
                                                        output_directory=output_directory,
@@ -61,7 +64,11 @@ class TestProcessor(unittest.TestCase):
         self.assertEqual(len(reactions_to_compare[0].rmg_kinetics), 3)
         self.assertEqual(len(reactions_to_compare[1].rmg_kinetics), 1)
         self.assertTrue(os.path.isfile(os.path.join(output_directory, 'rate_plots.pdf')))
-        self.assertTrue(os.path.isfile(os.path.join(output_directory, 'RMG_kinetics.yml')))
+        kinetics_yml_path = os.path.join(output_directory, 'RMG_kinetics.yml')
+        self.assertTrue(os.path.isfile(kinetics_yml_path))
+        content = read_yaml_file(path=kinetics_yml_path)
+        self.assertIn(TS_IRC_FAILED_MARKER, content[0]['ts_validation'])
+        self.assertNotIn('ts_validation', content[1])
 
 
     @classmethod

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -872,7 +872,7 @@ class Scheduler(object):
 
                 if not len(job_list) and not self.has_pending_pipe_work(label):
                     self.check_all_done(label)
-                    if not self.running_jobs[label]:
+                    if label in self.running_jobs and not self.running_jobs[label]:
                         # Delete the label only if it represents an empty entry.
                         del self.running_jobs[label]
 
@@ -3155,7 +3155,8 @@ class Scheduler(object):
 
     def check_irc_species(self, label: str):
         """
-        Check that the optimized geometry of the two species created from a TS IRC runs makes sense
+        Check that the optimized geometry of the two species created from a TS IRC runs makes sense.
+        A TS for which the IRC check positively failed is rejected, and a different TS guess is sought.
 
         Args:
             label (str): The label of one of the optimized IRC-resulting species.
@@ -3164,10 +3165,53 @@ class Scheduler(object):
         if len(self.output[ts_label]['paths']['irc']) == 2:
             irc_species_labels = self.species_dict[ts_label].irc_label.split()
             if all(self.output[irc_label]['paths']['geo'] for irc_label in irc_species_labels):
+                rxn = self.rxn_dict.get(self.species_dict[ts_label].rxn_index, None)
                 check_irc_species_and_rxn(xyz_1=self.output[irc_species_labels[0]]['paths']['geo'],
                                           xyz_2=self.output[irc_species_labels[1]]['paths']['geo'],
-                                          rxn=self.rxn_dict.get(self.species_dict[ts_label].rxn_index, None),
+                                          rxn=rxn,
                                           )
+                self.process_irc_verdict(ts_label=ts_label, rxn=rxn)
+
+    def process_irc_verdict(self,
+                            ts_label: str,
+                            rxn: ARCReaction | None,
+                            ):
+        """
+        Act on the verdict of the IRC check of a TS species.
+
+        The verdict is three-valued: ``True`` means the optimized IRC endpoints correspond to the
+        requested wells, ``False`` means they positively do not, and ``None`` means the check was not
+        performed or its result could not be determined (e.g., IRC jobs were not requested).
+        Only a ``False`` verdict rejects the TS, in which case a different TS guess is sought.
+        Once every guess was tried, the TS is marked unconverged and the verdict is restored.
+
+        Args:
+            ts_label (str): The label of the TS species the IRC check was performed for.
+            rxn (ARCReaction, optional): The reaction the TS species belongs to.
+        """
+        ts_species = self.species_dict.get(ts_label, None)
+        ts_checks = getattr(ts_species, 'ts_checks', None)
+        verdict = ts_checks.get('IRC', None) if isinstance(ts_checks, dict) else None
+        rxn_label = getattr(rxn, 'label', None) or 'unknown reaction'
+        if verdict is True:
+            logger.info(f'The optimized IRC endpoints of TS {ts_label} correspond to the reactants and products '
+                        f'of reaction {rxn_label}.')
+            return
+        if verdict is not False:
+            logger.debug(f'The IRC check for TS {ts_label} of reaction {rxn_label} was not performed, '
+                         f'or its result could not be determined.')
+            return
+        logger.error(f'The optimized IRC endpoints of TS {ts_label} do NOT correspond to the reactants and '
+                     f'products of reaction {rxn_label}. This TS does not connect the requested wells, '
+                     f'therefore any rate coefficient computed from it does not describe this reaction.\n'
+                     f'Status is:\n{ts_checks}\n'
+                     f'Searching for a better TS conformer...')
+        self.switch_ts(ts_label)
+        if ts_species.ts_guesses_exhausted or ts_species.chosen_ts is None:
+            logger.error(f'Could not find a TS conformer for {ts_label} of reaction {rxn_label} '
+                         f'that passes the IRC check. Marking as unconverged.')
+            self.output[ts_label]['convergence'] = False
+            ts_species.ts_checks['IRC'] = False
 
     def check_scan_job(self,
                        label: str,
@@ -3412,9 +3456,10 @@ class Scheduler(object):
         """
         all_converged = True
         if label in self.output and not self.output[label]['convergence']:
-            # A TS that failed the E0 check should stay unconverged even if all jobs succeeded.
+            # A TS that failed the E0 or the IRC check should stay unconverged even if all jobs succeeded.
             if self.species_dict[label].is_ts \
-                    and getattr(self.species_dict[label], 'ts_checks', {}).get('E0') is False \
+                    and any(getattr(self.species_dict[label], 'ts_checks', {}).get(check) is False
+                            for check in ['E0', 'IRC']) \
                     and (self.species_dict[label].ts_guesses_exhausted
                          or self.species_dict[label].chosen_ts is None):
                 all_converged = False

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -1460,6 +1460,159 @@ H      -1.82570782    0.42754384   -0.56130718"""
             self.assertIsNone(tsg.opt_xyz)
         self.assertEqual([tsg.index for tsg in sched.species_dict[ts_label].ts_guesses], [5, 2])
 
+    def make_irc_scheduler(self,
+                           ts_label: str,
+                           project_directory_name: str,
+                           num_guesses: int = 2,
+                           chosen_ts_list: list | None = None,
+                           ) -> Scheduler:
+        """
+        A helper for generating a Scheduler instance with a single TS species that has several TS guesses,
+        simulating the state right after the first chosen guess completed its opt/freq/sp jobs.
+
+        Args:
+            ts_label (str): The TS species label.
+            project_directory_name (str): The name of the testing project directory.
+            num_guesses (int, optional): The number of TS guesses to generate.
+            chosen_ts_list (list, optional): The indices of the TS guesses that were already tried.
+
+        Returns:
+            Scheduler: The Scheduler instance.
+        """
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        chosen_ts_list = chosen_ts_list if chosen_ts_list is not None else [0]
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=i, method='heuristics', success=True, energy=100.0 + 10 * i,
+                                     xyz=ts_xyz, execution_time='0:00:01')
+                             for i in range(num_guesses)]
+        for tsg in ts_spc.ts_guesses:
+            tsg.opt_xyz = ts_xyz
+            tsg.imaginary_freqs = [-500.0]
+        ts_spc.chosen_ts = chosen_ts_list[-1]
+        ts_spc.chosen_ts_list = list(chosen_ts_list)
+        ts_spc.ts_guesses_exhausted = False
+        project_directory = os.path.join(ARC_PATH, 'Projects', project_directory_name)
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=project_directory_name, ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.output[ts_label]['job_types']['opt'] = True
+        sched.output[ts_label]['job_types']['freq'] = True
+        sched.output[ts_label]['job_types']['sp'] = True
+        sched.output[ts_label]['convergence'] = True
+        sched.job_dict[ts_label] = {'opt': {}, 'freq': {}, 'sp': {}}
+        sched.running_jobs[ts_label] = list()
+        return sched
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_false_switches_ts(self, mock_switch_ts):
+        """Test that a positively failed IRC check rejects the TS and searches for a different TS guess."""
+        ts_label = 'TS_irc_false'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_1')
+        sched.species_dict[ts_label].ts_checks['IRC'] = False
+        with self.assertLogs('arc', level='ERROR') as log_records:
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_called_once_with(ts_label)
+        self.assertTrue(any('do NOT correspond' in record for record in log_records.output))
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_none_does_not_switch_ts(self, mock_switch_ts):
+        """Test that an IRC check which was not performed does not reject the TS."""
+        ts_label = 'TS_irc_none'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_2')
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['IRC'])
+        with self.assertNoLogs('arc', level='ERROR'):
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_not_called()
+        self.assertTrue(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_process_irc_verdict_true_does_not_switch_ts(self, mock_switch_ts):
+        """Test that a passed IRC check does not reject the TS."""
+        ts_label = 'TS_irc_true'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_3')
+        sched.species_dict[ts_label].ts_checks['IRC'] = True
+        with self.assertNoLogs('arc', level='ERROR'):
+            sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_switch_ts.assert_not_called()
+        self.assertTrue(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_process_irc_verdict_false_terminates_when_guesses_are_exhausted(self, mock_run_opt):
+        """Test that rejecting a TS by the IRC check terminates once all TS guesses were tried."""
+        ts_label = 'TS_irc_exhausted'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_4',
+                                        num_guesses=1,
+                                        chosen_ts_list=[0],
+                                        )
+        sched.species_dict[ts_label].ts_checks['IRC'] = False
+        sched.process_irc_verdict(ts_label=ts_label, rxn=None)
+        mock_run_opt.assert_not_called()
+        self.assertTrue(sched.species_dict[ts_label].ts_guesses_exhausted
+                        or sched.species_dict[ts_label].chosen_ts is None)
+        self.assertFalse(sched.output[ts_label]['convergence'])
+        self.assertIs(sched.species_dict[ts_label].ts_checks['IRC'], False)
+        for job_type in sched.output[ts_label]['job_types']:
+            sched.output[ts_label]['job_types'][job_type] = True
+        sched.check_all_done(ts_label)
+        self.assertFalse(sched.output[ts_label]['convergence'])
+
+    @patch('arc.scheduler.check_irc_species_and_rxn')
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_check_irc_species_rejects_a_ts_with_a_failed_irc(self, mock_run_opt, mock_check_irc_species_and_rxn):
+        """Test that check_irc_species rejects a TS whose IRC endpoints do not match the requested wells."""
+        ts_label = 'TS_irc_reject'
+        sched = self.make_irc_scheduler(ts_label=ts_label,
+                                        project_directory_name='arc_project_for_testing_delete_after_usage_irc_5',
+                                        num_guesses=2,
+                                        )
+        ts_spc = sched.species_dict[ts_label]
+
+        def fail_irc(**kwargs):
+            """Simulate an IRC check the TS did not pass."""
+            ts_spc.ts_checks['IRC'] = False
+
+        mock_check_irc_species_and_rxn.side_effect = fail_irc
+        irc_label_1, irc_label_2 = f'IRC_{ts_label}_1', f'IRC_{ts_label}_2'
+        for irc_label in [irc_label_1, irc_label_2]:
+            irc_spc = ARCSpecies(label=irc_label, xyz=ts_spc.get_xyz(), compute_thermo=False, irc_label=ts_label)
+            sched.species_dict[irc_label] = irc_spc
+            sched.species_list.append(irc_spc)
+            sched.unique_species_labels.append(irc_label)
+            sched.job_dict[irc_label] = {'opt': {}}
+            sched.running_jobs[irc_label] = list()
+            sched.initialize_output_dict(label=irc_label)
+            sched.output[irc_label]['paths']['geo'] = f'{irc_label}_geo.out'
+        ts_spc.irc_label = f'{irc_label_1} {irc_label_2}'
+        sched.output[ts_label]['paths']['irc'] = ['irc_f.out', 'irc_r.out']
+
+        sched.check_irc_species(label=irc_label_1)
+
+        mock_check_irc_species_and_rxn.assert_called_once()
+        self.assertEqual(sched.species_dict[ts_label].chosen_ts, 1)
+        self.assertIn(1, sched.species_dict[ts_label].chosen_ts_list)
+        self.assertNotIn(irc_label_1, sched.species_dict)
+        self.assertNotIn(irc_label_2, sched.species_dict)
+        self.assertNotIn(irc_label_1, sched.running_jobs)
+        self.assertNotIn(irc_label_2, sched.output)
+        self.assertIsNone(sched.species_dict[ts_label].irc_label)
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['IRC'])
+        mock_run_opt.assert_called_once()
+
     @patch('arc.scheduler.Scheduler.run_job')
     def test_run_sp_monoatomic_dlpno(self, mock_run_job):
         """Monoatomic H falls back to HF; heavier atoms (O) keep DLPNO intact."""

--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from mako.template import Template
 
 import arc.plotter as plotter
-from arc.common import ARC_PATH, get_logger, read_yaml_file
+from arc.common import ARC_PATH, get_logger, get_ts_validation_comment, read_yaml_file
 from arc.exceptions import AtomTypeError, InputError
 from arc.imports import incore_commands, settings
 from arc.molecule.molecule import Molecule
@@ -254,6 +254,10 @@ class ArkaneAdapter(StatmechAdapter, ABC):
         self.parse_arkane_kinetics_output(statmech_dir)
         for reaction in self.reactions:
             plotter.log_kinetics(reaction.ts_species.label, path=statmech_dir)
+            ts_validation = get_ts_validation_comment(reaction.ts_species)
+            if ts_validation is not None:
+                logger.error(f'The above rate coefficient of reaction {reaction.label} is not validated. '
+                             f'{ts_validation}')
             clean_output_directory(species_path=os.path.join(self.output_directory, 'rxns', reaction.ts_species.label),
                                    is_ts=True)
 
@@ -1325,7 +1329,32 @@ def parse_reaction_kinetics(reaction, output_content: str) -> None:
         if m_dea:
             kinetics['dEa'] = float(m_dea.group(1))
             kinetics['dEa_units'] = m_dea.group(2) or 'kJ/mol'
+    mark_ts_validation_in_kinetics(reaction=reaction, kinetics=kinetics)
     reaction.kinetics = kinetics
+
+
+def mark_ts_validation_in_kinetics(reaction, kinetics: dict) -> None:
+    """
+    Stamp the TS validation verdict onto a parsed kinetics dictionary.
+
+    Adds a ``ts_validation`` key and appends the marker to the Arrhenius ``comment``. The rate
+    coefficient values are not modified. A TS for which the IRC check was not performed
+    (``None``) or was passed (``True``) leaves ``kinetics`` untouched.
+
+    Args:
+        reaction: The reaction object the kinetics were computed for.
+        kinetics (dict): The parsed Arrhenius kinetics dictionary, modified in place.
+    """
+    ts_species = getattr(reaction, 'ts_species', None)
+    marker = get_ts_validation_comment(ts_species)
+    if marker is None:
+        return
+    kinetics['ts_validation'] = marker
+    comment = kinetics.get('comment', None) or ''
+    kinetics['comment'] = f'{comment}\n{marker}' if comment else marker
+    logger.error(f'Computed a rate coefficient for reaction {reaction.label} although its TS '
+                 f'{ts_species.label} failed the IRC check. {marker}\n'
+                 f'TS checks: {ts_species.ts_checks}')
 
 
 def _parse_conformer_statmech(species, content: str) -> None:

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-from arc.common import ARC_PATH, ARC_TESTING_PATH
+from arc.common import ARC_TESTING_PATH, TS_IRC_FAILED_MARKER
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -429,6 +429,23 @@ class TestArkaneAdapter(unittest.TestCase):
 class TestArkaneOutputParsing(unittest.TestCase):
     """Tests for parsing functions that read Arkane output.py content."""
 
+    kinetics_output_content = """
+conformer(label='TS0', E0=(50.0, 'kJ/mol'), modes=[], spin_multiplicity=2, optical_isomers=1)
+
+kinetics(
+    label = 'X <=> Y',
+    kinetics = Arrhenius(
+        A = (5.0, 's^-1'),
+        n = 1.0,
+        Ea = (20.0, 'kJ/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2000, 'K'),
+        comment = 'Fitted to 10 data points; dA = *|/ 1.1, dn = +|- 0.01, dEa = +|- 0.1 kJ/mol',
+    ),
+)
+"""
+
     def test_parse_e0(self):
         """Test parse_e0 extracts E0 from conformer blocks."""
         from arc.statmech.arkane import parse_e0
@@ -560,6 +577,38 @@ kinetics(
         self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
         self.assertAlmostEqual(rxn.kinetics['n'], 1.0)
         self.assertNotIn('dA', rxn.kinetics)
+
+    def test_parse_reaction_kinetics_marks_an_irc_invalid_ts(self):
+        """Kinetics of a TS that failed the IRC check are reported, and are labeled as invalid."""
+        from arc.statmech.arkane import parse_reaction_kinetics
+        from unittest.mock import MagicMock
+        content = self.kinetics_output_content
+        rxn = MagicMock()
+        rxn.label = 'X <=> Y'
+        rxn.ts_species = ARCSpecies(label='TS0', is_ts=True)
+        rxn.ts_species.ts_checks['IRC'] = False
+        rxn.ts_species.ts_checks['NMD'] = True
+        parse_reaction_kinetics(rxn, content)
+        self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
+        self.assertAlmostEqual(rxn.kinetics['Ea'][0], 20.0)
+        self.assertIn(TS_IRC_FAILED_MARKER, rxn.kinetics['ts_validation'])
+        self.assertIn(TS_IRC_FAILED_MARKER, rxn.kinetics['comment'])
+        self.assertIn('Fitted to 10 data points', rxn.kinetics['comment'])
+
+    def test_parse_reaction_kinetics_does_not_mark_an_unchecked_or_valid_ts(self):
+        """Kinetics of a TS for which the IRC check was not performed or was passed are not labeled."""
+        from arc.statmech.arkane import parse_reaction_kinetics
+        from unittest.mock import MagicMock
+        content = self.kinetics_output_content
+        for irc_value in [None, True]:
+            rxn = MagicMock()
+            rxn.label = 'X <=> Y'
+            rxn.ts_species = ARCSpecies(label='TS0', is_ts=True)
+            rxn.ts_species.ts_checks['IRC'] = irc_value
+            parse_reaction_kinetics(rxn, content)
+            self.assertAlmostEqual(rxn.kinetics['A'][0], 5.0)
+            self.assertNotIn('ts_validation', rxn.kinetics)
+            self.assertNotIn(TS_IRC_FAILED_MARKER, rxn.kinetics['comment'])
 
     def test_parse_thermo_data_block_scalars_are_float(self):
         """Verify Tmin, Tmax, H298, S298 are parsed as floats, not strings."""


### PR DESCRIPTION
> **Top of stack #939 — depends on #937 (`fix_irc_gated_kinetics`), which must merge first.**
> Enforcing IRC before #937 lands would reject valid TSs whenever the check merely *could not run*, because `False` currently also means "could not check". This PR's diff shows only its own layer.
>
> **This is where the user-visible behaviour change ships.** Once this lands, a fresh run never reaches #937's failed-validation markers: `processor.py` drops any reaction whose TS is unconverged, which is what this PR sets for an IRC-invalid TS. #937 remains meaningful on restart, for projects that do not enforce, and as defence in depth — but on a clean run the TS is rejected here, before a rate is ever fitted.

## What went wrong

`ts_checks['IRC']` was **computed correctly and read nowhere.** It is written in `arc/checks/ts.py` and consumed by no production code. It was explicitly exempted:

```python
ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings', 'IRC'])
```

and `check_ts`'s docstring still carried `Todo: check IRC`. By contrast, an NMD failure **does** act — it logs and calls `switch_ts` to try another guess. There was no IRC equivalent.

Consequence: `r3_16` accepted a TS that connects product↔product, and published a rate wrong by ~9 orders of magnitude (see #937). A re-run that happened to reject that guess found the true saddle and produced `Ea = 253.639 kJ/mol`, matching the literature.

## The fix

- Un-exempt IRC (`exemptions=['E0', 'warnings']`), and drop the stale `Todo`.
- New `Scheduler.process_irc_verdict`: on `IRC is False`, log at ERROR and call `switch_ts`, mirroring the existing NMD path, with the same E0-style exhaustion fallback (restores the verdict and marks the TS unconverged when no guesses remain).
- `check_all_done`'s "stay unconverged" guard extended from `E0` to `['E0', 'IRC']`.

## Three-valued logic — the trap this had to avoid

`ts_checks` values are `True` / `False` / `None`, and `ts_passed_checks` used `not value`, which treats `None` and `False` identically. **Naively un-exempting IRC would have failed every run that skips IRC** (`job_types: irc: false`). So:

```python
if check in exemptions or (check == 'IRC' and value is None):
    continue
```

Scoped to IRC only; `None` semantics for the other keys are unchanged.

## Is switching the TS after IRC actually supported? Yes — verified

IRC runs later in the pipeline than NMD, so this needed checking. `switch_ts` → `delete_all_species_jobs` resets `output[ts]['paths']`, all `job_types`, `convergence`, discards pending pipe work, **deletes the IRC species spawned from the rejected guess** and sets `irc_label = None` — so `spawn_post_opt_jobs` re-enqueues the full chain for the new guess. No stale state survives. Termination is bounded by `len(ts_guesses)` via `chosen_ts_list`.

This surfaced one latent bug that only appears once switching is enabled: `check_irc_species` is reached while the main loop iterates the *IRC species'* label; rejecting the TS deletes that label, and the loop then did `del self.running_jobs[label]` unconditionally → `KeyError`. Now guarded.

## Measured impact across all 61 completed benchmark runs

- **Exactly one run changes**: `r3_16` — the invalid TS is rejected, the search continues, and the wrong `Ea = 65.8` is no longer published.
- The four runs with `IRC = None` (`r2_11`, `r2_19`, `r3_01`, `r3_10`) are **unaffected by construction**.
- `IRC = True` runs: behaviour identical, one extra INFO line.

## Evidence

60 tests pass (`ts_test`, `scheduler_test`), including exhaustion-termination and the `None` → no-switch case. Full suite: `2501 passed, 5 failed` — the 5 are pre-existing TorchANI path failures, unrelated to the touched modules.

**174 tests pass with both stack layers applied together** — the first time these two changes were exercised as a unit.

