### PR TITLE
Troubleshoot the opt job that failed, not the highest-numbered one

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2683,7 +2683,7 @@ class Scheduler(object):
                                                project_directory=self.project_directory,
                                                method='draw_3d')
         elif self.trsh_ess_jobs:
-            self.troubleshoot_opt_jobs(label=label)
+            self.troubleshoot_opt_jobs(label=label, job=job)
         return success
 
     def post_opt_geo_work(self, 
@@ -3750,7 +3750,46 @@ class Scheduler(object):
                                      )
         return trsh_success, actual_actions
 
-    def troubleshoot_opt_jobs(self, label):
+    def get_latest_opt_job(self, label: str) -> JobAdapter | None:
+        """
+        Get the most recently spawned ``opt`` job of a species.
+
+        Recency is taken from the insertion order of ``job_dict[label]['opt']``, not from the job
+        number: job numbers are only monotonic within a single execution, so a project that was
+        restarted holds jobs from several numbering eras at once and the highest number can belong
+        to an old job.
+
+        Args:
+            label (str): The species label.
+
+        Returns:
+            JobAdapter | None: The most recently spawned ``opt`` job, or ``None`` if there is none.
+        """
+        opt_jobs = list(self.job_dict.get(label, dict()).get('opt', dict()).values())
+        return opt_jobs[-1] if opt_jobs else None
+
+    def get_preceding_opt_job(self, label: str, job: JobAdapter) -> JobAdapter | None:
+        """
+        Get the ``opt`` job of a species that was spawned immediately before ``job``.
+
+        The match is done on the job's identity rather than on its name or number, so that the
+        result is the actual predecessor of the given job.
+
+        Args:
+            label (str): The species label.
+            job (JobAdapter): The job to find the predecessor of.
+
+        Returns:
+            JobAdapter | None: The preceding ``opt`` job, or ``None`` if ``job`` is the first one
+                                  or is not registered for this species.
+        """
+        opt_jobs = list(self.job_dict.get(label, dict()).get('opt', dict()).values())
+        for i, candidate in enumerate(opt_jobs):
+            if candidate is job:
+                return opt_jobs[i - 1] if i else None
+        return None
+
+    def troubleshoot_opt_jobs(self, label, job=None):
         """
         We're troubleshooting for opt jobs.
         First check for server status and troubleshoot if needed. Then check for ESS status and troubleshoot
@@ -3758,20 +3797,20 @@ class Scheduler(object):
 
         Args:
             label (str): The species label.
+            job (JobAdapter, optional): The opt job to troubleshoot. Callers that already hold the
+                                        job which failed must pass it: resolving it here instead
+                                        can select a different job than the one that failed.
         """
         if not self.trsh_ess_jobs:
             logger.warning(f'Not troubleshooting failed opt job for {label}. To enable troubleshooting, set the '
                            f'"trsh_ess_jobs" to "True".')
             return None
 
-        previous_job_num, latest_job_num = -1, -1
-        job = None
-        for job_name in self.job_dict[label]['opt'].keys():  # get the latest Job object for the species / TS
-            job_name_int = int(job_name[5:])
-            if job_name_int > latest_job_num:
-                previous_job_num = latest_job_num
-                latest_job_num = job_name_int
-                job = self.job_dict[label]['opt'][job_name]
+        job = job if job is not None else self.get_latest_opt_job(label)
+        if job is None:
+            logger.error(f'Cannot troubleshoot an opt job for {label}, no opt job was found.')
+            return None
+        previous_job = self.get_preceding_opt_job(label=label, job=job)
         if job.job_status[0] == 'done':
             if job.job_status[1]['status'] == 'done':
                 if job.fine:
@@ -3792,8 +3831,7 @@ class Scheduler(object):
             else:
                 trsh_opt = True
                 # job passed on the server, but failed in ESS calculation
-                if previous_job_num >= 0 and job.fine:
-                    previous_job = self.job_dict[label]['opt']['opt_a' + str(previous_job_num)]
+                if previous_job is not None and job.fine:
                     if not previous_job.fine and previous_job.job_status[0] == 'done' \
                             and previous_job.job_status[1]['status'] == 'done' \
                                 and 'all_attempted' in job.ess_trsh_methods:

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -2204,5 +2204,115 @@ class TestSchedulerAdaptiveReactionLevels(unittest.TestCase):
             self.build_scheduler(rxn, r + p + [collider], 'adaptive_collision')
 
 
