### PR TITLE
Don't emit NaN coordinates for a collinear zmat reference

### DIFF
--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1461,8 +1461,8 @@ def embed_rdkit(label, mol, num_confs=None, xyz=None):
     if num_confs is not None:
         try:
             Chem.AllChem.EmbedMultipleConfs(rd_mol, numConfs=num_confs, randomSeed=1, enforceChirality=True)
-        except:
-            logger.warning(f'Could not embed conformers using RDKit for {label}')
+        except Exception as e:
+            logger.warning(f'Could not embed conformers using RDKit for {label}, failed with: {e}')
             return None
     elif xyz is not None:
         rd_conf = Chem.Conformer(rd_mol.GetNumAtoms())
@@ -1568,8 +1568,9 @@ def rdkit_force_field(label: str,
                                                           maxIters=500,
                                                           ignoreInterfragInteractions=False,
                                                           )
-                except:
-                    pass
+                except Exception as e:
+                    logger.warning(f'Could not optimize conformer {i} of {label} using RDKit, failed with: {e}')
+                    break
                 else:
                     j += 1
         mol_properties = Chem.AllChem.MMFFGetMoleculeProperties(rd_mol, mmffVariant=force_field)

--- a/arc/species/conformers_test.py
+++ b/arc/species/conformers_test.py
@@ -6,6 +6,7 @@ This module contains unit tests of the arc.species.conformers module
 """
 
 import unittest
+import unittest.mock
 
 from rdkit.Chem import rdMolTransforms as rdMT
 
@@ -665,6 +666,26 @@ H       0.68104300    0.74807180    0.61546062""")]
         xyzs, energies = conformers.rdkit_force_field(label='CJ', rd_mol=rd_mol)
         for atom, symbol in zip(self.cj_spc.mol.atoms, xyzs[0]['symbols']):
             self.assertEqual(atom.symbol, symbol)
+
+    def test_embed_rdkit_reports_why_embedding_failed(self):
+        """Test that a failure to embed names the underlying error instead of swallowing it"""
+        with unittest.mock.patch('rdkit.Chem.AllChem.EmbedMultipleConfs',
+                                 side_effect=RuntimeError('Bad Conformer Id')):
+            with self.assertLogs('arc', level='WARNING') as captured:
+                rd_mol = conformers.embed_rdkit(label='CJ', mol=self.cj_spc.mol, num_confs=1)
+        self.assertIsNone(rd_mol)
+        self.assertIn('Bad Conformer Id', '\n'.join(captured.output))
+
+    def test_rdkit_force_field_abandons_an_optimization_that_raises(self):
+        """Test that a raising optimization is logged and attempted once per conformer"""
+        rd_mol = conformers.embed_rdkit(label='CJ', mol=self.cj_spc.mol, num_confs=1)
+        num_confs = rd_mol.GetNumConformers()
+        with unittest.mock.patch('rdkit.Chem.AllChem.MMFFOptimizeMolecule',
+                                 side_effect=[RuntimeError('no MMFF parameters'), 0] * num_confs) as optimize:
+            with self.assertLogs('arc', level='WARNING') as captured:
+                conformers.rdkit_force_field(label='CJ', rd_mol=rd_mol)
+        self.assertEqual(optimize.call_count, num_confs)
+        self.assertIn('no MMFF parameters', '\n'.join(captured.output))
 
     def test_read_rdkit_embedded_conformers(self):
         """Test reading coordinates from embedded RDKit conformers"""

