### PR TITLE
Only let a geometry-determining job reject a TS guess

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -72,6 +72,11 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+TS_GEOMETRY_JOB_TYPES: tuple[str, ...] = ('opt', 'optfreq', 'composite', 'freq')
+"""tuple: The job types that determine or validate a TS geometry, and may therefore reject a TS guess.
+Refinement job types (``scan``, ``directed_scan``, ``sp``, ``irc``, ``orbitals``, ``onedmin``) report on a
+geometry rather than establish it, so their failure must not discard an otherwise valid TS."""
+
 LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ, default_job_settings, \
     default_job_types, default_ts_adapters, max_ess_trsh, max_rotor_trsh, rotor_scan_resolution, servers_dict = \
     settings['LOWEST_MAJOR_TS_FREQ'], settings['HIGHEST_MAJOR_TS_FREQ'], settings['default_job_settings'], \
@@ -3856,6 +3861,13 @@ class Scheduler(object):
         """
         Troubleshoot issues related to the electronic structure software, such as conversion.
 
+        When troubleshooting is exhausted, the failed job type determines the response. Only a
+        ``TS_GEOMETRY_JOB_TYPES`` job may reject a TS guess and trigger ``switch_ts()``; a failed
+        refinement job reports on a geometry rather than establishing one, and must not discard a TS
+        that has already passed its checks. An exhausted rotor scan invalidates just that rotor, since
+        leaving its ``'success'`` entry as ``None`` would make ``run_scan_jobs()`` re-spawn the very
+        scan that just exhausted troubleshooting.
+
         Args:
             label (str): The species label.
             job (JobAdapter): The job object to troubleshoot.
@@ -3960,14 +3972,29 @@ class Scheduler(object):
                          cpu_cores=cpu_cores,
                          shift=shift,
                          )
+        elif job.job_type in ('scan', 'directed_scan') and job.rotor_index is not None \
+                and job.rotor_index in self.species_dict[label].rotors_dict.keys():
+            rotor = self.species_dict[label].rotors_dict[job.rotor_index]
+            rotor['success'] = False
+            rotor['invalidation_reason'] = rotor.get('invalidation_reason', '') \
+                + 'ESS troubleshooting attempts exhausted for this rotor scan; '
+            logger.warning(f'Could not troubleshoot the rotor scan of {label} about pivots '
+                           f'{rotor.get("pivots")}. '
+                           f'Invalidating this rotor and keeping {label}; its torsional mode will be '
+                           f'treated approximately.')
         elif self.species_dict[label].is_ts and not self.species_dict[label].ts_guesses_exhausted \
-                and conformer is None:
+                and conformer is None and job.job_type in TS_GEOMETRY_JOB_TYPES:
             # Only switch TS guess when a full optimization fails, not when a single
             # conformer search job fails. Other conformers may still be running.
             logger.info(f'TS {label} did not converge. '
                         f'Status is:\n{self.species_dict[label].ts_checks}\n'
                         f'Searching for a better TS conformer...')
             self.switch_ts(label=label)
+        elif self.species_dict[label].is_ts and conformer is None \
+                and job.job_type not in TS_GEOMETRY_JOB_TYPES:
+            logger.error(f'Could not troubleshoot the {job.job_type} job of TS {label}. This job type does not '
+                         f'determine the TS geometry, so the TS is kept and not replaced; {label} will likely be '
+                         f'reported as unconverged.')
         elif conformer is not None and couldnt_trsh:
             logger.warning(f'Could not troubleshoot conformer {conformer} for {label}. '
                            f'Abandoning this conformer; waiting for others to finish.')

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -2267,5 +2267,153 @@ class TestSchedulerAdaptiveReactionLevels(unittest.TestCase):
             self.build_scheduler(rxn, r + p + [collider], 'adaptive_collision')
 
 
+class TestTroubleshootEssJobTypeGuard(unittest.TestCase):
+    """
+    Test that only a geometry-determining job type may reject a TS guess when ESS troubleshooting
+    is exhausted, and that an exhausted rotor scan invalidates just that rotor.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1'], 'qchem': ['server1']}
+        cls.job_types = {'conf_opt': False, 'opt': True, 'fine': False, 'freq': True, 'sp': True,
+                         'rotors': True, 'irc': False}
+        cls.ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+
+    def build_sched(self, name: str):
+        """Build a minimal Scheduler holding a single TS with two guesses and one rotor."""
+        ts_spc = ARCSpecies(label='TS_test', is_ts=True, xyz=self.ts_xyz, multiplicity=1, charge=0,
+                            compute_thermo=False)
+        ts_spc.ts_guesses = [
+            TSGuess(index=0, method='heuristics', success=True, energy=100.0, xyz=self.ts_xyz,
+                    execution_time='0:00:01'),
+            TSGuess(index=1, method='heuristics', success=True, energy=110.0, xyz=self.ts_xyz,
+                    execution_time='0:00:01'),
+        ]
+        for tsg in ts_spc.ts_guesses:
+            tsg.opt_xyz = self.ts_xyz
+            tsg.imaginary_freqs = [-500.0]
+        ts_spc.chosen_ts = 0
+        ts_spc.chosen_ts_list = [0]
+        ts_spc.ts_guesses_exhausted = False
+        ts_spc.rotors_dict = {0: {'pivots': [1, 2], 'top': [2, 3], 'scan': [3, 1, 2, 4], 'torsion': [2, 0, 1, 3],
+                                  'number_of_running_jobs': 0, 'success': None, 'invalidation_reason': '',
+                                  'times_dihedral_set': 0, 'trsh_counter': 0, 'trsh_methods': list(),
+                                  'scan_path': '', 'directed_scan_type': '', 'directed_scan': dict(),
+                                  'dimensions': 1, 'original_dihedrals': list(), 'cont_indices': list()}}
+        project_directory = os.path.join(ARC_PATH, 'Projects', f'arc_test_trsh_guard_{name}')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=f'test_trsh_guard_{name}', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types,
+                          )
+        sched.trsh_ess_jobs, sched.trsh_rotors = True, True
+        return sched
+
+    def make_failed_job(self, sched, job_type: str, job_num: int, rotor_index=None):
+        """Build a job that has failed at the ESS level."""
+        kwargs = dict()
+        if rotor_index is not None:
+            kwargs['rotor_index'] = rotor_index
+            kwargs['torsions'] = [sched.species_dict['TS_test'].rotors_dict[rotor_index]['torsion']]
+        job = job_factory(job_adapter='gaussian', project='project_test', ess_settings=self.ess_settings,
+                          species=[sched.species_dict['TS_test']], xyz=self.ts_xyz, job_type=job_type,
+                          level=Level(repr={'method': 'wb97xd', 'basis': 'def2tzvp'}),
+                          project_directory=sched.project_directory, job_num=job_num, **kwargs)
+        job.job_status = ['done', {'status': 'errored', 'keywords': ['MaxOptCycles'],
+                                   'error': 'Maximum optimization cycles reached', 'line': 'Number of steps exceeded'}]
+        return job
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_exhausted_scan_invalidates_rotor_and_keeps_ts(self, mock_switch_ts, mock_trsh):
+        """An unconvergeable rotor scan must invalidate only that rotor, never discard the TS."""
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'scan', False, '', 14, '', 8, True)
+        sched = self.build_sched('scan')
+        job = self.make_failed_job(sched, 'scan', 300, rotor_index=0)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        mock_switch_ts.assert_not_called()
+        rotor = sched.species_dict['TS_test'].rotors_dict[0]
+        self.assertIs(rotor['success'], False)
+        self.assertIn('exhausted', rotor['invalidation_reason'])
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_exhausted_directed_scan_invalidates_rotor(self, mock_switch_ts, mock_trsh):
+        """A directed scan is gated by the same 'success is not None' check, so it must also be invalidated."""
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'directed_scan', False, '', 14, '', 8, True)
+        sched = self.build_sched('directed')
+        job = self.make_failed_job(sched, 'directed_scan', 301, rotor_index=0)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        mock_switch_ts.assert_not_called()
+        self.assertIs(sched.species_dict['TS_test'].rotors_dict[0]['success'], False)
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_exhausted_opt_still_switches_ts(self, mock_switch_ts, mock_trsh):
+        """A failed geometry-determining job must still reject the TS guess, as before."""
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'opt', False, '', 14, '', 8, True)
+        sched = self.build_sched('opt')
+        job = self.make_failed_job(sched, 'opt', 302)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        mock_switch_ts.assert_called_once_with(label='TS_test')
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_exhausted_sp_does_not_switch_ts(self, mock_switch_ts, mock_trsh):
+        """A refinement job that cannot invalidate a geometry must not discard the TS."""
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'sp', False, '', 14, '', 8, True)
+        sched = self.build_sched('sp')
+        job = self.make_failed_job(sched, 'sp', 303)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        mock_switch_ts.assert_not_called()
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_exhausted_scan_on_a_rotor_without_an_invalidation_reason(self, mock_switch_ts, mock_trsh):
+        """
+        A rotor restored from older restart data can lack the 'invalidation_reason' key.
+
+        ``ARCSpecies.as_dict()`` serializes a rotor by iterating the keys it happens to have, so a
+        key absent when the project was written stays absent after the round trip. Appending to it
+        must therefore not assume it exists.
+        """
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'scan', False, '', 14, '', 8, True)
+        sched = self.build_sched('legacy_rotor')
+        del sched.species_dict['TS_test'].rotors_dict[0]['invalidation_reason']
+        job = self.make_failed_job(sched, 'scan', 305, rotor_index=0)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        mock_switch_ts.assert_not_called()
+        rotor = sched.species_dict['TS_test'].rotors_dict[0]
+        self.assertIs(rotor['success'], False)
+        self.assertIn('exhausted', rotor['invalidation_reason'])
+
+    @patch('arc.scheduler.trsh_ess_job')
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_scan_rotor_not_left_pending(self, mock_switch_ts, mock_trsh):
+        """Leaving 'success' as None would make run_scan_jobs() re-spawn the exhausted scan."""
+        mock_trsh.return_value = (list(), list(), False, Level(repr='wb97xd/def2tzvp'),
+                                  'gaussian', 'scan', False, '', 14, '', 8, True)
+        sched = self.build_sched('pending')
+        job = self.make_failed_job(sched, 'scan', 304, rotor_index=0)
+        sched.troubleshoot_ess(label='TS_test', job=job, level_of_theory=Level(repr='wb97xd/def2tzvp'))
+        self.assertIsNotNone(sched.species_dict['TS_test'].rotors_dict[0]['success'])
+
+
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
> **Standalone PR, base `main`.** Previously layer 3 of stack #942, which has been dissolved. This
> was written on top of #817 but does not depend on it — it applies to `main` unchanged. #817 covers
> TS guess identity; this PR covers which job types may reject a TS.

