### PR TITLE
Assign every hydrogen and reject an incomplete atom map

### DIFF
--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -71,6 +71,9 @@ def map_reaction(rxn: ARCReaction,
         if general_map is not None:
             return check_atom_map_and_return(general_map)
         return map_reaction(rxn, backend=backend, flip=True)
+    if rxn.product_dicts and all(product_dict.get('discovered_in_reverse', False)
+                                 for product_dict in rxn.product_dicts):
+        return map_reaction(rxn, backend=backend, flip=True)
     raw_map = try_mapping(rxn)
     if raw_map is None:
         return map_reaction(rxn, backend=backend, flip=True)
@@ -303,7 +306,7 @@ def map_rxn(rxn: ARCReaction,
         p_label_map = rxn.product_dicts[pdi]['p_label_map']
         template_products = rxn.product_dicts[pdi]['products']
     except (IndexError, KeyError) as e:
-        logger.error(f"No valid template maps for reaction {rxn} ({rxn.family}), cannot atom map. Got:\n{e}")
+        logger.debug(f"No valid template maps for reaction {rxn} ({rxn.family}) in this orientation. Got:\n{e}")
         return None
     try:
         template_order = get_template_product_order(rxn, template_products)
@@ -311,7 +314,7 @@ def map_rxn(rxn: ARCReaction,
         if rxn.product_dicts is not None and len(rxn.product_dicts) - 1 > pdi < MAX_PDI:
             return map_rxn(rxn, backend=backend, product_dict_index_to_try=pdi + 1)
         else:
-            logger.error(f'No valid template order for reaction {rxn} ({rxn.family}), cannot atom map.')
+            logger.debug(f'No valid template order for reaction {rxn} ({rxn.family}) in this orientation.')
             return None
 
     updated_p_label_map = reorder_p_label_map(p_label_map=p_label_map,

--- a/arc/mapping/driver_test.py
+++ b/arc/mapping/driver_test.py
@@ -8,7 +8,7 @@ This module contains unit tests of the arc.mapping.driver module
 import os
 import unittest
 
-from arc.common import ARC_PATH
+from arc.common import ARC_PATH, logger
 from arc.family import get_reaction_family_products
 from arc.mapping.driver import *
 from arc.reaction import ARCReaction
@@ -480,6 +480,73 @@ class TestMappingDriver(unittest.TestCase):
         for index in [2, 3, 4, 5]:
             self.assertIn(atom_map[index], [0, 1, 3, 4, 5])
         self.assertTrue(any(atom_map[r_index] in [0, 1] for r_index in [2, 3, 4, 5]))
+        self.assertTrue(check_atom_map(rxn))
+
+    def test_map_retro_diels_alder_in_discovered_direction(self):
+        """Map a retro-Diels-Alder reaction without first trying its invalid template orientation."""
+        rxn = ARCReaction(
+            label='R1 <=> P1 + P2',
+            r_species=[ARCSpecies(label='R1', smiles='C1=CCCCC1', multiplicity=1)],
+            p_species=[ARCSpecies(label='P1', smiles='C=C', multiplicity=1),
+                       ARCSpecies(label='P2', smiles='C=CC=C', multiplicity=1)],
+            multiplicity=1,
+        )
+
+        self.assertEqual(rxn.family, 'Diels_alder_addition')
+        self.assertTrue(all(product_dict['discovered_in_reverse'] for product_dict in rxn.product_dicts))
+        with self.assertNoLogs(logger, level='ERROR'):
+            atom_map = rxn.atom_map
+
+        self.assertIsNotNone(atom_map)
+        self.assertTrue(check_atom_map(rxn))
+
+        mapped_reactant_bonds = dict()
+        reactant_atoms = rxn.r_species[0].mol.atoms
+        for i, atom in enumerate(reactant_atoms):
+            for bonded_atom, bond in atom.bonds.items():
+                j = reactant_atoms.index(bonded_atom)
+                if i < j and not atom.is_hydrogen() and not bonded_atom.is_hydrogen():
+                    mapped_reactant_bonds[tuple(sorted((atom_map[i], atom_map[j])))] = bond.order
+        product_bonds, offset = dict(), 0
+        for product in rxn.p_species:
+            for i, atom in enumerate(product.mol.atoms):
+                for bonded_atom, bond in atom.bonds.items():
+                    j = product.mol.atoms.index(bonded_atom)
+                    if i < j and not atom.is_hydrogen() and not bonded_atom.is_hydrogen():
+                        product_bonds[(i + offset, j + offset)] = bond.order
+            offset += product.number_of_atoms
+
+        removed_bond_orders = sorted(mapped_reactant_bonds[bond]
+                                     for bond in mapped_reactant_bonds.keys() - product_bonds.keys())
+        changed_bond_orders = sorted((mapped_reactant_bonds[bond], product_bonds[bond])
+                                     for bond in mapped_reactant_bonds.keys() & product_bonds.keys()
+                                     if mapped_reactant_bonds[bond] != product_bonds[bond])
+        self.assertEqual(removed_bond_orders, [1, 1])
+        self.assertEqual(changed_bond_orders, [(1, 2), (1, 2), (1, 2), (2, 1)])
+
+    def test_map_rxn_first_orientation_failure_is_quiet(self):
+        """A recoverable first-orientation template-order failure must not log at ERROR level.
+
+        For a reaction whose family was discovered in the reverse direction, the forward-orientation
+        ``map_rxn`` attempt fails on ``get_template_product_order`` and returns None. ``map_reaction``
+        then recovers via its flip fallback, so this intermediate failure is benign and should be logged
+        at DEBUG, not ERROR (which previously read as a false hard failure). The genuine total-failure
+        error is surfaced separately by ``ARCReaction.atom_map``.
+        """
+        rxn = ARCReaction(
+            label='R1 <=> P1 + P2',
+            r_species=[ARCSpecies(label='R1', smiles='C1=CCCCC1', multiplicity=1)],
+            p_species=[ARCSpecies(label='P1', smiles='C=C', multiplicity=1),
+                       ARCSpecies(label='P2', smiles='C=CC=C', multiplicity=1)],
+            multiplicity=1,
+        )
+        with self.assertNoLogs(logger, level='ERROR'):
+            raw_map = map_rxn(rxn)
+        self.assertIsNone(raw_map)
+
+        atom_map = map_reaction(rxn=rxn, backend='ARC')
+        self.assertIsNotNone(atom_map)
+        rxn.atom_map = atom_map
         self.assertTrue(check_atom_map(rxn))
 
     def test_map_abstractions_h_plus_ch4_to_ch3_plus_h2(self):

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -47,6 +47,9 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
     If a dict type atom map is returned, it could conveniently be used to map ``spc_2`` -> ``spc_1`` by doing::
         ordered_spc1.atoms = [spc_2.atoms[atom_map[i]] for i in range(len(spc_2.atoms))]
 
+    A ``ValueError`` is raised if the resulting map is not a permutation of the atoms of the two
+    species.
+
     When several superimposable backbone candidates are identified, each is scored by the RMSD
     between the two backbone distance matrices, so candidates tie within ``RMSD_TIE_TOLERANCE``
     when the permutation leaves every backbone interatomic distance unchanged. That score covers
@@ -141,6 +144,11 @@ def map_two_species(spc_1: ARCSpecies | Molecule,
             atom_maps = dict()
             for i in tied_indices:
                 atom_maps[i] = map_hydrogens(fixed_spcs[i][0], fixed_spcs[i][1], candidates[i])
+                if sorted(atom_maps[i].keys()) != list(range(spc_1.number_of_atoms)) \
+                        or sorted(atom_maps[i].values()) != list(range(spc_2.number_of_atoms)):
+                    raise ValueError(f'The atom map of {spc_1.label} and {spc_2.label} is not a permutation of their '
+                                     f'{spc_1.number_of_atoms} and {spc_2.number_of_atoms} atoms, '
+                                     f'got:\n{atom_maps[i]}')
             if len(tied_indices) > 1:
                 displacements = {i: fixed_spcs[i][0].kabsch(fixed_spcs[i][1],
                                                             [v for k, v in sorted(atom_maps[i].items(),
@@ -1280,6 +1288,8 @@ def map_hydrogens(spc_1: ARCSpecies,
     If only a single hydrogen atom is bonded to a given heavy atom, it is straight-forwardly mapped.
     The three hydrogens of an XH3 group are always assigned, and their azimuthal cyclic order about
     the bond to the mapped heavy neighbor is retained whenever 3D coordinates are available.
+    Every hydrogen of every heavy atom in ``backbone_map`` is assigned, falling back to the order in
+    which the hydrogens appear in the two species when no geometric refinement applies to them.
 
     Args:
         spc_1 (ARCSpecies): Species 1.
@@ -1310,12 +1320,18 @@ def map_hydrogens(spc_1: ARCSpecies,
             continue
         elif len(h_indices_1) == 2:
             mapped = _map_xh2_group(heavy_index_1, heavy_index_2, spc_1, spc_2, atom_map)
-            if mapped:
-                atom_map.update(mapped)
-                continue
+            if not mapped:
+                logger.debug(f'Assigning the hydrogens of the XH2 center {heavy_index_1} of {spc_1.label} by '
+                             f'their order, their dihedrals could not be compared.')
+                mapped = dict(zip(h_indices_1, h_indices_2))
+            atom_map.update(mapped)
         elif len(h_indices_1) == 3:
             atom_map.update(_map_xh3_hydrogens(heavy_index_1, heavy_index_2, spc_1, spc_2, atom_map,
                                                h_indices_1, h_indices_2))
+        else:
+            logger.debug(f'Assigning the {len(h_indices_1)} hydrogens of the heavy atom {heavy_index_1} of '
+                         f'{spc_1.label} by their order, no geometric refinement is available for them.')
+            atom_map.update(dict(zip(h_indices_1, h_indices_2)))
     return atom_map
 
 

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -13,15 +13,17 @@ from collections import deque
 from itertools import product
 from typing import TYPE_CHECKING
 
-from arc.common import extremum_list, get_angle_in_180_range, logger, signed_angular_diff
-from arc.exceptions import AtomTypeError, ConformerError, InputError, SpeciesError
+from arc.common import extremum_list, get_angle_in_180_range, is_angle_linear, logger, signed_angular_diff
+from arc.exceptions import AtomTypeError, ConformerError, InputError, SpeciesError, VectorsError
 from arc.family import ReactionFamily
 from arc.molecule import Molecule
 from arc.molecule.resonance import generate_resonance_structures_safely
 from arc.species import ARCSpecies
 from arc.species.conformers import determine_chirality
 from arc.species.converter import compare_confs, sort_xyz_using_indices, xyz_from_data
-from arc.species.vectors import apply_rodrigues_rotation, calculate_dihedral_angle, get_delta_angle
+from arc.species.vectors import (apply_rodrigues_rotation, calculate_dihedral_angle, get_angle, get_delta_angle,
+                                 get_perpendicular_axes, get_vector, get_vector_length, unit_vector)
+from arc.species.zmat import TOL_180
 
 if TYPE_CHECKING:
     from arc.molecule.molecule import Atom
@@ -790,43 +792,106 @@ def _find_preferably_heavy_neighbor(heavy_index: int,
     return None
 
 
+def _anchors_define_a_plane(center_index: int,
+                            anchor_1_index: int,
+                            anchor_2_index: int,
+                            coords: list[tuple[float, float, float]],
+                            ) -> bool:
+    """
+    Check whether two anchors span a well-defined plane through a central atom.
+
+    The A-X-B angle must not be linear within ``TOL_180``, and the pair must additionally pass
+    the cross-product test that ``_construct_local_axes`` applies internally, so an anchor pair
+    accepted here can never make ``_construct_local_axes`` raise.
+
+    Args:
+        center_index (int): Index of the central atom X.
+        anchor_1_index (int): Index of the primary anchor A.
+        anchor_2_index (int): Index of the secondary anchor B.
+        coords (list[tuple[float, float, float]]): 3D coordinates for all atoms.
+
+    Returns: bool
+        Whether the X->A and X->B vectors are both non-degenerate and span a plane.
+        ``False`` is returned if any index is ``None``, negative, or out of range for ``coords``.
+    """
+    if center_index is None or anchor_1_index is None or anchor_2_index is None:
+        return False
+    if any(index < 0 or index >= len(coords) for index in [center_index, anchor_1_index, anchor_2_index]):
+        return False
+    if anchor_1_index == anchor_2_index or center_index in [anchor_1_index, anchor_2_index]:
+        return False
+    xyz = {'coords': coords}
+    v_xa = get_vector(pivot=center_index, anchor=anchor_1_index, xyz=xyz)
+    v_xb = get_vector(pivot=center_index, anchor=anchor_2_index, xyz=xyz)
+    if get_vector_length(v_xa) < 1e-8 or get_vector_length(v_xb) < 1e-8:
+        return False
+    if is_angle_linear(get_angle(v1=v_xa, v2=v_xb, units='degs'), tolerance=TOL_180):
+        return False
+    return bool(get_vector_length(np.cross(unit_vector(v_xa), v_xb)) >= 1e-8)
+
+
 def _select_ch3_anchors(heavy_index: int,
                         spc: ARCSpecies,
                         backbone_map: dict[int, int],
                         ) -> tuple[int | None, int | None]:
     """
     Select two anchors A and B for a XH3 center X (usually X is C) so that:
-      - A is the mapped heavy neighbor (C → A)
-      - B is a second anchor forming a non-linear angle B-A-X
+      - A is the mapped heavy neighbor (X → A)
+      - B is a second anchor forming a non-linear angle B-X-A
 
-    Strategy:
-      1) Identify the one heavy neighbor A of X.
-      2) B should preferably be a heavy atom, but can also be an H.
-      3) Fallback to any other heavy atom B ≠ X, A that gives a non‐linear angle.
-      4) Fallback to any hydrogen already present in backbone_map.
-      5) Fallback to any hydrogen.
+    Candidates for B are considered in the following priority order, and the first candidate
+    that spans a plane with the X→A axis, as judged by ``_anchors_define_a_plane``, is returned:
+      1) The preferably-heavy neighbor of A other than X.
+      2) Any other neighbor of A other than X.
+      3) Any atom bonded to X other than A, i.e., one of the XH3 hydrogens.
+
+    A returned anchor pair can never make ``_construct_local_axes`` raise. A molecule with a
+    linear heavy-atom skeleton (e.g., propyne) resolves to a tier-3 anchor, in which case the
+    azimuthal phase of the resulting local frame is undetermined while the azimuthal cyclic
+    order of the three hydrogens about the X→A axis is retained.
 
     Args:
-        heavy_index: index of CH3 carbon in spc.mol.atoms
+        heavy_index: index of the XH3 carbon in spc.mol.atoms
         spc: ARCSpecies with rotors_dict and xyz
-        backbone_map: heavy-atom map C→C' in product
+        backbone_map: heavy-atom map X→X' in product
 
     Returns:
-        Tuple(A_index, B_index) or None, None if no valid anchors.
+        Tuple(A_index, B_index), or (None, None) if no valid anchors could be found.
     """
     A_index = _find_preferably_heavy_neighbor(heavy_index=heavy_index, spc=spc, partial_atom_map=backbone_map)
     if A_index is None:
         return None, None
-    B_index = _find_preferably_heavy_neighbor(heavy_index=A_index, spc=spc, partial_atom_map=backbone_map, exclude_index=heavy_index)
-    if B_index is None:
-        for atom in spc.mol.atoms[A_index].edges:
-            atom_index = spc.mol.atoms.index(atom)
-            if atom_index != heavy_index:
-                B_index = atom_index
-                break
-    if B_index is None:
+    xyz = spc.get_xyz()
+    if xyz is None:
         return None, None
-    return A_index, B_index
+    coords = xyz['coords']
+    candidates = list()
+    preferred = _find_preferably_heavy_neighbor(heavy_index=A_index, spc=spc,
+                                                partial_atom_map=backbone_map, exclude_index=heavy_index)
+    if preferred is not None:
+        candidates.append(preferred)
+    for atom in spc.mol.atoms[A_index].edges:
+        atom_index = spc.mol.atoms.index(atom)
+        if atom_index != heavy_index:
+            candidates.append(atom_index)
+    own_neighbors = set()
+    for atom in spc.mol.atoms[heavy_index].edges:
+        atom_index = spc.mol.atoms.index(atom)
+        if atom_index != A_index:
+            candidates.append(atom_index)
+            own_neighbors.add(atom_index)
+    seen = set()
+    for B_index in candidates:
+        if B_index in seen:
+            continue
+        seen.add(B_index)
+        if _anchors_define_a_plane(center_index=heavy_index, anchor_1_index=A_index,
+                                   anchor_2_index=B_index, coords=coords):
+            if B_index in own_neighbors:
+                logger.debug(f'Anchoring the XH3 center {heavy_index} of {spc.label} on its own hydrogen '
+                             f'{B_index}, the azimuthal phase of this XH3 group is undetermined.')
+            return A_index, B_index
+    return None, None
 
 
 def _construct_local_axes(center_idx: int,
@@ -889,8 +954,8 @@ def _construct_local_axes(center_idx: int,
 def _compute_azimuthal_angles(center_idx: int,
                               hydrogen_indices: list[int],
                               coords: list[tuple[float, float, float]],
-                              e_y: np.ndarray,
-                              e_z: np.ndarray
+                              e_y: list[float] | np.ndarray,
+                              e_z: list[float] | np.ndarray
                               ) -> dict[int, float]:
     """
     Compute the azimuthal angles (in degrees) of hydrogen atoms around a principal axis.
@@ -902,8 +967,8 @@ def _compute_azimuthal_angles(center_idx: int,
         center_idx (int): Index of the central atom C.
         hydrogen_indices (list[int]): List of hydrogen atom indices.
         coords (list[tuple[float, float, float]]): 3D coordinates for all atoms.
-        e_y (np.ndarray): Local unit y-axis.
-        e_z (np.ndarray): Local unit z-axis.
+        e_y (list, np.ndarray): Local unit y-axis.
+        e_z (list, np.ndarray): Local unit z-axis.
 
     Returns:
         Dict mapping each hydrogen index to its azimuthal angle in [0, 360).
@@ -983,18 +1048,23 @@ def _map_xh3_group(heavy_idx_1: int,
         backbone_map (dict[int, int]): Existing backbone atom mapping.
 
     Returns:
-        dict[int, int] | None: Mapping from hydrogen indices in spc_1 to hydrogen indices in spc_2.
+        dict[int, int] | None: Mapping from hydrogen indices in spc_1 to hydrogen indices in spc_2,
+                               or None if no local frame could be constructed for either species.
     """
     anchors_1 = _select_ch3_anchors(heavy_idx_1, spc_1, backbone_map)
     anchors_2 = _select_ch3_anchors(heavy_index_2, spc_2, {val: key for key, val in backbone_map.items()})  # reverse map
 
-    if not anchors_1 or not anchors_2:
+    if not anchors_1 or not anchors_2 or any(anchor is None for anchor in list(anchors_1) + list(anchors_2)):
         return None
 
     coords_1, coords_2 = spc_1.get_xyz()['coords'], spc_2.get_xyz()['coords']
 
-    e_x1, e_y1, e_z1 = _construct_local_axes(heavy_idx_1, anchors_1[0], anchors_1[1], coords_1)
-    e_x2, e_y2, e_z2 = _construct_local_axes(heavy_index_2, anchors_2[0], anchors_2[1], coords_2)
+    try:
+        e_x1, e_y1, e_z1 = _construct_local_axes(heavy_idx_1, anchors_1[0], anchors_1[1], coords_1)
+        e_x2, e_y2, e_z2 = _construct_local_axes(heavy_index_2, anchors_2[0], anchors_2[1], coords_2)
+    except ValueError as e:
+        logger.debug(f"Could not construct a local frame for the XH3 group refinement: {e}")
+        return None
 
     hydrogens_1 = _find_hydrogen_neighbors(heavy_idx_1, spc_1.mol.atoms)
     hydrogens_2 = _find_hydrogen_neighbors(heavy_index_2, spc_2.mol.atoms)
@@ -1003,6 +1073,92 @@ def _map_xh3_group(heavy_idx_1: int,
     angles_2 = _compute_azimuthal_angles(heavy_index_2, hydrogens_2, coords_2, e_y2, e_z2)
 
     return _determine_cyclic_shift(angles_1, angles_2)
+
+
+def _map_xh3_group_by_azimuthal_order(heavy_index_1: int,
+                                      heavy_index_2: int,
+                                      spc_1: ARCSpecies,
+                                      spc_2: ARCSpecies,
+                                      backbone_map: dict[int, int],
+                                      ) -> dict[int, int]:
+    """
+    Map hydrogens of a XH3 group by their azimuthal cyclic order about the X->A axis.
+
+    Only the bond from the XH3 center X to its mapped neighbor A is required. Each frame is
+    built by ``vectors.get_perpendicular_axes()`` about the X->A axis, whose azimuthal origin
+    is arbitrary, so the common phase of the returned mapping is undetermined while the cyclic
+    order of the three hydrogens is retained.
+
+    Args:
+        heavy_index_1 (int): Index of the XH3 center in species 1.
+        heavy_index_2 (int): Index of the XH3 center in species 2.
+        spc_1 (ARCSpecies): Species 1.
+        spc_2 (ARCSpecies): Species 2.
+        backbone_map (dict[int, int]): Existing backbone atom mapping.
+
+    Returns:
+        dict[int, int]: Mapping from hydrogen indices in ``spc_1`` to hydrogen indices in ``spc_2``,
+                        or an empty dict if no mapped neighbor or no 3D coordinates are available,
+                        or if X and A coincide in either species.
+    """
+    a_index_1 = _find_preferably_heavy_neighbor(heavy_index=heavy_index_1, spc=spc_1, partial_atom_map=backbone_map)
+    a_index_2 = backbone_map.get(a_index_1, None) if a_index_1 is not None else None
+    if a_index_1 is None or a_index_2 is None:
+        return dict()
+    xyz_1, xyz_2 = spc_1.get_xyz(), spc_2.get_xyz()
+    if xyz_1 is None or xyz_2 is None:
+        return dict()
+    coords_1, coords_2 = xyz_1['coords'], xyz_2['coords']
+    try:
+        axes_1 = get_perpendicular_axes(get_vector(pivot=heavy_index_1, anchor=a_index_1, xyz=xyz_1))
+        axes_2 = get_perpendicular_axes(get_vector(pivot=heavy_index_2, anchor=a_index_2, xyz=xyz_2))
+    except VectorsError as e:
+        logger.debug(f"Could not construct an azimuthal reference frame for the XH3 group refinement: {e}")
+        return dict()
+    angles_1 = _compute_azimuthal_angles(heavy_index_1, _find_hydrogen_neighbors(heavy_index_1, spc_1.mol.atoms),
+                                         coords_1, axes_1[0], axes_1[1])
+    angles_2 = _compute_azimuthal_angles(heavy_index_2, _find_hydrogen_neighbors(heavy_index_2, spc_2.mol.atoms),
+                                         coords_2, axes_2[0], axes_2[1])
+    return _determine_cyclic_shift(angles_1, angles_2)
+
+
+def _map_xh3_hydrogens(heavy_index_1: int,
+                       heavy_index_2: int,
+                       spc_1: ARCSpecies,
+                       spc_2: ARCSpecies,
+                       backbone_map: dict[int, int],
+                       h_indices_1: list[int],
+                       h_indices_2: list[int],
+                       ) -> dict[int, int]:
+    """
+    Map the three hydrogens of a XH3 group, always returning an assignment for all three.
+
+    The anchored local frames of ``_map_xh3_group`` are used when a secondary anchor is available.
+    Otherwise the hydrogens are matched by their azimuthal cyclic order about the X->A axis, which
+    leaves only their common phase undetermined. Without a mapped neighbor or 3D coordinates the
+    hydrogens are assigned in the order they appear in the two species.
+
+    Args:
+        heavy_index_1 (int): Index of the XH3 center in species 1.
+        heavy_index_2 (int): Index of the XH3 center in species 2.
+        spc_1 (ARCSpecies): Species 1.
+        spc_2 (ARCSpecies): Species 2.
+        backbone_map (dict[int, int]): Existing backbone atom mapping.
+        h_indices_1 (list[int]): The three hydrogen indices in species 1.
+        h_indices_2 (list[int]): The three hydrogen indices in species 2.
+
+    Returns:
+        dict[int, int]: Mapping from the hydrogen indices in ``spc_1`` to those in ``spc_2``.
+    """
+    mapped = _map_xh3_group(heavy_index_1, heavy_index_2, spc_1, spc_2, backbone_map)
+    if mapped:
+        return mapped
+    mapped = _map_xh3_group_by_azimuthal_order(heavy_index_1, heavy_index_2, spc_1, spc_2, backbone_map)
+    if mapped:
+        return mapped
+    logger.debug(f'Assigning the hydrogens of the XH3 center {heavy_index_1} of {spc_1.label} by their order, '
+                 f'no local frame could be constructed.')
+    return dict(zip(h_indices_1, h_indices_2))
 
 
 def _compute_ch2_pair_dihedrals(coords_1, coords_2,
@@ -1122,6 +1278,8 @@ def map_hydrogens(spc_1: ARCSpecies,
     """
     Atom map hydrogen atoms between two species with a known mapped heavy atom backbone.
     If only a single hydrogen atom is bonded to a given heavy atom, it is straight-forwardly mapped.
+    The three hydrogens of an XH3 group are always assigned, and their azimuthal cyclic order about
+    the bond to the mapped heavy neighbor is retained whenever 3D coordinates are available.
 
     Args:
         spc_1 (ARCSpecies): Species 1.
@@ -1156,15 +1314,8 @@ def map_hydrogens(spc_1: ARCSpecies,
                 atom_map.update(mapped)
                 continue
         elif len(h_indices_1) == 3:
-            if len(spc_1.mol.atoms) <= 5:
-                # A-XH3 should be a trivial assignment:
-                atom_map[h_indices_1[0]] = h_indices_2[0]
-                atom_map[h_indices_1[1]] = h_indices_2[1]
-                atom_map[h_indices_1[2]] = h_indices_2[2]
-            else:
-                mapped = _map_xh3_group(heavy_index_1, heavy_index_2, spc_1, spc_2, atom_map)
-                if mapped:
-                    atom_map.update(mapped)
+            atom_map.update(_map_xh3_hydrogens(heavy_index_1, heavy_index_2, spc_1, spc_2, atom_map,
+                                               h_indices_1, h_indices_2))
     return atom_map
 
 

--- a/arc/mapping/engine_test.py
+++ b/arc/mapping/engine_test.py
@@ -562,6 +562,34 @@ class TestMappingEngine(unittest.TestCase):
                              H      -0.00000000    1.01981200   -1.62685500
                              H       0.88318300   -0.50990600   -1.62685500
                              H      -0.88318300   -0.50990600   -1.62685500"""
+        cls.ch2con_1_xyz = """C       1.71777985    0.22186921   -0.32888859
+                              C       0.44722671   -0.23882480    0.28782542
+                              O      -0.48797990    0.84313759    0.23934840
+                              N      -1.74672519    0.40251813    0.83397838
+                              H       2.63121996   -0.33161432   -0.15320366
+                              H       1.70806777    0.99933016   -1.08280545
+                              H       0.62398733   -0.52636323    1.32981975
+                              H       0.05456545   -1.09437630   -0.27196331
+                              H      -1.88642313    1.12251331    1.54492954
+                              H      -2.40284632    0.62316863    0.08295105"""
+        cls.ch2con_2_xyz = """C      -1.31502876    0.82850696   -2.07759014
+                              C      -0.39947562    0.21077887   -1.00438259
+                              O      -1.19482148   -0.26236793    0.08578119
+                              N      -1.88870944    0.77572628    0.62474305
+                              H      -1.24822024    1.46878060    0.95557426
+                              H       0.28584783    0.95234699   -0.65039319
+                              H       0.14645095   -0.60595702   -1.42841876
+                              H      -1.70702067    0.21669181   -2.86303559
+                              H      -1.55916794    1.86952281   -2.03781486
+                              H      -2.48322447    1.17684842   -0.07214496"""
+        cls.ethane_xyz = """C      -0.75655400    0.00000000    0.00000000
+                            C       0.75655400    0.00000000    0.00000000
+                            H      -1.15563800    0.65808100    0.78050200
+                            H      -1.15563800    0.34718900   -0.96042500
+                            H      -1.15563800   -1.00527000    0.17992300
+                            H       1.15563800   -0.65808100   -0.78050200
+                            H       1.15563800   -0.34718900    0.96042500
+                            H       1.15563800    1.00527000   -0.17992300"""
         cls.ch3f_xyz = """C      -0.00000000    0.00000000    0.63706000
                           F      -0.00000000    0.00000000   -0.75694000
                           H      -0.00000000    1.02755000    0.99106000
@@ -1716,28 +1744,8 @@ class TestMappingEngine(unittest.TestCase):
 
     def test_map_xh2_group(self):
         """Test the _map_xh2_group() function"""
-        xyz_1 = """C       1.71777985    0.22186921   -0.32888859
-                   C       0.44722671   -0.23882480    0.28782542
-                   O      -0.48797990    0.84313759    0.23934840
-                   N      -1.74672519    0.40251813    0.83397838
-                   H       2.63121996   -0.33161432   -0.15320366
-                   H       1.70806777    0.99933016   -1.08280545
-                   H       0.62398733   -0.52636323    1.32981975
-                   H       0.05456545   -1.09437630   -0.27196331
-                   H      -1.88642313    1.12251331    1.54492954
-                   H      -2.40284632    0.62316863    0.08295105"""
-        xyz_2 = """C      -1.31502876    0.82850696   -2.07759014
-                   C      -0.39947562    0.21077887   -1.00438259
-                   O      -1.19482148   -0.26236793    0.08578119
-                   N      -1.88870944    0.77572628    0.62474305
-                   H      -1.24822024    1.46878060    0.95557426
-                   H       0.28584783    0.95234699   -0.65039319
-                   H       0.14645095   -0.60595702   -1.42841876
-                   H      -1.70702067    0.21669181   -2.86303559
-                   H      -1.55916794    1.86952281   -2.03781486
-                   H      -2.48322447    1.17684842   -0.07214496"""
-        spc_1 = ARCSpecies(label='spc1', smiles='[CH2]CON', xyz=xyz_1)
-        spc_2 = ARCSpecies(label='spc2', smiles='[CH2]CON', xyz=xyz_2)
+        spc_1 = ARCSpecies(label='spc1', smiles='[CH2]CON', xyz=self.ch2con_1_xyz)
+        spc_2 = ARCSpecies(label='spc2', smiles='[CH2]CON', xyz=self.ch2con_2_xyz)
         spc_1, spc_2 = engine.fix_dihedrals_by_backbone_mapping(spc_1=spc_1, spc_2=spc_2,
                                                                 backbone_map={0: 0, 1: 1, 2: 2, 3: 3})
         atom_map = engine.map_hydrogens(spc_1, spc_2, backbone_map={0: 0, 1: 1, 2: 2, 3: 3})
@@ -1786,6 +1794,47 @@ class TestMappingEngine(unittest.TestCase):
         self.assertIn(atom_map,
                       [{0: 0, 1: 2, 2: 13, 3: 14, 4: 6, 5: 8, 6: 10, 7: 9, 8: 7, 9: 11, 10: 16, 11: 3, 12: 5, 13: 1, 14: 12, 15: 4, 16: 15},
                        {0: 0, 1: 2, 2: 13, 3: 14, 4: 6, 5: 8, 6: 10, 7: 9, 8: 7, 9: 11, 10: 16, 11: 3, 12: 5, 13: 1, 14: 12, 15: 15, 16: 4}])
+
+    def test_map_hydrogens_assigns_the_hydrogens_of_an_unrefined_xh2_group(self):
+        """Test that map_hydrogens() assigns both hydrogens of an XH2 group whose refinement returns nothing."""
+        spc_1 = ARCSpecies(label='spc1', smiles='[CH2]CON', xyz=self.ch2con_1_xyz)
+        spc_2 = ARCSpecies(label='spc2', smiles='[CH2]CON', xyz=self.ch2con_2_xyz)
+        backbone_map = {0: 0, 1: 1, 2: 2, 3: 3}
+        spc_1, spc_2 = engine.fix_dihedrals_by_backbone_mapping(spc_1=spc_1, spc_2=spc_2,
+                                                                backbone_map=backbone_map)
+        with mock.patch.object(engine, '_map_xh2_group', return_value=dict()) as patched:
+            atom_map = engine.map_hydrogens(spc_1, spc_2, backbone_map)
+        self.assertTrue(patched.called)
+        self.assertEqual(sorted(atom_map.keys()), list(range(spc_1.number_of_atoms)))
+        self.assertEqual(sorted(atom_map.values()), list(range(spc_2.number_of_atoms)))
+
+    def test_map_hydrogens_assigns_more_than_three_hydrogens(self):
+        """Test that map_hydrogens() assigns the hydrogens of a heavy atom that carries more than three."""
+        spc_1 = ARCSpecies(label='ethane_1', smiles='CC', xyz=self.ethane_xyz)
+        spc_2 = ARCSpecies(label='ethane_2', smiles='CC', xyz=self.ethane_xyz)
+
+        def four_hydrogens(heavy_index, atoms):
+            """Report four hydrogens on the first carbon and two on the second one."""
+            return [2, 3, 4, 5] if heavy_index == 0 else [6, 7]
+
+        with mock.patch.object(engine, '_find_hydrogen_neighbors', side_effect=four_hydrogens):
+            atom_map = engine.map_hydrogens(spc_1, spc_2, {0: 0, 1: 1})
+        self.assertEqual(sorted(atom_map.keys()), list(range(8)))
+        self.assertEqual(sorted(atom_map.values()), list(range(8)))
+
+    def test_map_two_species_rejects_an_incomplete_map(self):
+        """Test that map_two_species() raises rather than returning a list built from an incomplete map."""
+        spc_1 = ARCSpecies(label='ethane_1', smiles='CC', xyz=self.ethane_xyz)
+        spc_2 = ARCSpecies(label='ethane_2', smiles='CC', xyz=self.ethane_xyz)
+        complete_map = engine.map_two_species(spc_1, spc_2, map_type='dict')
+        self.assertEqual(sorted(complete_map.keys()), list(range(8)))
+
+        for dropped_key in [2, 7]:
+            partial_map = {key: value for key, value in complete_map.items() if key != dropped_key}
+            with mock.patch.object(engine, 'map_hydrogens', return_value=partial_map):
+                for map_type in ['dict', 'list']:
+                    with self.assertRaises(ValueError):
+                        engine.map_two_species(spc_1, spc_2, map_type=map_type)
 
     def test_map_hydrogens_for_rotors(self):
         """Test the map_hydrogens() function for a species with 5 heavy atoms."""

--- a/arc/mapping/engine_test.py
+++ b/arc/mapping/engine_test.py
@@ -6,16 +6,20 @@ This module contains unit tests of the arc.species.atom_mapping_wf module
 """
 
 import unittest
+import unittest.mock as mock
 import numpy as np
 import os
 import itertools
 
 import arc.mapping.engine as engine
 from arc.common import ARC_PATH, is_equal_family_product_dicts
+from arc.exceptions import VectorsError
 from arc.family import determine_possible_reaction_products_from_family
 from arc.reaction import ARCReaction
 from arc.species import ARCSpecies
+from arc.species.converter import xyz_from_data
 from arc.species.vectors import calculate_dihedral_angle, get_delta_angle
+from arc.species.zmat import TOL_180
 
 from arc.molecule import Molecule
 
@@ -538,6 +542,37 @@ class TestMappingEngine(unittest.TestCase):
                             H      -0.92134271   -0.74783968   -0.82281679
                             H      -1.04996634   -0.37234114    0.91874740
                             H       1.36260637    0.37153887   -0.86221771"""
+        cls.penta_1_2_diene_xyz = """C      -2.20579300   -0.47138300    0.00008800
+                                     C      -1.12951700    0.26186600    0.00004200
+                                     C      -0.05856100    1.00336000   -0.00000500
+                                     C       1.36944100    0.51049300   -0.00005700
+                                     C       1.53382200   -1.00469100   -0.00005100
+                                     H      -2.67513600   -0.78962500   -0.92471600
+                                     H      -2.67506400   -0.78961300    0.92493200
+                                     H      -0.19126000    2.08343300   -0.00000700
+                                     H       1.87718200    0.93950100   -0.87135500
+                                     H       1.87725000    0.93951600    0.87119400
+                                     H       1.06982400   -1.45280900   -0.88042600
+                                     H       1.06989300   -1.45279500    0.88036800
+                                     H       2.59095500   -1.27547900   -0.00009000"""
+        cls.propyne_xyz = """C       0.00000000    0.00000000    1.41812200
+                             C       0.00000000    0.00000000    0.21837000
+                             C       0.00000000    0.00000000   -1.23643100
+                             H       0.00000000    0.00000000    2.48019500
+                             H      -0.00000000    1.01981200   -1.62685500
+                             H       0.88318300   -0.50990600   -1.62685500
+                             H      -0.88318300   -0.50990600   -1.62685500"""
+        cls.ch3f_xyz = """C      -0.00000000    0.00000000    0.63706000
+                          F      -0.00000000    0.00000000   -0.75694000
+                          H      -0.00000000    1.02755000    0.99106000
+                          H       0.88989000   -0.51378000    0.99106000
+                          H      -0.88989000   -0.51378000    0.99106000"""
+        cls.ethylene_xyz = """C      -0.00000000    0.00000000    0.66237500
+                              C       0.00000000    0.00000000   -0.66237500
+                              H      -0.00000000    0.92138100    1.23241800
+                              H      -0.00000000   -0.92138100    1.23241800
+                              H       0.00000000    0.92138100   -1.23241800
+                              H      -0.00000000   -0.92138100   -1.23241800"""
         cls.ip1_xyz = """ C                  0.23537226    1.11846087   -0.01756422
                           H                  0.62797226    0.12368275   -0.05194069
                           H                  0.55388639    1.65778122   -0.88507924
@@ -1404,6 +1439,226 @@ class TestMappingEngine(unittest.TestCase):
         self.assertEqual(set(h_map.values()), to_atoms)
         self.assertEqual(len(h_map), 3)
         self.assertEqual(len(set(h_map.values())), 3)
+
+    @staticmethod
+    def _xh3_center(spc, occurrence=0):
+        """Return the index of an XH3 center of ``spc`` and the indices of its three hydrogens."""
+        atoms = spc.mol.atoms
+        centers = [i for i in range(len(atoms)) if not atoms[i].is_hydrogen()
+                   and len(engine._find_hydrogen_neighbors(i, atoms)) == 3]
+        return centers[occurrence], engine._find_hydrogen_neighbors(centers[occurrence], atoms)
+
+    @staticmethod
+    def _xh3_handedness(coords, center_index, h_indices):
+        """Return the signed triple product of the three center->H vectors, which flips sign under a swap."""
+        center = np.array(coords[center_index], dtype=float)
+        v_1, v_2, v_3 = [np.array(coords[h], dtype=float) - center for h in h_indices]
+        return float(np.dot(np.cross(v_1, v_2), v_3))
+
+    @staticmethod
+    def _swap_coords(xyz, index_1, index_2):
+        """Return a copy of ``xyz`` with the coordinates of two atoms exchanged."""
+        coords = list(xyz['coords'])
+        coords[index_1], coords[index_2] = coords[index_2], coords[index_1]
+        return xyz_from_data(coords=coords, symbols=xyz['symbols'], isotopes=xyz['isotopes'])
+
+    def _assert_xh3_hydrogens_are_evenly_permuted(self, spc_1, spc_2, atom_map, centers=None):
+        """Assert that the XH3 groups of ``spc_1`` keep their handedness under ``atom_map``."""
+        coords_1, coords_2 = spc_1.get_xyz()['coords'], spc_2.get_xyz()['coords']
+        atoms_1 = spc_1.mol.atoms
+        centers = centers if centers is not None else \
+            [i for i in range(len(atoms_1)) if not atoms_1[i].is_hydrogen()
+             and len(engine._find_hydrogen_neighbors(i, atoms_1)) == 3]
+        self.assertTrue(centers)
+        for center in centers:
+            h_indices_1 = engine._find_hydrogen_neighbors(center, atoms_1)
+            h_indices_2 = [atom_map[h] for h in h_indices_1]
+            self.assertEqual(len(set(h_indices_2)), 3)
+            handedness_1 = self._xh3_handedness(coords_1, center, h_indices_1)
+            handedness_2 = self._xh3_handedness(coords_2, atom_map[center], h_indices_2)
+            self.assertEqual(np.sign(handedness_1), np.sign(handedness_2),
+                             msg=f'XH3 center {center} was mapped by an odd permutation: '
+                                 f'{h_indices_1} -> {h_indices_2}.')
+
+    def test_select_ch3_anchors_linear_molecule(self):
+        """Test that _select_ch3_anchors() rejects the colinear heavy anchors of a linear molecule."""
+        spc = ARCSpecies(label='propyne', smiles='C#CC', multiplicity=1, xyz=self.propyne_xyz)
+        atoms = spc.mol.atoms
+        heavy_index, hydrogens = self._xh3_center(spc)
+        backbone_map = {i: i for i in range(len(atoms)) if not atoms[i].is_hydrogen()}
+        a_index, b_index = engine._select_ch3_anchors(heavy_index, spc, backbone_map)
+        self.assertIsNotNone(a_index)
+        self.assertIsNotNone(b_index)
+        self.assertIn(b_index, hydrogens)
+        coords = spc.get_xyz()['coords']
+        heavy_candidate = next(i for i in range(len(atoms))
+                               if not atoms[i].is_hydrogen() and i not in [heavy_index, a_index])
+        self.assertFalse(engine._anchors_define_a_plane(heavy_index, a_index, heavy_candidate, coords))
+        e_x, e_y, e_z = engine._construct_local_axes(heavy_index, a_index, b_index, coords)
+        for vector in [e_x, e_y, e_z]:
+            self.assertTrue(np.all(np.isfinite(vector)))
+            self.assertAlmostEqual(float(np.linalg.norm(vector)), 1.0, places=6)
+        self.assertAlmostEqual(float(np.dot(e_x, e_y)), 0.0, places=6)
+        self.assertAlmostEqual(float(np.dot(e_x, e_z)), 0.0, places=6)
+        self.assertAlmostEqual(float(np.dot(e_y, e_z)), 0.0, places=6)
+
+    def test_anchors_define_a_plane(self):
+        """Test that _anchors_define_a_plane() accepts only well-defined, in-range anchor pairs."""
+        coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (2.0, 0.0, 0.0), (0.0, 0.0, 0.0)]
+        self.assertTrue(engine._anchors_define_a_plane(0, 1, 2, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, 3, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, 4, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 4, 1, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, 1, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 0, 1, coords))
+        self.assertFalse(engine._anchors_define_a_plane(None, 1, 2, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, None, 2, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, None, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, 5, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, 1, -1, coords))
+        self.assertFalse(engine._anchors_define_a_plane(0, -3, 1, coords))
+        self.assertFalse(engine._anchors_define_a_plane(-5, 1, 2, coords))
+
+    def test_anchors_define_a_plane_angular_threshold(self):
+        """Test that _anchors_define_a_plane() rejects an anchor pair exactly when its angle is linear."""
+        self.assertEqual(TOL_180, 0.9)
+        for angle, expected in [(0.0, False), (0.5, False), (0.89, False), (0.91, True), (2.0, True),
+                                (90.0, True), (178.0, True), (179.09, True), (179.11, False),
+                                (179.5, False), (180.0, False)]:
+            radians = np.radians(angle)
+            coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (float(np.cos(radians)), float(np.sin(radians)), 0.0)]
+            self.assertEqual(engine._anchors_define_a_plane(0, 1, 2, coords), expected,
+                             msg=f'An X-A / X-B angle of {angle} degrees should '
+                                 f'{"" if expected else "not "}define a plane.')
+        for length in [0.05, 1.0, 100.0]:
+            for angle, expected in [(0.5, False), (5.0, True), (179.5, False)]:
+                radians = np.radians(angle)
+                coords = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0),
+                          (length * float(np.cos(radians)), length * float(np.sin(radians)), 0.0)]
+                self.assertEqual(engine._anchors_define_a_plane(0, 1, 2, coords), expected,
+                                 msg=f'An X-A / X-B angle of {angle} degrees at a distance of {length} '
+                                     f'should {"" if expected else "not "}define a plane.')
+
+    def test_anchors_define_a_plane_agrees_with_construct_local_axes(self):
+        """Test that an anchor pair accepted by _anchors_define_a_plane() never makes _construct_local_axes() raise."""
+        origin = np.zeros(3)
+        accepted, rejected = 0, 0
+        for length_a in [1e-12, 1e-9, 1e-8, 1e-6, 1e-3, 1.0, 1e3]:
+            for length_b in [1e-12, 1e-9, 1e-8, 2e-8, 1e-7, 1e-6, 1e-3, 1.0, 1e3]:
+                for angle in [0.0, 1e-6, 0.5, 0.89, 0.91, 1.0, 5.0, 90.0, 175.0, 179.09, 179.11, 179.5, 180.0]:
+                    radians = np.radians(angle)
+                    coords = [tuple(origin), (length_a, 0.0, 0.0),
+                              (length_b * float(np.cos(radians)), length_b * float(np.sin(radians)), 0.0)]
+                    if engine._anchors_define_a_plane(0, 1, 2, coords):
+                        accepted += 1
+                        e_x, e_y, e_z = engine._construct_local_axes(0, 1, 2, coords)
+                        for vector in [e_x, e_y, e_z]:
+                            self.assertTrue(np.all(np.isfinite(vector)))
+                            self.assertAlmostEqual(float(np.linalg.norm(vector)), 1.0, places=6)
+                    else:
+                        rejected += 1
+        self.assertGreater(accepted, 0)
+        self.assertGreater(rejected, 0)
+
+    def test_map_xh3_group_returns_none_for_undefined_plane(self):
+        """Test that _map_xh3_group() returns None (and does not raise) when no local frame is possible."""
+        spc1 = ARCSpecies(label='ip1', smiles='CCC(C)C', xyz=self.ip1_xyz)
+        spc2 = ARCSpecies(label='ip2', smiles='CCC(C)C', xyz=self.ip2_xyz)
+        backbone_map = engine.identify_superimposable_candidates(engine.fingerprint(spc1), engine.fingerprint(spc2))[0]
+        heavy_idx_1, _ = self._xh3_center(spc1, occurrence=-1)
+        heavy_idx_2 = backbone_map[heavy_idx_1]
+
+        with mock.patch.object(engine, '_select_ch3_anchors', return_value=(None, None)):
+            self.assertIsNone(engine._map_xh3_group(heavy_idx_1, heavy_idx_2, spc1, spc2, backbone_map))
+
+        with mock.patch.object(engine, '_construct_local_axes',
+                               side_effect=ValueError("Anchors are colinear; cannot define unique plane.")):
+            self.assertIsNone(engine._map_xh3_group(heavy_idx_1, heavy_idx_2, spc1, spc2, backbone_map))
+            atom_map = engine.map_hydrogens(spc1, spc2, backbone_map)
+        self.assertEqual(len(atom_map), len(spc1.mol.atoms))
+        self.assertEqual(sorted(atom_map.values()), list(range(len(spc2.mol.atoms))))
+
+    def test_map_hydrogens_xh3_fallback_is_an_even_permutation(self):
+        """Test that the XH3 fallback of map_hydrogens() never permutes the three hydrogens oddly.
+
+        ``spc_2`` carries the geometry of ``spc_1`` with the coordinates of two hydrogens of one methyl
+        exchanged, so an assignment made by hydrogen order alone is an odd permutation of that methyl.
+        """
+        spc_1 = ARCSpecies(label='2-methylbutane_1', smiles='CC(C)CC', xyz=self.methylbutane_xyz)
+        _, hydrogens = self._xh3_center(spc_1)
+        spc_2 = ARCSpecies(label='2-methylbutane_2', smiles='CC(C)CC',
+                           xyz=self._swap_coords(spc_1.get_xyz(), hydrogens[0], hydrogens[1]))
+        backbone_map = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                                 engine.fingerprint(spc_2))[0]
+        with mock.patch.object(engine, '_map_xh3_group', return_value=None):
+            atom_map = engine.map_hydrogens(spc_1, spc_2, backbone_map)
+        self.assertEqual(len(atom_map), spc_1.number_of_atoms)
+        self.assertEqual(sorted(atom_map.values()), list(range(spc_2.number_of_atoms)))
+        self._assert_xh3_hydrogens_are_evenly_permuted(spc_1, spc_2, atom_map)
+
+    def test_map_two_species_xh3_of_a_small_species_is_an_even_permutation(self):
+        """Test that the three hydrogens of a five-atom XH3 species are not permuted oddly."""
+        spc_1 = ARCSpecies(label='CH3F_1', smiles='CF', xyz=self.ch3f_xyz)
+        _, hydrogens = self._xh3_center(spc_1)
+        spc_2 = ARCSpecies(label='CH3F_2', smiles='CF',
+                           xyz=self._swap_coords(spc_1.get_xyz(), hydrogens[0], hydrogens[1]))
+        self.assertEqual(spc_1.number_of_atoms, 5)
+        atom_map = engine.map_two_species(spc_1, spc_2, map_type='dict')
+        self.assertEqual(sorted(atom_map.values()), list(range(5)))
+        self._assert_xh3_hydrogens_are_evenly_permuted(spc_1, spc_2, atom_map)
+
+    def test_map_xh3_group_by_azimuthal_order(self):
+        """Test that _map_xh3_group_by_azimuthal_order() retains the cyclic order of the three hydrogens."""
+        spc_1 = ARCSpecies(label='2-methylbutane_1', smiles='CC(C)CC', xyz=self.methylbutane_xyz)
+        center, hydrogens = self._xh3_center(spc_1)
+        spc_2 = ARCSpecies(label='2-methylbutane_2', smiles='CC(C)CC',
+                           xyz=self._swap_coords(spc_1.get_xyz(), hydrogens[0], hydrogens[1]))
+        backbone_map = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                                 engine.fingerprint(spc_2))[0]
+        mapped = engine._map_xh3_group_by_azimuthal_order(center, backbone_map[center], spc_1, spc_2, backbone_map)
+        self.assertEqual(sorted(mapped.keys()), sorted(hydrogens))
+        self._assert_xh3_hydrogens_are_evenly_permuted(spc_1, spc_2, {**backbone_map, **mapped},
+                                                       centers=[center])
+        self.assertEqual(engine._map_xh3_group_by_azimuthal_order(center, backbone_map[center],
+                                                                  spc_1, spc_2, dict()), dict())
+
+    def test_map_xh3_group_by_azimuthal_order_without_a_frame(self):
+        """Test that _map_xh3_group_by_azimuthal_order() falls back cleanly when no frame can be built."""
+        spc_1 = ARCSpecies(label='2-methylbutane_1', smiles='CC(C)CC', xyz=self.methylbutane_xyz)
+        center, hydrogens = self._xh3_center(spc_1)
+        spc_2 = ARCSpecies(label='2-methylbutane_2', smiles='CC(C)CC',
+                           xyz=self._swap_coords(spc_1.get_xyz(), hydrogens[0], hydrogens[1]))
+        backbone_map = engine.identify_superimposable_candidates(engine.fingerprint(spc_1),
+                                                                 engine.fingerprint(spc_2))[0]
+        hydrogens_2 = engine._find_hydrogen_neighbors(backbone_map[center], spc_2.mol.atoms)
+        with mock.patch.object(engine, 'get_perpendicular_axes',
+                               side_effect=VectorsError('vector must be finite, got [nan, nan, nan].')):
+            self.assertEqual(engine._map_xh3_group_by_azimuthal_order(center, backbone_map[center],
+                                                                      spc_1, spc_2, backbone_map), dict())
+            with mock.patch.object(engine, '_map_xh3_group', return_value=None):
+                mapped = engine._map_xh3_hydrogens(center, backbone_map[center], spc_1, spc_2, backbone_map,
+                                                   hydrogens, hydrogens_2)
+        self.assertEqual(mapped, dict(zip(hydrogens, hydrogens_2)))
+
+    def test_map_retroene_reaction_with_optimized_geometries(self):
+        """Test atom mapping a Retroene reaction whose product has a fully linear heavy-atom skeleton."""
+        rxn = ARCReaction(label='R1 <=> P1 + P2',
+                          r_species=[ARCSpecies(label='R1', smiles='C=C=CCC', multiplicity=1,
+                                                xyz=self.penta_1_2_diene_xyz)],
+                          p_species=[ARCSpecies(label='P1', smiles='C#CC', multiplicity=1, xyz=self.propyne_xyz),
+                                     ARCSpecies(label='P2', smiles='C=C', multiplicity=1, xyz=self.ethylene_xyz)])
+        self.assertEqual(rxn.family, 'Retroene')
+        self.assertIsNotNone(rxn.atom_map)
+        self.assertEqual(sorted(rxn.atom_map), list(range(13)))
+        self.assertTrue(engine.check_atom_map(rxn))
+
+        rxn_no_xyz = ARCReaction(label='R1 <=> P1 + P2',
+                                 r_species=[ARCSpecies(label='R1', smiles='C=C=CCC', multiplicity=1)],
+                                 p_species=[ARCSpecies(label='P1', smiles='C#CC', multiplicity=1),
+                                            ARCSpecies(label='P2', smiles='C=C', multiplicity=1)])
+        self.assertIsNotNone(rxn_no_xyz.atom_map)
+        self.assertEqual(sorted(rxn_no_xyz.atom_map), list(range(13)))
+        self.assertTrue(engine.check_atom_map(rxn_no_xyz))
 
     def test_map_hydrogens_for_ch4(self):
         """Test the map_hydrogens() function for a single heavy atom with only H's."""

--- a/arc/species/vectors.py
+++ b/arc/species/vectors.py
@@ -59,6 +59,40 @@ def get_perpendicular_unit_vector(vector: list[float]) -> list[float]:
     return get_normal(vector, reference)
 
 
+def get_perpendicular_axes(vector: list[float],
+                           tol: float = 1e-8,
+                           ) -> tuple[list[float], list[float]]:
+    """
+    Get the two unit vectors that complete a right-handed orthonormal frame with a given direction.
+
+    Writing ``e_x`` for the unit vector along ``vector``, the returned ``e_y`` and ``e_z`` satisfy
+    ``e_x`` x ``e_y`` = ``e_z``. Their common phase about ``e_x`` is arbitrary: it is fixed by
+    ``get_perpendicular_unit_vector()``, so it is reproducible for a given input but carries no
+    meaning of its own. Angles measured against the returned pair therefore retain their cyclic
+    order about ``e_x`` while their absolute values do not.
+
+    Args:
+        vector (list): The vector defining the first axis of the frame. Need not be normalized.
+        tol (float, optional): The minimal accepted length of ``vector``.
+
+    Raises:
+        VectorsError: If ``vector`` is not of length three, is not finite, is shorter than ``tol``,
+                      or is long enough for its squared length to overflow.
+
+    Returns: tuple
+        The ``e_y`` and ``e_z`` unit vectors.
+    """
+    if len(vector) != 3:
+        raise VectorsError(f'vector must be of length three, got {len(vector)}.')
+    if not all(math.isfinite(component) for component in vector):
+        raise VectorsError(f'vector must be finite, got {vector}.')
+    if get_vector_length(vector) < tol:
+        raise VectorsError(f'vector must be longer than {tol}, got {vector}.')
+    e_x = unit_vector(vector)
+    e_z = get_perpendicular_unit_vector(e_x)
+    return get_normal(e_z, e_x), e_z
+
+
 def get_angle(v1: list[float],
               v2: list[float],
               units: str = 'rads',

--- a/arc/species/vectors_test.py
+++ b/arc/species/vectors_test.py
@@ -74,6 +74,44 @@ class TestVectors(unittest.TestCase):
                 with self.assertRaises(VectorsError):
                     vectors.get_perpendicular_unit_vector(vector)
 
+    def test_get_perpendicular_axes(self):
+        """Test that a right-handed orthonormal pair perpendicular to the input vector is returned"""
+        for vector in ([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0],
+                       [-1.0, 0.0, 0.0], [0.0, -2.0, 0.0], [0.0, 0.0, -3.0],
+                       [1.0, 1.0, 1.0], [-3.0, 0.5, 0.0], [0.7, -0.7, 0.14], [1e-4, 1e5, 2.0]):
+            with self.subTest(vector=vector):
+                e_y, e_z = vectors.get_perpendicular_axes(vector)
+                e_x = vectors.unit_vector(vector)
+                self.assertAlmostEqual(vectors.get_vector_length(e_y), 1.0, places=10)
+                self.assertAlmostEqual(vectors.get_vector_length(e_z), 1.0, places=10)
+                self.assertAlmostEqual(sum(e_x[i] * e_y[i] for i in range(3)), 0.0, places=10)
+                self.assertAlmostEqual(sum(e_x[i] * e_z[i] for i in range(3)), 0.0, places=10)
+                self.assertAlmostEqual(sum(e_y[i] * e_z[i] for i in range(3)), 0.0, places=10)
+                for expected, obtained in zip(e_z, vectors.get_normal(e_x, e_y)):
+                    self.assertAlmostEqual(expected, obtained, places=10)
+        e_y, e_z = vectors.get_perpendicular_axes([0.0, 0.0, 1.0])
+        for expected, obtained in zip([1.0, 0.0, 0.0], e_y):
+            self.assertAlmostEqual(expected, obtained, places=10)
+        for expected, obtained in zip([0.0, 1.0, 0.0], e_z):
+            self.assertAlmostEqual(expected, obtained, places=10)
+
+    def test_get_perpendicular_axes_is_deterministic(self):
+        """Test that repeated calls with the same input, and with a scaled input, return the same axes"""
+        self.assertEqual(vectors.get_perpendicular_axes([1.0, 2.0, 3.0]),
+                         vectors.get_perpendicular_axes([1.0, 2.0, 3.0]))
+        for scaled, unscaled in zip(vectors.get_perpendicular_axes([5.0, 10.0, 15.0]),
+                                    vectors.get_perpendicular_axes([1.0, 2.0, 3.0])):
+            for expected, obtained in zip(unscaled, scaled):
+                self.assertAlmostEqual(expected, obtained, places=10)
+
+    def test_get_perpendicular_axes_rejects_degenerate_input(self):
+        """Test that a vector which is not a finite, sufficiently long 3-vector is rejected"""
+        for vector in ([0.0, 0.0, 0.0], [1.0, 0.0], [1.0, 2.0, 3.0, 4.0], [1e-12, 0.0, 0.0],
+                       [float('nan'), 0.0, 1.0], [float('nan')] * 3, [float('inf'), 0.0, 1.0]):
+            with self.subTest(vector=vector):
+                with self.assertRaises(VectorsError):
+                    vectors.get_perpendicular_axes(vector)
+
     def test_get_angle(self):
         """Test calculating the angle between two vectors"""
         v1 = [-1.45707856 + 0.02416711, -0.94104506 - 0.17703194, -0.20275830 - 0.08644641]


### PR DESCRIPTION
**Stack position:** top of the atom-mapping stack — sits on #935, which sits on #947. Read them in that order.

The order matters: #935 makes the XH3 branch of `map_hydrogens` always return an assignment for all three hydrogens. Only once that hole is closed can the completeness check added here be made unconditional — on `main` it would fire on ordinary XH3 groups. This PR closes the two remaining holes and then makes any future hole fail loudly.

### The gap

- `map_hydrogens` handled an XH2 group with `if mapped: … continue` and no `else`, so whenever `_map_xh2_group` returned `{}` — no mapped heavy neighbour, or a heavy atom not carrying exactly two hydrogens — **both hydrogens were silently left out of the map**.
- A heavy atom carrying four or more hydrogens alongside a heavy neighbour matched no branch at all and was dropped the same way.

### Why omission was not a clean failure

- `map_two_species` builds its list map with `[v for k, v in sorted(atom_map.items(), …)]` and no length check, so a missing key **shifts every subsequent index by one** — every atom past the gap silently refers to the wrong one, and the reaction is mapped with a plausible-looking but wrong map.
- It surfaces much later as an `IndexError` in `glue_maps`, which `try_mapping` does not catch, since it catches only `ValueError`.

### The fix

- Both cases now fall back to assigning the hydrogens in the order they appear in the two species, each with a DEBUG log naming the centre.
- `map_two_species` checks that the map is a permutation of both species' atoms before returning it, raising `ValueError` otherwise — so any future gap degrades to a mapping failure instead of corrupting indices.
- **XH2 needs no parity guard.** Unlike an XH3 group, the two hydrogens of an XH2 group are related by a reflection rather than by a rotation, so there is no handedness for the order-based fallback to preserve. (Contrast #935, where the parity of an XH3 assignment is load-bearing.)

### Behaviour change to be aware of

`map_two_species` can now raise `ValueError` where it previously returned a shifted map. Not every caller catches that, so the failure mode differs by path:

**Already guarded** — the raise degrades to a clean mapping failure:
- everything reached from `map_rxn` (`map_pairs`, `reorder_p_label_map`), which sits inside `try_mapping`'s `except ValueError`
- `get_new_zmat_2_map`, reached via `combine_coordinates_with_redundant_atoms`, inside `h_abstraction`'s `except (ValueError, SpeciesError)`

**Not guarded** — an incomplete map now surfaces as an uncaught exception rather than as silently wrong indices:
- `map_isomerization_reaction` → `map_general_rxn` → `map_reaction`; `ARCReaction.atom_map` does not catch, so it escapes the property
- `h_abstraction` (`arc/job/adapters/ts/heuristics.py:897`), which the Heuristics TS adapter calls without a guard

This is the intended trade — an exception beats a corrupted map — but it is a real change in failure mode, and reviewers should decide whether those two paths want their own guard. With the fallbacks added here a gap should not be reachable through the normal paths; the check is a backstop.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