-if __name__ == '__main__':
-    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))
+class TestTroubleshootOptJobIdentity(unittest.TestCase):
+    """
+    Test that opt troubleshooting acts on the job that actually failed, rather than re-deriving one
+    from the highest job number. Job numbers are only monotonic within a single execution, so a
+    restarted project holds several numbering eras at once.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ess_settings = {'gaussian': ['server1'], 'molpro': ['server2', 'server1'], 'qchem': ['server1']}
+        cls.xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+
+    def build_sched(self, name: str):
+        """Build a minimal Scheduler holding one species."""
+        spc = ARCSpecies(label='spc_test', xyz=self.xyz, multiplicity=1, charge=0, compute_thermo=False)
+        project_directory = os.path.join(ARC_PATH, 'Projects', f'arc_test_optjob_{name}')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project=f'test_optjob_{name}', ess_settings=self.ess_settings,
+                          species_list=[spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types={'conf_opt': False, 'opt': True, 'fine': True, 'freq': True,
+                                     'sp': True, 'rotors': False, 'irc': False},
+                          )
+        sched.trsh_ess_jobs = True
+        return sched
+
+    @staticmethod
+    def make_job(job_name: str, fine: bool, ess_done: bool):
+        """Build a stand-in opt job. Only the attributes troubleshoot_opt_jobs reads are set."""
+        job = MagicMock()
+        job.job_name = job_name
+        job.fine = fine
+        job.ess_trsh_methods = list()
+        job.job_status = ['done', {'status': 'done' if ess_done else 'errored',
+                                   'keywords': [] if ess_done else ['SCF'],
+                                   'error': '' if ess_done else 'SCF failed', 'line': ''}]
+        return job
+
+    def register(self, sched, jobs):
+        """Register opt jobs on the scheduler in the given (insertion) order."""
+        sched.job_dict['spc_test'] = {'opt': {j.job_name: j for j in jobs}}
+
+    def test_restarted_project_does_not_troubleshoot_a_stale_higher_numbered_job(self):
+        """The reported crash: a stale high-numbered done+fine job must not be picked over the real failure."""
+        sched = self.build_sched('stale')
+        stale = self.make_job('opt_a9755', fine=True, ess_done=True)     # old era, higher number, looks healthy
+        failed = self.make_job('opt_a2098', fine=True, ess_done=False)   # actually latest, actually failed
+        self.register(sched, [stale, failed])
+        with patch.object(Scheduler, 'troubleshoot_ess') as mock_trsh_ess:
+            sched.troubleshoot_opt_jobs(label='spc_test', job=failed)
+        mock_trsh_ess.assert_called_once()
+        self.assertIs(mock_trsh_ess.call_args.kwargs['job'], failed)
+
+    def test_get_latest_opt_job_uses_insertion_order_not_job_number(self):
+        """Recency must come from insertion order; the highest number can belong to an old era."""
+        sched = self.build_sched('latest')
+        stale = self.make_job('opt_a9755', fine=True, ess_done=True)
+        newest = self.make_job('opt_a2098', fine=True, ess_done=True)
+        self.register(sched, [stale, newest])
+        self.assertIs(sched.get_latest_opt_job('spc_test'), newest)
+
+    def test_get_preceding_opt_job_matches_by_identity(self):
+        """The predecessor is resolved by the job's identity, not by decrementing its number."""
+        sched = self.build_sched('prev')
+        first = self.make_job('opt_a9755', fine=False, ess_done=True)
+        second = self.make_job('opt_a2095', fine=False, ess_done=True)
+        third = self.make_job('opt_a2098', fine=True, ess_done=False)
+        self.register(sched, [first, second, third])
+        self.assertIs(sched.get_preceding_opt_job('spc_test', third), second)
+        self.assertIsNone(sched.get_preceding_opt_job('spc_test', first))
+
+    def test_get_preceding_opt_job_returns_none_for_unregistered_job(self):
+        """A job that is not registered for this species has no predecessor."""
+        sched = self.build_sched('unreg')
+        registered = self.make_job('opt_a2095', fine=False, ess_done=True)
+        self.register(sched, [registered])
+        stranger = self.make_job('opt_a3000', fine=True, ess_done=False)
+        self.assertIsNone(sched.get_preceding_opt_job('spc_test', stranger))
+
+    def test_stale_high_numbered_job_is_not_selected_when_no_job_is_passed(self):
+        """
+        Reproduces the reported crash using the original call signature.
+
+        A restarted project holds a stale ``opt_a9755`` (done, fine) alongside the real, newer
+        ``opt_a2098`` that failed. Selecting by highest job number picks the stale one, finds it
+        healthy, and raises ``SchedulerError: opt job ... seems right, yet "run_opt_job" was
+        called``, which aborts the whole run.
+        """
+        sched = self.build_sched('fallback')
+        stale = self.make_job('opt_a9755', fine=True, ess_done=True)
+        failed = self.make_job('opt_a2098', fine=True, ess_done=False)
+        self.register(sched, [stale, failed])
+        with patch.object(Scheduler, 'troubleshoot_ess') as mock_trsh_ess:
+            sched.troubleshoot_opt_jobs(label='spc_test')
+        mock_trsh_ess.assert_called_once()
+        self.assertIs(mock_trsh_ess.call_args.kwargs['job'], failed)
+
+    def test_no_opt_jobs_does_not_raise(self):
+        """With no opt job to troubleshoot, log and return rather than raising."""
+        sched = self.build_sched('none')
+        sched.job_dict['spc_test'] = {'opt': dict()}
+        self.assertIsNone(sched.troubleshoot_opt_jobs(label='spc_test'))
+
+


