### PR TITLE
Map hydrogens using the backbone map of the chosen candidate

### DIFF
--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -32,6 +32,7 @@ from arc.species.converter import check_molecule_list_order
 if TYPE_CHECKING:
     from arc.molecule.molecule import Molecule
     from arc.reaction import ARCReaction
+    from arc.species.species import ARCSpecies
 
 MAX_PDI = 25
 
@@ -128,6 +129,28 @@ def map_general_rxn(rxn: ARCReaction,
     return atom_map
 
 
+def flatten_bond_orders(*species: ARCSpecies) -> None:
+    """
+    Set all bond orders of the given species' molecules to single.
+
+    Also discards the localized structures, the rotors and the directed rotor scans of each species,
+    which were derived from the previous bond orders, so that they are re-determined from the
+    flattened molecule. Species marked to skip rotor scans (a ``None`` ``rotors_dict``) keep that mark.
+
+    Args:
+        species (ARCSpecies): The species to flatten.
+    """
+    for spc in species:
+        for atom in spc.mol.atoms:
+            for bond in atom.bonds.values():
+                bond.order = 1
+        spc.mol_list = None
+        if spc.rotors_dict is not None:
+            spc.rotors_dict = dict()
+            spc.number_of_rotors = 0
+            spc.directed_rotors = dict()
+
+
 def map_isomerization_reaction(rxn: ARCReaction) -> list[int] | None:
     """
     Map isomerization reaction that has no corresponding RMG family.
@@ -210,9 +233,7 @@ def map_isomerization_reaction(rxn: ARCReaction) -> list[int] | None:
                 success = False
 
             if success:
-                for atom in r_copy.mol.atoms + p_copy.mol.atoms:
-                    for bd in atom.bonds.values():
-                        bd.order = 1
+                flatten_bond_orders(r_copy, p_copy)
                 return map_two_species(r_copy, p_copy, map_type='list')
 
         # 3) If fingerprint branch *didn’t* yield pairs, still do a deterministic edge‐removal mapping for *any* ring opening
@@ -232,9 +253,7 @@ def map_isomerization_reaction(rxn: ARCReaction) -> list[int] | None:
             except ValueError:
                 pass
             else:
-                for atom in r_copy.mol.atoms + p_copy.mol.atoms:
-                    for bd in atom.bonds.values():
-                        bd.order = 1
+                flatten_bond_orders(r_copy, p_copy)
                 return map_two_species(r_copy, p_copy, map_type='list')
 
     # 4) Fallback to the general mapping

--- a/arc/mapping/driver_test.py
+++ b/arc/mapping/driver_test.py
@@ -846,6 +846,47 @@ class TestMappingDriver(unittest.TestCase):
         self.assertIn(atom_map[7], [3, 4, 5, 8])
         self.assertIn(atom_map[8], [3, 4, 5, 8])
 
+    def test_flatten_bond_orders(self):
+        """Test the flatten_bond_orders() function."""
+        spc_1 = ARCSpecies(label='2-butene', smiles='CC=CC')
+        spc_2 = ARCSpecies(label='1,3-butadiene', smiles='C=CC=C')
+        spc_1.determine_rotors()
+        self.assertIn(2, [bond.order for atom in spc_1.mol.atoms for bond in atom.bonds.values()])
+        self.assertIsNotNone(spc_1.mol_list)
+        self.assertEqual(spc_1.number_of_rotors, 2)
+
+        flatten_bond_orders(spc_1, spc_2)
+
+        for spc in [spc_1, spc_2]:
+            self.assertTrue(all(bond.order == 1 for atom in spc.mol.atoms for bond in atom.bonds.values()))
+            self.assertIsNone(spc.mol_list)
+            self.assertEqual(spc.rotors_dict, dict())
+            self.assertEqual(spc.number_of_rotors, 0)
+
+        spc_1.determine_rotors()
+        self.assertIn([2, 3], [rotor['pivots'] for rotor in spc_1.rotors_dict.values()])
+
+    def test_flatten_bond_orders_discards_the_directed_rotors(self):
+        """Test that flatten_bond_orders() discards the directed rotor scans along with the rotors."""
+        spc = ARCSpecies(label='nbutane', smiles='CCCC', directed_rotors={'brute_force_sp': [[[1, 2], [2, 3]]]})
+        spc.determine_rotors()
+        self.assertEqual(spc.directed_rotors, {'brute_force_sp': [[[5, 1, 2, 3], [1, 2, 3, 4]]]})
+
+        flatten_bond_orders(spc)
+
+        self.assertEqual(spc.directed_rotors, dict())
+        spc.determine_rotors()
+        self.assertEqual([rotor['pivots'] for rotor in spc.rotors_dict.values()], [[1, 2], [2, 3], [3, 4]])
+
+    def test_flatten_bond_orders_keeps_the_skip_rotor_scans_mark(self):
+        """Test that flatten_bond_orders() keeps a None rotors_dict, which marks a species to skip rotor scans."""
+        spc = ARCSpecies(label='2-butene', smiles='CC=CC')
+        spc.rotors_dict = None
+
+        flatten_bond_orders(spc)
+
+        self.assertIsNone(spc.rotors_dict)
+
     def test_map_isomerization_reaction(self):
         """Test the map_isomerization_reaction() function."""
         reactant_xyz = """C  -1.3087    0.0068    0.0318

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from arc.reaction import ARCReaction
 
 RESERVED_FINGERPRINT_KEYS = ['self', 'chirality', 'label']
+RMSD_TIE_TOLERANCE = 1e-6
 
 
 def map_two_species(spc_1: ARCSpecies | Molecule,
@@ -43,6 +44,14 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
     All indices are 0-indexed.
     If a dict type atom map is returned, it could conveniently be used to map ``spc_2`` -> ``spc_1`` by doing::
         ordered_spc1.atoms = [spc_2.atoms[atom_map[i]] for i in range(len(spc_2.atoms))]
+
+    When several superimposable backbone candidates are identified, each is scored by the RMSD
+    between the two backbone distance matrices, so candidates tie within ``RMSD_TIE_TOLERANCE``
+    when the permutation leaves every backbone interatomic distance unchanged. That score covers
+    the backbone only, so the tied candidates are further scored by the Kabsch RMSD of the full
+    atom map each of them yields, and the last candidate that also ties on that displacement is
+    used. Both the backbone map and the dihedral-corrected geometries of that same candidate are
+    used to map the hydrogen atoms.
 
     Args:
         spc_1 (ARCSpecies | Molecule): Species 1.
@@ -110,7 +119,6 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
                 return None
         else:
             rmsds, fixed_spcs = list(), list()
-            candidate = None
             for candidate in candidates:
                 fixed_spc_1, fixed_spc_2 = fix_dihedrals_by_backbone_mapping(spc_1, spc_2, backbone_map=candidate)
                 fixed_spcs.append((fixed_spc_1, fixed_spc_2))
@@ -126,12 +134,23 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
                 xyz2 = sort_xyz_using_indices(xyz2, indices=[v for k, v in sorted(no_gap_candidate.items(),
                                                                                   key=lambda item: item[0])])
                 rmsds.append(compare_confs(xyz1=xyz1, xyz2=xyz2, rmsd_score=True))
-            chosen_candidate_index = rmsds.index(min(rmsds))
-            fixed_spc_1, fixed_spc_2 = fixed_spcs[chosen_candidate_index]
-            if candidate is not None:
-                atom_map = map_hydrogens(fixed_spc_1, fixed_spc_2, candidate)
-                if map_type == 'list':
-                    atom_map = [v for k, v in sorted(atom_map.items(), key=lambda item: item[0])]
+            lowest_rmsd = min(rmsds)
+            tied_indices = [i for i, rmsd in enumerate(rmsds) if rmsd - lowest_rmsd <= RMSD_TIE_TOLERANCE]
+            atom_maps = dict()
+            for i in tied_indices:
+                atom_maps[i] = map_hydrogens(fixed_spcs[i][0], fixed_spcs[i][1], candidates[i])
+            if len(tied_indices) > 1:
+                displacements = {i: fixed_spcs[i][0].kabsch(fixed_spcs[i][1],
+                                                            [v for k, v in sorted(atom_maps[i].items(),
+                                                                                  key=lambda item: item[0])])
+                                 for i in tied_indices}
+                lowest_displacement = min(displacements.values())
+                tied_indices = [i for i in tied_indices
+                                if displacements[i] - lowest_displacement <= RMSD_TIE_TOLERANCE]
+            chosen_candidate_index = max(tied_indices)
+            atom_map = atom_maps[chosen_candidate_index]
+            if map_type == 'list':
+                atom_map = [v for k, v in sorted(atom_map.items(), key=lambda item: item[0])]
 
     if inc_vals is not None:
         atom_map = [value + inc_vals for value in atom_map]

--- a/arc/mapping/engine_test.py
+++ b/arc/mapping/engine_test.py
@@ -572,6 +572,55 @@ class TestMappingEngine(unittest.TestCase):
                           H                  0.34179135    2.75680752   -1.36901816
                           H                  1.78229521    1.76788614   -1.37607384
                           H                  0.34142026    1.21854517   -2.19776146"""
+        cls.methylbutane_xyz = """C      -0.97433227    1.17065473   -0.35442290
+                                  C      -0.45192007   -0.26483788   -0.28088601
+                                  C      -0.33943943   -0.84708671   -1.69187722
+                                  C      -1.34349197   -1.16914868    0.58768626
+                                  C      -1.40105018   -0.74536522    2.04847109
+                                  H      -2.00419427    1.19988237   -0.72602982
+                                  H      -0.35559338    1.77478281   -1.02687519
+                                  H      -0.95159170    1.65360691    0.62712610
+                                  H       0.55534772   -0.24133144    0.15407433
+                                  H       0.32353843   -0.23606931   -2.31364700
+                                  H       0.07332070   -1.86107875   -1.66298158
+                                  H      -1.31775660   -0.89266154   -2.18248872
+                                  H      -0.96063413   -2.19652174    0.54586182
+                                  H      -2.36224242   -1.19617367    0.18190102
+                                  H      -1.90298172    0.21908306    2.16797716
+                                  H      -0.39634721   -0.67043363    2.47612199
+                                  H      -1.96252182   -1.48324241    2.63070314"""
+        cls.dimethylbutane_xyz = """C      -0.82461851    1.14673080   -0.77842678
+                                    C      -0.42610728   -0.06063487    0.08629698
+                                    C      -0.47034470   -1.33504078   -0.77290194
+                                    C      -1.45116287   -0.20442011    1.22812003
+                                    C       0.97587301    0.14090229    0.71707616
+                                    C       2.12880735    0.30329591   -0.26614701
+                                    H      -0.76102821    2.07968065   -0.20742874
+                                    H      -0.18120395    1.24559899   -1.65876690
+                                    H      -1.85453719    1.04872389   -1.14068352
+                                    H       0.17558199   -1.25377401   -1.65320345
+                                    H      -0.14861173   -2.21043461   -0.19787833
+                                    H      -1.48632406   -1.53069938   -1.13494088
+                                    H      -2.46459886   -0.34995913    0.83714693
+                                    H      -1.21500982   -1.06356074    1.86613835
+                                    H      -1.46522531    0.68925624    1.86223603
+                                    H       0.95650220    1.02607021    1.36632791
+                                    H       1.20453979   -0.71149012    1.37019493
+                                    H       2.24605190   -0.57899874   -0.90132288
+                                    H       1.99489999    1.18037559   -0.90523893
+                                    H       3.06651626    0.43837793    0.28340204"""
+        cls.benzene_xyz = """C      -1.39298622   -0.07016743    0.01432698
+                             C      -0.63555191   -1.24137615    0.02446132
+                             C       0.75743431   -1.17120872    0.01013428
+                             C       1.39298622    0.07016743   -0.01432699
+                             C       0.63555191    1.24137616   -0.02446130
+                             C      -0.75743431    1.17120872   -0.01013444
+                             H      -2.47828288   -0.12483594    0.02548953
+                             H      -1.13072003   -2.20855112    0.04351957
+                             H       1.34756286   -2.08371519    0.01803002
+                             H       2.47828289    0.12483592   -0.02548935
+                             H       1.13072003    2.20855114   -0.04351930
+                             H      -1.34756286    2.08371519   -0.01803033"""
 
     def test_map_two_species(self):
         """Test the map_two_species() function."""
@@ -730,6 +779,68 @@ class TestMappingEngine(unittest.TestCase):
         e2 = ARCSpecies(label='ethane_2', smiles='CC')
         atom_map = engine.map_two_species(e1, e2)
         self.assertEqual(len(atom_map), 8)
+
+    def test_map_two_species_uses_the_lowest_rmsd_candidate(self):
+        """Test that map_two_species() maps hydrogens using the backbone map of the lowest-RMSD candidate.
+
+        2-methylbutane fingerprints into more than one superimposable backbone candidate, and the
+        candidate that is not last in the list is the one that superimposes best. Mapping the species
+        onto a copy of itself with identical coordinates makes the lowest-RMSD candidate the identity
+        backbone map, so the full atom map must be the identity map.
+        """
+        spc_1 = ARCSpecies(label='2-methylbutane_1', smiles='CC(C)CC', xyz=self.methylbutane_xyz)
+        spc_2 = ARCSpecies(label='2-methylbutane_2', smiles='CC(C)CC', xyz=self.methylbutane_xyz)
+        candidates = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                               engine.fingerprint(spc_2))
+        identity_backbone = {i: i for i in range(5)}
+        self.assertGreater(len(candidates), 1)
+        self.assertIn(identity_backbone, candidates)
+        self.assertNotEqual(candidates[-1], identity_backbone)
+
+        atom_map = engine.map_two_species(spc_1, spc_2, map_type='dict')
+        self.assertEqual(atom_map, {i: i for i in range(spc_1.number_of_atoms)})
+
+    def test_map_two_species_breaks_a_backbone_tie_on_the_all_atom_displacement(self):
+        """Test that map_two_species() breaks a backbone RMSD tie on the displacement of the full atom map.
+
+        2,2-dimethylbutane fingerprints into three superimposable backbone candidates, the first of
+        which is the identity backbone map. Mapped onto a copy of itself with identical coordinates,
+        the second candidate ties with the first on the backbone distance matrix, since permuting the
+        two methyl groups leaves every backbone interatomic distance unchanged. The two candidates
+        place the hydrogen atoms differently, so the tie is broken on the Kabsch RMSD of the full atom
+        map, and the identity map, which superimposes the species exactly, is the one returned.
+        """
+        spc_1 = ARCSpecies(label='2,2-dimethylbutane_1', smiles='CC(C)(C)CC', xyz=self.dimethylbutane_xyz)
+        spc_2 = ARCSpecies(label='2,2-dimethylbutane_2', smiles='CC(C)(C)CC', xyz=self.dimethylbutane_xyz)
+        candidates = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                               engine.fingerprint(spc_2))
+        self.assertEqual(len(candidates), 3)
+        self.assertEqual(candidates[0], {i: i for i in range(6)})
+        self.assertNotEqual(candidates[1], candidates[0])
+
+        atom_map = engine.map_two_species(spc_1, spc_2, map_type='list')
+
+        self.assertEqual(atom_map, list(range(spc_1.number_of_atoms)))
+        self.assertLess(spc_1.kabsch(spc_2, atom_map), 1e-5)
+
+    def test_map_two_species_uses_the_last_of_the_displacement_tied_candidates(self):
+        """Test that map_two_species() uses the last candidate when the displacement does not discriminate.
+
+        Benzene fingerprints into six superimposable backbone candidates, every one of which is an
+        exact symmetry of the ring, so all six tie on the backbone distance matrix and all six yield
+        an atom map of zero Kabsch RMSD. Nothing discriminates them, and the last candidate is used.
+        """
+        spc_1 = ARCSpecies(label='benzene_1', smiles='c1ccccc1', xyz=self.benzene_xyz)
+        spc_2 = ARCSpecies(label='benzene_2', smiles='c1ccccc1', xyz=self.benzene_xyz)
+        candidates = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                               engine.fingerprint(spc_2))
+        self.assertEqual(len(candidates), 6)
+
+        atom_map = engine.map_two_species(spc_1, spc_2, map_type='dict')
+
+        self.assertLess(spc_1.kabsch(spc_2, [v for k, v in sorted(atom_map.items(), key=lambda i: i[0])]), 1e-5)
+        self.assertEqual({key: val for key, val in atom_map.items() if key < 6}, candidates[-1])
+        self.assertNotEqual(candidates[-1], {i: i for i in range(6)})
 
     def test_inc_valss(self):
         s1 = ARCSpecies(label='S1', smiles='C=CC1C(C)C=CC(C)C1C')


### PR DESCRIPTION
**Stack position:** bottom of a three-PR atom-mapping stack, based on `main`. #935 sits on this, and #948 sits on #935 — that is the reading order. This PR is self-contained: it can be reviewed and reverted without either of the others.

### The bug

- `map_two_species` scores every superimposable backbone candidate by the RMSD of its dihedral-corrected superposition and picks the best one — then hands `map_hydrogens` the leftover loop variable `candidate`, the **last** iterate, instead of `candidates[chosen_candidate_index]`.
- So the best-RMSD *geometries* are paired with a different candidate's *backbone map*. Every anchor lookup downstream then runs in an inconsistent frame.
- The mismatch is invisible whenever there is exactly one candidate, because the last iterate is then also the chosen one — which is why it lasted.
- The new test uses 2-methylbutane, which fingerprints into two superimposable candidates with the best-scoring one not last. Mapped onto a copy of itself with identical coordinates it must return the identity; without the fix it returns backbone `{0:2, 1:1, 2:0, …}`.

### Why it read as intentional

- `candidate = None` is a sentinel set before the loop, and `if candidate is not None:` reads as a deliberate "did the loop body execute at least once?" check. The accident is that the *same variable* is then passed as the value, since after the loop it holds a perfectly valid-looking candidate. One name is doing double duty as a flag and as the chosen item.
- The guard is also unreachable-false. Emptiness is excluded three lines above, and `rmsds.index(min(rmsds))` would raise `ValueError` on an empty list a line earlier in any case.
- The `map_type == 'list'` conversion sat *inside* that guard, so had it ever been False the function would have returned a dict where a list was requested. Unreachable, but it confirms the guard had drifted past its purpose.
- The sentinel is therefore removed, not merely the argument swapped.

### Second defect: the RMSD was not a reproducible number

Consulting the score for the first time exposed that it had never been trustworthy.

- `map_isomerization_reaction` sets every bond order of its reactant and product copies to single so the two skeletons can be superimposed — but left `mol_list` holding the localized structures generated from the **original** bond orders.
- `determine_rotors()` reads `mol_list`, so the rotatable bonds, and with them the backbone torsions `fix_dihedrals_by_backbone_mapping` aligns, came from a molecule that no longer matched the one being mapped. It was aligning on the wrong hinges.
- Which localized structure ends up at `mol_list[0]` is not stable across interpreter runs, so the aligned geometries — and the RMSD scored for each candidate — moved from run to run. On `main` this was invisible: the score was computed, a winner chosen, and then the last candidate used regardless. "Always the last one" is a stable answer, not a right one.
- New `flatten_bond_orders()` discards `mol_list` and the rotors together with the bond orders, so the rotors follow the flattened molecule and every candidate is scored against the same reproducible alignment.

**Reproducing the instability:** it is only visible on the two middle commits of this PR — after `Map hydrogens using the backbone map of the chosen candidate` and before `Determine the mapping rotors from the flattened molecule`. `main` is stable because it discards the score entirely, and the finished branch is stable because the fix landed, so sweeping `PYTHONHASHSEED` on either endpoint shows nothing. Checked here: `test_interpolate_birad_recombination` passes on all of 11 seeds on `main` and on this branch's head. That is the expected result, not a refutation — but note that the intermediate window itself was **not** re-measured, so treat the instability as diagnosed from the code path rather than demonstrated by a seed sweep.

Measured on the birad recombination in `linear_test.py`:

| | before | after |
|---|---|---|
| candidate RMSDs (lower is better) | 3.09 / 3.14 | **0.151 / 0.127** |
| gap between them | 1.5% — noise | **19%** — a real winner |

Alignment improves about twenty-fold, and it selects **the same answer `main` produced**, so the geometry that test has always expected is unchanged. Nothing was re-blessed to make a test pass.

### Third: the tie between symmetry-equivalent candidates

- The score is the RMSD between the two **backbone distance matrices**, so it is identical up to floating-point noise for any permutation that leaves every backbone interatomic distance unchanged — which is every symmetry of the backbone. RMSD cannot discriminate them.
- A strict argmin would therefore hand the choice — and every reaction map built on it — to floating-point noise. `main` was insulated only because `candidates[-1]` is deterministic, which is coincidence rather than correctness.
- `RMSD_TIE_TOLERANCE = 1e-6`: candidates within that of the lowest score are treated as tied.
- **The backbone score is blind to hydrogens**, so tied candidates are not interchangeable — they are precisely the ones that place the hydrogens differently. Mapping neopentane onto a copy of itself with identical coordinates, the four tied candidates yield atom maps of 0.000, 9.432, 5.235 and 9.157 Å all-atom Kabsch RMSD. Selecting either end of the tied list by position picks one of those blind.
- Tied candidates are therefore scored a second time by the Kabsch RMSD of the full atom map each yields, and the last candidate that also ties on that displacement is used. Every symmetric species measured now maps onto a copy of itself at 0.000 Å, and `test_get_atom_map_5`'s reaction map is unchanged, so no existing expectation moved.


### Scope

- Behaviour change: for species with more than one superimposable candidate the hydrogen map changes — that is the fix. Where the backbone RMSDs differ genuinely, the best-scoring candidate is now used; where they tie, the candidate whose full atom map has the lowest displacement is used. Single-candidate species are unaffected.
- **Not fixed here:** `reorder_p_label_map` has no way to request the candidate consistent with the reactant labelling. That is the real defect behind the tie and deserves its own change.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