## What went wrong

When ESS troubleshooting was exhausted, `troubleshoot_ess()` switched the TS guess for **any** failed job with `conformer is None`. Its own comment states the intent:

```python
elif ...is_ts and not ...ts_guesses_exhausted and conformer is None:
    # Only switch TS guess when a full optimization fails, not when a single
    # conformer search job fails. Other conformers may still be running.
    self.switch_ts(label=label)
```

The comment says *"only when a full optimization fails"*, but the condition **never checks `job_type`** — it only excludes conformer jobs. A rotor scan also has `conformer=None`, so an unconvergeable **hindered-rotor scan discarded the transition state**.

A rotor scan is a thermochemical refinement: it reports on a geometry, it cannot demonstrate that a structure is not a saddle point. Letting it veto a TS inverts the hierarchy.

## Benchmark evidence — 2 of 28 no-rate runs

Both discarded a TS that had **already passed every check**:

```
{'E0': True, 'IRC': True, 'freq': True, 'NMD': True}
```

| run | what happened after the TS was discarded |
|---|---|
| `r3_01` cyclic_ether_formation | scan burned 7h20m exhausting all 5 trsh attempts on a flat torsional PES (`MaxOptCycles`/`DispUnconverged`), TS discarded, 2 remaining guesses failed NMD → **NO_TS** |
| `reaction_17` xy_elimination_hydroxyl | TS discarded, then **7** guess switches drifting to −2154 / −2044 cm⁻¹ H-motion saddles → **NO_TS** |