--- a/arc/species/vectors.py
+++ b/arc/species/vectors.py
@@ -28,6 +28,37 @@ def get_normal(v1: list[float],
     return unit_vector(normal)
 
 
+def get_perpendicular_unit_vector(vector: list[float]) -> list[float]:
+    """
+    Get a deterministic unit vector perpendicular to ``vector``.
+
+    Crossing ``vector`` with the Cartesian axis it is least aligned with can never be degenerate:
+    the smallest component of a vector of length L is at most L / sqrt(3), so the cross product has
+    a length of at least L * sqrt(2/3). Picking the axis by magnitude rather than arbitrarily keeps
+    the result reproducible for a given input.
+
+    Args:
+        vector (list): The vector to find a perpendicular of. Need not be normalized.
+
+    Raises:
+        VectorsError: If ``vector`` is not a finite, non-zero vector of length three.
+        ZeroDivisionError: If ``vector`` is non-zero but its squared length underflows to zero,
+                           which happens below a magnitude of about 1e-162.
+
+    Returns: list
+        A unit vector perpendicular to ``vector``.
+    """
+    if len(vector) != 3:
+        raise VectorsError(f'vector must be of length three, got {len(vector)}.')
+    if not all(math.isfinite(component) for component in vector):
+        raise VectorsError(f'vector must be finite, got {vector}.')
+    if not any(vector):
+        raise VectorsError(f'vector must be non-zero, got {vector}.')
+    reference = [0.0, 0.0, 0.0]
+    reference[min(range(3), key=lambda index: abs(vector[index]))] = 1.0
+    return get_normal(vector, reference)
+
+
 def get_angle(v1: list[float],
               v2: list[float],
               units: str = 'rads',

--- a/arc/species/vectors_test.py
+++ b/arc/species/vectors_test.py
@@ -51,6 +51,29 @@ class TestVectors(unittest.TestCase):
         for ni, expected_ni in zip(n, expected_n):
             self.assertEqual(ni, expected_ni)
 
+    def test_get_perpendicular_unit_vector(self):
+        """Test that a unit vector orthogonal to the input is returned for any input direction"""
+        for vector in ([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0],
+                       [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0],
+                       [1.0, 1.0, 1.0], [-3.0, 0.5, 0.0], [0.0, 0.0, -2.0]):
+            with self.subTest(vector=vector):
+                perpendicular = vectors.get_perpendicular_unit_vector(vector)
+                self.assertAlmostEqual(vectors.get_vector_length(perpendicular), 1.0, places=10)
+                self.assertAlmostEqual(sum(perpendicular[i] * vector[i] for i in range(3)), 0.0, places=10)
+
+    def test_get_perpendicular_unit_vector_is_deterministic(self):
+        """Test that repeated calls with the same input return the same vector"""
+        self.assertEqual(vectors.get_perpendicular_unit_vector([1.0, 2.0, 3.0]),
+                         vectors.get_perpendicular_unit_vector([1.0, 2.0, 3.0]))
+
+    def test_get_perpendicular_unit_vector_rejects_degenerate_input(self):
+        """Test that a vector which is not a finite, non-zero 3-vector is rejected"""
+        for vector in ([0.0, 0.0, 0.0], [1.0, 0.0], [1.0, 2.0, 3.0, 4.0],
+                       [float('nan'), 0.0, 1.0], [float('inf'), 0.0, 1.0]):
+            with self.subTest(vector=vector):
+                with self.assertRaises(VectorsError):
+                    vectors.get_perpendicular_unit_vector(vector)
+
     def test_get_angle(self):
         """Test calculating the angle between two vectors"""
         v1 = [-1.45707856 + 0.02416711, -0.94104506 - 0.17703194, -0.20275830 - 0.08644641]

--- a/arc/species/zmat.py
+++ b/arc/species/zmat.py
@@ -1061,7 +1061,9 @@ def add_dummy_atom(zmat: dict,
     if d_str is not None:
         zmat['vars'][d_str] = 180
     # Update xyz with the dummy atom (useful when this atom is used to define dihedrals of other atoms).
-    coords = _add_nth_atom_to_coords(zmat=zmat, coords=list(coords), i=n)
+    zmat_ordered_coords = [tuple(coords[map_index_to_int(zmat['map'][zmat_index])]) for zmat_index in range(n)]
+    zmat_ordered_coords = _add_nth_atom_to_coords(zmat=zmat, coords=zmat_ordered_coords, i=n)
+    coords = list(coords) + [zmat_ordered_coords[n]]
     if connectivity is not None:
         # Update the connectivity dict to reflect that X is connected to the respective atom (r_atoms[1]),
         # this will help later in avoiding linear angles in the last three indices of a dihedral.
@@ -1157,11 +1159,26 @@ def _add_nth_atom_to_coords(zmat: dict,
     """
     Add the n-th atom to the coords (n >= 0).
 
+    The reference atoms are read from the zmat's R/A/D parameter strings, so ``coords`` is indexed
+    in the zmat's index space: entry ``k`` holds the coordinates of the atom at zmat index ``k``,
+    which is not the same as its index in the mol/xyz whenever the two orders differ.
+
+    Atoms 0 and 1 define the frame: they are placed at the origin and on the +z axis, respectively.
+    Given zmat-ordered ``coords``, every atom from index 2 onwards is placed relative to the
+    coordinates already present, so the frame they are in is honoured rather than replaced. Atom 2
+    has no reference plane to fix its azimuth about the 0-1 axis, which is therefore taken from
+    ``vectors.get_perpendicular_unit_vector()`` of that axis; for the canonical frame this
+    reproduces the +y half plane.
+
     Args:
         zmat (dict): The zmat.
-        coords (list): The coordinates to be updated (not the entire xyz dict).
+        coords (list): The coordinates to be updated (not the entire xyz dict), ordered by zmat index.
         i (int): The atom number in the zmat to be added to the coords (0-indexed)
         coords_to_skip (list, optional): Entries are indices to skip.
+
+    Raises:
+        VectorsError: If atom 2 is being added and atoms 0 and 1 are coincident, or if the B and C
+                      reference atoms of the atom being added are coincident.
 
     Returns:
         list: The updated coords.
@@ -1180,25 +1197,37 @@ def _add_nth_atom_to_coords(zmat: dict,
         bc_length = zmat['vars'][r_key]
         alpha = zmat['vars'][a_key]
         alpha = math.radians(alpha if alpha < 180 else 360 - alpha)
-        b_index = [indices for indices in get_atom_indices_from_zmat_parameter(r_key) if indices[0] == i][0][1]
-        b_z = coords[b_index][2]
-        c_y = bc_length * math.sin(alpha)
+        a_indices = [indices for indices in get_atom_indices_from_zmat_parameter(a_key) if indices[0] == i][0]
+        b_index, a_index = a_indices[1], a_indices[2]
         r"""
-        We differentiate between two cases for c_z:
-        Either atom A is at the origin (case 1), or atom B is at the origin (case 2).
-        One of them has to be at the origin (0, 0, 0), since we're adding the 3rd atom (so either A or B were 1st).
-        
-         y
-         ^                    C                         C
-         |           (1)       \        or     (2)     /
-         L__ > z           A -- B                    B -- A
-        
-        In case 1, we need to deduct len(B-C) from the z coordinate of atom B,
-        but in case 2 we need to take the positive value of len(B-C).
-        The above is also true if alpha(A-B-C) is > 90 degrees.
+        Atom C is placed relative to atom B, at a distance of bc_length from it, and rotated by alpha
+        away from the direction B -> A, where alpha is the A-B-C angle folded into [0, 180] just above:
+
+            C = B + bc_length * (cos(alpha) * u_BA + sin(alpha) * u_perp)
+
+        u_BA is the unit vector pointing from B towards A, and u_perp is a unit vector perpendicular to
+        the A-B axis. The two are orthonormal, so they span the plane C is placed in, and the component
+        along each is what makes the A-B-C angle come out at exactly alpha. Atoms A and B fix an axis
+        but not a plane, so the azimuth of u_perp about that axis is a convention.
+
+                              u_perp                                      u_perp
+                                ^                                           ^
+                             C  |                                           |  C
+                              \ |                                           | /
+                         alpha \|                                     alpha |/
+                    A <---------B                               A <---------B
+                         u_BA                                        u_BA
+
+                       alpha < 90                                  alpha > 90
+
+        Both terms are taken relative to atom B and to the direction B -> A, so the placement holds for
+        atoms A and B wherever they lie. For alpha > 90 degrees cos(alpha) is negative, the u_BA term
+        points away from A, and C falls on the far side of B, as drawn on the right.
         """
-        c_z = b_z - bc_length * math.cos(alpha) if b_z else bc_length * math.cos(alpha)
-        coords.append((0.0, c_y, c_z))
+        u_perp = vectors.get_perpendicular_unit_vector([coords[1][k] - coords[0][k] for k in range(3)])
+        u_ba = vectors.unit_vector([coords[a_index][k] - coords[b_index][k] for k in range(3)])
+        coords.append(tuple(coords[b_index][k] + bc_length * (math.cos(alpha) * u_ba[k]
+                                                              + math.sin(alpha) * u_perp[k]) for k in range(3)))
     elif i not in coords_to_skip:
         d_indices = [indices for indices in get_atom_indices_from_zmat_parameter(zmat['coords'][i][2])
                      if indices[0] == i][0]
@@ -1212,6 +1241,10 @@ def _add_nth_atom_to_coords(zmat: dict,
         bc_length = vectors.get_vector_length([coords[c_index][0] - coords[b_index][0],
                                        coords[c_index][1] - coords[b_index][1],
                                        coords[c_index][2] - coords[b_index][2]])
+        if not bc_length:
+            raise VectorsError(f'Cannot place atom {i} of the zmat: its reference atoms {b_index} and {c_index} '
+                               f'are coincident, so the direction from atom {b_index} to atom {c_index} is '
+                               f'undefined, and with it the angle and the dihedral that place atom {i}.')
         # A vector pointing from atom A to atom B:
         ab = [(coords[b_index][0] - coords[a_index][0]),
               (coords[b_index][1] - coords[a_index][1]),
@@ -1221,7 +1254,18 @@ def _add_nth_atom_to_coords(zmat: dict,
                (coords[c_index][1] - coords[b_index][1]) / bc_length,
                (coords[c_index][2] - coords[b_index][2]) / bc_length]
         n = np.cross(ab, ubc)
-        un = n / vectors.get_vector_length(n)
+        n_length = vectors.get_vector_length(n)
+        un = n / n_length if n_length else np.full(3, np.nan)
+        if not np.all(np.isfinite(un)):
+            logger.warning(f'Atoms {a_index}, {b_index} and {c_index} of the zmat do not define a reference plane '
+                           f'(they are collinear or coincident), so the dihedral about them is undefined. Placing '
+                           f'atom {i} against an arbitrary plane; the requested distance and angle are still '
+                           f'honoured, and the dihedral is measured from an arbitrary zero. zmat construction '
+                           f'inserts dummy atoms to keep linear segments out of a dihedral reference, so a '
+                           f'linear segment reaching this branch means either that the reference atoms were '
+                           f'resolved incorrectly, or that the segment was never recognized as linear, which '
+                           f'can happen when the connectivity is unavailable.')
+            un = vectors.get_perpendicular_unit_vector(ubc)
         un_cross_ubc = np.cross(un, ubc)
         m = np.array([[ubc[0], un_cross_ubc[0], un[0]],
                       [ubc[1], un_cross_ubc[1], un[1]],

--- a/arc/species/zmat_test.py
+++ b/arc/species/zmat_test.py
@@ -5,13 +5,39 @@
 This module contains unit tests of the arc.species.species module
 """
 
+import itertools
+import math
 import unittest
 
+import arc.species.vectors as vectors
 import arc.species.zmat as zmat
-from arc.exceptions import ZMatError
+from arc.exceptions import VectorsError, ZMatError
 from arc.molecule.molecule import Molecule
-from arc.species.converter import str_to_xyz
+from arc.species.converter import str_to_xyz, zmat_to_xyz
 from arc.species.species import ARCSpecies
+
+KETENE_ON_Y = {'symbols': ('C', 'C', 'O', 'H', 'H'), 'isotopes': (12, 12, 16, 1, 1),
+               'coords': ((0.0, 0.0, 0.0), (0.0, 1.315, 0.0), (0.0, 2.478, 0.0),
+                          (0.941, -0.539, 0.0), (-0.941, -0.539, 0.0))}
+
+
+def max_distance_discrepancy(xyz_1: dict, xyz_2: dict) -> float:
+    """
+    Get the largest difference between two geometries' interatomic distances.
+
+    The distance matrix is invariant under every isometry, so this compares the molecules
+    themselves without first having to superpose them.
+
+    Args:
+        xyz_1 (dict): The first xyz dict.
+        xyz_2 (dict): The second xyz dict, with atoms in the same order.
+
+    Returns: float
+        The largest absolute difference, in Angstrom.
+    """
+    return max(abs(vectors.calculate_param(coords=xyz_1['coords'], atoms=[i, j])
+                   - vectors.calculate_param(coords=xyz_2['coords'], atoms=[i, j]))
+               for i in range(len(xyz_1['symbols'])) for j in range(i + 1, len(xyz_1['symbols'])))
 
 
 class TestZMat(unittest.TestCase):
@@ -836,7 +862,7 @@ class TestZMat(unittest.TestCase):
                                  ('R_14_0', 'A_14_0_1', 'DX_14_0_1_12'), ('R_15_13', 'A_15_13_11', 'D_15_13_11_14')),
                       'vars': {'R_1_0': 1.3280952001482191, 'R_11_9': 1.1999728537508982, 'R_13_11': 1.689800107747744,
                                'R_14_0': 0.9721366076390169, 'A_14_0_1': 110.47038205347816,
-                               'DX_14_0_1_12': 23.38932439442073, 'R_15_13': 1.3410220734118692,
+                               'DX_14_0_1_12': 180.72845407726243, 'R_15_13': 1.3410220734118692,
                                'A_15_13_11': 97.88723623341478, 'D_15_13_11_14': 179.99850519058072,
                                'RX_2|4|6|8|10|12_1|3|5|7|9|11': 1.0, 'R_3|7_1|5': 1.2000592040351243,
                                'R_5|9_3|7': 1.5398025274560583,
@@ -874,7 +900,7 @@ class TestZMat(unittest.TestCase):
                                  ('R_24_16', 'AX_2|3|4|5|6|7|11|12|13|14|15|16|17|18|19|20|21|22|23|24_1|1|3|3|5|5|8|8|9|9|10|10|14|14|18|18|0|0|16|16_0|2|1|4|3|6|7|11|7|13|7|15|9|17|14|19|1|21|10|23', 'DX_3|4|5|6|7|11|12|13|14|15|16|17|18|19|20|21|22|23|24_1|3|3|5|5|8|8|9|9|10|10|14|14|18|18|0|0|16|16_2|1|4|3|6|7|11|7|13|7|15|9|17|14|19|1|21|10|23_0|2|1|4|3|5|7|5|7|5|7|5|9|16|14|20|1|5|10')),
                       'vars': {'R_1_0': 1.199903964996338, 'R_3_1': 1.5391608476638794, 'R_5_3': 1.2011795043945312,
                                'R_7_5': 1.4856303930282593, 'R_8_7': 1.4922382831573486, 'A_8_7_5': 109.90699005126953,
-                               'DX_8_7_5_6': 359.9999987925818, 'R_9_7': 1.4877170324325562,
+                               'DX_8_7_5_6': 217.02802901839746, 'R_9_7': 1.4877170324325562,
                                'A_9_7_5': 109.04773712158203, 'D_9_7_5_8': 120.33149888420691,
                                'R_10_7': 1.4911911487579346, 'A_10_7_5': 109.24951171875,
                                'D_10_7_5_9': 118.98353452695731, 'R_12_8': 1.1634670495986938,
@@ -2450,6 +2476,293 @@ H   1.3230  -1.0712   1.2760""")
         result = zmat.find_smart_anchors(mol, breaking_bonds=[(0, 1)])
         self.assertEqual(len(result), len(set(result)),
                          msg=f'Duplicate anchors {result} with reactive core on cyclohexane')
+
+
+class TestCollinearReference(unittest.TestCase):
+    """
+    Test placing an atom whose three zmat reference atoms are collinear.
+
+    The dihedral about a collinear A-B-C is undefined, so no reference plane exists. The placement
+    must still honour the requested distance and angle rather than producing NaN coordinates.
+    """
+
+    @staticmethod
+    def build_collinear_zmat(cd_length: float, bcd_angle: float, abcd_dihedral: float = 0.0) -> dict:
+        """Build a 4-atom zmat whose first three atoms lie on a straight line."""
+        return {'symbols': ('H', 'H', 'H', 'H'),
+                'coords': ((None, None, None),
+                           ('R_1_0', None, None),
+                           ('R_2_1', 'A_2_1_0', None),
+                           ('R_3_2', 'A_3_2_1', 'D_3_2_1_0')),
+                'vars': {'R_1_0': 1.0, 'R_2_1': 1.0, 'A_2_1_0': 180.0,
+                         'R_3_2': cd_length, 'A_3_2_1': bcd_angle, 'D_3_2_1_0': abcd_dihedral},
+                'map': {0: 0, 1: 1, 2: 2, 3: 3}}
+
+    @staticmethod
+    def distance(p, q):
+        """The distance between points ``p`` and ``q``."""
+        return vectors.get_vector_length([p[k] - q[k] for k in range(3)])
+
+    @staticmethod
+    def angle(p, q, r):
+        """The angle at ``q`` in degrees."""
+        return vectors.get_angle([p[k] - q[k] for k in range(3)],
+                                 [r[k] - q[k] for k in range(3)],
+                                 units='degs')
+
+    def test_collinear_reference_does_not_produce_nan(self):
+        """The reported failure: a collinear A-B-C gave (nan, nan, nan) with only a RuntimeWarning."""
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5)
+        coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]
+        coords = zmat._add_nth_atom_to_coords(zmat=z, coords=coords, i=3)
+        self.assertEqual(len(coords), 4)
+        for value in coords[3]:
+            self.assertFalse(math.isnan(value), f'Atom 3 was placed at {coords[3]}, which contains NaN.')
+
+    def test_propyne_round_trip_is_not_nan_or_collapsed(self):
+        """
+        An end-to-end guard on the path that actually failed: xyz -> zmat -> xyz.
+
+        A linear backbone lying on a Cartesian axis drove a NaN into the zmat vars, and
+        ``translate_to_center_of_mass`` then rewrote every NaN coordinate to 0.0, because
+        ``abs(nan) > 1e-10`` is False. The molecule therefore came back with all atoms at the
+        origin rather than as NaN, so asserting only that the coordinates are finite would not
+        detect the failure; the geometry itself is asserted.
+        """
+        c_c, cc3, ch_sp, ch3, ang = 1.46, 1.208, 1.062, 1.091, math.radians(110.0)
+        r, dz = ch3 * math.sin(ang), ch3 * math.cos(ang)
+        xyz = {'symbols': ('C', 'C', 'C', 'H', 'H', 'H', 'H'),
+               'isotopes': (12, 12, 12, 1, 1, 1, 1),
+               'coords': ((0.0, 0.0, 0.0), (0.0, 0.0, c_c), (0.0, 0.0, c_c + cc3),
+                          (0.0, 0.0, c_c + cc3 + ch_sp), (r, 0.0, dz),
+                          (-r / 2, r * math.sqrt(3) / 2, dz), (-r / 2, -r * math.sqrt(3) / 2, dz))}
+        z = zmat.xyz_to_zmat(xyz)
+        for key, value in z['vars'].items():
+            self.assertTrue(math.isfinite(value), f'zmat var {key} is {value}, which is not finite.')
+
+        back = zmat_to_xyz(z)
+        for index, atom_coords in enumerate(back['coords']):
+            for value in atom_coords:
+                self.assertTrue(math.isfinite(value), f'Atom {index} was placed at {atom_coords}.')
+        self.assertFalse(all(abs(value) < 1e-10 for atom_coords in back['coords'] for value in atom_coords),
+                         'Every atom collapsed onto the origin, which is what a laundered NaN looks like.')
+        self.assertAlmostEqual(self.distance(back['coords'][0], back['coords'][1]), c_c, places=4)
+        self.assertAlmostEqual(self.distance(back['coords'][1], back['coords'][2]), cc3, places=4)
+        self.assertAlmostEqual(self.distance(back['coords'][2], back['coords'][3]), ch_sp, places=4)
+        self.assertAlmostEqual(self.angle(back['coords'][0], back['coords'][1], back['coords'][2]), 180.0, places=3)
+
+    def test_collinear_reference_honours_distance_and_angle(self):
+        """Not merely non-NaN: the requested C-D distance and B-C-D angle must both be reproduced."""
+        for cd_length, bcd_angle in ((1.5, 109.5), (1.09, 120.0), (2.0, 90.0)):
+            with self.subTest(cd_length=cd_length, bcd_angle=bcd_angle):
+                z = self.build_collinear_zmat(cd_length=cd_length, bcd_angle=bcd_angle)
+                coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]
+                coords = zmat._add_nth_atom_to_coords(zmat=z, coords=coords, i=3)
+                self.assertAlmostEqual(self.distance(coords[3], coords[2]), cd_length, places=6)
+                self.assertAlmostEqual(self.angle(coords[1], coords[2], coords[3]), bcd_angle, places=4)
+
+    def test_collinear_reference_is_deterministic(self):
+        """The arbitrary reference plane must be chosen reproducibly, not at random."""
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5)
+        first = zmat._add_nth_atom_to_coords(zmat=z, coords=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)], i=3)
+        second = zmat._add_nth_atom_to_coords(zmat=z, coords=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)], i=3)
+        self.assertEqual(first[3], second[3])
+
+    def test_non_collinear_reference_is_unchanged(self):
+        """A well-defined reference must keep using the real A-B-C plane, dihedral included."""
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5, abcd_dihedral=60.0)
+        coords = [(0.3, 1.2, -0.4), (0.0, 0.0, 0.0), (1.1, 0.2, 0.5)]
+        coords = zmat._add_nth_atom_to_coords(zmat=z, coords=coords, i=3)
+        self.assertAlmostEqual(self.distance(coords[3], coords[2]), 1.5, places=6)
+        self.assertAlmostEqual(self.angle(coords[1], coords[2], coords[3]), 109.5, places=4)
+        self.assertAlmostEqual(vectors.get_dihedral([coords[1][k] - coords[0][k] for k in range(3)],
+                                                    [coords[2][k] - coords[1][k] for k in range(3)],
+                                                    [coords[3][k] - coords[2][k] for k in range(3)],
+                                                    units='degs'),
+                               60.0, places=4)
+        for value in coords[3]:
+            self.assertFalse(math.isnan(value))
+
+    def test_coincident_reference_atoms_are_refused(self):
+        """
+        Coincident B and C reference atoms are refused rather than placed against an arbitrary frame.
+
+        A collinear A-B-C still leaves the B-C direction, so the requested distance and angle are
+        honoured and only the dihedral's zero is arbitrary. Coincident B and C leave no direction at
+        all, so neither the angle nor the dihedral of the atom being placed has a value.
+        """
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5)
+        coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+        with self.assertRaises(VectorsError) as error:
+            zmat._add_nth_atom_to_coords(zmat=z, coords=coords, i=3)
+        self.assertIn('coincident', str(error.exception))
+
+    def test_coincident_reference_atoms_are_refused_by_zmat_to_coords(self):
+        """A zmat whose third atom sits on its own reference atom is refused by the public entry point."""
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5)
+        z['vars']['R_2_1'] = 0.0
+        with self.assertRaises(VectorsError):
+            zmat.zmat_to_coords(z)
+
+    def test_coincident_first_two_atoms_are_refused(self):
+        """The other documented refusal: atoms 0 and 1 coincident leave no axis for the third atom."""
+        z = self.build_collinear_zmat(cd_length=1.5, bcd_angle=109.5)
+        with self.assertRaises(VectorsError):
+            zmat._add_nth_atom_to_coords(zmat=z, coords=[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0)], i=2)
+
+
+class TestThirdAtomFrame(unittest.TestCase):
+    """
+    Test that the third atom of a zmat is placed relative to the coordinates already present.
+
+    ``zmat_to_coords`` starts from an empty list and gets the canonical frame, while
+    ``add_dummy_atom`` extends the coordinates of a real molecule in its own frame. A dummy
+    atom that marks a linear segment starting at the first zmat atom is the third atom, so
+    both callers reach the same branch with different frames.
+    """
+
+    @staticmethod
+    def build_three_atom_zmat(bc_length: float, alpha: float, b_index: int = 1) -> dict:
+        """Build a 3-atom zmat whose third atom is at ``bc_length`` and ``alpha`` from atom ``b_index``."""
+        a_index = 1 - b_index
+        return {'symbols': ('H', 'H', 'H'),
+                'coords': ((None, None, None),
+                           ('R_1_0', None, None),
+                           (f'R_2_{b_index}', f'A_2_{b_index}_{a_index}', None)),
+                'vars': {'R_1_0': 1.0, f'R_2_{b_index}': bc_length, f'A_2_{b_index}_{a_index}': alpha},
+                'map': {0: 0, 1: 1, 2: 2}}
+
+    @staticmethod
+    def linear_molecule_on_axis(axis: str) -> dict:
+        """Allene with its C=C=C backbone along ``axis`` and the two CH2 planes perpendicular."""
+        cc, ch, hch = 1.308, 1.087, math.radians(118.0)
+        s, c = ch * math.sin(hch / 2), ch * math.cos(hch / 2)
+        points = ((0.0, 0.0, 0.0), (0.0, 0.0, cc), (0.0, 0.0, -cc),
+                  (s, 0.0, cc + c), (-s, 0.0, cc + c), (0.0, s, -cc - c), (0.0, -s, -cc - c))
+        permutation = {'z': (0, 1, 2), 'y': (0, 2, 1), 'x': (2, 1, 0)}[axis]
+        return {'symbols': ('C', 'C', 'C', 'H', 'H', 'H', 'H'),
+                'isotopes': (12, 12, 12, 1, 1, 1, 1),
+                'coords': tuple(tuple(point[k] for k in permutation) for point in points)}
+
+    def test_third_atom_is_placed_relative_to_the_existing_frame(self):
+        """The requested distance and angle must be honoured in whatever frame ``coords`` is in."""
+        frames = {'canonical': [(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)],
+                  'on the y axis': [(0.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+                  'on the x axis': [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
+                  'translated': [(2.5, -1.5, 0.75), (2.5, -1.5, 1.75)],
+                  'general position': [(0.3, 1.2, -0.4), (0.9, 1.5, 0.3)]}
+        for name, frame in frames.items():
+            for b_index in (0, 1):
+                for alpha in (90.0, 109.5, 120.0):
+                    with self.subTest(frame=name, b_index=b_index, alpha=alpha):
+                        z = self.build_three_atom_zmat(bc_length=1.4, alpha=alpha, b_index=b_index)
+                        coords = zmat._add_nth_atom_to_coords(zmat=z, coords=list(frame), i=2)
+                        self.assertAlmostEqual(vectors.calculate_param(coords=coords, atoms=[2, b_index]),
+                                               1.4, places=6)
+                        self.assertAlmostEqual(vectors.calculate_param(coords=coords, atoms=[2, b_index, 1 - b_index]),
+                                               alpha, places=4)
+
+    def test_canonical_frame_placement_is_unchanged(self):
+        """The canonical frame must keep landing on exactly the same point, to the last bit."""
+        expected = {(0, 90.0): (0.0, 1.4, 8.572527594031472e-17),
+                    (0, 109.5): (0.0, 1.3196980875290496, -0.4673296029272794),
+                    (1, 90.0): (0.0, 1.4, 0.9999999999999999),
+                    (1, 109.5): (0.0, 1.3196980875290496, 1.4673296029272793)}
+        for (b_index, alpha), point in expected.items():
+            with self.subTest(b_index=b_index, alpha=alpha):
+                z = self.build_three_atom_zmat(bc_length=1.4, alpha=alpha, b_index=b_index)
+                coords = zmat._add_nth_atom_to_coords(zmat=z, coords=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)], i=2)
+                self.assertEqual(coords[2], point)
+
+    def test_a_leading_dummy_atom_does_not_land_on_the_molecular_axis(self):
+        """
+        Allene on the y axis drove a NaN into the zmat vars, and then out of ``zmat_to_xyz``.
+
+        The dummy that marks the leading C=C=C segment is the third zmat atom, so it was placed
+        in the canonical frame while the molecule was in its own. On the y axis that put it on
+        the molecular axis, making the reference triad of a later dummy genuinely collinear.
+        """
+        for axis in ('x', 'y', 'z'):
+            for use_mol in (False, True):
+                with self.subTest(axis=axis, mol=use_mol):
+                    xyz = self.linear_molecule_on_axis(axis)
+                    mol = ARCSpecies(label='allene', xyz=xyz, smiles='C=C=C').mol if use_mol else None
+                    z = zmat.xyz_to_zmat(xyz, mol=mol, consolidate=False)
+                    self.assertIn('X', z['symbols'])
+                    for key, value in z['vars'].items():
+                        self.assertTrue(math.isfinite(value), f'zmat var {key} is {value}, which is not finite.')
+                    back = zmat_to_xyz(z)
+                    self.assertEqual(back['symbols'], xyz['symbols'])
+                    self.assertLess(max_distance_discrepancy(xyz, back), 1e-4,
+                                    msg=f'The geometry of allene on {axis} was not recovered.')
+
+    def test_ketene_on_the_y_axis_round_trips(self):
+        """Ketene is the other reported trigger, and it has no symmetry to mask the failure."""
+        xyz = KETENE_ON_Y
+        z = zmat.xyz_to_zmat(xyz, mol=ARCSpecies(label='ketene', xyz=xyz, smiles='C=C=O').mol, consolidate=False)
+        for key, value in z['vars'].items():
+            self.assertTrue(math.isfinite(value), f'zmat var {key} is {value}, which is not finite.')
+        self.assertLess(max_distance_discrepancy(xyz, zmat_to_xyz(z)), 1e-4)
+
+
+class TestDummyAtomIndexSpace(unittest.TestCase):
+    """
+    Test that a dummy atom's reference atoms are resolved in the zmat's index space.
+
+    ``add_dummy_atom`` is handed the xyz-ordered coordinates, while the parameter strings that say
+    where the dummy goes are written in zmat indices. The two orders coincide only for the identity
+    atom order, and a dummy guarantees they diverge from its own index on, since every later atom
+    sits one zmat index further along than its xyz index. Output read back from an ESS carries an
+    arbitrary atom order, so the shuffled orders below are the ordinary case, not a contrived one.
+    """
+
+    @staticmethod
+    def relabel(xyz: dict, order: tuple) -> dict:
+        """Relabel ``xyz`` so that its atom ``i`` is the original atom ``order[i]``."""
+        return {'symbols': tuple(xyz['symbols'][i] for i in order),
+                'isotopes': tuple(xyz['isotopes'][i] for i in order),
+                'coords': tuple(xyz['coords'][i] for i in order)}
+
+    def test_every_relabeling_of_ketene_round_trips(self):
+        """All 120 atom orders of the reported trigger, not only the one the input happened to use."""
+        for order in itertools.permutations(range(len(KETENE_ON_Y['symbols']))):
+            with self.subTest(order=order):
+                xyz = self.relabel(KETENE_ON_Y, order)
+                z = zmat.xyz_to_zmat(xyz, mol=None, consolidate=False)
+                self.assertIn('X', z['symbols'])
+                for key, value in z['vars'].items():
+                    self.assertTrue(math.isfinite(value), f'zmat var {key} is {value}, which is not finite.')
+                self.assertLess(max_distance_discrepancy(xyz, zmat_to_xyz(z)), 1e-4,
+                                msg=f'The geometry of ketene relabelled {order} was not recovered.')
+
+    def test_an_explicit_atom_order_round_trips(self):
+        """``atom_order`` divorces the zmat index space from the xyz index space from the first atom on."""
+        xyz = {'symbols': ('C', 'C', 'C', 'H', 'H', 'H', 'H'), 'isotopes': (12, 12, 12, 1, 1, 1, 1),
+               'coords': ((0.0, 0.0, 0.0), (0.0, 0.0, 1.46), (0.0, 0.0, 2.668), (0.0, 0.0, 3.73),
+                          (1.025, 0.0, -0.373), (-0.512, 0.888, -0.373), (-0.512, -0.888, -0.373))}
+        for atom_order in ([3, 2, 1, 0, 4, 5, 6], [4, 0, 5, 6, 1, 2, 3], [6, 5, 4, 0, 1, 2, 3]):
+            with self.subTest(atom_order=atom_order):
+                z = zmat.xyz_to_zmat(xyz, mol=None, consolidate=False, atom_order=atom_order)
+                for key, value in z['vars'].items():
+                    self.assertTrue(math.isfinite(value), f'zmat var {key} is {value}, which is not finite.')
+                self.assertLess(max_distance_discrepancy(xyz, zmat_to_xyz(z)), 1e-4)
+
+    def test_a_dummy_is_mapped_to_its_index_in_the_augmented_coordinates(self):
+        """
+        The placement reads reference coordinates through ``zmat['map']``, so the map must index them.
+
+        A dummy is mapped to 'X<i>', where ``i`` is its index in the coordinates the dummies are
+        appended to; ``map_index_to_int`` decodes it, the same decoding
+        ``vectors.calculate_dihedral_angle`` performs.
+        """
+        z = zmat.xyz_to_zmat(KETENE_ON_Y, mol=None, consolidate=False)
+        dummy_indices = [zmat.map_index_to_int(value) for value in z['map'].values() if isinstance(value, str)]
+        real_indices = [value for value in z['map'].values() if not isinstance(value, str)]
+        self.assertTrue(dummy_indices)
+        self.assertEqual(sorted(real_indices), list(range(len(KETENE_ON_Y['symbols']))))
+        self.assertEqual(sorted(dummy_indices),
+                         list(range(len(KETENE_ON_Y['symbols']),
+                                    len(KETENE_ON_Y['symbols']) + len(dummy_indices))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What went wrong

`zmat_to_coords()` could return a geometry containing `NaN` **without failing**, and `xyz_to_zmat()` could store a `NaN` in `zmat['vars']`. Three defects sit behind that, all in how an atom is placed against its zmat reference atoms.

They are **one commit**, because they are in one file — and they could not usefully be split anyway. Each hides the next, and two of the three are harmful on their own. Measured over 1,200 relabelled and reoriented ketene and propyne geometries, counting how many put **every** dummy atom at its own declared `RX = 1.0 Å` / `AX = 90°`:

| | dummies correctly placed | hard failures | worst round-trip error |
|---|---|---|---|
| `origin/main` | 106 / 1200 | 0 | 4.23 Å |
| guard only | 106 / 1200 | 120 | 3.73 Å |
| guard + index space | 334 / 1200 | 120 | 3.20 Å |
| guard + frame | 225 / 1200 | 0 | 1.92 Å |
| **all three** | **1200 / 1200** | **0** | **0.0000 Å** |

### 1. Index space

`add_dummy_atom()` is handed `coords`, the `'coords'` part of the xyz dict, indexed by the **mol/xyz** atom order. It passed that straight to `_add_nth_atom_to_coords()`, which resolves its A/B/C reference atoms out of the zmat's own R/A/D parameter strings — i.e. in **zmat** indices — and then used them to index the xyz-ordered list. The function's own docstring notes the two spaces differ.

They coincide only for the identity atom order, and **a dummy atom guarantees they diverge from its own index on**, since every later atom sits one zmat index further along than its xyz index. Geometry read back from an ESS carries an arbitrary atom order, so this is the ordinary case, not a contrived one.

The dummy was therefore placed against three atoms chosen **by number rather than by identity**. On the six-dummy polyyne `OC#CC#CC#CS` already in `zmat_test.py`, not one of the six dummies honoured its own declared internals: against 1.0 Å / 90°, the placements measured up to **4.54 Å and 167°**. On a linear backbone the misread triad is frequently three atoms of the chain itself, whose cross product vanishes — so the dummy landed at `(nan, nan, nan)` and every later dihedral measured against it became `nan`.

### 2. Frame

The `i == 2` branch placed the third atom at

```python
c_y = bc_length * math.sin(alpha)
c_z = b_z - bc_length * math.cos(alpha) if b_z else bc_length * math.cos(alpha)
coords.append((0.0, c_y, c_z))
```

That is the **canonical** frame — atom 0 at the origin, atom 1 on +z — hard-coded, right down to the `if b_z` test that picks the sign of the cos term by asking whether atom B happens to sit at `z = 0`. Every other branch from index 2 onwards places its atom relative to whatever is already in `coords`, so the function was frame-covariant everywhere except here.

`zmat_to_coords()` never notices: it builds `coords` from scratch and its atoms 0 and 1 really are at the origin and on +z. **`add_dummy_atom()` does notice** — it supplies the coordinates of a real molecule, in the molecule's own frame. A dummy marking a linear segment that begins at the *first* zmat atom is the third zmat atom, so it was written into those lab-frame coordinates at `(0, 1.0, b_z)` no matter where the molecule was. Measured for allene by reading back what `add_dummy_atom()` actually wrote:

| backbone on | `RX`, should be 1.0 Å | `AX`, should be 90.0° |
|---|---|---|
| z | 1.000000 | 90.0000 |
| y | **0.308000** | **0.0000** |
| x | **1.646470** | **37.3989** |

On z the canonical and lab frames coincide, which is why this was never seen. On x the marker is silently misplaced — no NaN, no warning, just a wrong reference for every dihedral that uses it. On y it lands **on the molecular axis** (`AX = 0°`), making the reference triad of the *next* dummy genuinely collinear; `vectors.calculate_param()` then stored a `NaN` in `zmat['vars']` — `DX_4_0_1_2` for ketene, `DX_4_2_1_0` for allene. A `NaN` that is already in `vars` is upstream of any placement guard.

### 3. A collinear reference produced NaN coordinates

For atom D the reference frame comes from the normal of the A-B-C plane:

```python
n = np.cross(ab, ubc)
un = n / vectors.get_vector_length(n)
```

Exactly collinear A-B-C makes `n` the zero vector and `un` `NaN`, reported only as `RuntimeWarning: invalid value encountered in divide`.

**The NaN is then laundered into zeros.** `translate_to_center_of_mass()` keeps each coordinate as `x[i] if abs(x[i]) > 1e-10 else 0.0`, and `abs(nan) > 1e-10` is `False`, so **every NaN coordinate is silently rewritten to `0.0`**. A guard written to clean up rounding dust reclassifies "not a number" as "small". The result is not a crash and not a `NaN` — it is a plausible-looking geometry with every atom on the origin, which would be handed to an ESS as coincident nuclei.

## The fix

**Index space.** The coordinates are translated into zmat order before the call, and only the resulting dummy position is appended back onto the xyz-ordered list. The `'X<i>'` map value already carries the dummy's index in that list; `map_index_to_int()` decodes it — the same decoding `vectors.calculate_dihedral_angle()` performs — so the two lists stay in step for any number of dummies.

**Frame.** Atom 2 is placed from the frame it is given:

```
C = B + R * (cos(alpha) * u_BA + sin(alpha) * u_perp)
```

Two atoms fix an axis but not a plane, so only the **azimuth** about the 0-1 axis is a convention; it comes from `vectors.get_perpendicular_unit_vector()` of that axis. That the azimuth is free is measured, not assumed: substituting a different valid perpendicular changes the round-tripped geometry of 5,152 cases by at most **2.2e-11 Å**.

`get_perpendicular_unit_vector()` returns `+y` for the canonical axis, so the previous choice is reproduced, and the new expression is **bit-identical to the old formula for every canonical frame** — 500,016 randomized cases plus the `alpha = 0 / 180 / 360` boundaries, zero differences. The third atom of every zmat built by `zmat_to_coords()` is unaffected to the last bit; only `add_dummy_atom()`, the one caller supplying a non-canonical frame, sees a change.

**Guard.** A collinear A-B-C has no reference plane, so the dihedral about it is genuinely undefined: any vector perpendicular to BC is an equally valid reference, and D's position is fully determined by the remaining distance and angle. `get_perpendicular_unit_vector()` supplies one deterministically, by crossing with the Cartesian axis the input is least aligned with, which cannot itself be degenerate. The guard triggers on the result not being finite rather than on a length threshold, so it **fires exactly where the previous code produced NaN and nowhere else**.

The guard is last, and least, of the three. **On its own it is a regression**, which is the main reason the three are landing together:

- On the ketene corpus it fires **120 times during reconstruction**, and all 120 then raise `VectorsError: vector must be finite` — a crash where `origin/main` returned a (wrong) geometry.
- On the propyne corpus it fires 11 times during *generation*, and there is 1 case where `origin/main` stored a `NaN` and the guard alone instead returns a finite geometry that is wrong by more than 1e-4 Å.
- Every one of those firings is a symptom of the two defects underneath, not of a genuinely degenerate input.

In fairness to it, I could not reproduce a case where the guard alone is *numerically worse* than `origin/main` — over 1,200 cases that count is 0, because `main`'s laundered collapse is itself a large error. The objection is that it substitutes an arbitrary-plane answer for a loud one, and floods the log.

With the other two fixed, **the guard fires zero times in either direction** across 6,230 round trips plus the 1,200-case permutation corpus. It is kept because `zmat_to_xyz()` is public and accepts Z-matrices ARC did not build, where a degenerate reference is a legitimate input, and because a linear segment can genuinely go unrecognized when the connectivity is unavailable (`mol=None`). Its message now says exactly that, rather than asserting the reference atoms must have been misresolved.

## Measurements

Two round-trip sweeps of xyz → `xyz_to_zmat` → `zmat_to_xyz`, comparing the interatomic-distance matrix (invariant under every isometry) and superposing with `converter.kabsch` (proper rotations only, so a reflection cannot hide):

- **Sweep A** — 77 RDKit-embedded molecules × 7 orientations (as-is, principal axis snapped to x/y/z, 3 random rotations) × {with `mol`, without} = **1,078 cases**.
- **Sweep B** — 28 linear-segment molecules × 46 orientations (6 axis-snapped, 40 random) × 4 atom orders (identity + 3 shuffles) = **5,152 cases**.
- **Permutation corpus** — ketene over all 120 relabelings and propyne over 120, each × 5 orientations = **1,200 cases**, additionally instrumenting `add_dummy_atom()` to check every dummy against its own declared internals, and counting guard firings separately for generation (`xyz_to_zmat`) and reconstruction (`zmat_to_xyz`).

| | `origin/main` | this PR |
|---|---|---|
| NaN in `zmat['vars']` (sweeps A+B) | 4 | **0** |
| geometries collapsed onto the origin | 2 | **0** |
| guard firings, generation / reconstruction | n/a | **0 / 0** |
| worst distance-matrix error | **3.42 Å** | **0.036 Å** |
| dummies at their declared 1.0 Å / 90° | 106 / 1200 | **1200 / 1200** |

Per case, sweep B: **5,118 of 5,152 bit-for-bit unchanged, 34 improve, 0 regress.** Sweep A: 17 improve, 0 regress. I looked specifically for a previously-correct geometry made worse and there is none. The residual 0.036 Å is the near-collinear regime named under "still out of scope", unchanged from `origin/main`.

## Fixture changes

Two hard-coded expectations in `test_zmat_from_xyz` move. Both are dihedrals measured **against a dummy atom**, and a dummy's azimuth about the linear axis it decorates is a **free gauge** — correcting where the dummy sits rotates the zero they are measured from.

| var | before | after | old vs new, Kabsch | old vs new, distance matrix | each vs the source geometry |
|---|---|---|---|---|---|
| `DX_14_0_1_12` (`OC#CC#CC#CS`) | 23.389 | **180.728** | 2.4e-07 Å | 8.9e-16 Å | 8.806e-04 Å, both |
| `DX_8_7_5_6` (`c4linear`) | 360.0 | **217.028** | 0.0 Å | 3.6e-15 Å | 1.014e-02 Å, both |

Neither is an internal coordinate of the molecule at all. Sweeping `DX_14_0_1_12` over 0°, 23.389°, 90°, 180°, 270° and both stored values reconstructs **the same geometry** every time, to within 3.4e-07 Å under proper rotations. It is exactly determined and frame-dependent — not noise-sensitive, and not ill-conditioned: its reference angle O-C-X is 159.9°, twenty degrees off collinear.

## Two commits

1. **`vectors.py`** — adds `get_perpendicular_unit_vector()`. This construction is open-coded at more than a dozen sites across `converter.py` and the transition-state `linear_utils` package under several inconsistent criteria; two of them, in `converter.py`, test `np.allclose(unit, [1, 0, 0])`, which matches only `+x` and returns `[nan, nan, nan]` for a bond on that axis. Choosing the axis by magnitude floors the cross product at `sqrt(2/3) = 0.816` instead of the `0.436` the common `abs(dot) > 0.9` idiom allows. It lives in `vectors.py` because that module owns geometry maths and is the intended Cython target. **The existing sites are deliberately not converted here** — most are fallback branches in transition-state guess code, where changing which arbitrary plane is chosen changes the guess geometry. That needs its own branch and review.
2. **`zmat.py`** — all three fixes above, plus tests.

`fix_dummy_atom_index_space` (`a90fe782`), which carried the index-space fix as a standalone branch, is **folded into this PR** and will not be opened separately. Landing it apart would have moved `DX_14_0_1_12` a second time and left the sequencing between the two branches to be resolved by hand.

## Scope: what is still not fixed

- **Near-collinear references still degrade silently.** At `|n| ~ 1e-16` the frame is built from cancelling digits and the realized distance and angle drift from the requested ones with no warning — up to 0.20 Å / 18.7° in randomized testing, and it is what the residual 0.036 Å above consists of. The guard does not fire there. Orthogonalizing `un` against `ubc` fixes the whole regime unconditionally and is a no-op on good input, but it changes the stored coordinates of an existing test fixture, so it belongs in its own branch with a chemistry review.
- **A non-finite value that reaches `zmat['vars']` from any other source still bypasses the guard.** The guard inspects the reference plane at placement time; it cannot see a `NaN` that was already stored. This PR removes the two sources we know of, but it does not add a check that `xyz_to_zmat()` never stores one, and `zmat_to_coords()` does not reject a `vars` entry that is not finite.
- **`get_perpendicular_unit_vector()` raises `ZeroDivisionError`, not `VectorsError`, below ‖v‖ ≈ 1e-162**, where the squared length underflows. This was raised in review as a broken contract; it is not — the helper's docstring documents both, deliberately and by name. It is left as documented rather than converted: the threshold is unreachable for any quantity in Ångström, and converting it would mean reopening `vectors.py`, whose sole commit is otherwise untouched by this round.

## Tests

Every new test was checked against the unfixed code. Across the three test classes that cover these defects, subtest failures are: `origin/main` **153**, guard only **146**, guard + index space **146**, guard + frame **6**, all three **0**.

| test | fails without the fix |
|---|---|
| `test_every_relabeling_of_ketene_round_trips` | yes — `DX_4_2_1_0 is nan` on `main`; on guard+frame, `1.9207 not less than 0.0001` for 6 of the 120 relabelings |
| `test_an_explicit_atom_order_round_trips` | yes — `zmat var DX_6_5_3_4 is nan` |
| `test_a_dummy_is_mapped_to_its_index_in_the_augmented_coordinates` | pins the invariant the placement reads through |
| `test_third_atom_is_placed_relative_to_the_existing_frame` | yes — `0.3999999 != 1.4` (distance), `0.0 != 90.0` (angle); 23 of its 30 subtests |
| `test_a_leading_dummy_atom_does_not_land_on_the_molecular_axis` | yes — `zmat var DX_4_2_1_0 is nan` |
| `test_ketene_on_the_y_axis_round_trips` | yes — `zmat var DX_4_0_1_2 is nan` |
| `test_canonical_frame_placement_is_unchanged` | mutation-tested (below) |
| `test_propyne_round_trip_is_not_nan_or_collapsed` | yes — `zmat var DX_6_5_3_4 is nan` |
| `test_collinear_reference_does_not_produce_nan` | yes — `Atom 3 was placed at (nan, nan, nan)` |
| `test_collinear_reference_honours_distance_and_angle` | yes — `nan != 1.5 / 1.09 / 2.0` |
| `test_non_collinear_reference_is_unchanged` | mutation-tested (below) |
| `test_get_perpendicular_unit_vector*` (3, in `vectors_test.py`) | yes — helper does not exist |

`test_every_relabeling_of_ketene_round_trips` is the one that closes the coverage gap: **every** test in the previous revision of this PR used the identity atom order, which is exactly the special case in which the index-space defect is invisible. It sweeps all 120 relabelings of the reported trigger.

Two tests assert an unchanged path and so cannot fail without the fix; both are verified by mutation.

- `test_canonical_frame_placement_is_unchanged` pins the exact float tuple the *original* formula produces. Replacing `get_perpendicular_unit_vector()` with a different but equally valid perpendicular makes all four of its subtests fail while every other test still passes — which is also the demonstration that the azimuth is a free convention.
- `test_non_collinear_reference_is_unchanged` asserts the guard does not steal the well-defined case. Replacing the guard condition with `if True:` so the real A-B-C plane is always discarded makes it fail with `82.717 != 60.0`. An earlier version of this test was **vacuous** — its reference geometry made the arbitrary plane coincide with the real one, so it passed under that mutant; it now uses a general-position triple and asserts the dihedral.

`arc/species/`: 314 passed. Full suite `pytest arc/ -n 6 --dist worksteal`: 2529 passed, 6 failed — the same 6 as `origin/main` (5 × `torch_ani_test`, `TypeError: … os.PathLike`, and `test_arc_families_path`, which asserts `'ARC'` is in the checkout path).