### PR DESCRIPTION
> **Standalone PR, base `main`.** Previously the top of stack #942, which has been dissolved. This
> was written on top of #941 but does not depend on it — only its tests sat next to #941's, and they
> have been separated. #941 covers which job types may reject a TS; this PR covers which opt job gets
> troubleshooted.

## What went wrong

A production run died with:

```
SchedulerError: opt job for TS0 seems right, yet "run_opt_job" was called.
```

`parse_opt_geo()` reaches troubleshooting only on the failure branch, and it already holds the job that failed — but it passed only the species label:

```python
elif self.trsh_ess_jobs:
    self.troubleshoot_opt_jobs(label=label)      # the failed `job` is in scope, and dropped
```

`troubleshoot_opt_jobs()` then re-derived a job by scanning for the largest job number:

```python
for job_name in self.job_dict[label]['opt'].keys():
    job_name_int = int(job_name[5:])
    if job_name_int > latest_job_num:            # "latest" == biggest number
        previous_job_num = latest_job_num
        latest_job_num = job_name_int
        job = self.job_dict[label]['opt'][job_name]
```

**Job numbers are only monotonic within a single execution.** A project that has been restarted holds jobs from several numbering eras at once, so the highest number can belong to an old job.

In the run that crashed, `job_dict['TS0']['opt']` held **102 opt jobs numbered 1332–9779** (22 of them 9xxx), while the chronologically newest was `opt_a2098`:

| | |
|---|---|
| newest by mtime | `opt_a2098` — 08-01 00:51 |
| highest by number | `opt_a9779` — an earlier era |

So when `opt_a2098` failed, troubleshooting selected a stale 9xxx job, found it converged *and* run with a fine grid, and hit the sanity guard — which raises and **aborts the entire run**, discarding 3.5 hours of completed optimization plus everything queued behind it.

## The fix

- `troubleshoot_opt_jobs(label, job=None)` accepts the job to troubleshoot; `parse_opt_geo()` passes the one that actually failed.
- The fine/coarse pairing no longer decrements a job number. New `get_preceding_opt_job()` locates the predecessor by the job's **identity** (`candidate is job`).
- New `get_latest_opt_job()` resolves recency from the **insertion order** of `job_dict[label]['opt']` rather than from the job number, for callers that supply no job.
- An absent opt job is logged and returns, instead of raising `AttributeError` on `None`.

The `SchedulerError` guard is deliberately **kept**. It is a real invariant check, and with the correct job passed it is unreachable from this path — since `parse_opt_geo()` only troubleshoots when the status is *not* done. Removing it would hide a future bug rather than fix one.

## Evidence

6 new tests in `TestTroubleshootOptJobIdentity`. The central one calls `troubleshoot_opt_jobs(label=...)` with the **original signature**, against a `job_dict` seeded exactly like the failing project — a stale `opt_a9755` (done, fine) plus the newer `opt_a2098` that failed. Without this change it fails with the reported error verbatim:

```
arc.exceptions.SchedulerError: opt job for spc_test seems right, yet "run_opt_job" was called.
```

The other five cover insertion-order recency, identity-based predecessor lookup, an unregistered job, and the empty-`job_dict` path.

**245 tests pass** across all four stack layers applied together (`scheduler_test`, `output_test`, `species_test`, `checks/ts_test`, `job/trsh_test`).

## Why this belongs on this stack

Same root pattern as the three layers below: **an integer that merely looks like an ordering, used as identity**. #940 was list position vs `TSGuess.index`; #941 was a `tsg<i>` adapter number used as a list subscript; this is a job number used as a timestamp. Each is a valid ordering within one context and silently wrong across contexts — and each surfaces as a function that receives a *label* and re-derives an object the caller already held.