So ~7% of that benchmark's NO_TS results were not TS-search failures at all — ARC had found and validated the transition state, then threw it away.

## The fix — two parts, both required

**1. Gate the switch on job type.** New module constant:

```python
TS_GEOMETRY_JOB_TYPES = ('opt', 'optfreq', 'composite', 'freq')
```

A failed refinement job (`scan`, `directed_scan`, `sp`, `irc`, `orbitals`, `onedmin`) now logs an ERROR and **keeps** the TS.

**2. An exhausted scan invalidates just that rotor.** This is not cosmetic — it is required for correctness. `run_scan_jobs()` treats `rotor['success'] is None` as *"not yet run"*:

```python
if rotor['success'] is not None:
    ... continue          # resolved — skip
# else: fall through and SPAWN the scan
```

So suppressing the switch **without** recording the failure would re-spawn the very scan that just exhausted all five troubleshooting attempts — an infinite resubmit loop, strictly worse than the original bug. The rotor is therefore marked `success=False` with an `invalidation_reason`, and the species is preserved so the torsion falls back to an approximate treatment. `directed_scan` is gated by the same check and handled alongside `scan`.

## Evidence

5 new tests in `TestTroubleshootEssJobTypeGuard`. **4 fail without the fix** — with `AssertionError: Expected 'switch_ts' to not have been called. Called 1 times.`, literally the `r3_01` bug — and `test_exhausted_opt_still_switches_ts` passes **both** with and without, proving geometry-job behaviour is unchanged.

**380 tests pass across all four stack layers applied together** (`species_test`, `scheduler_test`, `output_test`, `job/pipe`), run serially — this suite is flaky under `xdist` because its workers collide on shared `Projects/` directories.


