### PR TITLE
Parse Mayer bond orders from ESS log files

### DIFF
--- a/arc/parser/adapter.py
+++ b/arc/parser/adapter.py
@@ -216,6 +216,20 @@ class ESSAdapter(ABC):
         """
         return None
 
+    def parse_bond_orders(self) -> np.ndarray | None:
+        """
+        Parse the Mayer bond order matrix from the log file.
+
+        The Mayer bond order is a density-derived bond index, useful for inferring connectivity
+        (including partial bonds at a TS) without relying on interatomic distances.
+
+        Returns: np.ndarray | None
+            A symmetric NxN matrix of Mayer bond orders in the log file's atom order.
+            The diagonal holds the Mayer atomic valence of each atom.
+            ``None`` if the log file does not contain a Mayer population analysis.
+        """
+        return None
+
     def check_logfile_exists(self,
                              counter: int = 5,
                              sleep_time: int = 5,

--- a/arc/parser/adapters/gaussian.py
+++ b/arc/parser/adapters/gaussian.py
@@ -781,6 +781,56 @@ class GaussianParser(ESSAdapter, ABC):
                 return m.group(1).rstrip(',')
         return None
 
+    def parse_bond_orders(self) -> np.ndarray | None:
+        """
+        Parse the Mayer bond order matrix from a Gaussian log file.
+
+        Requires ``IOp(6/80=1)`` in the route section, which makes Gaussian print an
+        "Atomic Valencies and Mayer Atomic Bond Orders:" section. The matrix is printed in
+        Fortran-style column blocks of six, each block preceded by a line of column indices.
+        The last such section in the file is used (relevant for multi-step jobs).
+
+        Returns: np.ndarray | None
+            A symmetric NxN matrix of Mayer bond orders in the log file's atom order.
+            The diagonal holds the Mayer atomic valence of each atom.
+            ``None`` if the log file does not contain a Mayer bond order section.
+        """
+        lines = _get_lines_from_file(self.log_file_path)
+        start = None
+        for i in reversed(range(len(lines))):
+            if 'Atomic Valencies and Mayer Atomic Bond Orders' in lines[i]:
+                start = i + 1
+                break
+        if start is None:
+            return None
+        matrix, columns = dict(), list()
+        for line in lines[start:]:
+            splits = line.split()
+            if not splits:
+                continue
+            if all(split.isdigit() for split in splits):
+                # A column index header line, e.g. "   1   2   3   4   5   6".
+                columns = [int(split) - 1 for split in splits]
+                continue
+            # A data line, e.g. "     1  C    3.931186   1.908673   ...".
+            if len(splits) < 3 or not splits[0].isdigit() or not columns:
+                break
+            try:
+                row = int(splits[0]) - 1
+                values = [float(split) for split in splits[2:]]
+            except ValueError:
+                break
+            for column, value in zip(columns, values):
+                matrix[(row, column)] = value
+        if not matrix:
+            return None
+        n = max(max(key) for key in matrix.keys()) + 1
+        bond_orders = np.zeros((n, n), np.float64)
+        for (i, j), value in matrix.items():
+            bond_orders[i, j] = value
+        # Gaussian prints the full square matrix, symmetrizing absorbs print-precision asymmetry.
+        return 0.5 * (bond_orders + bond_orders.T)
+
     def _load_scan_specs(self, letter_spec, get_after_letter_spec=False):
         """
         This method reads the ouptput file for optional parameters

--- a/arc/parser/adapters/orca.py
+++ b/arc/parser/adapters/orca.py
@@ -361,5 +361,53 @@ class OrcaParser(ESSAdapter, ABC):
                     return f'ORCA {m.group(1)}'
         return None
 
+    def parse_bond_orders(self) -> np.ndarray | None:
+        """
+        Parse the Mayer bond order matrix from an Orca log file.
+
+        Orca prints a "MAYER POPULATION ANALYSIS" section by default. It consists of a per-atom
+        table (from which the number of atoms and the Mayer total valence ``VA`` are taken) followed
+        by a sparse list of atom pairs, e.g. ``B(  0-O ,  1-C ) :   1.0172``. Note that Orca only
+        prints pairs above a threshold (0.1 by default), so bond orders below that threshold are
+        reported here as zero. The last such section in the file is used.
+
+        Returns: np.ndarray | None
+            A symmetric NxN matrix of Mayer bond orders in the log file's atom order.
+            The diagonal holds the Mayer atomic valence of each atom.
+            ``None`` if the log file does not contain a Mayer population analysis.
+        """
+        lines = _get_lines_from_file(self.log_file_path)
+        start = None
+        for i in reversed(range(len(lines))):
+            if 'MAYER POPULATION ANALYSIS' in lines[i]:
+                start = i + 1
+                break
+        if start is None:
+            return None
+        atom_pattern = re.compile(r'^\s*(\d+)\s+[A-Za-z]{1,3}\s+(-?\d+\.\d+(?:\s+-?\d+\.\d+){5})\s*$')
+        bond_pattern = re.compile(r'B\(\s*(\d+)-\w+\s*,\s*(\d+)-\w+\s*\)\s*:\s*(-?\d+\.\d+)')
+        valences, bonds = dict(), dict()
+        for line in lines[start:]:
+            if 'TIMINGS' in line:
+                break
+            match = atom_pattern.match(line)
+            if match is not None:
+                # The six columns are NA, ZA, QA, VA, BVA and FA; VA is the Mayer total valence.
+                valences[int(match.group(1))] = float(match.group(2).split()[3])
+                continue
+            for i, j, value in bond_pattern.findall(line):
+                bonds[(int(i), int(j))] = float(value)
+        if not valences:
+            return None
+        n = max(valences.keys()) + 1
+        bond_orders = np.zeros((n, n), np.float64)
+        for i, valence in valences.items():
+            bond_orders[i, i] = valence
+        for (i, j), value in bonds.items():
+            if i >= n or j >= n:
+                return None
+            bond_orders[i, j] = bond_orders[j, i] = value
+        return bond_orders
+
 
 register_ess_adapter('orca', OrcaParser)

--- a/arc/parser/parser.py
+++ b/arc/parser/parser.py
@@ -266,6 +266,12 @@ parse_ess_version = make_parser(
     error_message='Could not parse ESS version from {path}',
 )
 
+parse_bond_orders = make_parser(
+    parse_method='parse_bond_orders',
+    return_type=np.ndarray | None,
+    error_message='Could not parse bond orders from {path}',
+)
+
 
 def parse_1d_scan_energies_from_specific_angle(log_file_path: str,
                                                initial_angle: float,

--- a/arc/parser/parser_test.py
+++ b/arc/parser/parser_test.py
@@ -1127,6 +1127,50 @@ H      -1.69381305    0.40788834    0.90078104"""
         path5 = os.path.join(ARC_TESTING_PATH, 'freq', 'CH2O_freq_molpro.out')
         self.assertEqual(parser.parse_ess_version(path5), 'Molpro 2015.1.37')
 
+    def test_parse_bond_orders(self):
+        """Test parsing Mayer bond orders from various ESS output files."""
+        # Gaussian, requires IOp(6/80=1) in the route section.
+        path1 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C8H14O2_mayer_gaussian.out')
+        bond_orders_1 = parser.parse_bond_orders(path1)
+        self.assertEqual(bond_orders_1.shape, (24, 24))
+        self.assertTrue(np.allclose(bond_orders_1, bond_orders_1.T))
+        # The diagonal holds the Mayer atomic valence.
+        self.assertAlmostEqual(bond_orders_1[0, 0], 3.931186, places=6)  # C
+        self.assertAlmostEqual(bond_orders_1[4, 4], 1.861909, places=6)  # O
+        self.assertAlmostEqual(bond_orders_1[0, 1], 1.908673, places=6)  # a C=C double bond
+        self.assertAlmostEqual(bond_orders_1[4, 5], 0.822247, places=6)  # a strained O-O bond
+        self.assertAlmostEqual(bond_orders_1[0, 10], 0.965318, places=6)  # a C-H bond
+        self.assertAlmostEqual(bond_orders_1[0, 6], 0.000079, places=6)  # not bonded
+
+        # Orca, printed by default.
+        path2 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C4H5NO2_mayer_orca.out')
+        bond_orders_2 = parser.parse_bond_orders(path2)
+        self.assertEqual(bond_orders_2.shape, (12, 12))
+        self.assertTrue(np.allclose(bond_orders_2, bond_orders_2.T))
+        self.assertAlmostEqual(bond_orders_2[0, 0], 1.8586, places=4)  # O
+        self.assertAlmostEqual(bond_orders_2[1, 1], 3.9312, places=4)  # C
+        self.assertAlmostEqual(bond_orders_2[0, 1], 1.0121, places=4)  # a C-O bond
+        self.assertAlmostEqual(bond_orders_2[5, 6], 1.6025, places=4)  # a C=C double bond
+        self.assertAlmostEqual(bond_orders_2[2, 3], 1.5612, places=4)  # a C=N double bond
+        self.assertEqual(bond_orders_2[0, 2], 0)  # not bonded, below Orca's print threshold
+
+        # An Orca TS, with two partial bonds of a migrating H atom.
+        path3 = os.path.join(ARC_TESTING_PATH, 'freq', 'orca_neg_freq_ts.out')
+        bond_orders_3 = parser.parse_bond_orders(path3)
+        self.assertEqual(bond_orders_3.shape, (7, 7))
+        self.assertAlmostEqual(bond_orders_3[2, 5], 0.6169, places=4)  # a breaking C-H bond
+        self.assertAlmostEqual(bond_orders_3[0, 5], 0.3644, places=4)  # a forming O-H bond
+
+        # A double bond in an Orca opt job.
+        path4 = os.path.join(ARC_TESTING_PATH, 'orca_example_opt.log')
+        bond_orders_4 = parser.parse_bond_orders(path4)
+        self.assertEqual(bond_orders_4.shape, (4, 4))
+        self.assertAlmostEqual(bond_orders_4[0, 1], 2.1427, places=4)  # a C=O double bond
+
+        # Log files without a Mayer population analysis.
+        self.assertIsNone(parser.parse_bond_orders(os.path.join(ARC_TESTING_PATH, 'opt', 'iC3H7.out')))
+        self.assertIsNone(parser.parse_bond_orders(os.path.join(ARC_TESTING_PATH, 'freq', 'orca6_example.out')))
+
     def test_yaml_parser(self):
         """Test the YAMLParser adapter for all its parse methods."""
         import tempfile

--- a/arc/testing/bond_orders/C4H5NO2_mayer_orca.out
+++ b/arc/testing/bond_orders/C4H5NO2_mayer_orca.out
@@ -1,0 +1,4787 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Cooperlake SINGLE_THREADED
+        Core in use  :  Cooperlake
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+NOTE: MaxCore=9800 MB was set to SCF,MP2,MDCI,CIPSI,MRCI and CIS
+      => If you want to overwrite this, your respective input block should be placed after the MaxCore statement
+
+
+***************************************
+The coordinates will be read from file: geom.xyz
+***************************************
+
+
+Your calculation utilizes the geometrical counterpoise correction gCP
+Please cite in your paper:
+H.Kruse, S. Grimme J.Chem.Phys., 136, (2012), 154101 
+   
+
+Your calculation utilizes the atom-pairwise dispersion correction
+based on EEQ partial charges (D4)
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-mTZVPP
+   Stefan Grimme, Andreas Hansen, Sebastian Ehlert, and Jan-Michael Mewes 
+   J. Chem. Phys. 154, 064103 (2021). DOI: 10.1063/5.0040021
+
+----- AuxJ basis set information -----
+Your calculation utilizes the basis: def2-mTZVPP/J
+   Stefan Grimme, Andreas Hansen, Sebastian Ehlert, and Jan-Michael Mewes 
+   J. Chem. Phys. 154, 000000 (2021). DOI: 10.1063/5.0040021
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Using LibXC functional ID 497 : Re-regularized SCAN exchange by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 498 : Re-regularized SCAN correlation by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 497 : Re-regularized SCAN exchange by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 498 : Re-regularized SCAN correlation by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> ! r2SCAN-3c Opt TightSCF
+|  2> %maxcore 9800
+|  3> %pal nprocs 30 end
+|  4> * xyzfile 0 1 geom.xyz
+|  5> 
+|  6>                          ****END OF INPUT****
+================================================================================
+
+                       *****************************
+                       * Geometry Optimization Run *
+                       *****************************
+
+Geometry optimization settings:
+Update method            Update   .... BFGS
+Choice of coordinates    CoordSys .... (2022) Redundant Internals
+Initial Hessian          InHess   .... Almloef's Model
+Max. no of cycles        MaxIter  .... 50
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+Strict Convergence                .... False
+
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in redundant internal coordinates (2022)
+Making redundant internal coordinates   ...  (2022 redundants) done
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....   22
+The number of degrees of freedom        ....   30
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(C   1,O   0)                  1.4016         0.536161   
+      2. B(C   2,C   1)                  1.5023         0.413625   
+      3. B(N   3,C   2)                  1.3059         0.762264   
+      4. B(O   4,N   3)                  1.3747         0.530148   
+      5. B(C   5,O   4)                  1.3381         0.677169   
+      6. B(C   6,C   5)                  1.3529         0.715991   
+      7. B(C   6,C   2)                  1.4253         0.548714   
+      8. B(H   7,N   3)                  2.2607         0.004374   
+      9. B(H   7,O   0)                  0.9672         0.506404   
+     10. B(H   8,C   1)                  1.0956         0.352781   
+     11. B(H   9,C   1)                  1.1025         0.343879   
+     12. B(H  10,C   5)                  1.0809         0.372366   
+     13. B(H  11,C   6)                  1.0813         0.371786   
+     14. A(C   1,O   0,H   7)          107.9876         0.359401   
+     15. A(O   0,C   1,C   2)          113.4851         0.391166   
+     16. A(C   2,C   1,H   9)          107.7276         0.327307   
+     17. A(C   2,C   1,H   8)          109.1865         0.328689   
+     18. A(O   0,C   1,H   9)          111.6828         0.339642   
+     19. A(H   8,C   1,H   9)          107.0122         0.287819   
+     20. A(O   0,C   1,H   8)          107.5389         0.341096   
+     21. A(N   3,C   2,C   6)          111.4732         0.437829   
+     22. A(C   1,C   2,C   6)          128.6497         0.395273   
+     23. A(C   1,C   2,N   3)          119.8132         0.416214   
+     24. A(C   2,N   3,O   4)          106.2614         0.429393   
+     25. A(N   3,O   4,C   5)          108.8231         0.420394   
+     26. A(O   4,C   5,H  10)          115.7424         0.358047   
+     27. A(O   4,C   5,C   6)          110.6142         0.449689   
+     28. A(C   6,C   5,H  10)          133.6433         0.363724   
+     29. A(C   5,C   6,H  11)          128.6085         0.363627   
+     30. A(C   2,C   6,H  11)          128.5631         0.347575   
+     31. A(C   2,C   6,C   5)          102.8277         0.435773   
+     32. D(H   9,C   1,O   0,H   7)    -90.0199         0.022853   
+     33. D(C   2,C   1,O   0,H   7)     31.9877         0.022853   
+     34. D(H   8,C   1,O   0,H   7)    152.8596         0.022853   
+     35. D(N   3,C   2,C   1,H   9)    112.0034         0.012663   
+     36. D(N   3,C   2,C   1,O   0)    -12.1782         0.012663   
+     37. D(C   6,C   2,C   1,O   0)    170.9922         0.012663   
+     38. D(C   6,C   2,C   1,H   8)     51.0522         0.012663   
+     39. D(N   3,C   2,C   1,H   8)   -132.1181         0.012663   
+     40. D(O   4,N   3,C   2,C   1)   -177.4883         0.048973   
+     41. D(O   4,N   3,C   2,C   6)     -0.1485         0.048973   
+     42. D(C   5,O   4,N   3,C   2)      0.0686         0.023667   
+     43. D(H  10,C   5,O   4,N   3)   -179.9308         0.034129   
+     44. D(C   6,C   5,O   4,N   3)      0.0403         0.034129   
+     45. D(C   5,C   6,C   2,N   3)      0.1693         0.020594   
+     46. D(C   5,C   6,C   2,C   1)    177.2135         0.020594   
+     47. D(H  11,C   6,C   5,H  10)      0.1244         0.036247   
+     48. D(H  11,C   6,C   5,O   4)   -179.8397         0.036247   
+     49. D(C   2,C   6,C   5,H  10)    179.8427         0.036247   
+     50. D(C   2,C   6,C   5,O   4)     -0.1215         0.036247   
+     51. D(H  11,C   6,C   2,N   3)    179.8877         0.020594   
+     52. D(H  11,C   6,C   2,C   1)     -3.0681         0.020594   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 12
+Number of degrees of freedom            .... 52
+
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   1            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.395228    0.684671   -0.299258
+  C     -1.519928   -0.341179    0.082965
+  C     -0.071100    0.048560    0.006529
+  N      0.273780    1.148830   -0.606456
+  O      1.646680    1.201571   -0.559433
+  C      2.098429    0.119960    0.085951
+  C      1.068943   -0.665751    0.477350
+  H     -1.955213    1.215476   -0.977556
+  H     -1.764714   -0.616735    1.114694
+  H     -1.657471   -1.244830   -0.533562
+  H      3.172080    0.048803    0.188507
+  H      1.102033   -1.601569    1.018066
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.526324    1.293840   -0.565517
+   1 C     6.0000    0    12.011   -2.872247   -0.644735    0.156780
+   2 C     6.0000    0    12.011   -0.134360    0.091765    0.012339
+   3 N     7.0000    0    14.007    0.517370    2.170974   -1.146035
+   4 O     8.0000    0    15.999    3.111773    2.270640   -1.057176
+   5 C     6.0000    0    12.011    3.965456    0.226691    0.162423
+   6 C     6.0000    0    12.011    2.020010   -1.258086    0.902061
+   7 H     1.0000    0     1.008   -3.694818    2.296917   -1.847312
+   8 H     1.0000    0     1.008   -3.334827   -1.165460    2.106466
+   9 H     1.0000    0     1.008   -3.132165   -2.352388   -1.008287
+  10 H     1.0000    0     1.008    5.994362    0.092224    0.356227
+  11 H     1.0000    0     1.008    2.082541   -3.026526    1.923866
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.401646054604     0.00000000     0.00000000
+ C      2   1   0     1.502277930273   113.48513828     0.00000000
+ N      3   2   1     1.305866432147   119.81324858   347.82178838
+ O      4   3   2     1.374716176382   106.26144275   182.51174683
+ C      5   4   3     1.338088525173   108.82314381     0.06863269
+ C      6   5   4     1.352913641848   110.61424602     0.04034923
+ H      1   2   3     0.967188908037   107.98763851    31.98770577
+ H      2   1   3     1.095589972985   107.53894261   120.87187829
+ H      2   1   3     1.102546449325   111.68278606   237.99240944
+ H      6   5   4     1.080882332732   115.74243121   180.06916430
+ H      7   6   5     1.081306548703   128.60849852   180.16029170
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.648727179892     0.00000000     0.00000000
+ C      2   1   0     2.838893865250   113.48513828     0.00000000
+ N      3   2   1     2.467729924239   119.81324858   347.82178838
+ O      4   3   2     2.597837085233   106.26144275   182.51174683
+ C      5   4   3     2.528620855520   108.82314381     0.06863269
+ C      6   5   4     2.556636265939   110.61424602     0.04034923
+ H      1   2   3     1.827722155956   107.98763851    31.98770577
+ H      2   1   3     2.070365004013   107.53894261   120.87187829
+ H      2   1   3     2.083510839151   111.68278606   237.99240944
+ H      6   5   4     2.042571591858   115.74243121   180.06916430
+ H      7   6   5     2.043373243865   128.60849852   180.16029170
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   2 Type C   : 11s6p1d contracted to 5s3p1d pattern {62111/411/1}
+ Group   3 Type N   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   4 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   2 Type C   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   3 Type N   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   4 Type H   : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3075
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8267
+          la=0 lb=0:    921 shell pairs
+          la=1 lb=0:   1084 shell pairs
+          la=1 lb=1:    339 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    292.948676364878 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.141e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.005 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59178
+Total number of batches                      ...      930
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.3 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+  Functional kind                       .... Exchange
+  Functional name                       .... Re-regularized SCAN exchange by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 6
+    Parameter  0 _c1        =  6.670000e-01 : c1 parameter        
+    Parameter  1 _c2        =  8.000000e-01 : c2 parameter        
+    Parameter  2 _d         =  1.240000e+00 : d parameter         
+    Parameter  3 _k1        =  6.500000e-02 : k1 parameter        
+    Parameter  4 _eta       =  1.000000e-03 : eta parameter       
+    Parameter  5 _dp2       =  3.610000e-01 : dp2 parameter       
+  Functional kind                       .... Correlation
+  Functional name                       .... Re-regularized SCAN correlation by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 1
+    Parameter  0 _eta       =  1.000000e-03 : Regularization parameter
+ Gradients option       PostSCFGGA      .... off
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 265
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   52
+ Basis Dimension        Dim             ....  173
+ Nuclear Repulsion      ENuc            ....    292.9486763649 Eh
+
+Convergence Acceleration:
+ AO-DIIS                CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ MO-DIIS                CNVKDIIS        .... off
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....    50
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    24
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold    (grad. norm)   ....   1.000e-05
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   1.000e-02
+   NR start threshold (gradient norm)   ....   1.000e-04
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Quad. conv. algorithm                .... NR
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Pseudo random numbers                .... off
+   Inactive MOs                         .... canonical
+   Orbital update algorithm             .... Taylor
+   Preconditioner                       .... Diag
+   Full preconditioner red. dimension   ....   250
+   COSX micro iterations for RIJONX calc.... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+   Hessian update       SOSCFHessUp     .... L-BFGS
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Making the grid                                    ... done (   0.1 sec)
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+  promolecular density results
+     # of electrons  =     51.997427260
+     EX              =    -44.777806311
+     EC              =     -1.747990596
+     EX+EC           =    -46.525796907
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.6 sec
+Maximum memory used throughout the entire GUESS-calculation: 8.7 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+-------------------------------------------------------------------------------------------
+                                      ORCA LEAN-SCF
+                              memory conserving SCF solver
+-------------------------------------------------------------------------------------------
+
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -360.3791915020693182     0.00e+00  2.29e-03  4.25e-02  2.38e-01  0.700   0.1
+    2    -360.4409319704859058    -6.17e-02  1.67e-03  2.33e-02  9.26e-02  0.700   0.1
+                               ***Turning on AO-DIIS***
+    3    -360.4643195805953724    -2.34e-02  6.90e-04  1.00e-02  2.95e-02  0.700   0.1
+    4    -360.4788244647159559    -1.45e-02  1.30e-03  2.08e-02  1.46e-02  0.000   0.1
+    5    -360.5109344473849546    -3.21e-02  2.86e-04  5.11e-03  5.57e-03  0.000   0.1
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    6    -360.5110795135564672    -1.45e-04  1.05e-04  1.75e-03  1.27e-03     0.1
+               *** Restarting incremental Fock matrix formation ***
+    7    -360.5110897755789097    -1.03e-05  7.38e-05  1.07e-03  2.25e-04     0.1
+    8    -360.5110838178479185     5.96e-06  3.11e-05  5.18e-04  6.66e-04     0.1
+    9    -360.5110924623780306    -8.64e-06  1.67e-05  3.43e-04  1.15e-04     0.1
+   10    -360.5110916726303572     7.90e-07  1.06e-05  2.37e-04  2.06e-04     0.1
+   11    -360.5110926733950123    -1.00e-06  2.10e-06  3.82e-05  1.99e-05     0.1
+   12    -360.5110926622740521     1.11e-08  1.28e-06  2.95e-05  4.39e-05     0.1
+   13    -360.5110926766280386    -1.44e-08  4.63e-07  6.81e-06  1.98e-06     0.1
+                  *** Gradient check signals convergence ***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  13 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51109267662804 Eh           -9810.00556 eV
+
+Components:
+Nuclear Repulsion  :        292.94867636487760 Eh            7971.53875 eV
+Electronic Energy  :       -653.45976904150564 Eh          -17781.54431 eV
+One Electron Energy:      -1070.69220410476601 Eh          -29135.01607 eV
+Two Electron Energy:        417.23243506326037 Eh           11353.47176 eV
+
+Virial components:
+Potential Energy   :       -719.64763631154847 Eh          -19582.60774 eV
+Kinetic Energy     :        359.13654363492037 Eh            9772.60218 eV
+Virial Ratio       :          2.00382737169489
+
+DFT components:
+N(Alpha)           :       26.000022807016 electrons
+N(Beta)            :       26.000022807016 electrons
+N(Total)           :       52.000045614032 electrons
+E(X)               :      -45.779495933630 Eh       
+E(C)               :       -1.718007778258 Eh       
+E(XC)              :      -47.497503711888 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    1.4354e-08  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    6.8131e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    4.6293e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.2718e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.9820e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    5.8969e-06  Tolerance :   1.0000e-05
+
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -19.055391      -518.5236 
+   1   2.0000     -18.955373      -515.8019 
+   2   2.0000     -14.213298      -386.7635 
+   3   2.0000     -10.112358      -275.1712 
+   4   2.0000     -10.100287      -274.8428 
+   5   2.0000     -10.085200      -274.4322 
+   6   2.0000     -10.057192      -273.6701 
+   7   2.0000      -1.129851       -30.7448 
+   8   2.0000      -0.998129       -27.1605 
+   9   2.0000      -0.851400       -23.1678 
+  10   2.0000      -0.778745       -21.1907 
+  11   2.0000      -0.683523       -18.5996 
+  12   2.0000      -0.608226       -16.5507 
+  13   2.0000      -0.556117       -15.1327 
+  14   2.0000      -0.522108       -14.2073 
+  15   2.0000      -0.470086       -12.7917 
+  16   2.0000      -0.454741       -12.3741 
+  17   2.0000      -0.430719       -11.7205 
+  18   2.0000      -0.416154       -11.3241 
+  19   2.0000      -0.410976       -11.1832 
+  20   2.0000      -0.369489       -10.0543 
+  21   2.0000      -0.320005        -8.7078 
+  22   2.0000      -0.289548        -7.8790 
+  23   2.0000      -0.280325        -7.6280 
+  24   2.0000      -0.259509        -7.0616 
+  25   2.0000      -0.245318        -6.6755 
+  26   0.0000      -0.049920        -1.3584 
+  27   0.0000       0.014150         0.3850 
+  28   0.0000       0.047629         1.2960 
+  29   0.0000       0.076519         2.0822 
+  30   0.0000       0.087198         2.3728 
+  31   0.0000       0.105725         2.8769 
+  32   0.0000       0.119882         3.2621 
+  33   0.0000       0.136906         3.7254 
+  34   0.0000       0.146507         3.9867 
+  35   0.0000       0.158207         4.3050 
+  36   0.0000       0.176235         4.7956 
+*Only the first 10 virtual orbitals were printed.
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.413407
+   1 C :   -0.254060
+   2 C :    0.293973
+   3 N :   -0.344057
+   4 O :    0.056483
+   5 C :   -0.047692
+   6 C :   -0.223547
+   7 H :    0.325069
+   8 H :    0.144736
+   9 H :    0.142715
+  10 H :    0.155389
+  11 H :    0.164397
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.759547  s :     3.759547
+      pz      :     1.609290  p :     4.641678
+      px      :     1.598090
+      py      :     1.434299
+      dz2     :     0.004169  d :     0.012182
+      dxz     :     0.003776
+      dyz     :    -0.001876
+      dx2y2   :     0.001793
+      dxy     :     0.004320
+
+  1 C s       :     3.328161  s :     3.328161
+      pz      :     1.066133  p :     2.862357
+      px      :     0.868345
+      py      :     0.927879
+      dz2     :     0.011200  d :     0.063542
+      dxz     :     0.007633
+      dyz     :     0.011933
+      dx2y2   :     0.019231
+      dxy     :     0.013546
+
+  2 C s       :     3.123224  s :     3.123224
+      pz      :     0.901960  p :     2.518915
+      px      :     0.782713
+      py      :     0.834243
+      dz2     :     0.009318  d :     0.063887
+      dxz     :     0.010543
+      dyz     :     0.010139
+      dx2y2   :     0.017895
+      dxy     :     0.015992
+
+  3 N s       :     3.719616  s :     3.719616
+      pz      :     1.282079  p :     3.520799
+      px      :     0.917919
+      py      :     1.320801
+      dz2     :     0.015671  d :     0.103641
+      dxz     :     0.027102
+      dyz     :     0.012412
+      dx2y2   :     0.025792
+      dxy     :     0.022664
+
+  4 O s       :     3.730190  s :     3.730190
+      pz      :     1.577499  p :     4.144252
+      px      :     1.097695
+      py      :     1.469059
+      dz2     :     0.008971  d :     0.069075
+      dxz     :     0.024165
+      dyz     :     0.005675
+      dx2y2   :     0.013894
+      dxy     :     0.016369
+
+  5 C s       :     3.280711  s :     3.280711
+      pz      :     0.911642  p :     2.705762
+      px      :     0.987660
+      py      :     0.806460
+      dz2     :     0.009680  d :     0.061218
+      dxz     :     0.007583
+      dyz     :     0.011433
+      dx2y2   :     0.018339
+      dxy     :     0.014183
+
+  6 C s       :     3.152075  s :     3.152075
+      pz      :     1.082102  p :     3.034475
+      px      :     0.931875
+      py      :     1.020498
+      dz2     :     0.003855  d :     0.036997
+      dxz     :     0.007647
+      dyz     :     0.005291
+      dx2y2   :     0.007904
+      dxy     :     0.012300
+
+  7 H s       :     0.630759  s :     0.630759
+      pz      :     0.017545  p :     0.044173
+      px      :     0.012590
+      py      :     0.014037
+
+  8 H s       :     0.837979  s :     0.837979
+      pz      :     0.010607  p :     0.017285
+      px      :     0.003289
+      py      :     0.003389
+
+  9 H s       :     0.840177  s :     0.840177
+      pz      :     0.005632  p :     0.017108
+      px      :     0.003026
+      py      :     0.008450
+
+ 10 H s       :     0.824636  s :     0.824636
+      pz      :     0.003916  p :     0.019975
+      px      :     0.013171
+      py      :     0.002888
+
+ 11 H s       :     0.815351  s :     0.815351
+      pz      :     0.006587  p :     0.020252
+      px      :     0.003175
+      py      :     0.010490
+
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.569953
+   1 C :    0.055992
+   2 C :    0.171676
+   3 N :   -0.359923
+   4 O :   -0.362705
+   5 C :    0.186262
+   6 C :   -0.145034
+   7 H :    0.281200
+   8 H :    0.185714
+   9 H :    0.173026
+  10 H :    0.199459
+  11 H :    0.184285
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.512279  s :     3.512279
+      pz      :     1.649966  p :     4.794176
+      px      :     1.627131
+      py      :     1.517079
+      dz2     :     0.038220  d :     0.263498
+      dxz     :     0.034316
+      dyz     :     0.060471
+      dx2y2   :     0.066725
+      dxy     :     0.063766
+
+  1 C s       :     2.848895  s :     2.848895
+      pz      :     1.068505  p :     2.958532
+      px      :     0.931986
+      py      :     0.958041
+      dz2     :     0.025959  d :     0.136582
+      dxz     :     0.013676
+      dyz     :     0.026429
+      dx2y2   :     0.041662
+      dxy     :     0.028855
+
+  2 C s       :     2.798509  s :     2.798509
+      pz      :     0.903122  p :     2.901003
+      px      :     1.016100
+      py      :     0.981780
+      dz2     :     0.016421  d :     0.128812
+      dxz     :     0.019036
+      dyz     :     0.022338
+      dx2y2   :     0.035995
+      dxy     :     0.035023
+
+  3 N s       :     3.221123  s :     3.221123
+      pz      :     1.241435  p :     3.555750
+      px      :     0.978863
+      py      :     1.335451
+      dz2     :     0.073294  d :     0.583050
+      dxz     :     0.123217
+      dyz     :     0.069121
+      dx2y2   :     0.167569
+      dxy     :     0.149849
+
+  4 O s       :     3.392160  s :     3.392160
+      pz      :     1.548107  p :     4.393309
+      px      :     1.323812
+      py      :     1.521389
+      dz2     :     0.074403  d :     0.577236
+      dxz     :     0.134934
+      dyz     :     0.065320
+      dx2y2   :     0.141240
+      dxy     :     0.161339
+
+  5 C s       :     2.840742  s :     2.840742
+      pz      :     0.894174  p :     2.840716
+      px      :     1.055766
+      py      :     0.890776
+      dz2     :     0.018501  d :     0.132280
+      dxz     :     0.014507
+      dyz     :     0.026995
+      dx2y2   :     0.039589
+      dxy     :     0.032689
+
+  6 C s       :     2.897719  s :     2.897719
+      pz      :     1.062577  p :     3.171248
+      px      :     1.036804
+      py      :     1.071867
+      dz2     :     0.006037  d :     0.076067
+      dxz     :     0.015686
+      dyz     :     0.009026
+      dx2y2   :     0.018299
+      dxy     :     0.027019
+
+  7 H s       :     0.594890  s :     0.594890
+      pz      :     0.050689  p :     0.123910
+      px      :     0.035380
+      py      :     0.037841
+
+  8 H s       :     0.774840  s :     0.774840
+      pz      :     0.025123  p :     0.039446
+      px      :     0.007399
+      py      :     0.006924
+
+  9 H s       :     0.786809  s :     0.786809
+      pz      :     0.013844  p :     0.040165
+      px      :     0.006796
+      py      :     0.019525
+
+ 10 H s       :     0.757423  s :     0.757423
+      pz      :     0.008020  p :     0.043118
+      px      :     0.029221
+      py      :     0.005877
+
+ 11 H s       :     0.768953  s :     0.768953
+      pz      :     0.015142  p :     0.046761
+      px      :     0.006955
+      py      :     0.024663
+
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.4134     8.0000    -0.4134     1.8599     1.8599    -0.0000
+  1 C      6.2541     6.0000    -0.2541     3.9380     3.9380    -0.0000
+  2 C      5.7060     6.0000     0.2940     3.6883     3.6883    -0.0000
+  3 N      7.3441     7.0000    -0.3441     2.8446     2.8446    -0.0000
+  4 O      7.9435     8.0000     0.0565     2.2403     2.2403     0.0000
+  5 C      6.0477     6.0000    -0.0477     3.8339     3.8339    -0.0000
+  6 C      6.2235     6.0000    -0.2235     3.7431     3.7431    -0.0000
+  7 H      0.6749     1.0000     0.3251     0.9034     0.9034    -0.0000
+  8 H      0.8553     1.0000     0.1447     0.9499     0.9499    -0.0000
+  9 H      0.8573     1.0000     0.1427     0.9474     0.9474    -0.0000
+ 10 H      0.8446     1.0000     0.1554     0.9713     0.9713    -0.0000
+ 11 H      0.8356     1.0000     0.1644     0.9700     0.9700    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-C ) :   1.0172 B(  0-O ,  7-H ) :   0.8654 B(  1-C ,  2-C ) :   0.9148 
+B(  1-C ,  8-H ) :   0.9571 B(  1-C ,  9-H ) :   0.9603 B(  2-C ,  3-N ) :   1.5638 
+B(  2-C ,  6-C ) :   1.2059 B(  3-N ,  4-O ) :   1.0132 B(  3-N ,  5-C ) :   0.1232 
+B(  4-O ,  5-C ) :   1.1215 B(  5-C ,  6-C ) :   1.6026 B(  5-C , 10-H ) :   0.9632 
+B(  6-C , 11-H ) :   0.9240 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+
+Total time                  ....       1.401 sec
+Sum of individual times     ....       1.379 sec  ( 98.5%)
+
+SCF preparation             ....       0.318 sec  ( 22.7%)
+Fock matrix formation       ....       0.792 sec  ( 56.6%)
+  Startup                   ....       0.014 sec  (  1.8% of F)
+  Split-RI-J                ....       0.142 sec  ( 18.0% of F)
+  XC integration            ....       0.579 sec  ( 73.1% of F)
+    XC Preparation          ....       0.000 sec  (  0.0% of XC)
+    Basis function eval.    ....       0.065 sec  ( 11.2% of XC)
+    Density eval.           ....       0.107 sec  ( 18.4% of XC)
+    XC-Functional eval.     ....       0.040 sec  (  6.9% of XC)
+    XC-Potential eval.      ....       0.124 sec  ( 21.4% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.047 sec  (  3.4%)
+Total Energy calculation    ....       0.024 sec  (  1.7%)
+Population analysis         ....       0.013 sec  (  1.0%)
+Orbital Transformation      ....       0.019 sec  (  1.3%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.105 sec  (  7.5%)
+SOSCF solution              ....       0.060 sec  (  4.3%)
+Finished LeanSCF after   1.4 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.1 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+The R2SCAN3C composite method is recognized
+Using three-body term ABC
+Active option DFTDOPT                   ...         5   
+
+-------------------------   ----------------
+Dispersion correction           -0.003074526
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009882306
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504284896131
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000059276    0.000018168   -0.000018831
+   2   C   :   -0.000048599   -0.000018203    0.000003384
+   3   C   :    0.000015262    0.000002466   -0.000000340
+   4   N   :    0.000020247    0.000021895   -0.000011138
+   5   O   :    0.000045059    0.000023243   -0.000010221
+   6   C   :    0.000039518    0.000006139   -0.000000410
+   7   C   :    0.000039737   -0.000017784    0.000012866
+   8   H   :   -0.000035148    0.000001631    0.000004209
+   9   H   :   -0.000031230   -0.000004646    0.000008363
+  10   H   :   -0.000030912   -0.000009981   -0.000004385
+  11   H   :    0.000027465    0.000000845    0.000001276
+  12   H   :    0.000017878   -0.000023772    0.000015226
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000   -0.0000000000    0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001405740
+RMS gradient                       ...    0.0000234290
+MAX gradient                       ...    0.0000592762
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.004264584   -0.005472186    0.003409429
+   2   C   :   -0.005668889    0.001687317   -0.001780329
+   3   C   :    0.003799266    0.007357905   -0.003637573
+   4   N   :    0.010173290   -0.004061039    0.002920600
+   5   O   :   -0.009751628   -0.006448446    0.003333837
+   6   C   :   -0.007044106    0.005199081   -0.003275074
+   7   C   :    0.003341560    0.000407167   -0.000020498
+   8   H   :    0.000895303    0.000309722   -0.000963578
+   9   H   :    0.000050080    0.000945207   -0.001411772
+  10   H   :    0.000364994    0.001564112    0.000861229
+  11   H   :   -0.000115236   -0.000012176   -0.000304902
+  12   H   :   -0.000309219   -0.001476664    0.000868631
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000387581    0.0001357033    0.0001335436
+
+Norm of the Cartesian gradient     ...    0.0237887444
+RMS gradient                       ...    0.0039647907
+MAX gradient                       ...    0.0101732904
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.194 sec
+
+Densities                   ....       0.001 sec  (  0.3%)
+One electron gradient       ....       0.008 sec  (  4.4%)
+RI-J Coulomb gradient       ....       0.068 sec  ( 35.2%)
+XC gradient                 ....       0.089 sec  ( 45.9%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504284896 Eh
+Current gradient norm                   ....     0.023788744 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Evaluating the initial hessian          ....  (Almloef) done
+Projecting the Hessian                  .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.998896814
+Lowest eigenvalues of augmented Hessian:
+ -0.000640235  0.012643166  0.016618040  0.021254470  0.027280902
+Length of the computed step             ....  0.047010948
+The final length of the internal step   ....  0.047010948
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0065192456
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0105747119 RMS(Int)=    0.0065302684
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          RMS gradient        0.0025416945            0.0001000000      NO
+          MAX gradient        0.0120188992            0.0003000000      NO
+          RMS step            0.0065192456            0.0020000000      NO
+          MAX step            0.0235818632            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0125      Max(Angles)    0.49
+          Max(Dihed)        0.61      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4016 -0.007115  0.0075    1.4091   
+     2. B(C   2,C   1)                1.5023  0.001097 -0.0006    1.5017   
+     3. B(N   3,C   2)                1.3059 -0.005834  0.0042    1.3100   
+     4. B(O   4,N   3)                1.3747 -0.012019  0.0122    1.3869   
+     5. B(C   5,O   4)                1.3381 -0.006926  0.0055    1.3435   
+     6. B(C   6,C   5)                1.3529 -0.003929  0.0028    1.3557   
+     7. B(C   6,C   2)                1.4253 -0.000533  0.0004    1.4257   
+     8. B(H   7,N   3)                2.2607 -0.000806  0.0125    2.2731   
+     9. B(H   7,O   0)                0.9672  0.001003 -0.0013    0.9659   
+    10. B(H   8,C   1)                1.0956 -0.001581  0.0024    1.0980   
+    11. B(H   9,C   1)                1.1025 -0.001810  0.0028    1.1053   
+    12. B(H  10,C   5)                1.0809 -0.000142  0.0002    1.0811   
+    13. B(H  11,C   6)                1.0813  0.001705 -0.0024    1.0789   
+    14. A(C   1,O   0,H   7)          107.99  0.000328    0.11    108.10   
+    15. A(O   0,C   1,C   2)          113.49  0.000379    0.24    113.72   
+    16. A(C   2,C   1,H   9)          107.73 -0.000034   -0.07    107.66   
+    17. A(C   2,C   1,H   8)          109.19 -0.000064   -0.05    109.13   
+    18. A(O   0,C   1,H   9)          111.68  0.000004   -0.08    111.60   
+    19. A(H   8,C   1,H   9)          107.01  0.000255   -0.14    106.87   
+    20. A(O   0,C   1,H   8)          107.54 -0.000543    0.08    107.62   
+    21. A(N   3,C   2,C   6)          111.47  0.000167   -0.10    111.37   
+    22. A(C   1,C   2,C   6)          128.65 -0.001046    0.07    128.72   
+    23. A(C   1,C   2,N   3)          119.81  0.000877    0.04    119.85   
+    24. A(C   2,N   3,O   4)          106.26  0.000632   -0.03    106.23   
+    25. A(N   3,O   4,C   5)          108.82  0.001960   -0.21    108.61   
+    26. A(O   4,C   5,H  10)          115.74 -0.000660    0.10    115.84   
+    27. A(O   4,C   5,C   6)          110.61  0.001073   -0.16    110.46   
+    28. A(C   6,C   5,H  10)          133.64 -0.000413    0.06    133.70   
+    29. A(C   5,C   6,H  11)          128.61  0.002288   -0.30    128.31   
+    30. A(C   2,C   6,H  11)          128.56  0.001544   -0.19    128.37   
+    31. A(C   2,C   6,C   5)          102.83 -0.003831    0.49    103.32   
+    32. D(H   9,C   1,O   0,H   7)    -90.02  0.000230   -0.37    -90.39   
+    33. D(C   2,C   1,O   0,H   7)     31.99  0.000469   -0.35     31.64   
+    34. D(H   8,C   1,O   0,H   7)    152.86  0.000249   -0.20    152.65   
+    35. D(N   3,C   2,C   1,H   9)    112.00  0.000070   -0.20    111.80   
+    36. D(N   3,C   2,C   1,O   0)    -12.18 -0.000168   -0.21    -12.39   
+    37. D(C   6,C   2,C   1,O   0)    170.99 -0.000114   -0.39    170.61   
+    38. D(C   6,C   2,C   1,H   8)     51.05  0.000373   -0.61     50.44   
+    39. D(N   3,C   2,C   1,H   8)   -132.12  0.000320   -0.43   -132.55   
+    40. D(O   4,N   3,C   2,C   1)   -177.49  0.000122   -0.19   -177.68   
+    41. D(O   4,N   3,C   2,C   6)     -0.15  0.000034   -0.04     -0.18   
+    42. D(C   5,O   4,N   3,C   2)      0.07  0.000047   -0.10     -0.04   
+    43. D(H  10,C   5,O   4,N   3)   -179.93 -0.000160    0.28   -179.65   
+    44. D(C   6,C   5,O   4,N   3)      0.04 -0.000112    0.21      0.25   
+    45. D(C   5,C   6,C   2,N   3)      0.17 -0.000105    0.16      0.33   
+    46. D(C   5,C   6,C   2,C   1)    177.21 -0.000132    0.32    177.54   
+    47. D(H  11,C   6,C   5,H  10)      0.12  0.000069   -0.08      0.04   
+    48. D(H  11,C   6,C   5,O   4)   -179.84  0.000008    0.00   -179.84   
+    49. D(C   2,C   6,C   5,H  10)    179.84  0.000191   -0.31    179.54   
+    50. D(C   2,C   6,C   5,O   4)     -0.12  0.000130   -0.22     -0.34   
+    51. D(H  11,C   6,C   2,N   3)    179.89  0.000020   -0.07    179.82   
+    52. D(H  11,C   6,C   2,C   1)     -3.07 -0.000008    0.10     -2.97   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (10.365 %)
+Internal coordinates            :      0.000 s ( 2.163 %)
+B/P matrices and projection     :      0.000 s (20.433 %)
+Hessian update/contruction      :      0.000 s (11.484 %)
+Making the step                 :      0.000 s (17.226 %)
+Converting the step to Cartesian:      0.000 s ( 3.952 %)
+Storing new data                :      0.000 s ( 1.864 %)
+Checking convergence            :      0.000 s ( 0.149 %)
+Final printing                  :      0.000 s (32.066 %)
+Total time                      :      0.001 s
+
+Time for energy+gradient        :      5.136 s
+Time for complete geometry iter :      5.925 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   2            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.405691    0.686408   -0.297295
+  C     -1.520702   -0.342259    0.082517
+  C     -0.072448    0.046660    0.002583
+  N      0.273579    1.148629   -0.615567
+  O      1.658569    1.202360   -0.566173
+  C      2.106697    0.118209    0.088747
+  C      1.069308   -0.664086    0.475709
+  H     -1.970186    1.222953   -0.972164
+  H     -1.761404   -0.622995    1.116325
+  H     -1.659452   -1.247561   -0.536291
+  H      3.179516    0.045161    0.200403
+  H      1.100507   -1.595670    1.019003
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.546097    1.297122   -0.561807
+   1 C     6.0000    0    12.011   -2.873711   -0.646776    0.155935
+   2 C     6.0000    0    12.011   -0.136907    0.088175    0.004882
+   3 N     7.0000    0    14.007    0.516988    2.170594   -1.163252
+   4 O     8.0000    0    15.999    3.134240    2.272131   -1.069913
+   5 C     6.0000    0    12.011    3.981081    0.223382    0.167707
+   6 C     6.0000    0    12.011    2.020699   -1.254940    0.898960
+   7 H     1.0000    0     1.008   -3.723113    2.311046   -1.837124
+   8 H     1.0000    0     1.008   -3.328571   -1.177290    2.109548
+   9 H     1.0000    0     1.008   -3.135910   -2.357549   -1.013443
+  10 H     1.0000    0     1.008    6.008414    0.085343    0.378706
+  11 H     1.0000    0     1.008    2.079656   -3.015380    1.925636
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.409119576996     0.00000000     0.00000000
+ C      2   1   0     1.501695102215   113.72105677     0.00000000
+ N      3   2   1     1.310030184048   119.84842370   347.61250516
+ O      4   3   2     1.386911787129   106.23360003   182.32493104
+ C      5   4   3     1.343548994233   108.61317289   359.96410032
+ C      6   5   4     1.355692507463   110.45936233     0.25178821
+ H      1   2   3     0.965915728100   108.09884985    31.64212758
+ H      2   1   3     1.097956486226   107.62356339   121.01273800
+ H      2   1   3     1.105326453349   111.60252259   237.96700538
+ H      6   5   4     1.081083891910   115.83999168   180.35019476
+ H      7   6   5     1.078884133849   128.30657551   180.16381570
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.662850090469     0.00000000     0.00000000
+ C      2   1   0     2.837792479837   113.72105677     0.00000000
+ N      3   2   1     2.475598275021   119.84842370   347.61250516
+ O      4   3   2     2.620883449580   106.23360003   182.32493104
+ C      5   4   3     2.538939646606   108.61317289   359.96410032
+ C      6   5   4     2.561887560914   110.45936233     0.25178821
+ H      1   2   3     1.825316194556   108.09884985    31.64212758
+ H      2   1   3     2.074837065930   107.62356339   121.01273800
+ H      2   1   3     2.088764285408   111.60252259   237.96700538
+ H      6   5   4     2.042952483504   115.83999168   180.35019476
+ H      7   6   5     2.038795543207   128.30657551   180.16381570
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3072
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8261
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1084 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    292.000727055229 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.154e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59187
+Total number of batches                      ...      930
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -360.5112608081105918     0.00e+00  6.10e-05  9.36e-04  5.12e-03  0.700   0.1
+    2    -360.5113184988539388    -5.77e-05  5.43e-05  8.76e-04  3.58e-03  0.700   0.1
+                               ***Turning on AO-DIIS***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    3    -360.5113602918914921    -4.18e-05  1.44e-04  2.46e-03  2.44e-03     0.1
+               *** Restarting incremental Fock matrix formation ***
+    4    -360.5114552814064837    -9.50e-05  5.62e-05  1.19e-03  4.81e-04     0.1
+    5    -360.5114393730551683     1.59e-05  3.96e-05  8.68e-04  1.47e-03     0.1
+    6    -360.5114581014587429    -1.87e-05  1.00e-05  1.30e-04  3.21e-05     0.1
+    7    -360.5114580426187558     5.88e-08  5.67e-06  7.45e-05  5.97e-05     0.1
+    8    -360.5114581872551298    -1.45e-07  1.57e-06  2.85e-05  1.18e-05     0.1
+    9    -360.5114581810599930     6.20e-09  1.01e-06  2.04e-05  2.54e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   9 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51145818105999 Eh           -9810.01551 eV
+
+Components:
+Nuclear Repulsion  :        292.00072705522905 Eh            7945.74374 eV
+Electronic Energy  :       -652.51218523628904 Eh          -17755.75925 eV
+One Electron Energy:      -1068.82865116620860 Eh          -29084.30622 eV
+Two Electron Energy:        416.31646592991962 Eh           11328.54697 eV
+
+Virial components:
+Potential Energy   :       -719.57446993181509 Eh          -19580.61679 eV
+Kinetic Energy     :        359.06301175075509 Eh            9770.60128 eV
+Virial Ratio       :          2.00403396168055
+
+DFT components:
+N(Alpha)           :       26.000022169377 electrons
+N(Beta)            :       26.000022169377 electrons
+N(Total)           :       52.000044338754 electrons
+E(X)               :      -45.761242331560 Eh       
+E(C)               :       -1.716671632140 Eh       
+E(XC)              :      -47.477913963700 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -6.1951e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.0358e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.0089e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    2.4375e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    2.5430e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    4.2715e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.3 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.003070053
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009829895
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504698339386
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000059126    0.000018053   -0.000018496
+   2   C   :   -0.000049316   -0.000018475    0.000003427
+   3   C   :    0.000007623    0.000001285   -0.000000140
+   4   N   :    0.000018281    0.000023929   -0.000012592
+   5   O   :    0.000046184    0.000024153   -0.000010824
+   6   C   :    0.000047849    0.000005080    0.000000641
+   7   C   :    0.000040013   -0.000018300    0.000013174
+   8   H   :   -0.000035036    0.000001645    0.000004132
+   9   H   :   -0.000031087   -0.000004704    0.000008233
+  10   H   :   -0.000030799   -0.000009790   -0.000004209
+  11   H   :    0.000027615    0.000000781    0.000001417
+  12   H   :    0.000017799   -0.000023658    0.000015237
+
+Difference to translation invariance:
+           :   -0.0000000000   -0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000   -0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001434311
+RMS gradient                       ...    0.0000239052
+MAX gradient                       ...    0.0000591260
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.001692919   -0.001197778    0.000732344
+   2   C   :   -0.002783562    0.001006357   -0.000674218
+   3   C   :   -0.000252158    0.002172664   -0.001020928
+   4   N   :    0.005194855   -0.001228687    0.001080373
+   5   O   :   -0.004137085   -0.001922560    0.000679509
+   6   C   :   -0.001117059    0.002677223   -0.001163249
+   7   C   :    0.001365877   -0.001544245    0.000573022
+   8   H   :   -0.000119436    0.000039968   -0.000157098
+   9   H   :    0.000022994    0.000016183    0.000113990
+  10   H   :    0.000387936   -0.000184839    0.000049131
+  11   H   :    0.000082588   -0.000004978   -0.000102884
+  12   H   :   -0.000337870    0.000170692   -0.000109992
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000535006    0.0001253288    0.0001401202
+
+Norm of the Cartesian gradient     ...    0.0092507879
+RMS gradient                       ...    0.0015417980
+MAX gradient                       ...    0.0051948551
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.185 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.009 sec  (  5.0%)
+RI-J Coulomb gradient       ....       0.060 sec  ( 32.4%)
+XC gradient                 ....       0.091 sec  ( 49.2%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504698339 Eh
+Current gradient norm                   ....     0.009250788 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999594788
+Lowest eigenvalues of augmented Hessian:
+ -0.000127594  0.012569688  0.016694469  0.021208924  0.027273322
+Length of the computed step             ....  0.028476594
+The final length of the internal step   ....  0.028476594
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0039489931
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0063284867 RMS(Int)=    0.0039499988
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000063849
+Previously predicted energy change      ....    -0.000320825
+Actually observed energy change         ....    -0.000413443
+Ratio of predicted to observed change   ....     1.288688245
+New trust radius                        ....     0.300000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0004134433            0.0000050000      NO
+          RMS gradient        0.0008770391            0.0001000000      NO
+          MAX gradient        0.0047050154            0.0003000000      NO
+          RMS step            0.0039489931            0.0020000000      NO
+          MAX step            0.0146796709            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0078      Max(Angles)    0.24
+          Max(Dihed)        0.56      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4091 -0.001941  0.0033    1.4124   
+     2. B(C   2,C   1)                1.5017  0.000914 -0.0016    1.5001   
+     3. B(N   3,C   2)                1.3100 -0.001317  0.0016    1.3117   
+     4. B(O   4,N   3)                1.3869 -0.004705  0.0078    1.3947   
+     5. B(C   5,O   4)                1.3435 -0.002165  0.0029    1.3464   
+     6. B(C   6,C   5)                1.3557  0.000185 -0.0001    1.3556   
+     7. B(C   6,C   2)                1.4257  0.000788 -0.0012    1.4245   
+     8. B(H   7,N   3)                2.2731 -0.000066  0.0007    2.2738   
+     9. B(H   7,O   0)                0.9659  0.000063 -0.0002    0.9657   
+    10. B(H   8,C   1)                1.0980  0.000096 -0.0000    1.0979   
+    11. B(H   9,C   1)                1.1053  0.000074  0.0000    1.1054   
+    12. B(H  10,C   5)                1.0811  0.000072 -0.0001    1.0810   
+    13. B(H  11,C   6)                1.0789 -0.000211  0.0003    1.0791   
+    14. A(C   1,O   0,H   7)          108.10  0.000330   -0.05    108.05   
+    15. A(O   0,C   1,C   2)          113.72 -0.000280    0.12    113.84   
+    16. A(C   2,C   1,H   9)          107.66 -0.000256    0.06    107.72   
+    17. A(C   2,C   1,H   8)          109.13 -0.000023    0.02    109.15   
+    18. A(O   0,C   1,H   9)          111.60  0.000498   -0.16    111.44   
+    19. A(H   8,C   1,H   9)          106.87 -0.000022   -0.03    106.84   
+    20. A(O   0,C   1,H   8)          107.62  0.000092   -0.02    107.61   
+    21. A(N   3,C   2,C   6)          111.37 -0.000779    0.11    111.48   
+    22. A(C   1,C   2,C   6)          128.72  0.000362   -0.06    128.66   
+    23. A(C   1,C   2,N   3)          119.85  0.000414   -0.04    119.81   
+    24. A(C   2,N   3,O   4)          106.23  0.001157   -0.19    106.04   
+    25. A(N   3,O   4,C   5)          108.61  0.000724   -0.11    108.50   
+    26. A(O   4,C   5,H  10)          115.84 -0.000127    0.04    115.88   
+    27. A(O   4,C   5,C   6)          110.46  0.000153   -0.05    110.41   
+    28. A(C   6,C   5,H  10)          133.70 -0.000026    0.01    133.71   
+    29. A(C   5,C   6,H  11)          128.31  0.000970   -0.20    128.11   
+    30. A(C   2,C   6,H  11)          128.37  0.000286   -0.04    128.33   
+    31. A(C   2,C   6,C   5)          103.32 -0.001256    0.24    103.56   
+    32. D(H   9,C   1,O   0,H   7)    -90.39  0.000253   -0.36    -90.75   
+    33. D(C   2,C   1,O   0,H   7)     31.64  0.000089   -0.31     31.33   
+    34. D(H   8,C   1,O   0,H   7)    152.65 -0.000054   -0.23    152.43   
+    35. D(N   3,C   2,C   1,H   9)    111.80  0.000186   -0.32    111.48   
+    36. D(N   3,C   2,C   1,O   0)    -12.39 -0.000072   -0.24    -12.63   
+    37. D(C   6,C   2,C   1,O   0)    170.61  0.000041   -0.49    170.12   
+    38. D(C   6,C   2,C   1,H   8)     50.44  0.000124   -0.56     49.89   
+    39. D(N   3,C   2,C   1,H   8)   -132.55  0.000011   -0.31   -132.86   
+    40. D(O   4,N   3,C   2,C   1)   -177.68  0.000034   -0.10   -177.78   
+    41. D(O   4,N   3,C   2,C   6)     -0.18 -0.000035    0.10     -0.08   
+    42. D(C   5,O   4,N   3,C   2)     -0.04 -0.000042    0.09      0.05   
+    43. D(H  10,C   5,O   4,N   3)   -179.65 -0.000015    0.06   -179.59   
+    44. D(C   6,C   5,O   4,N   3)      0.25  0.000108   -0.25      0.00   
+    45. D(C   5,C   6,C   2,N   3)      0.33  0.000089   -0.24      0.09   
+    46. D(C   5,C   6,C   2,C   1)    177.54  0.000010   -0.01    177.52   
+    47. D(H  11,C   6,C   5,H  10)      0.04  0.000091   -0.22     -0.18   
+    48. D(H  11,C   6,C   5,O   4)   -179.84 -0.000063    0.16   -179.68   
+    49. D(C   2,C   6,C   5,H  10)    179.54  0.000037   -0.09    179.44   
+    50. D(C   2,C   6,C   5,O   4)     -0.34 -0.000117    0.29     -0.05   
+    51. D(H  11,C   6,C   2,N   3)    179.82  0.000041   -0.11    179.71   
+    52. D(H  11,C   6,C   2,C   1)     -2.97 -0.000039    0.11     -2.85   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 7.976 %)
+Internal coordinates            :      0.000 s ( 1.545 %)
+B/P matrices and projection     :      0.000 s (13.559 %)
+Hessian update/contruction      :      0.001 s (40.877 %)
+Making the step                 :      0.000 s (10.768 %)
+Converting the step to Cartesian:      0.000 s ( 1.745 %)
+Storing new data                :      0.000 s ( 1.147 %)
+Checking convergence            :      0.000 s ( 0.598 %)
+Final printing                  :      0.000 s (21.685 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      4.565 s
+Time for complete geometry iter :      5.478 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   3            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.409823    0.685672   -0.294846
+  C     -1.518849   -0.343761    0.081228
+  C     -0.072647    0.046217   -0.000499
+  N      0.271119    1.149047   -0.621821
+  O      1.663780    1.202862   -0.569523
+  C      2.108984    0.115890    0.088627
+  C      1.068041   -0.660708    0.477205
+  H     -1.975151    1.227342   -0.965842
+  H     -1.757311   -0.628370    1.114459
+  H     -1.659469   -1.246947   -0.540315
+  H      3.181073    0.040800    0.204580
+  H      1.098545   -1.590236    1.024544
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.553905    1.295733   -0.557179
+   1 C     6.0000    0    12.011   -2.870209   -0.649615    0.153498
+   2 C     6.0000    0    12.011   -0.137283    0.087338   -0.000943
+   3 N     7.0000    0    14.007    0.512340    2.171383   -1.175071
+   4 O     8.0000    0    15.999    3.144089    2.273081   -1.076242
+   5 C     6.0000    0    12.011    3.985402    0.219000    0.167480
+   6 C     6.0000    0    12.011    2.018304   -1.248557    0.901787
+   7 H     1.0000    0     1.008   -3.732495    2.319340   -1.825177
+   8 H     1.0000    0     1.008   -3.320836   -1.187448    2.106021
+   9 H     1.0000    0     1.008   -3.135942   -2.356388   -1.021047
+  10 H     1.0000    0     1.008    6.011356    0.077100    0.386600
+  11 H     1.0000    0     1.008    2.075950   -3.005111    1.936108
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.412444097037     0.00000000     0.00000000
+ C      2   1   0     1.500087626384   113.83865717     0.00000000
+ N      3   2   1     1.311658444428   119.80557989   347.37066720
+ O      4   3   2     1.394681519809   106.04462313   182.22084201
+ C      5   4   3     1.346431096331   108.50301044     0.05099477
+ C      6   5   4     1.355603161306   110.40764351     0.00000000
+ H      1   2   3     0.965702344294   108.05196821    31.32964259
+ H      2   1   3     1.097921801999   107.60749106   121.09835342
+ H      2   1   3     1.105365467016   111.44199824   237.91952705
+ H      6   5   4     1.080952381362   115.87811956   180.40729059
+ H      7   6   5     1.079135577696   128.10750288   180.32390540
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.669132522873     0.00000000     0.00000000
+ C      2   1   0     2.834754790751   113.83865717     0.00000000
+ N      3   2   1     2.478675241214   119.80557989   347.37066720
+ O      4   3   2     2.635566116480   106.04462313   182.22084201
+ C      5   4   3     2.544386030261   108.50301044     0.05099477
+ C      6   5   4     2.561718721146   110.40764351     0.00000000
+ H      1   2   3     1.824912957602   108.05196821    31.32964259
+ H      2   1   3     2.074771522240   107.60749106   121.09835342
+ H      2   1   3     2.088838010554   111.44199824   237.91952705
+ H      6   5   4     2.042703964585   115.87811956   180.40729059
+ H      7   6   5     2.039270703216   128.10750288   180.32390540
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3073
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8262
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1085 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    291.653356647577 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.156e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59188
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.5114479242591869     0.00e+00  1.61e-04  3.01e-03  2.67e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.5115262009617254    -7.83e-05  8.46e-05  1.56e-03  5.49e-04     0.1
+    3    -360.5115112490530009     1.50e-05  4.72e-05  1.04e-03  1.63e-03     0.1
+    4    -360.5115338846605937    -2.26e-05  2.46e-05  3.78e-04  1.14e-04     0.1
+    5    -360.5115338281123059     5.65e-08  1.15e-05  1.78e-04  1.16e-04     0.1
+    6    -360.5115343442199674    -5.16e-07  5.48e-06  8.96e-05  2.67e-05     0.1
+    7    -360.5115343453719561    -1.15e-09  2.70e-06  3.58e-05  2.16e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   7 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51153434537196 Eh           -9810.01758 eV
+
+Components:
+Nuclear Repulsion  :        291.65335664757674 Eh            7936.29131 eV
+Electronic Energy  :       -652.16489099294859 Eh          -17746.30889 eV
+One Electron Energy:      -1068.15176042223993 Eh          -29065.88708 eV
+Two Electron Energy:        415.98686942929129 Eh           11319.57819 eV
+
+Virial components:
+Potential Energy   :       -719.54976841074051 Eh          -19579.94462 eV
+Kinetic Energy     :        359.03823406536856 Eh            9769.92704 eV
+Virial Ratio       :          2.00410346347608
+
+DFT components:
+N(Alpha)           :       26.000020926628 electrons
+N(Beta)            :       26.000020926628 electrons
+N(Total)           :       52.000041853256 electrons
+E(X)               :      -45.754859452726 Eh       
+E(C)               :       -1.716145848976 Eh       
+E(XC)              :      -47.471005301702 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    1.1520e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    3.5824e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    2.6960e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    3.2593e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    2.1645e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    2.4135e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.4 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.003069050
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009833467
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504769928708
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000059001    0.000018011   -0.000018299
+   2   C   :   -0.000049471   -0.000018453    0.000003367
+   3   C   :    0.000005807    0.000001003   -0.000000123
+   4   N   :    0.000017232    0.000024902   -0.000013336
+   5   O   :    0.000046356    0.000024370   -0.000011020
+   6   C   :    0.000050324    0.000004540    0.000001069
+   7   C   :    0.000040087   -0.000018560    0.000013417
+   8   H   :   -0.000035009    0.000001586    0.000004114
+   9   H   :   -0.000031012   -0.000004778    0.000008239
+  10   H   :   -0.000030758   -0.000009778   -0.000004229
+  11   H   :    0.000027694    0.000000723    0.000001476
+  12   H   :    0.000017749   -0.000023565    0.000015326
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000   -0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001443988
+RMS gradient                       ...    0.0000240665
+MAX gradient                       ...    0.0000590009
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000409079    0.000172871   -0.000036754
+   2   C   :   -0.000807568    0.000343549   -0.000099701
+   3   C   :   -0.000912919   -0.000527994   -0.000085170
+   4   N   :    0.001377648    0.000430232   -0.000071466
+   5   O   :   -0.001340584    0.000279456    0.000023050
+   6   C   :    0.000954888   -0.000014268   -0.000245617
+   7   C   :    0.000390824   -0.000359752    0.000403223
+   8   H   :   -0.000249007   -0.000032841    0.000018034
+   9   H   :    0.000064969   -0.000110935    0.000119055
+  10   H   :    0.000300297   -0.000277278   -0.000003335
+  11   H   :    0.000001133   -0.000051339   -0.000017038
+  12   H   :   -0.000188762    0.000148299   -0.000004281
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000690625    0.0001324544    0.0001297671
+
+Norm of the Cartesian gradient     ...    0.0027930140
+RMS gradient                       ...    0.0004655023
+MAX gradient                       ...    0.0013776484
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.189 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.009 sec  (  4.9%)
+RI-J Coulomb gradient       ....       0.058 sec  ( 30.4%)
+XC gradient                 ....       0.091 sec  ( 48.0%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504769929 Eh
+Current gradient norm                   ....     0.002793014 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999857245
+Lowest eigenvalues of augmented Hessian:
+ -0.000013923  0.012251844  0.016604158  0.021286270  0.027373586
+Length of the computed step             ....  0.016898865
+The final length of the internal step   ....  0.016898865
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0023434509
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0035359174 RMS(Int)=    0.0023418831
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000006963
+Previously predicted energy change      ....    -0.000063849
+Actually observed energy change         ....    -0.000071589
+Ratio of predicted to observed change   ....     1.121229436
+New trust radius                        ....     0.450000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000715893            0.0000050000      NO
+          RMS gradient        0.0002498306            0.0001000000      NO
+          MAX gradient        0.0008989779            0.0003000000      NO
+          RMS step            0.0023434509            0.0020000000      NO
+          MAX step            0.0059775598            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0024      Max(Angles)    0.10
+          Max(Dihed)        0.34      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4124 -0.000040  0.0005    1.4130   
+     2. B(C   2,C   1)                1.5001  0.000177 -0.0005    1.4996   
+     3. B(N   3,C   2)                1.3117  0.000498 -0.0001    1.3115   
+     4. B(O   4,N   3)                1.3947 -0.000899  0.0022    1.3968   
+     5. B(C   5,O   4)                1.3464  0.000367  0.0001    1.3465   
+     6. B(C   6,C   5)                1.3556  0.000588 -0.0005    1.3551   
+     7. B(C   6,C   2)                1.4245  0.000628 -0.0009    1.4236   
+     8. B(H   7,N   3)                2.2738  0.000070 -0.0024    2.2714   
+     9. B(H   7,O   0)                0.9657 -0.000115  0.0001    0.9658   
+    10. B(H   8,C   1)                1.0979  0.000125 -0.0002    1.0978   
+    11. B(H   9,C   1)                1.1054  0.000189 -0.0003    1.1051   
+    12. B(H  10,C   5)                1.0810  0.000003 -0.0000    1.0809   
+    13. B(H  11,C   6)                1.0791 -0.000133  0.0002    1.0793   
+    14. A(C   1,O   0,H   7)          108.05  0.000221   -0.06    107.99   
+    15. A(O   0,C   1,C   2)          113.84 -0.000166    0.02    113.86   
+    16. A(C   2,C   1,H   9)          107.72 -0.000255    0.07    107.80   
+    17. A(C   2,C   1,H   8)          109.15 -0.000043    0.03    109.18   
+    18. A(O   0,C   1,H   9)          111.44  0.000374   -0.10    111.34   
+    19. A(H   8,C   1,H   9)          106.84 -0.000052    0.01    106.86   
+    20. A(O   0,C   1,H   8)          107.61  0.000144   -0.03    107.57   
+    21. A(N   3,C   2,C   6)          111.48 -0.000391    0.07    111.55   
+    22. A(C   1,C   2,C   6)          128.66  0.000379   -0.06    128.60   
+    23. A(C   1,C   2,N   3)          119.81  0.000014   -0.02    119.79   
+    24. A(C   2,N   3,O   4)          106.04  0.000341   -0.07    105.98   
+    25. A(N   3,O   4,C   5)          108.50  0.000337   -0.06    108.44   
+    26. A(O   4,C   5,H  10)          115.88  0.000192   -0.02    115.85   
+    27. A(O   4,C   5,C   6)          110.41 -0.000300    0.04    110.44   
+    28. A(C   6,C   5,H  10)          133.71  0.000107   -0.01    133.70   
+    29. A(C   5,C   6,H  11)          128.11  0.000181   -0.06    128.05   
+    30. A(C   2,C   6,H  11)          128.33 -0.000195    0.03    128.36   
+    31. A(C   2,C   6,C   5)          103.56  0.000014    0.02    103.58   
+    32. D(H   9,C   1,O   0,H   7)    -90.75  0.000175   -0.23    -90.98   
+    33. D(C   2,C   1,O   0,H   7)     31.33  0.000003   -0.19     31.14   
+    34. D(H   8,C   1,O   0,H   7)    152.43 -0.000055   -0.17    152.26   
+    35. D(N   3,C   2,C   1,H   9)    111.48  0.000203   -0.34    111.14   
+    36. D(N   3,C   2,C   1,O   0)    -12.63  0.000026   -0.28    -12.91   
+    37. D(C   6,C   2,C   1,O   0)    170.12  0.000009   -0.17    169.95   
+    38. D(C   6,C   2,C   1,H   8)     49.89 -0.000034   -0.16     49.72   
+    39. D(N   3,C   2,C   1,H   8)   -132.86 -0.000018   -0.27   -133.13   
+    40. D(O   4,N   3,C   2,C   1)   -177.78 -0.000002   -0.00   -177.78   
+    41. D(O   4,N   3,C   2,C   6)     -0.09  0.000031   -0.10     -0.18   
+    42. D(C   5,O   4,N   3,C   2)      0.05  0.000059   -0.09     -0.04   
+    43. D(H  10,C   5,O   4,N   3)   -179.59 -0.000047    0.09   -179.50   
+    44. D(C   6,C   5,O   4,N   3)      0.00 -0.000131    0.25      0.26   
+    45. D(C   5,C   6,C   2,N   3)      0.09 -0.000106    0.24      0.33   
+    46. D(C   5,C   6,C   2,C   1)    177.52 -0.000084    0.14    177.66   
+    47. D(H  11,C   6,C   5,H  10)     -0.18 -0.000019    0.01     -0.16   
+    48. D(H  11,C   6,C   5,O   4)   -179.68  0.000085   -0.18   -179.86   
+    49. D(C   2,C   6,C   5,H  10)    179.45  0.000037   -0.09    179.35   
+    50. D(C   2,C   6,C   5,O   4)     -0.05  0.000142   -0.29     -0.34   
+    51. D(H  11,C   6,C   2,N   3)    179.71 -0.000048    0.13    179.84   
+    52. D(H  11,C   6,C   2,C   1)     -2.85 -0.000025    0.03     -2.83   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (14.774 %)
+Internal coordinates            :      0.000 s ( 1.770 %)
+B/P matrices and projection     :      0.000 s (16.239 %)
+Hessian update/contruction      :      0.000 s (18.926 %)
+Making the step                 :      0.000 s (13.248 %)
+Converting the step to Cartesian:      0.000 s ( 2.747 %)
+Storing new data                :      0.000 s ( 1.832 %)
+Checking convergence            :      0.000 s ( 0.611 %)
+Final printing                  :      0.000 s (29.609 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      4.587 s
+Time for complete geometry iter :      5.551 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   4            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.410275    0.685400   -0.292754
+  C     -1.517847   -0.344341    0.080947
+  C     -0.072377    0.046137   -0.001784
+  N      0.270399    1.147081   -0.626687
+  O      1.665188    1.200944   -0.573614
+  C      2.108398    0.116550    0.090335
+  C      1.067310   -0.660105    0.476773
+  H     -1.974755    1.229603   -0.961303
+  H     -1.755596   -0.630392    1.113765
+  H     -1.660408   -1.245826   -0.542139
+  H      3.180201    0.041987    0.209094
+  H      1.098055   -1.589230    1.025163
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.554760    1.295218   -0.553225
+   1 C     6.0000    0    12.011   -2.868315   -0.650711    0.152968
+   2 C     6.0000    0    12.011   -0.136773    0.087187   -0.003371
+   3 N     7.0000    0    14.007    0.510980    2.167669   -1.184266
+   4 O     8.0000    0    15.999    3.146749    2.269455   -1.083973
+   5 C     6.0000    0    12.011    3.984295    0.220248    0.170709
+   6 C     6.0000    0    12.011    2.016924   -1.247418    0.900971
+   7 H     1.0000    0     1.008   -3.731747    2.323614   -1.816600
+   8 H     1.0000    0     1.008   -3.317596   -1.191268    2.104711
+   9 H     1.0000    0     1.008   -3.137716   -2.354271   -1.024494
+  10 H     1.0000    0     1.008    6.009709    0.079344    0.395130
+  11 H     1.0000    0     1.008    2.075023   -3.003210    1.937277
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.412957165097     0.00000000     0.00000000
+ C      2   1   0     1.499567065736   113.85700212     0.00000000
+ N      3   2   1     1.311516918667   119.78871800   347.09116018
+ O      4   3   2     1.396836950529   105.97638804   182.22089208
+ C      5   4   3     1.346541425413   108.44205245   359.95966236
+ C      6   5   4     1.355135086722   110.44351701     0.25560170
+ H      1   2   3     0.965811791036   107.99363052    31.13592477
+ H      2   1   3     1.097753455272   107.57480963   121.12304574
+ H      2   1   3     1.105095037680   111.34031924   237.88636014
+ H      6   5   4     1.080937181104   115.85462508   180.50000091
+ H      7   6   5     1.079328436363   128.05128577   180.13910638
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.670102080996     0.00000000     0.00000000
+ C      2   1   0     2.833771073688   113.85700212     0.00000000
+ N      3   2   1     2.478407796285   119.78871800   347.09116018
+ O      4   3   2     2.639639290242   105.97638804   182.22089208
+ C      5   4   3     2.544594522010   108.44205245   359.95966236
+ C      6   5   4     2.560834188372   110.44351701     0.25560170
+ H      1   2   3     1.825119781970   107.99363052    31.13592477
+ H      2   1   3     2.074453393030   107.57480963   121.12304574
+ H      2   1   3     2.088326973171   111.34031924   237.88636014
+ H      6   5   4     2.042675240259   115.85462508   180.50000091
+ H      7   6   5     2.039635153279   128.05128577   180.13910638
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3073
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8264
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1085 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    291.637889921657 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.154e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.005 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59185
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.4 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.5115244621764532     0.00e+00  7.30e-05  1.02e-03  2.32e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.5115511305232303    -2.67e-05  3.67e-05  4.59e-04  2.71e-04     0.1
+    3    -360.5115516533065829    -5.23e-07  2.28e-05  4.02e-04  4.45e-04     0.1
+    4    -360.5115527076219450    -1.05e-06  1.98e-05  2.82e-04  2.54e-04     0.1
+    5    -360.5115534613803447    -7.54e-07  7.70e-06  1.43e-04  4.92e-05     0.1
+    6    -360.5115534686985939    -7.32e-09  5.25e-06  1.02e-04  4.98e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51155346869859 Eh           -9810.01810 eV
+
+Components:
+Nuclear Repulsion  :        291.63788992165712 Eh            7935.87044 eV
+Electronic Energy  :       -652.14944339035571 Eh          -17745.88854 eV
+One Electron Energy:      -1068.12041695412472 Eh          -29065.03418 eV
+Two Electron Energy:        415.97097356376901 Eh           11319.14564 eV
+
+Virial components:
+Potential Energy   :       -719.55037360747838 Eh          -19579.96109 eV
+Kinetic Energy     :        359.03882013877984 Eh            9769.94299 eV
+Virial Ratio       :          2.00410187770044
+
+DFT components:
+N(Alpha)           :       26.000020386783 electrons
+N(Beta)            :       26.000020386783 electrons
+N(Total)           :       52.000040773566 electrons
+E(X)               :      -45.754800822369 Eh       
+E(C)               :       -1.716096451867 Eh       
+E(XC)              :      -47.470897274236 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    7.3182e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.0171e-04  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    5.2464e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.7744e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    4.9821e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.0829e-04  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+Finished LeanSCF after   0.8 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.5 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.003069263
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009845830
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504776901106
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000058961    0.000018054   -0.000018188
+   2   C   :   -0.000049442   -0.000018404    0.000003353
+   3   C   :    0.000006024    0.000001015   -0.000000139
+   4   N   :    0.000017115    0.000024952   -0.000013495
+   5   O   :    0.000046296    0.000024317   -0.000011096
+   6   C   :    0.000050235    0.000004481    0.000001114
+   7   C   :    0.000040069   -0.000018586    0.000013431
+   8   H   :   -0.000035028    0.000001549    0.000004129
+   9   H   :   -0.000030997   -0.000004800    0.000008263
+  10   H   :   -0.000030750   -0.000009771   -0.000004244
+  11   H   :    0.000027698    0.000000736    0.000001526
+  12   H   :    0.000017741   -0.000023543    0.000015345
+
+Difference to translation invariance:
+           :   -0.0000000000   -0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001443217
+RMS gradient                       ...    0.0000240536
+MAX gradient                       ...    0.0000589612
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000088085    0.000130384    0.000013854
+   2   C   :   -0.000118628    0.000090339   -0.000032748
+   3   C   :   -0.000478879   -0.000452504    0.000397725
+   4   N   :    0.000273343    0.000350325   -0.000152230
+   5   O   :   -0.000420862    0.000267346   -0.000403429
+   6   C   :    0.000603344   -0.000269170    0.000535777
+   7   C   :    0.000158366    0.000044636   -0.000349536
+   8   H   :   -0.000114685   -0.000005157   -0.000024095
+   9   H   :    0.000004633   -0.000037962    0.000014057
+  10   H   :    0.000143126   -0.000094598    0.000024835
+  11   H   :   -0.000038994   -0.000010741    0.000010489
+  12   H   :   -0.000098849   -0.000012899   -0.000034700
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0001262890    0.0001622126    0.0001903799
+
+Norm of the Cartesian gradient     ...    0.0014844659
+RMS gradient                       ...    0.0002474110
+MAX gradient                       ...    0.0006033441
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.181 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.007 sec  (  3.7%)
+RI-J Coulomb gradient       ....       0.054 sec  ( 30.1%)
+XC gradient                 ....       0.093 sec  ( 51.3%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504776901 Eh
+Current gradient norm                   ....     0.001484466 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.450
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999934235
+Lowest eigenvalues of augmented Hessian:
+ -0.000004255  0.010776799  0.015956159  0.021339291  0.027464742
+Length of the computed step             ....  0.011469210
+The final length of the internal step   ....  0.011469210
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0015904932
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0024968485 RMS(Int)=    0.0015897957
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000002128
+Previously predicted energy change      ....    -0.000006963
+Actually observed energy change         ....    -0.000006972
+Ratio of predicted to observed change   ....     1.001307811
+New trust radius                        ....     0.675000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000069724            0.0000050000      NO
+          RMS gradient        0.0001292222            0.0001000000      NO
+          MAX gradient        0.0005412001            0.0003000000      NO
+          RMS step            0.0015904932            0.0020000000      YES
+          MAX step            0.0039864786            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0021      Max(Angles)    0.06
+          Max(Dihed)        0.23      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4130  0.000085  0.0001    1.4130   
+     2. B(C   2,C   1)                1.4996 -0.000069 -0.0001    1.4995   
+     3. B(N   3,C   2)                1.3115  0.000393 -0.0003    1.3112   
+     4. B(O   4,N   3)                1.3968 -0.000076  0.0007    1.3976   
+     5. B(C   5,O   4)                1.3465  0.000541 -0.0004    1.3461   
+     6. B(C   6,C   5)                1.3551  0.000125 -0.0002    1.3549   
+     7. B(C   6,C   2)                1.4236  0.000132 -0.0004    1.4233   
+     8. B(H   7,N   3)                2.2715  0.000042 -0.0021    2.2694   
+     9. B(H   7,O   0)                0.9658 -0.000016  0.0000    0.9659   
+    10. B(H   8,C   1)                1.0978  0.000020 -0.0001    1.0977   
+    11. B(H   9,C   1)                1.1051  0.000042 -0.0001    1.1050   
+    12. B(H  10,C   5)                1.0809 -0.000036  0.0001    1.0810   
+    13. B(H  11,C   6)                1.0793 -0.000007  0.0000    1.0794   
+    14. A(C   1,O   0,H   7)          107.99  0.000097   -0.04    107.95   
+    15. A(O   0,C   1,C   2)          113.86 -0.000034   -0.00    113.85   
+    16. A(C   2,C   1,H   9)          107.80 -0.000126    0.05    107.85   
+    17. A(C   2,C   1,H   8)          109.18 -0.000004    0.02    109.20   
+    18. A(O   0,C   1,H   9)          111.34  0.000171   -0.06    111.28   
+    19. A(H   8,C   1,H   9)          106.86 -0.000037    0.02    106.87   
+    20. A(O   0,C   1,H   8)          107.57  0.000028   -0.01    107.56   
+    21. A(N   3,C   2,C   6)          111.55 -0.000130    0.04    111.59   
+    22. A(C   1,C   2,C   6)          128.61  0.000153   -0.03    128.57   
+    23. A(C   1,C   2,N   3)          119.79 -0.000025   -0.00    119.78   
+    24. A(C   2,N   3,O   4)          105.98  0.000048   -0.03    105.95   
+    25. A(N   3,O   4,C   5)          108.44  0.000097   -0.03    108.41   
+    26. A(O   4,C   5,H  10)          115.85  0.000142   -0.03    115.83   
+    27. A(O   4,C   5,C   6)          110.44 -0.000230    0.04    110.49   
+    28. A(C   6,C   5,H  10)          133.70  0.000088   -0.01    133.69   
+    29. A(C   5,C   6,H  11)          128.05 -0.000000   -0.02    128.03   
+    30. A(C   2,C   6,H  11)          128.36 -0.000215    0.04    128.41   
+    31. A(C   2,C   6,C   5)          103.58  0.000215   -0.02    103.56   
+    32. D(H   9,C   1,O   0,H   7)    -90.98  0.000071   -0.17    -91.14   
+    33. D(C   2,C   1,O   0,H   7)     31.14  0.000011   -0.15     30.98   
+    34. D(H   8,C   1,O   0,H   7)    152.26  0.000004   -0.14    152.11   
+    35. D(N   3,C   2,C   1,H   9)    111.14  0.000087   -0.20    110.93   
+    36. D(N   3,C   2,C   1,O   0)    -12.91 -0.000016   -0.16    -13.07   
+    37. D(C   6,C   2,C   1,O   0)    169.95  0.000046   -0.23    169.72   
+    38. D(C   6,C   2,C   1,H   8)     49.72  0.000036   -0.22     49.50   
+    39. D(N   3,C   2,C   1,H   8)   -133.13 -0.000027   -0.15   -133.28   
+    40. D(O   4,N   3,C   2,C   1)   -177.78  0.000005   -0.01   -177.78   
+    41. D(O   4,N   3,C   2,C   6)     -0.18 -0.000041    0.05     -0.13   
+    42. D(C   5,O   4,N   3,C   2)     -0.04 -0.000047    0.05      0.01   
+    43. D(H  10,C   5,O   4,N   3)   -179.50  0.000034   -0.03   -179.53   
+    44. D(C   6,C   5,O   4,N   3)      0.26  0.000122   -0.14      0.11   
+    45. D(C   5,C   6,C   2,N   3)      0.33  0.000112   -0.13      0.19   
+    46. D(C   5,C   6,C   2,C   1)    177.66  0.000055   -0.07    177.59   
+    47. D(H  11,C   6,C   5,H  10)     -0.17  0.000046   -0.08     -0.24   
+    48. D(H  11,C   6,C   5,O   4)   -179.86 -0.000063    0.06   -179.80   
+    49. D(C   2,C   6,C   5,H  10)    179.35 -0.000030    0.03    179.38   
+    50. D(C   2,C   6,C   5,O   4)     -0.34 -0.000139    0.16     -0.18   
+    51. D(H  11,C   6,C   2,N   3)    179.84  0.000037   -0.03    179.81   
+    52. D(H  11,C   6,C   2,C   1)     -2.83 -0.000020    0.04     -2.79   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (15.756 %)
+Internal coordinates            :      0.000 s ( 1.686 %)
+B/P matrices and projection     :      0.000 s (16.279 %)
+Hessian update/contruction      :      0.000 s (18.198 %)
+Making the step                 :      0.000 s (12.907 %)
+Converting the step to Cartesian:      0.000 s ( 1.860 %)
+Storing new data                :      0.000 s ( 1.395 %)
+Checking convergence            :      0.000 s ( 0.640 %)
+Final printing                  :      0.001 s (31.163 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      3.989 s
+Time for complete geometry iter :      4.699 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   5            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.410286    0.685020   -0.291776
+  C     -1.517410   -0.345101    0.080081
+  C     -0.072177    0.045941   -0.002615
+  N      0.270085    1.146085   -0.628545
+  O      1.665562    1.200340   -0.574671
+  C      2.107802    0.116288    0.089685
+  C      1.066810   -0.658962    0.478492
+  H     -1.973666    1.231408   -0.957895
+  H     -1.754991   -0.632680    1.112456
+  H     -1.660996   -1.245111   -0.544693
+  H      3.179632    0.041665    0.208654
+  H      1.097928   -1.587085    1.028621
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.554780    1.294500   -0.551377
+   1 C     6.0000    0    12.011   -2.867490   -0.652146    0.151331
+   2 C     6.0000    0    12.011   -0.136395    0.086815   -0.004941
+   3 N     7.0000    0    14.007    0.510387    2.165787   -1.187778
+   4 O     8.0000    0    15.999    3.147456    2.268314   -1.085970
+   5 C     6.0000    0    12.011    3.983168    0.219753    0.169480
+   6 C     6.0000    0    12.011    2.015978   -1.245257    0.904219
+   7 H     1.0000    0     1.008   -3.729689    2.327025   -1.810158
+   8 H     1.0000    0     1.008   -3.316452   -1.195592    2.102238
+   9 H     1.0000    0     1.008   -3.138828   -2.352919   -1.029320
+  10 H     1.0000    0     1.008    6.008633    0.078735    0.394300
+  11 H     1.0000    0     1.008    2.074783   -2.999157    1.943812
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.413029611124     0.00000000     0.00000000
+ C      2   1   0     1.499483809472   113.85334968     0.00000000
+ N      3   2   1     1.311201720135   119.78317380   346.93404956
+ O      4   3   2     1.397570015221   105.95060634   182.21476747
+ C      5   4   3     1.346147552895   108.40867195     0.00000000
+ C      6   5   4     1.354934728778   110.48629343     0.11213110
+ H      1   2   3     0.965862752838   107.95393260    30.98260988
+ H      2   1   3     1.097700059641   107.56150934   121.13190738
+ H      2   1   3     1.104978270377   111.27715153   237.87316156
+ H      6   5   4     1.080990880882   115.82636637   180.46813989
+ H      7   6   5     1.079362428931   128.03202777   180.19901661
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.670238984147     0.00000000     0.00000000
+ C      2   1   0     2.833613742152   113.85334968     0.00000000
+ N      3   2   1     2.477812157382   119.78317380   346.93404956
+ O      4   3   2     2.641024581747   105.95060634   182.21476747
+ C      5   4   3     2.543850210820   108.40867195     0.00000000
+ C      6   5   4     2.560455566730   110.48629343     0.11213110
+ H      1   2   3     1.825216085819   107.95393260    30.98260988
+ H      2   1   3     2.074352489911   107.56150934   121.13190738
+ H      2   1   3     2.088106314947   111.27715153   237.87316156
+ H      6   5   4     2.042776718134   115.82636637   180.46813989
+ H      7   6   5     2.039699389923   128.03202777   180.19901661
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3073
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8264
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1085 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    291.658459738423 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.153e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59184
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.5115557187593822     0.00e+00  6.38e-05  1.57e-03  8.99e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.5115634791466164    -7.76e-06  2.37e-05  4.74e-04  9.08e-05     0.1
+    3    -360.5115639341014457    -4.55e-07  1.16e-05  2.24e-04  1.03e-04     0.1
+    4    -360.5115638326021781     1.01e-07  9.80e-06  1.96e-04  1.46e-04     0.1
+    5    -360.5115640844807103    -2.52e-07  4.70e-06  7.43e-05  2.49e-05     0.1
+    6    -360.5115640583129561     2.62e-08  3.22e-06  5.88e-05  3.23e-05     0.1
+    7    -360.5115641055916740    -4.73e-08  7.10e-07  8.56e-06  2.66e-06     0.1
+    8    -360.5115641073490451    -1.76e-09  4.16e-07  6.04e-06  6.11e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   8 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51156410734905 Eh           -9810.01839 eV
+
+Components:
+Nuclear Repulsion  :        291.65845973842261 Eh            7936.43017 eV
+Electronic Energy  :       -652.17002384577177 Eh          -17746.44856 eV
+One Electron Energy:      -1068.15974857995889 Eh          -29066.10445 eV
+Two Electron Energy:        415.98972473418718 Eh           11319.65589 eV
+
+Virial components:
+Potential Energy   :       -719.55288972430708 Eh          -19580.02956 eV
+Kinetic Energy     :        359.04132561695798 Eh            9770.01117 eV
+Virial Ratio       :          2.00409490046268
+
+DFT components:
+N(Alpha)           :       26.000019734942 electrons
+N(Beta)            :       26.000019734942 electrons
+N(Total)           :       52.000039469884 electrons
+E(X)               :      -45.755100795925 Eh       
+E(C)               :       -1.716118143901 Eh       
+E(XC)              :      -47.471218939826 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    1.7574e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    6.0437e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    4.1648e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    9.7959e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    6.1130e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.2020e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.5 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.003069467
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009854155
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504779418854
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000058934    0.000018093   -0.000018132
+   2   C   :   -0.000049412   -0.000018391    0.000003320
+   3   C   :    0.000006370    0.000001051   -0.000000152
+   4   N   :    0.000017149    0.000024899   -0.000013510
+   5   O   :    0.000046234    0.000024270   -0.000011108
+   6   C   :    0.000049902    0.000004488    0.000001078
+   7   C   :    0.000040054   -0.000018555    0.000013471
+   8   H   :   -0.000035051    0.000001513    0.000004123
+   9   H   :   -0.000030987   -0.000004825    0.000008255
+  10   H   :   -0.000030757   -0.000009769   -0.000004273
+  11   H   :    0.000027693    0.000000735    0.000001523
+  12   H   :    0.000017740   -0.000023509    0.000015404
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001441655
+RMS gradient                       ...    0.0000240276
+MAX gradient                       ...    0.0000589345
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000038151    0.000004528    0.000081469
+   2   C   :    0.000039619    0.000055977   -0.000044590
+   3   C   :   -0.000063121   -0.000363006    0.000167222
+   4   N   :   -0.000065830    0.000150438   -0.000058845
+   5   O   :    0.000015716    0.000275363   -0.000147949
+   6   C   :    0.000124841   -0.000386092    0.000208469
+   7   C   :    0.000002860    0.000321624   -0.000183421
+   8   H   :   -0.000030591   -0.000035070   -0.000021000
+   9   H   :   -0.000036616    0.000001432   -0.000021456
+  10   H   :    0.000044531   -0.000013217    0.000017523
+  11   H   :   -0.000021075    0.000010271   -0.000008544
+  12   H   :   -0.000048485   -0.000022248    0.000011123
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000654274    0.0001350505    0.0001588789
+
+Norm of the Cartesian gradient     ...    0.0008139935
+RMS gradient                       ...    0.0001356656
+MAX gradient                       ...    0.0003860920
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.192 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.1%)
+RI-J Coulomb gradient       ....       0.054 sec  ( 27.9%)
+XC gradient                 ....       0.102 sec  ( 52.9%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504779419 Eh
+Current gradient norm                   ....     0.000813994 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.675
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999986440
+Lowest eigenvalues of augmented Hessian:
+ -0.000000851  0.009467817  0.015394341  0.021356020  0.027454527
+Length of the computed step             ....  0.005207769
+The final length of the internal step   ....  0.005207769
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0007221876
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0011182349 RMS(Int)=    0.0007218940
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000000426
+Previously predicted energy change      ....    -0.000002128
+Actually observed energy change         ....    -0.000002518
+Ratio of predicted to observed change   ....     1.183359938
+New trust radius                        ....     0.700000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000025177            0.0000050000      YES
+          RMS gradient        0.0000703869            0.0001000000      YES
+          MAX gradient        0.0003063847            0.0003000000      NO
+          RMS step            0.0007221876            0.0020000000      YES
+          MAX step            0.0023151943            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0012      Max(Angles)    0.03
+          Max(Dihed)        0.11      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4130 -0.000048  0.0000    1.4131   
+     2. B(C   2,C   1)                1.4995 -0.000072  0.0001    1.4996   
+     3. B(N   3,C   2)                1.3112  0.000189 -0.0002    1.3110   
+     4. B(O   4,N   3)                1.3976  0.000126 -0.0001    1.3975   
+     5. B(C   5,O   4)                1.3461  0.000306 -0.0004    1.3458   
+     6. B(C   6,C   5)                1.3549 -0.000099  0.0001    1.3550   
+     7. B(C   6,C   2)                1.4233 -0.000159  0.0001    1.4234   
+     8. B(H   7,N   3)                2.2694  0.000012 -0.0012    2.2682   
+     9. B(H   7,O   0)                0.9659 -0.000009  0.0000    0.9659   
+    10. B(H   8,C   1)                1.0977 -0.000014  0.0000    1.0977   
+    11. B(H   9,C   1)                1.1050 -0.000006 -0.0000    1.1050   
+    12. B(H  10,C   5)                1.0810 -0.000022  0.0000    1.0810   
+    13. B(H  11,C   6)                1.0794  0.000026 -0.0000    1.0793   
+    14. A(C   1,O   0,H   7)          107.95 -0.000012   -0.01    107.95   
+    15. A(O   0,C   1,C   2)          113.85  0.000018   -0.01    113.84   
+    16. A(C   2,C   1,H   9)          107.85 -0.000039    0.02    107.86   
+    17. A(C   2,C   1,H   8)          109.20  0.000028   -0.00    109.19   
+    18. A(O   0,C   1,H   9)          111.28  0.000042   -0.02    111.26   
+    19. A(H   8,C   1,H   9)          106.87 -0.000011    0.01    106.88   
+    20. A(O   0,C   1,H   8)          107.56 -0.000038    0.01    107.57   
+    21. A(N   3,C   2,C   6)          111.59 -0.000016    0.01    111.61   
+    22. A(C   1,C   2,C   6)          128.57  0.000005   -0.01    128.57   
+    23. A(C   1,C   2,N   3)          119.78  0.000011   -0.01    119.78   
+    24. A(C   2,N   3,O   4)          105.95 -0.000018   -0.00    105.95   
+    25. A(N   3,O   4,C   5)          108.41 -0.000070    0.00    108.41   
+    26. A(O   4,C   5,H  10)          115.83  0.000026   -0.01    115.82   
+    27. A(O   4,C   5,C   6)          110.49 -0.000060    0.02    110.50   
+    28. A(C   6,C   5,H  10)          133.69  0.000034   -0.01    133.68   
+    29. A(C   5,C   6,H  11)          128.03 -0.000028   -0.00    128.03   
+    30. A(C   2,C   6,H  11)          128.41 -0.000137    0.03    128.44   
+    31. A(C   2,C   6,C   5)          103.56  0.000165   -0.03    103.53   
+    32. D(H   9,C   1,O   0,H   7)    -91.14  0.000023   -0.10    -91.25   
+    33. D(C   2,C   1,O   0,H   7)     30.98  0.000017   -0.10     30.88   
+    34. D(H   8,C   1,O   0,H   7)    152.11  0.000037   -0.11    152.01   
+    35. D(N   3,C   2,C   1,H   9)    110.93  0.000032   -0.10    110.84   
+    36. D(N   3,C   2,C   1,O   0)    -13.07 -0.000005   -0.08    -13.14   
+    37. D(C   6,C   2,C   1,O   0)    169.72 -0.000005   -0.07    169.65   
+    38. D(C   6,C   2,C   1,H   8)     49.50  0.000012   -0.08     49.43   
+    39. D(N   3,C   2,C   1,H   8)   -133.28  0.000012   -0.08   -133.36   
+    40. D(O   4,N   3,C   2,C   1)   -177.79  0.000005   -0.00   -177.79   
+    41. D(O   4,N   3,C   2,C   6)     -0.13  0.000005   -0.01     -0.14   
+    42. D(C   5,O   4,N   3,C   2)      0.01  0.000001    0.01      0.02   
+    43. D(H  10,C   5,O   4,N   3)   -179.53 -0.000001   -0.01   -179.54   
+    44. D(C   6,C   5,O   4,N   3)      0.11 -0.000007   -0.01      0.11   
+    45. D(C   5,C   6,C   2,N   3)      0.19 -0.000009    0.00      0.20   
+    46. D(C   5,C   6,C   2,C   1)    177.59 -0.000008    0.00    177.59   
+    47. D(H  11,C   6,C   5,H  10)     -0.24 -0.000003   -0.01     -0.25   
+    48. D(H  11,C   6,C   5,O   4)   -179.80  0.000005   -0.01   -179.81   
+    49. D(C   2,C   6,C   5,H  10)    179.38  0.000001    0.00    179.38   
+    50. D(C   2,C   6,C   5,O   4)     -0.18  0.000009    0.00     -0.18   
+    51. D(H  11,C   6,C   2,N   3)    179.81 -0.000004    0.01    179.82   
+    52. D(H  11,C   6,C   2,C   1)     -2.79 -0.000004    0.01     -2.78   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 8.324 %)
+Internal coordinates            :      0.000 s ( 0.652 %)
+B/P matrices and projection     :      0.003 s (58.151 %)
+Hessian update/contruction      :      0.001 s ( 9.954 %)
+Making the step                 :      0.000 s ( 5.044 %)
+Converting the step to Cartesian:      0.000 s ( 0.729 %)
+Storing new data                :      0.000 s ( 0.556 %)
+Checking convergence            :      0.000 s ( 0.249 %)
+Final printing                  :      0.001 s (16.302 %)
+Total time                      :      0.005 s
+
+Time for energy+gradient        :      4.469 s
+Time for complete geometry iter :      5.219 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   6            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.410226    0.685062   -0.291580
+  C     -1.517461   -0.345386    0.079765
+  C     -0.072154    0.045719   -0.002923
+  N      0.269990    1.145213   -0.629590
+  O      1.665360    1.199707   -0.575372
+  C      2.107507    0.116503    0.089675
+  C      1.066790   -0.658908    0.479073
+  H     -1.972835    1.232612   -0.956276
+  H     -1.754891   -0.633486    1.112042
+  H     -1.661485   -1.244877   -0.545630
+  H      3.179392    0.042268    0.208802
+  H      1.098304   -1.586620    1.029809
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.554668    1.294580   -0.551006
+   1 C     6.0000    0    12.011   -2.867586   -0.652685    0.150734
+   2 C     6.0000    0    12.011   -0.136350    0.086396   -0.005523
+   3 N     7.0000    0    14.007    0.510206    2.164140   -1.189752
+   4 O     8.0000    0    15.999    3.147074    2.267117   -1.087296
+   5 C     6.0000    0    12.011    3.982612    0.220159    0.169460
+   6 C     6.0000    0    12.011    2.015940   -1.245156    0.905317
+   7 H     1.0000    0     1.008   -3.728118    2.329299   -1.807099
+   8 H     1.0000    0     1.008   -3.316263   -1.197114    2.101455
+   9 H     1.0000    0     1.008   -3.139751   -2.352476   -1.031091
+  10 H     1.0000    0     1.008    6.008181    0.079875    0.394579
+  11 H     1.0000    0     1.008    2.075494   -2.998278    1.946056
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.413064149010     0.00000000     0.00000000
+ C      2   1   0     1.499571424689   113.84412027     0.00000000
+ N      3   2   1     1.310977571878   119.77763182   346.85905445
+ O      4   3   2     1.397485962436   105.94690066   182.21008255
+ C      5   4   3     1.345775732001   108.41114952     0.00000000
+ C      6   5   4     1.354986087389   110.50468866     0.10626125
+ H      1   2   3     0.965889160667   107.94701132    30.87787557
+ H      2   1   3     1.097711483789   107.56965417   121.13028546
+ H      2   1   3     1.104963737495   111.25620473   237.87555129
+ H      6   5   4     1.081036206211   115.81662822   180.46269327
+ H      7   6   5     1.079329823558   128.03109355   180.19287842
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.670304251291     0.00000000     0.00000000
+ C      2   1   0     2.833779310916   113.84412027     0.00000000
+ N      3   2   1     2.477388578562   119.77763182   346.85905445
+ O      4   3   2     2.640865745004   105.94690066   182.21008255
+ C      5   4   3     2.543147571159   108.41114952     0.00000000
+ C      6   5   4     2.560552620439   110.50468866     0.10626125
+ H      1   2   3     1.825265989384   107.94701132    30.87787557
+ H      2   1   3     2.074374078421   107.56965417   121.13028546
+ H      2   1   3     2.088078851779   111.25620473   237.87555129
+ H      6   5   4     2.042862370592   115.81662822   180.46269327
+ H      7   6   5     2.039637774697   128.03109355   180.19287842
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3073
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8264
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1085 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    291.673420765348 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.153e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59183
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.5115652088840648     0.00e+00  2.28e-05  5.59e-04  5.49e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.5115669897731436    -1.78e-06  1.06e-05  2.09e-04  4.47e-05     0.1
+    3    -360.5115670358088096    -4.60e-08  6.15e-06  1.17e-04  1.04e-04     0.1
+    4    -360.5115670833720856    -4.76e-08  5.51e-06  1.08e-04  5.22e-05     0.1
+    5    -360.5115671383203448    -5.49e-08  1.91e-06  3.35e-05  1.17e-05     0.1
+    6    -360.5115671347498960     3.57e-09  1.29e-06  2.05e-05  1.26e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51156713474990 Eh           -9810.01847 eV
+
+Components:
+Nuclear Repulsion  :        291.67342076534823 Eh            7936.83728 eV
+Electronic Energy  :       -652.18498790009812 Eh          -17746.85575 eV
+One Electron Energy:      -1068.18831702669991 Eh          -29066.88184 eV
+Two Electron Energy:        416.00332912660173 Eh           11320.02608 eV
+
+Virial components:
+Potential Energy   :       -719.55379267736566 Eh          -19580.05413 eV
+Kinetic Energy     :        359.04222554261571 Eh            9770.03566 eV
+Virial Ratio       :          2.00409239216895
+
+DFT components:
+N(Alpha)           :       26.000019461754 electrons
+N(Beta)            :       26.000019461754 electrons
+N(Total)           :       52.000038923507 electrons
+E(X)               :      -45.755390684054 Eh       
+E(C)               :       -1.716136763097 Eh       
+E(XC)              :      -47.471527447150 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.5704e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.0548e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.2939e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    4.5616e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.2558e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    2.2218e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.1 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.6 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.003069527
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009856672
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504779990007
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000058917    0.000018123   -0.000018102
+   2   C   :   -0.000049405   -0.000018382    0.000003309
+   3   C   :    0.000006532    0.000001071   -0.000000161
+   4   N   :    0.000017178    0.000024848   -0.000013508
+   5   O   :    0.000046209    0.000024238   -0.000011113
+   6   C   :    0.000049724    0.000004508    0.000001055
+   7   C   :    0.000040057   -0.000018549    0.000013484
+   8   H   :   -0.000035065    0.000001498    0.000004115
+   9   H   :   -0.000030987   -0.000004834    0.000008253
+  10   H   :   -0.000030762   -0.000009764   -0.000004282
+  11   H   :    0.000027688    0.000000743    0.000001525
+  12   H   :    0.000017747   -0.000023501    0.000015426
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001440886
+RMS gradient                       ...    0.0000240148
+MAX gradient                       ...    0.0000589166
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000024693   -0.000022746    0.000084262
+   2   C   :    0.000051641    0.000008381   -0.000028739
+   3   C   :    0.000066030   -0.000036559    0.000022858
+   4   N   :   -0.000073699   -0.000009689    0.000013929
+   5   O   :    0.000024994    0.000069188   -0.000017813
+   6   C   :   -0.000047660   -0.000165760    0.000065259
+   7   C   :    0.000014960    0.000167251   -0.000088547
+   8   H   :   -0.000010230   -0.000022142   -0.000029966
+   9   H   :   -0.000041131    0.000006523   -0.000013425
+  10   H   :    0.000007058    0.000002964    0.000002659
+  11   H   :    0.000002819    0.000019755   -0.000013029
+  12   H   :   -0.000019473   -0.000017166    0.000002551
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000768465    0.0001449258    0.0001696044
+
+Norm of the Cartesian gradient     ...    0.0003228354
+RMS gradient                       ...    0.0000538059
+MAX gradient                       ...    0.0001672508
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.194 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.3%)
+RI-J Coulomb gradient       ....       0.063 sec  ( 32.5%)
+XC gradient                 ....       0.094 sec  ( 48.4%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.4 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  52
+Current Energy                          ....  -360.504779990 Eh
+Current gradient norm                   ....     0.000322835 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.700
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999982225
+Lowest eigenvalues of augmented Hessian:
+ -0.000000402  0.006878346  0.014567856  0.021402393  0.027528159
+Length of the computed step             ....  0.005962537
+The final length of the internal step   ....  0.005962537
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0008268552
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0013073465 RMS(Int)=    0.0008264835
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000000201
+Previously predicted energy change      ....    -0.000000426
+Actually observed energy change         ....    -0.000000571
+Ratio of predicted to observed change   ....     1.342192330
+New trust radius                        ....     0.700000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000005712            0.0000050000      YES
+          RMS gradient        0.0000309046            0.0001000000      YES
+          MAX gradient        0.0001100680            0.0003000000      YES
+          RMS step            0.0008268552            0.0020000000      YES
+          MAX step            0.0024491917            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0012      Max(Angles)    0.02
+          Max(Dihed)        0.14      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+                    ***********************HURRAY********************
+                    ***        THE OPTIMIZATION HAS CONVERGED     ***
+                    *************************************************
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+
+                          --- Optimized Parameters ---  
+                            (Angstroem and degrees)
+
+        Definition                    OldVal   dE/dq     Step     FinalVal
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4131 -0.000054  0.0001    1.4132   
+     2. B(C   2,C   1)                1.4996 -0.000029  0.0001    1.4996   
+     3. B(N   3,C   2)                1.3110 -0.000024 -0.0001    1.3109   
+     4. B(O   4,N   3)                1.3975  0.000044 -0.0000    1.3974   
+     5. B(C   5,O   4)                1.3458  0.000068 -0.0002    1.3455   
+     6. B(C   6,C   5)                1.3550 -0.000110  0.0001    1.3551   
+     7. B(C   6,C   2)                1.4234 -0.000100  0.0002    1.4235   
+     8. B(H   7,N   3)                2.2682  0.000001 -0.0012    2.2669   
+     9. B(H   7,O   0)                0.9659  0.000011 -0.0000    0.9659   
+    10. B(H   8,C   1)                1.0977 -0.000007  0.0000    1.0977   
+    11. B(H   9,C   1)                1.1050 -0.000007 -0.0000    1.1050   
+    12. B(H  10,C   5)                1.0810  0.000001  0.0000    1.0811   
+    13. B(H  11,C   6)                1.0793  0.000018 -0.0000    1.0793   
+    14. A(C   1,O   0,H   7)          107.95 -0.000011   -0.00    107.94   
+    15. A(O   0,C   1,C   2)          113.84  0.000015   -0.01    113.84   
+    16. A(C   2,C   1,H   9)          107.86 -0.000001    0.01    107.87   
+    17. A(C   2,C   1,H   8)          109.19  0.000030   -0.01    109.19   
+    18. A(O   0,C   1,H   9)          111.26  0.000000   -0.01    111.24   
+    19. A(H   8,C   1,H   9)          106.88 -0.000004    0.01    106.89   
+    20. A(O   0,C   1,H   8)          107.57 -0.000041    0.02    107.59   
+    21. A(N   3,C   2,C   6)          111.61  0.000028    0.00    111.61   
+    22. A(C   1,C   2,C   6)          128.57 -0.000037    0.00    128.57   
+    23. A(C   1,C   2,N   3)          119.78  0.000009   -0.00    119.77   
+    24. A(C   2,N   3,O   4)          105.95 -0.000033    0.00    105.95   
+    25. A(N   3,O   4,C   5)          108.41 -0.000027    0.00    108.41   
+    26. A(O   4,C   5,H  10)          115.82 -0.000008   -0.00    115.81   
+    27. A(O   4,C   5,C   6)          110.50 -0.000017    0.01    110.52   
+    28. A(C   6,C   5,H  10)          133.68  0.000026   -0.01    133.67   
+    29. A(C   5,C   6,H  11)          128.03  0.000000   -0.00    128.03   
+    30. A(C   2,C   6,H  11)          128.44 -0.000050    0.02    128.46   
+    31. A(C   2,C   6,C   5)          103.53  0.000049   -0.02    103.51   
+    32. D(H   9,C   1,O   0,H   7)    -91.25  0.000011   -0.13    -91.38   
+    33. D(C   2,C   1,O   0,H   7)     30.88  0.000021   -0.14     30.74   
+    34. D(H   8,C   1,O   0,H   7)    152.01  0.000040   -0.14    151.87   
+    35. D(N   3,C   2,C   1,H   9)    110.84  0.000006   -0.09    110.74   
+    36. D(N   3,C   2,C   1,O   0)    -13.14 -0.000003   -0.08    -13.22   
+    37. D(C   6,C   2,C   1,O   0)    169.65 -0.000004   -0.09    169.56   
+    38. D(C   6,C   2,C   1,H   8)     49.43  0.000017   -0.10     49.33   
+    39. D(N   3,C   2,C   1,H   8)   -133.36  0.000017   -0.09   -133.45   
+    40. D(O   4,N   3,C   2,C   1)   -177.79  0.000003   -0.01   -177.80   
+    41. D(O   4,N   3,C   2,C   6)     -0.14  0.000002   -0.00     -0.14   
+    42. D(C   5,O   4,N   3,C   2)      0.02  0.000005   -0.01      0.02   
+    43. D(H  10,C   5,O   4,N   3)   -179.54 -0.000003    0.00   -179.53   
+    44. D(C   6,C   5,O   4,N   3)      0.11 -0.000010    0.01      0.11   
+    45. D(C   5,C   6,C   2,N   3)      0.20 -0.000007    0.00      0.20   
+    46. D(C   5,C   6,C   2,C   1)    177.59 -0.000007    0.02    177.61   
+    47. D(H  11,C   6,C   5,H  10)     -0.25 -0.000004    0.00     -0.25   
+    48. D(H  11,C   6,C   5,O   4)   -179.81  0.000004   -0.01   -179.81   
+    49. D(C   2,C   6,C   5,H  10)    179.38  0.000002   -0.00    179.38   
+    50. D(C   2,C   6,C   5,O   4)     -0.18  0.000010   -0.01     -0.19   
+    51. D(H  11,C   6,C   2,N   3)    179.82 -0.000001    0.00    179.83   
+    52. D(H  11,C   6,C   2,C   1)     -2.78 -0.000001    0.01     -2.77   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 9.049 %)
+Internal coordinates            :      0.000 s ( 0.797 %)
+B/P matrices and projection     :      0.002 s (60.308 %)
+Hessian update/contruction      :      0.000 s ( 7.841 %)
+Making the step                 :      0.000 s ( 5.707 %)
+Converting the step to Cartesian:      0.000 s ( 0.977 %)
+Storing new data                :      0.000 s ( 0.617 %)
+Checking convergence            :      0.000 s ( 0.283 %)
+Final printing                  :      0.001 s (14.370 %)
+Total time                      :      0.004 s
+                 *******************************************************
+                 *** FINAL ENERGY EVALUATION AT THE STATIONARY POINT ***
+                 ***               (AFTER    6 CYCLES)               ***
+                 *******************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.410285    0.685130   -0.291391
+  C     -1.517614   -0.345723    0.079386
+  C     -0.072217    0.045322   -0.003373
+  N      0.269919    1.144262   -0.630867
+  O      1.665216    1.199047   -0.576345
+  C      2.107327    0.116755    0.089731
+  C      1.066782   -0.658850    0.479625
+  H     -1.972020    1.234151   -0.954290
+  H     -1.754705   -0.634427    1.111581
+  H     -1.661998   -1.244732   -0.546608
+  H      3.179215    0.042914    0.209207
+  H      1.098671   -1.586042    1.031139
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.554778    1.294709   -0.550649
+   1 C     6.0000    0    12.011   -2.867876   -0.653322    0.150017
+   2 C     6.0000    0    12.011   -0.136470    0.085646   -0.006373
+   3 N     7.0000    0    14.007    0.510073    2.162342   -1.192165
+   4 O     8.0000    0    15.999    3.146802    2.265870   -1.089134
+   5 C     6.0000    0    12.011    3.982271    0.220636    0.169568
+   6 C     6.0000    0    12.011    2.015926   -1.245047    0.906359
+   7 H     1.0000    0     1.008   -3.726578    2.332207   -1.803347
+   8 H     1.0000    0     1.008   -3.315912   -1.198893    2.100584
+   9 H     1.0000    0     1.008   -3.140721   -2.352202   -1.032939
+  10 H     1.0000    0     1.008    6.007847    0.081096    0.395343
+  11 H     1.0000    0     1.008    2.076188   -2.997184    1.948571
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.413150714206     0.00000000     0.00000000
+ C      2   1   0     1.499646507543   113.83736998     0.00000000
+ N      3   2   1     1.310906047007   119.77274872   346.78344627
+ O      4   3   2     1.397436151756   105.94897770   182.20044464
+ C      5   4   3     1.345538718598   108.41229535     0.00000000
+ C      6   5   4     1.355107143162   110.51821419     0.11470483
+ H      1   2   3     0.965885634484   107.94401518    30.74038509
+ H      2   1   3     1.097720201936   107.58572202   121.12735874
+ H      2   1   3     1.104957058871   111.24287957   237.88233172
+ H      6   5   4     1.081051152165   115.81339361   180.46546264
+ H      7   6   5     1.079290979884   128.02713058   180.18759593
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.670467835804     0.00000000     0.00000000
+ C      2   1   0     2.833921196947   113.83736998     0.00000000
+ N      3   2   1     2.477253416145   119.77274872   346.78344627
+ O      4   3   2     2.640771616459   105.94897770   182.20044464
+ C      5   4   3     2.542699680738   108.41229535     0.00000000
+ C      6   5   4     2.560781382696   110.51821419     0.11470483
+ H      1   2   3     1.825259325864   107.94401518    30.74038509
+ H      2   1   3     2.074390553332   107.58572202   121.12735874
+ H      2   1   3     2.088066231010   111.24287957   237.88233172
+ H      6   5   4     2.042890614351   115.81339361   180.46546264
+ H      7   6   5     2.039564370791   128.02713058   180.18759593
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   2 Type C   : 11s6p1d contracted to 5s3p1d pattern {62111/411/1}
+ Group   3 Type N   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   4 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   2 Type C   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   3 Type N   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   4 Type H   : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3073
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8264
+          la=0 lb=0:    919 shell pairs
+          la=1 lb=0:   1085 shell pairs
+          la=1 lb=1:    338 shell pairs
+          la=2 lb=0:    427 shell pairs
+          la=2 lb=1:    251 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    291.675354645170 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.153e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.005 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59180
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4932
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+  Functional kind                       .... Exchange
+  Functional name                       .... Re-regularized SCAN exchange by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 6
+    Parameter  0 _c1        =  6.670000e-01 : c1 parameter        
+    Parameter  1 _c2        =  8.000000e-01 : c2 parameter        
+    Parameter  2 _d         =  1.240000e+00 : d parameter         
+    Parameter  3 _k1        =  6.500000e-02 : k1 parameter        
+    Parameter  4 _eta       =  1.000000e-03 : eta parameter       
+    Parameter  5 _dp2       =  3.610000e-01 : dp2 parameter       
+  Functional kind                       .... Correlation
+  Functional name                       .... Re-regularized SCAN correlation by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 1
+    Parameter  0 _eta       =  1.000000e-03 : Regularization parameter
+ Gradients option       PostSCFGGA      .... off
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 265
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   52
+ Basis Dimension        Dim             ....  173
+ Nuclear Repulsion      ENuc            ....    291.6753546452 Eh
+
+Convergence Acceleration:
+ AO-DIIS                CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ MO-DIIS                CNVKDIIS        .... off
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....     1
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    24
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold    (grad. norm)   ....   1.000e-05
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   1.000e-02
+   NR start threshold (gradient norm)   ....   1.000e-04
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Quad. conv. algorithm                .... NR
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Pseudo random numbers                .... off
+   Inactive MOs                         .... canonical
+   Orbital update algorithm             .... Taylor
+   Preconditioner                       .... Diag
+   Full preconditioner red. dimension   ....   250
+   COSX micro iterations for RIJONX calc.... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+   Hessian update       SOSCFHessUp     .... L-BFGS
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: input.gbw
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+Occupation numbers will be reassigned to an Aufbau configuration
+MOs were renormalized
+MOs were reorthogonalized (Cholesky)
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+-------------------------------------------------------------------------------------------
+                                      ORCA LEAN-SCF
+                              memory conserving SCF solver
+-------------------------------------------------------------------------------------------
+
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.5115663206941008     0.00e+00  2.63e-05  6.82e-04  5.90e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.5115686846877452    -2.36e-06  1.17e-05  2.48e-04  4.91e-05     0.1
+    3    -360.5115687813017757    -9.66e-08  6.92e-06  1.14e-04  1.08e-04     0.1
+    4    -360.5115687806226106     6.79e-10  6.31e-06  1.21e-04  7.49e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   4 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.51156878062261 Eh           -9810.01852 eV
+
+Components:
+Nuclear Repulsion  :        291.67535464516982 Eh            7936.88990 eV
+Electronic Energy  :       -652.18692342579243 Eh          -17746.90842 eV
+One Electron Energy:      -1068.19206320584226 Eh          -29066.98378 eV
+Two Electron Energy:        416.00513978004983 Eh           11320.07535 eV
+
+Virial components:
+Potential Energy   :       -719.55356622411387 Eh          -19580.04797 eV
+Kinetic Energy     :        359.04199744349131 Eh            9770.02945 eV
+Virial Ratio       :          2.00409303465220
+
+DFT components:
+N(Alpha)           :       26.000019131217 electrons
+N(Beta)            :       26.000019131217 electrons
+N(Total)           :       52.000038262434 electrons
+E(X)               :      -45.755464181228 Eh       
+E(C)               :       -1.716139110297 Eh       
+E(XC)              :      -47.471603291525 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -6.7917e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.2063e-04  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    6.3113e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    5.5759e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    7.4859e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.6090e-04  Tolerance :   1.0000e-05
+
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -19.053823      -518.4809 
+   1   2.0000     -18.956106      -515.8219 
+   2   2.0000     -14.214887      -386.8068 
+   3   2.0000     -10.114039      -275.2170 
+   4   2.0000     -10.102553      -274.9044 
+   5   2.0000     -10.087731      -274.5011 
+   6   2.0000     -10.057990      -273.6918 
+   7   2.0000      -1.118638       -30.4397 
+   8   2.0000      -0.995363       -27.0852 
+   9   2.0000      -0.851512       -23.1708 
+  10   2.0000      -0.775930       -21.1141 
+  11   2.0000      -0.685073       -18.6418 
+  12   2.0000      -0.604882       -16.4597 
+  13   2.0000      -0.556557       -15.1447 
+  14   2.0000      -0.520287       -14.1577 
+  15   2.0000      -0.467965       -12.7340 
+  16   2.0000      -0.451639       -12.2897 
+  17   2.0000      -0.429811       -11.6958 
+  18   2.0000      -0.416502       -11.3336 
+  19   2.0000      -0.410457       -11.1691 
+  20   2.0000      -0.367598       -10.0028 
+  21   2.0000      -0.321705        -8.7540 
+  22   2.0000      -0.291625        -7.9355 
+  23   2.0000      -0.281249        -7.6532 
+  24   2.0000      -0.258953        -7.0465 
+  25   2.0000      -0.246047        -6.6953 
+  26   0.0000      -0.053528        -1.4566 
+  27   0.0000       0.013234         0.3601 
+  28   0.0000       0.039779         1.0824 
+  29   0.0000       0.074264         2.0208 
+  30   0.0000       0.083505         2.2723 
+  31   0.0000       0.105091         2.8597 
+  32   0.0000       0.117935         3.2092 
+  33   0.0000       0.136976         3.7273 
+  34   0.0000       0.144768         3.9393 
+  35   0.0000       0.157113         4.2753 
+  36   0.0000       0.175571         4.7775 
+*Only the first 10 virtual orbitals were printed.
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.416984
+   1 C :   -0.255657
+   2 C :    0.301333
+   3 N :   -0.343383
+   4 O :    0.046084
+   5 C :   -0.042638
+   6 C :   -0.225892
+   7 H :    0.325450
+   8 H :    0.145855
+   9 H :    0.145322
+  10 H :    0.156389
+  11 H :    0.164120
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.763069  s :     3.763069
+      pz      :     1.624877  p :     4.641702
+      px      :     1.591540
+      py      :     1.425285
+      dz2     :     0.004143  d :     0.012213
+      dxz     :     0.003566
+      dyz     :    -0.001686
+      dx2y2   :     0.001840
+      dxy     :     0.004350
+
+  1 C s       :     3.332187  s :     3.332187
+      pz      :     1.067868  p :     2.861250
+      px      :     0.865470
+      py      :     0.927912
+      dz2     :     0.010923  d :     0.062221
+      dxz     :     0.007440
+      dyz     :     0.011808
+      dx2y2   :     0.018606
+      dxy     :     0.013445
+
+  2 C s       :     3.124317  s :     3.124317
+      pz      :     0.899334  p :     2.510821
+      px      :     0.776273
+      py      :     0.835214
+      dz2     :     0.009452  d :     0.063529
+      dxz     :     0.010642
+      dyz     :     0.010067
+      dx2y2   :     0.017692
+      dxy     :     0.015676
+
+  3 N s       :     3.728436  s :     3.728436
+      pz      :     1.284663  p :     3.512214
+      px      :     0.913383
+      py      :     1.314169
+      dz2     :     0.015910  d :     0.102733
+      dxz     :     0.026099
+      dyz     :     0.012185
+      dx2y2   :     0.025843
+      dxy     :     0.022696
+
+  4 O s       :     3.739050  s :     3.739050
+      pz      :     1.576905  p :     4.147931
+      px      :     1.099895
+      py      :     1.471131
+      dz2     :     0.008828  d :     0.066935
+      dxz     :     0.023139
+      dyz     :     0.005309
+      dx2y2   :     0.013233
+      dxy     :     0.016426
+
+  5 C s       :     3.282768  s :     3.282768
+      pz      :     0.905744  p :     2.699534
+      px      :     0.986327
+      py      :     0.807464
+      dz2     :     0.009707  d :     0.060336
+      dxz     :     0.007604
+      dyz     :     0.011280
+      dx2y2   :     0.017992
+      dxy     :     0.013753
+
+  6 C s       :     3.152913  s :     3.152913
+      pz      :     1.083076  p :     3.036059
+      px      :     0.929175
+      py      :     1.023807
+      dz2     :     0.003855  d :     0.036920
+      dxz     :     0.007716
+      dyz     :     0.005282
+      dx2y2   :     0.007922
+      dxy     :     0.012146
+
+  7 H s       :     0.630176  s :     0.630176
+      pz      :     0.017456  p :     0.044374
+      px      :     0.012574
+      py      :     0.014344
+
+  8 H s       :     0.836938  s :     0.836938
+      pz      :     0.010561  p :     0.017207
+      px      :     0.003230
+      py      :     0.003415
+
+  9 H s       :     0.837651  s :     0.837651
+      pz      :     0.005696  p :     0.017027
+      px      :     0.003012
+      py      :     0.008319
+
+ 10 H s       :     0.823643  s :     0.823643
+      pz      :     0.003919  p :     0.019968
+      px      :     0.013144
+      py      :     0.002905
+
+ 11 H s       :     0.815556  s :     0.815556
+      pz      :     0.006716  p :     0.020325
+      px      :     0.003178
+      py      :     0.010431
+
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.569116
+   1 C :    0.056335
+   2 C :    0.169952
+   3 N :   -0.356686
+   4 O :   -0.365065
+   5 C :    0.187441
+   6 C :   -0.146415
+   7 H :    0.279830
+   8 H :    0.185775
+   9 H :    0.174717
+  10 H :    0.199641
+  11 H :    0.183593
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.517319  s :     3.517319
+      pz      :     1.663144  p :     4.794151
+      px      :     1.621966
+      py      :     1.509041
+      dz2     :     0.036143  d :     0.257647
+      dxz     :     0.033583
+      dyz     :     0.059220
+      dx2y2   :     0.065203
+      dxy     :     0.063497
+
+  1 C s       :     2.851735  s :     2.851735
+      pz      :     1.071177  p :     2.958632
+      px      :     0.931095
+      py      :     0.956360
+      dz2     :     0.025203  d :     0.133298
+      dxz     :     0.013240
+      dyz     :     0.026191
+      dx2y2   :     0.040162
+      dxy     :     0.028503
+
+  2 C s       :     2.800059  s :     2.800059
+      pz      :     0.903940  p :     2.901779
+      px      :     1.017130
+      py      :     0.980709
+      dz2     :     0.016655  d :     0.128210
+      dxz     :     0.019370
+      dyz     :     0.022315
+      dx2y2   :     0.035625
+      dxy     :     0.034245
+
+  3 N s       :     3.236053  s :     3.236053
+      pz      :     1.248995  p :     3.551089
+      px      :     0.966777
+      py      :     1.335317
+      dz2     :     0.072615  d :     0.569544
+      dxz     :     0.118978
+      dyz     :     0.068825
+      dx2y2   :     0.164267
+      dxy     :     0.144859
+
+  4 O s       :     3.406715  s :     3.406715
+      pz      :     1.551420  p :     4.395302
+      px      :     1.321078
+      py      :     1.522804
+      dz2     :     0.074138  d :     0.563048
+      dxz     :     0.130469
+      dyz     :     0.064954
+      dx2y2   :     0.138443
+      dxy     :     0.155044
+
+  5 C s       :     2.844532  s :     2.844532
+      pz      :     0.891626  p :     2.838018
+      px      :     1.057049
+      py      :     0.889343
+      dz2     :     0.018451  d :     0.130010
+      dxz     :     0.014700
+      dyz     :     0.026627
+      dx2y2   :     0.038651
+      dxy     :     0.031580
+
+  6 C s       :     2.897724  s :     2.897724
+      pz      :     1.064100  p :     3.172511
+      px      :     1.035740
+      py      :     1.072672
+      dz2     :     0.006085  d :     0.076179
+      dxz     :     0.015849
+      dyz     :     0.009152
+      dx2y2   :     0.018388
+      dxy     :     0.026707
+
+  7 H s       :     0.595692  s :     0.595692
+      pz      :     0.050214  p :     0.124478
+      px      :     0.035350
+      py      :     0.038914
+
+  8 H s       :     0.774870  s :     0.774870
+      pz      :     0.025120  p :     0.039355
+      px      :     0.007238
+      py      :     0.006998
+
+  9 H s       :     0.785290  s :     0.785290
+      pz      :     0.013992  p :     0.039994
+      px      :     0.006750
+      py      :     0.019252
+
+ 10 H s       :     0.757130  s :     0.757130
+      pz      :     0.008020  p :     0.043230
+      px      :     0.029273
+      py      :     0.005937
+
+ 11 H s       :     0.769409  s :     0.769409
+      pz      :     0.015480  p :     0.046999
+      px      :     0.006968
+      py      :     0.024551
+
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.4170     8.0000    -0.4170     1.8586     1.8586     0.0000
+  1 C      6.2557     6.0000    -0.2557     3.9312     3.9312    -0.0000
+  2 C      5.6987     6.0000     0.3013     3.6818     3.6818     0.0000
+  3 N      7.3434     7.0000    -0.3434     2.8429     2.8429    -0.0000
+  4 O      7.9539     8.0000     0.0461     2.2374     2.2374     0.0000
+  5 C      6.0426     6.0000    -0.0426     3.8337     3.8337    -0.0000
+  6 C      6.2259     6.0000    -0.2259     3.7432     3.7432     0.0000
+  7 H      0.6745     1.0000     0.3255     0.9031     0.9031    -0.0000
+  8 H      0.8541     1.0000     0.1459     0.9497     0.9497    -0.0000
+  9 H      0.8547     1.0000     0.1453     0.9470     0.9470    -0.0000
+ 10 H      0.8436     1.0000     0.1564     0.9709     0.9709    -0.0000
+ 11 H      0.8359     1.0000     0.1641     0.9700     0.9700    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-C ) :   1.0121 B(  0-O ,  7-H ) :   0.8665 B(  1-C ,  2-C ) :   0.9151 
+B(  1-C ,  8-H ) :   0.9575 B(  1-C ,  9-H ) :   0.9571 B(  2-C ,  3-N ) :   1.5612 
+B(  2-C ,  6-C ) :   1.2030 B(  3-N ,  4-O ) :   1.0090 B(  3-N ,  5-C ) :   0.1261 
+B(  4-O ,  5-C ) :   1.1214 B(  5-C ,  6-C ) :   1.6025 B(  5-C , 10-H ) :   0.9628 
+B(  6-C , 11-H ) :   0.9238 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.911 sec
+Sum of individual times     ....       0.889 sec  ( 97.6%)
+
+SCF preparation             ....       0.483 sec  ( 53.0%)
+Fock matrix formation       ....       0.313 sec  ( 34.3%)
+  Startup                   ....       0.007 sec  (  2.3% of F)
+  Split-RI-J                ....       0.066 sec  ( 21.0% of F)
+  XC integration            ....       0.221 sec  ( 70.8% of F)
+    XC Preparation          ....       0.000 sec  (  0.0% of XC)
+    Basis function eval.    ....       0.022 sec  (  9.9% of XC)
+    Density eval.           ....       0.044 sec  ( 19.7% of XC)
+    XC-Functional eval.     ....       0.013 sec  (  5.9% of XC)
+    XC-Potential eval.      ....       0.046 sec  ( 20.9% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.011 sec  (  1.2%)
+Total Energy calculation    ....       0.008 sec  (  0.9%)
+Population analysis         ....       0.018 sec  (  1.9%)
+Orbital Transformation      ....       0.010 sec  (  1.1%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.014 sec  (  1.6%)
+SOSCF solution              ....       0.033 sec  (  3.7%)
+Finished LeanSCF after   0.9 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.7 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+The R2SCAN3C composite method is recognized
+Using three-body term ABC
+Active option DFTDOPT                   ...         5   
+
+-------------------------   ----------------
+Dispersion correction           -0.003069533
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.009858182
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.504780131754
+-------------------------   --------------------
+
+                                *** OPTIMIZATION RUN DONE ***
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+------------------------------------------------------------------------------
+                              ORCA PROPERTY CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                 ... input.gbw
+Number of atoms                         ...     12
+Number of basis functions               ...    173
+Max core memory                         ...   9800 MB
+
+Electric properties:
+Dipole moment                           ... YES
+Quadrupole moment                       ...  NO
+Static polarizability (Dipole/Dipole)   ...  NO
+Static polarizability (Dipole/Quad.)    ...  NO
+Static polarizability (Quad./Quad.)     ...  NO
+Static polarizability (Velocity)        ...  NO
+
+Atomic electric properties:
+Dipole moment                           ...  NO
+Quadrupole moment                       ...  NO
+Static polarizability                   ...  NO
+
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.186313     0.645511    -0.269093
+
+General magnetic properties:
+Magnetizability                         ...  NO
+
+EPR properties:
+g-Tensor (aka g-matrix)                 ...  NO
+Zero-Field splitting spin-orbit         ...  NO
+Zero-field splitting spin-spin          ...  NO
+Hyperfine couplings                     ...  NO (   0 nuclei)
+Quadrupole couplings                    ...  NO (   0 nuclei)
+Contact density                         ...  NO (   0 nuclei)
+
+NMR properties:
+Chemical shifts                         ...  NO (   0 nuclei)
+Spin-rotation constants                 ...  NO (   0 nuclei)
+Spin-spin couplings                     ...  NO (   0 nuclei,    0 pairs)
+
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+
+Properties with geometric perturbations:
+SCF Hessian                             ...  NO
+IR spectrum                             ...  NO
+VCD spectrum                            ...  NO
+X-ray spectroscopy properties:
+SCF XES/XAS/RIXS spectra                ...  NO
+
+
+-------------
+DIPOLE MOMENT
+-------------
+
+Method             : SCF
+Type of density    : Electron Density
+Multiplicity       :   1
+Irrep              :   0
+Energy             :  -360.5115687806226106 Eh
+Relativity type    : 
+Basis              : AO
+                                X                 Y                 Z
+Electronic contribution:      2.330911409       2.587201106      -1.093744708
+Nuclear contribution   :     -1.517638177      -3.633030977       1.455077244
+                        -----------------------------------------
+Total Dipole Moment    :      0.813273233      -1.045829872       0.361332537
+                        -----------------------------------------
+Magnitude (a.u.)       :      1.373220548
+Magnitude (Debye)      :      3.490449242
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:             0.252886             0.065953             0.052976 
+Rotational constants in MHz :          7581.324455          1977.228640          1588.190418 
+
+Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.787647    -1.104661    -0.212300 
+x,y,z [Debye]:     2.002040    -2.807824    -0.539625 
+
+ 
+
+Dipole moment calculation done in   0.0 sec 
+
+Maximum memory used throughout the entire PROP-calculation: 6.3 MB
+
+--------------------------------
+SUGGESTED CITATIONS FOR THIS RUN
+--------------------------------
+
+Below you find a list of papers that are relevant to this ORCA run
+We neither can nor want to force you to cite these papers, but we appreciate if you do
+You receive ORCA, which is the product of decades of hard work by many enthusiastic individuals, for free
+The only thing we kindly ask in return is that you cite our papers,
+We deeply appreciate it, if you show your appreciation for ORCA by not just citing the generic ORCA reference.
+
+Please note that relegating all ORCA citations to the supporting information does *not* help us.
+SI sections are not indexed - citations you put there will not count into any citation statistics
+But we need these citations in order to attract the funding resources that allow us to do what we are doing
+
+Therefore, if you are a happy ORCA user, please consider citing a few of the papers listed below in the main body of your paper
+
+In addition to the list printed below, the program has created the file input.bibtex that contains the list in bibtex format
+You can import this file easily into all common literature databanks and citation aid programs
+
+
+List of essential papers. We consider these as the minimum necessary citations
+
+  1. Neese,F.
+     Software update: the ORCA program system, version 5.0
+     WIRES Comput. Molec. Sci., 2022 12(1)e1606
+     doi.org/10.1002/wcms.1606
+  2. Grimme,S.; Hansen,A.; Ehlert,S.; Mewes,J.
+     r2SCAN-3c: A 'Swiss army knife' composite electronic-structure method
+     J. Chem. Phys., 2021 154 064103
+     doi.org/10.1063/5.0040021
+
+List of papers to cite with high priority. The work reported in these papers was absolutely
+necessary for this run to complete.
+Our perspective: the developers of density functionals and basis sets usually get cited in chemistry papers
+Good! But without the algorithms to do something with them, the functionals or basis sets would not do anything.
+Hence, in our opinion, the algorithm design and method developments papers are equally worthy of getting cited
+
+  1. Neese,F.
+     An improvement of the resolution of the identity approximation for the formation of the Coulomb matrix
+     J. Comp. Chem., 2003 24(14)1740-1747
+     doi.org/10.1002/jcc.10318
+  2. Neese,F.
+     The SHARK Integral Generation and Digestion System
+     J. Comp. Chem., 2022  1-16
+     doi.org/10.1002/jcc.26942
+  3. Lehtola,S.; Steigemann,C.; Oliveira,M.; Marques,M.
+     Recent developments in Libxc - A comprehensive library of functionals for density functional theory
+     Software X, 2018 7 
+     doi.org/10.1016/j.softx.2017.11.002
+  4. Caldeweyher,E.; Bannwarth,C.; Grimme,S.
+     Extension of the D3 dispersion coefficient model
+     J. Chem. Phys., 2017 147 034112-XXXX
+     doi.org/10.1063/1.4993215
+  5. Caldeweyher,E.; Ehlert,S.; Hansen,A.; Neugebauer,H.; Spicher,S.; Bannwarth,C.; Grimme,S.
+     A generally applicable atomic-charge dependent London dispersion correction
+     J. Chem. Phys., 2019 150 154122-XXXX
+     doi.org/10.1063/1.5090222
+  6. Caldeweyher,E.; Mewes,J.; Ehlert,S.; Grimme,S.
+     Extension and evaluation of the D4 London-dispersion model for periodic systems
+     Phys. Chem. Chem. Phys., 2020 22(16)8499-8512
+     doi.org/10.1039/D0CP00502A
+
+List of suggested additional citations. These are papers that are important in the 'surrounding' of 
+of this run, or papers that preceded the highly important papers. If you like your results we are grateful for a citation.
+
+  1. Neese,F.
+     The ORCA program system
+     WIRES Comput. Molec. Sci., 2012 2(1)73-78
+     doi.org/10.1002/wcms.81
+  2. Neese,F.
+     Software update: the ORCA program system, version 4.0
+     WIRES Comput. Molec. Sci., 2018 8(1)1-6
+     doi.org/10.1002/wcms.1327
+  3. Neese,F.; Wennmohs,F.; Becker,U.; Riplinger,C.
+     The ORCA quantum chemistry program package
+     J. Chem. Phys., 2020 152 Art. No. L224108
+     doi.org/10.1063/5.0004608
+
+List of optional additional citations
+
+  1. Neese,F.
+     Approximate second-order SCF convergence for spin unrestricted wavefunctions
+     Chem. Phys. Lett., 2000 325(1-3)93-98
+     doi.org/10.1016/s0009-2614(00)00662-x
+
+Timings for individual modules:
+
+Sum of individual times          ...       32.343 sec (=   0.539 min)
+Startup calculation              ...        8.231 sec (=   0.137 min)  25.4 %
+SCF iterations                   ...       16.474 sec (=   0.275 min)  50.9 %
+Property calculations            ...        1.067 sec (=   0.018 min)   3.3 %
+SCF Gradient evaluation          ...        6.550 sec (=   0.109 min)  20.3 %
+Geometry relaxation              ...        0.021 sec (=   0.000 min)   0.1 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 38 seconds 898 msec

--- a/arc/testing/bond_orders/C8H14O2_mayer_gaussian.out
+++ b/arc/testing/bond_orders/C8H14O2_mayer_gaussian.out
@@ -1,0 +1,1068 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /usr/local/g16/l1.exe "/gtmp/4471893.zeus-master/Gau-3329202.inp" -scrdir="/gtmp/4471893.zeus-master/"
+ Entering Link 1 = /usr/local/g16/l1.exe PID=   3329203.
+  
+ Copyright (c) 1988-2019, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision C.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2019.
+ 
+ ******************************************
+ Gaussian 16:  EM64L-G16RevC.01  3-Jul-2019
+                22-Jul-2026 
+ ******************************************
+ %chk=check.chk
+ %mem=81920mb
+ %NProcShared=16
+ Will use up to   16 processors via shared memory.
+ ---------------------------------------------------------
+ #P guess=mix wb97xd/def2tzvp IOp(2/9=2000,6/80=1) scf=xqc
+ ---------------------------------------------------------
+ 1/38=1,172=1/1;
+ 2/9=2000,12=2,17=6,18=5,40=1/2;
+ 3/5=44,7=101,11=2,25=1,30=1,74=-58/1,2,3;
+ 4/13=-1/1;
+ 5/5=2,8=3,13=1,38=5/2,8;
+ 6/7=2,8=2,9=2,10=2,28=1,80=1/1;
+ 99/5=1,9=1/99;
+ Leave Link    1 at Wed Jul 22 12:14:07 2026, MaxMem= 10737418240 cpu:               0.6 elap:               0.0
+ (Enter /usr/local/g16/l101.exe)
+ ---
+ 540
+ ---
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ C                    -3.5671   -1.30942  -0.07568 
+ C                    -2.83072  -0.39125   0.5552 
+ C                    -3.4066    0.85717   1.16248 
+ C                    -1.34486  -0.57694   0.71908 
+ O                    -0.70711   0.56084   0.17694 
+ O                     0.66549   0.4728    0.50583 
+ C                     0.94397   1.5008    1.43366 
+ C                     2.34479   1.28914   1.94557 
+ C                     3.25664   2.26085   1.8584 
+ C                     2.6202   -0.05098   2.56785 
+ H                    -3.11248  -2.19752  -0.52262 
+ H                    -4.65173  -1.20427  -0.16494 
+ H                    -3.15867   0.91798   2.23514 
+ H                    -4.49914   0.89325   1.05505 
+ H                    -2.97499   1.74947   0.68459 
+ H                    -0.99413  -1.493     0.21479 
+ H                    -1.09491  -0.65709   1.79585 
+ H                     0.83255   2.48999   0.95872 
+ H                     0.22526   1.43766   2.27496 
+ H                     3.02766   3.21781   1.38203 
+ H                     4.26422   2.13216   2.26297 
+ H                     2.48667  -0.85229   1.8256 
+ H                     1.91006  -0.25281   3.38684 
+ H                     3.64079  -0.10905   2.96971 
+ 
+ ITRead=  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ ITRead=  0  0  0  0
+ MicOpt= -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+ MicOpt= -1 -1 -1 -1
+ NAtoms=     24 NQM=       24 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          12          12          12          12          16          16          12          12          12          12
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  15.9949146  15.9949146  12.0000000  12.0000000  12.0000000  12.0000000
+ NucSpn=           0           0           0           0           0           0           0           0           0           0
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   8.0000000   8.0000000   6.0000000   6.0000000   6.0000000   6.0000000
+
+  Atom        11          12          13          14          15          16          17          18          19          20
+ IAtWgt=           1           1           1           1           1           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1           1           1           1           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        21          22          23          24
+ IAtWgt=           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1
+ AtZEff=  -0.0000000  -0.0000000  -0.0000000  -0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000
+ Leave Link  101 at Wed Jul 22 12:14:07 2026, MaxMem= 10737418240 cpu:               1.2 elap:               0.1
+ (Enter /usr/local/g16/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -3.567097   -1.309419   -0.075684
+      2          6           0       -2.830721   -0.391252    0.555196
+      3          6           0       -3.406604    0.857168    1.162476
+      4          6           0       -1.344856   -0.576939    0.719084
+      5          8           0       -0.707111    0.560842    0.176940
+      6          8           0        0.665488    0.472804    0.505826
+      7          6           0        0.943969    1.500797    1.433658
+      8          6           0        2.344786    1.289139    1.945571
+      9          6           0        3.256640    2.260846    1.858402
+     10          6           0        2.620195   -0.050976    2.567845
+     11          1           0       -3.112484   -2.197523   -0.522618
+     12          1           0       -4.651734   -1.204267   -0.164935
+     13          1           0       -3.158665    0.917982    2.235137
+     14          1           0       -4.499139    0.893251    1.055049
+     15          1           0       -2.974986    1.749467    0.684587
+     16          1           0       -0.994132   -1.492997    0.214788
+     17          1           0       -1.094905   -0.657085    1.795847
+     18          1           0        0.832546    2.489987    0.958716
+     19          1           0        0.225259    1.437664    2.274957
+     20          1           0        3.027661    3.217813    1.382027
+     21          1           0        4.264225    2.132163    2.262966
+     22          1           0        2.486668   -0.852292    1.825597
+     23          1           0        1.910059   -0.252810    3.386836
+     24          1           0        3.640788   -0.109053    2.969706
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.335399   0.000000
+     3  C    2.500579   1.502991   0.000000
+     4  C    2.471141   1.506364   2.550307   0.000000
+     5  O    3.426546   2.357813   2.889005   1.412510   0.000000
+     6  O    4.629174   3.601737   4.142567   2.277921   1.414194
+     7  C    5.524956   4.312752   4.406278   3.172747   2.277920
+     8  C    6.766708   5.616291   5.820509   4.312769   3.601742
+     9  C    7.940458   6.766678   6.844958   5.524928   4.629109
+    10  C    6.845035   5.820569   6.254766   4.406380   4.142670
+    11  H    1.093230   2.122190   3.501026   2.700486   3.726094
+    12  H    1.093371   2.120300   2.749888   3.480010   4.335036
+    13  H    3.235433   2.154958   1.102621   2.796982   3.220845
+    14  H    2.645565   2.164121   1.098397   3.496260   3.906539
+    15  H    3.207085   2.149473   1.100395   2.840894   2.610324
+    16  H    2.595809   2.168589   3.498773   1.102943   2.074143
+    17  H    3.168580   2.150102   2.835150   1.108295   2.062666
+    18  H    5.904433   4.678022   4.547308   3.768891   2.589077
+    19  H    5.239651   3.954937   3.842528   2.990757   2.457602
+    20  H    8.130903   6.930342   6.857158   5.827396   4.739225
+    21  H    8.868110   7.721552   7.853554   6.417522   5.615580
+    22  H    6.361753   5.486447   6.171923   3.997595   3.862026
+    23  H    6.565417   5.523798   5.869134   4.220952   4.220787
+    24  H    7.916368   6.913026   7.339305   5.490069   5.210809
+                    6          7          8          9         10
+     6  O    0.000000
+     7  C    1.412513   0.000000
+     8  C    2.357819   1.506367   0.000000
+     9  C    3.426460   2.471139   1.335399   0.000000
+    10  C    2.889143   2.550316   1.502991   2.500578   0.000000
+    11  H    4.739348   5.827469   6.930409   8.130932   6.857276
+    12  H    5.615633   6.417536   7.721567   8.868105   7.853605
+    13  H    4.220527   4.220622   5.523548   6.565162   5.868969
+    14  H    5.210738   5.489980   6.912964   7.916300   7.339280
+    15  H    3.861978   3.997643   5.486525   6.361801   6.172058
+    16  H    2.589095   3.768910   4.678062   5.904394   4.547490
+    17  H    2.457598   2.990760   3.954956   5.239673   3.842566
+    18  H    2.074137   1.102942   2.168591   2.595799   3.498782
+    19  H    2.062664   1.108293   2.150105   3.168662   2.835057
+    20  H    3.725945   2.700478   2.122188   1.093229   3.501025
+    21  H    4.334965   3.480011   2.120301   1.093370   2.749888
+    22  H    2.610435   2.840874   2.149477   3.207111   1.100395
+    23  H    3.221132   2.797029   2.154957   3.235407   1.102622
+    24  H    3.906619   3.496268   2.164120   2.645560   1.098397
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    1.866490   0.000000
+    13  H    4.160975   3.534620   0.000000
+    14  H    3.736941   2.431302   1.786082   0.000000
+    15  H    4.129768   3.501102   1.768986   1.787006   0.000000
+    16  H    2.351072   3.688578   3.818355   4.322649   3.828585
+    17  H    3.437856   4.098183   2.633043   3.813284   3.249784
+    18  H    6.303203   6.707267   4.475513   5.566481   3.888549
+    19  H    5.672877   6.059532   3.423828   4.909633   3.587209
+    20  H    8.405648   8.995610   6.654897   7.884366   6.218861
+    21  H    8.995638   9.824500   7.521589   8.932554   7.419158
+    22  H    6.218864   7.419089   5.930546   7.241696   6.156356
+    23  H    6.655199   7.521800   5.328145   6.915816   5.930845
+    24  H    7.884460   8.932603   6.915703   8.421932   7.241846
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    1.791271   0.000000
+    18  H    4.444586   3.784167   0.000000
+    19  H    3.784176   2.521974   1.791277   0.000000
+    20  H    6.303094   5.672886   2.351054   3.437981   0.000000
+    21  H    6.707245   6.059569   3.688567   4.098258   1.866489
+    22  H    3.888596   3.587012   3.828633   3.249584   4.129792
+    23  H    4.475967   3.424105   3.818342   2.632969   4.160951
+    24  H    5.566629   4.909692   4.322651   3.813246   3.736935
+                   21         22         23         24
+    21  H    0.000000
+    22  H    3.501139   0.000000
+    23  H    3.534583   1.768989   0.000000
+    24  H    2.431297   1.787004   1.786081   0.000000
+ Stoichiometry    C8H14O2
+ Framework group  C1[X(C8H14O2)]
+ Deg. of freedom    66
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        3.895364    0.767474   -0.228812
+      2          6           0        2.806751    0.088557    0.141704
+      3          6           0        2.856528   -1.273002    0.776262
+      4          6           0        1.433149    0.680219   -0.037976
+      5          8           0        0.667653   -0.232956   -0.796469
+      6          8           0       -0.667647    0.232790   -0.796519
+      7          6           0       -1.433133   -0.680206   -0.037793
+      8          6           0       -2.806748   -0.088519    0.141733
+      9          6           0       -3.895329   -0.767443   -0.228867
+     10          6           0       -2.856582    1.273067    0.776228
+     11          1           0        3.821820    1.748634   -0.705329
+     12          1           0        4.898709    0.364662   -0.066019
+     13          1           0        2.343837   -1.266125    1.752415
+     14          1           0        3.890307   -1.611615    0.928305
+     15          1           0        2.333028   -2.008059    0.146573
+     16          1           0        1.478023    1.659489   -0.543446
+     17          1           0        0.955495    0.823021    0.951859
+     18          1           0       -1.477988   -1.659598   -0.543025
+     19          1           0       -0.955476   -0.822744    0.952076
+     20          1           0       -3.821743   -1.748630   -0.705320
+     21          1           0       -4.898686   -0.364607   -0.066217
+     22          1           0       -2.332947    2.008083    0.146604
+     23          1           0       -2.344065    1.266206    1.752474
+     24          1           0       -3.890375    1.611725    0.928078
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           3.5158716           0.5068890           0.4835079
+ Leave Link  202 at Wed Jul 22 12:14:07 2026, MaxMem= 10737418240 cpu:               0.1 elap:               0.0
+ (Enter /usr/local/g16/l301.exe)
+ Standard basis: def2TZVP (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   444 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   394 symmetry adapted basis functions of A   symmetry.
+   394 basis functions,   622 primitive gaussians,   444 cartesian basis functions
+    39 alpha electrons       39 beta electrons
+       nuclear repulsion energy       527.0094706740 Hartrees.
+ IExCor= 4639 DFT=T Ex+Corr=wB97XD ExCW=0 ScaHFX=  1.000000
+ ScaDFX=  1.000000  1.000000  1.000000  1.000000 ScalE2=  1.000000  1.000000
+ IRadAn=      5 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=121
+ HFx  wShort=  0.000000 wLong=  0.200000 cFull=  0.222036 cShort=  0.000000 cLong=  0.777964
+ DFx  wShort=  0.000000 wLong=  0.200000 cFull=  0.000000 cShort=  0.000000 cLong=  1.000000
+ NAtoms=   24 NActive=   24 NUniq=   24 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ R6Disp:  Grimme-D2 Dispersion energy=       -0.0125763243 Hartrees.
+ Nuclear repulsion after empirical dispersion term =      526.9968943496 Hartrees.
+ Leave Link  301 at Wed Jul 22 12:14:07 2026, MaxMem= 10737418240 cpu:               0.3 elap:               0.0
+ (Enter /usr/local/g16/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   13861 NPrTT=   40732 LenC2=   12844 LenP2D=   28836.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   394 RedAO= T EigKep=  1.24D-04  NBF=   394
+ NBsUse=   394 1.00D-06 EigRej= -1.00D+00 NBFU=   394
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           5 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   439   439   439   439   439 MxSgAt=    24 MxSgA2=    24.
+ Leave Link  302 at Wed Jul 22 12:14:08 2026, MaxMem= 10737418240 cpu:               8.1 elap:               0.5
+ (Enter /usr/local/g16/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Wed Jul 22 12:14:08 2026, MaxMem= 10737418240 cpu:               0.7 elap:               0.1
+ (Enter /usr/local/g16/l401.exe)
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -443.342107073978    
+ JPrj=0 DoOrth=F DoCkMO=T.
+ Mixing orbitals, IMix= 1 IMixAn=  0 NRI=1 NE=   39 Coef=  7.07106781D-01  7.07106781D-01
+ Leave Link  401 at Wed Jul 22 12:14:10 2026, MaxMem= 10737418240 cpu:              38.7 elap:               2.5
+ (Enter /usr/local/g16/l502.exe)
+ Integral symmetry usage will be decided dynamically.
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ NGot= 10737418240 LenX= 10737012178 LenY= 10736814598
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=T KAlg= 0 I1Cent=           0 FoldK=F
+ IRaf=         1 NMat=       1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 0 IDoP0=0 IntGTp=1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ E= -462.748903644240    
+ DIIS: error= 4.44D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -462.748903644240     IErMin= 1 ErrMin= 4.44D-02
+ ErrMax= 4.44D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.58D+00 BMatP= 1.58D+00
+ IDIUse=3 WtCom= 5.56D-01 WtEn= 4.44D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.072 Goal=   None    Shift=    0.000
+ GapD=    0.072 DampG=0.500 DampE=0.500 DampFc=0.2500 IDamp=-1.
+ Damping current iteration by 2.50D-01
+ RMSDP=4.68D-03 MaxDP=2.35D-01              OVMax= 6.29D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  1.12D-03    CP:  9.60D-01
+ E= -462.936006733874     Delta-E=       -0.187103089635 Rises=F Damp=T
+ DIIS: error= 3.30D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -462.936006733874     IErMin= 2 ErrMin= 3.30D-02
+ ErrMax= 3.30D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.21D-01 BMatP= 1.58D+00
+ IDIUse=3 WtCom= 6.70D-01 WtEn= 3.30D-01
+ Coeff-Com: -0.496D+00 0.150D+01
+ Coeff-En:   0.199D+00 0.801D+00
+ Coeff:     -0.267D+00 0.127D+01
+ Gap=     0.044 Goal=   None    Shift=    0.000
+ RMSDP=2.03D-03 MaxDP=6.27D-02 DE=-1.87D-01 OVMax= 9.28D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  1.93D-03    CP:  8.99D-01  1.31D+00
+ E= -463.550399338498     Delta-E=       -0.614392604624 Rises=F Damp=F
+ DIIS: error= 8.05D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -463.550399338498     IErMin= 3 ErrMin= 8.05D-03
+ ErrMax= 8.05D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.06D-02 BMatP= 5.21D-01
+ IDIUse=3 WtCom= 9.20D-01 WtEn= 8.05D-02
+ Coeff-Com: -0.283D+00 0.428D+00 0.855D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.260D+00 0.394D+00 0.866D+00
+ Gap=     0.351 Goal=   None    Shift=    0.000
+ RMSDP=6.51D-04 MaxDP=2.15D-02 DE=-6.14D-01 OVMax= 1.22D-01
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  5.15D-04    CP:  8.76D-01  1.59D+00  1.09D+00
+ E= -463.604389618482     Delta-E=       -0.053990279984 Rises=F Damp=F
+ DIIS: error= 2.47D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -463.604389618482     IErMin= 4 ErrMin= 2.47D-03
+ ErrMax= 2.47D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.67D-03 BMatP= 5.06D-02
+ IDIUse=3 WtCom= 9.75D-01 WtEn= 2.47D-02
+ Coeff-Com: -0.116D+00 0.165D+00 0.207D+00 0.744D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.113D+00 0.161D+00 0.202D+00 0.750D+00
+ Gap=     0.381 Goal=   None    Shift=    0.000
+ RMSDP=1.94D-04 MaxDP=6.81D-03 DE=-5.40D-02 OVMax= 4.07D-02
+
+ Cycle   5  Pass 0  IDiag  1:
+ RMSU=  1.27D-04    CP:  8.70D-01  1.65D+00  1.10D+00  1.22D+00
+ E= -463.609808862026     Delta-E=       -0.005419243544 Rises=F Damp=F
+ DIIS: error= 1.45D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -463.609808862026     IErMin= 5 ErrMin= 1.45D-03
+ ErrMax= 1.45D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.07D-03 BMatP= 3.67D-03
+ IDIUse=3 WtCom= 9.86D-01 WtEn= 1.45D-02
+ Coeff-Com: -0.101D-01 0.833D-02-0.120D+00 0.207D+00 0.915D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.992D-02 0.821D-02-0.118D+00 0.204D+00 0.916D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=1.51D-04 MaxDP=5.55D-03 DE=-5.42D-03 OVMax= 2.59D-02
+
+ Cycle   6  Pass 0  IDiag  1:
+ RMSU=  5.02D-05    CP:  8.65D-01  1.70D+00  1.11D+00  1.45D+00  1.29D+00
+ E= -463.611573209723     Delta-E=       -0.001764347696 Rises=F Damp=F
+ DIIS: error= 3.72D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -463.611573209723     IErMin= 6 ErrMin= 3.72D-04
+ ErrMax= 3.72D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.90D-05 BMatP= 1.07D-03
+ IDIUse=3 WtCom= 9.96D-01 WtEn= 3.72D-03
+ Coeff-Com:  0.367D-02-0.767D-02-0.537D-01-0.492D-02 0.274D+00 0.788D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.366D-02-0.764D-02-0.535D-01-0.491D-02 0.273D+00 0.789D+00
+ Gap=     0.397 Goal=   None    Shift=    0.000
+ RMSDP=4.43D-05 MaxDP=1.45D-03 DE=-1.76D-03 OVMax= 8.55D-03
+
+ Cycle   7  Pass 0  IDiag  1:
+ RMSU=  1.89D-05    CP:  8.64D-01  1.71D+00  1.11D+00  1.51D+00  1.45D+00
+                    CP:  1.14D+00
+ E= -463.611706028727     Delta-E=       -0.000132819005 Rises=F Damp=F
+ DIIS: error= 1.62D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -463.611706028727     IErMin= 7 ErrMin= 1.62D-04
+ ErrMax= 1.62D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.44D-05 BMatP= 5.90D-05
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.62D-03
+ Coeff-Com:  0.209D-02-0.239D-02 0.112D-01-0.436D-01-0.110D+00 0.322D+00
+ Coeff-Com:  0.820D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00
+ Coeff-En:   0.100D+01
+ Coeff:      0.209D-02-0.238D-02 0.112D-01-0.435D-01-0.109D+00 0.322D+00
+ Coeff:      0.820D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=1.79D-05 MaxDP=5.19D-04 DE=-1.33D-04 OVMax= 3.07D-03
+
+ Cycle   8  Pass 0  IDiag  1:
+ RMSU=  8.88D-06    CP:  8.64D-01  1.71D+00  1.11D+00  1.52D+00  1.50D+00
+                    CP:  1.32D+00  1.11D+00
+ E= -463.611730583648     Delta-E=       -0.000024554921 Rises=F Damp=F
+ DIIS: error= 4.25D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -463.611730583648     IErMin= 8 ErrMin= 4.25D-05
+ ErrMax= 4.25D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.94D-07 BMatP= 1.44D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.381D-03-0.159D-03 0.753D-02-0.804D-02-0.465D-01-0.175D-02
+ Coeff-Com:  0.146D+00 0.903D+00
+ Coeff:      0.381D-03-0.159D-03 0.753D-02-0.804D-02-0.465D-01-0.175D-02
+ Coeff:      0.146D+00 0.903D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=5.79D-06 MaxDP=1.84D-04 DE=-2.46D-05 OVMax= 7.61D-04
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   9  Pass 1  IDiag  1:
+ E= -463.611585674727     Delta-E=        0.000144908921 Rises=F Damp=F
+ DIIS: error= 2.13D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -463.611585674727     IErMin= 1 ErrMin= 2.13D-04
+ ErrMax= 2.13D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.28D-06 BMatP= 4.28D-06
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 2.13D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=5.79D-06 MaxDP=1.84D-04 DE= 1.45D-04 OVMax= 2.84D-04
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  1.03D-04    CP:  1.00D+00
+ E= -463.611588428119     Delta-E=       -0.000002753392 Rises=F Damp=F
+ DIIS: error= 2.02D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -463.611588428119     IErMin= 2 ErrMin= 2.02D-05
+ ErrMax= 2.02D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.78D-07 BMatP= 4.28D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.123D+00 0.877D+00
+ Coeff:      0.123D+00 0.877D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=5.81D-06 MaxDP=1.85D-04 DE=-2.75D-06 OVMax= 2.29D-04
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  2.74D-06    CP:  1.00D+00  1.05D+00
+ E= -463.611588387118     Delta-E=        0.000000041001 Rises=F Damp=F
+ DIIS: error= 2.46D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -463.611588428119     IErMin= 2 ErrMin= 2.02D-05
+ ErrMax= 2.46D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.07D-07 BMatP= 4.78D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.239D-01 0.537D+00 0.487D+00
+ Coeff:     -0.239D-01 0.537D+00 0.487D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=1.59D-06 MaxDP=6.87D-05 DE= 4.10D-08 OVMax= 1.30D-04
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  1.08D-06    CP:  1.00D+00  1.06D+00  8.14D-01
+ E= -463.611588784151     Delta-E=       -0.000000397032 Rises=F Damp=F
+ DIIS: error= 1.75D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -463.611588784151     IErMin= 4 ErrMin= 1.75D-06
+ ErrMax= 1.75D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.39D-09 BMatP= 4.78D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.108D-01 0.166D+00 0.171D+00 0.674D+00
+ Coeff:     -0.108D-01 0.166D+00 0.171D+00 0.674D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=2.39D-07 MaxDP=7.91D-06 DE=-3.97D-07 OVMax= 2.84D-05
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  1.74D-07    CP:  1.00D+00  1.06D+00  8.52D-01  1.06D+00
+ E= -463.611588790912     Delta-E=       -0.000000006762 Rises=F Damp=F
+ DIIS: error= 1.14D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -463.611588790912     IErMin= 5 ErrMin= 1.14D-06
+ ErrMax= 1.14D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.50D-10 BMatP= 5.39D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.456D-02-0.118D+00-0.102D+00 0.122D+00 0.109D+01
+ Coeff:      0.456D-02-0.118D+00-0.102D+00 0.122D+00 0.109D+01
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=2.14D-07 MaxDP=6.98D-06 DE=-6.76D-09 OVMax= 3.61D-05
+
+ Cycle  14  Pass 1  IDiag  1:
+ RMSU=  1.28D-07    CP:  1.00D+00  1.06D+00  8.80D-01  1.16D+00  1.55D+00
+ E= -463.611588793513     Delta-E=       -0.000000002601 Rises=F Damp=F
+ DIIS: error= 4.51D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -463.611588793513     IErMin= 6 ErrMin= 4.51D-07
+ ErrMax= 4.51D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.65D-10 BMatP= 9.50D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.329D-02-0.696D-01-0.637D-01-0.355D-01 0.452D+00 0.713D+00
+ Coeff:      0.329D-02-0.696D-01-0.637D-01-0.355D-01 0.452D+00 0.713D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=6.35D-08 MaxDP=1.78D-06 DE=-2.60D-09 OVMax= 9.43D-06
+
+ Cycle  15  Pass 1  IDiag  1:
+ RMSU=  4.05D-08    CP:  1.00D+00  1.06D+00  8.82D-01  1.18D+00  1.78D+00
+                    CP:  1.16D+00
+ E= -463.611588793749     Delta-E=       -0.000000000236 Rises=F Damp=F
+ DIIS: error= 1.21D-07 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -463.611588793749     IErMin= 7 ErrMin= 1.21D-07
+ ErrMax= 1.21D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.37D-12 BMatP= 1.65D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.253D-03 0.847D-02 0.672D-02-0.247D-01-0.996D-01 0.855D-01
+ Coeff-Com:  0.102D+01
+ Coeff:     -0.253D-03 0.847D-02 0.672D-02-0.247D-01-0.996D-01 0.855D-01
+ Coeff:      0.102D+01
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=3.10D-08 MaxDP=9.34D-07 DE=-2.36D-10 OVMax= 3.44D-06
+
+ Cycle  16  Pass 1  IDiag  1:
+ RMSU=  1.14D-08    CP:  1.00D+00  1.06D+00  8.79D-01  1.17D+00  1.85D+00
+                    CP:  1.29D+00  1.11D+00
+ E= -463.611588793789     Delta-E=       -0.000000000040 Rises=F Damp=F
+ DIIS: error= 2.63D-08 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -463.611588793789     IErMin= 8 ErrMin= 2.63D-08
+ ErrMax= 2.63D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.72D-13 BMatP= 7.37D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.174D-03 0.461D-02 0.391D-02-0.646D-02-0.438D-01 0.395D-02
+ Coeff-Com:  0.312D+00 0.726D+00
+ Coeff:     -0.174D-03 0.461D-02 0.391D-02-0.646D-02-0.438D-01 0.395D-02
+ Coeff:      0.312D+00 0.726D+00
+ Gap=     0.396 Goal=   None    Shift=    0.000
+ RMSDP=3.23D-09 MaxDP=9.83D-08 DE=-3.99D-11 OVMax= 3.23D-07
+
+ SCF Done:  E(RwB97XD) =  -463.611588794     A.U. after   16 cycles
+            NFock= 16  Conv=0.32D-08     -V/T= 2.0054
+ KE= 4.611438039194D+02 PE=-2.134795653886D+03 EE= 6.830433668228D+02
+ Leave Link  502 at Wed Jul 22 12:16:18 2026, MaxMem= 10737418240 cpu:            2028.9 elap:             127.8
+ (Enter /usr/local/g16/l508.exe)
+ QCSCF skips out because SCF is already converged.
+ Leave Link  508 at Wed Jul 22 12:16:18 2026, MaxMem= 10737418240 cpu:               0.0 elap:               0.0
+ (Enter /usr/local/g16/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -19.30721 -19.30715 -10.33827 -10.33826 -10.30438
+ Alpha  occ. eigenvalues --  -10.30438 -10.28294 -10.28294 -10.28177 -10.28177
+ Alpha  occ. eigenvalues --   -1.24318  -1.03758  -0.91648  -0.89709  -0.79391
+ Alpha  occ. eigenvalues --   -0.79116  -0.78441  -0.74801  -0.63765  -0.62924
+ Alpha  occ. eigenvalues --   -0.61535  -0.58566  -0.57219  -0.55203  -0.54405
+ Alpha  occ. eigenvalues --   -0.52128  -0.51030  -0.49948  -0.49659  -0.47368
+ Alpha  occ. eigenvalues --   -0.46148  -0.45760  -0.45447  -0.43526  -0.41950
+ Alpha  occ. eigenvalues --   -0.37449  -0.35394  -0.34210  -0.33511
+ Alpha virt. eigenvalues --    0.06072   0.06949   0.10662   0.12430   0.14117
+ Alpha virt. eigenvalues --    0.14388   0.15151   0.16064   0.16638   0.16953
+ Alpha virt. eigenvalues --    0.17961   0.18286   0.18994   0.20519   0.21002
+ Alpha virt. eigenvalues --    0.21784   0.22606   0.23084   0.24064   0.24317
+ Alpha virt. eigenvalues --    0.25357   0.27132   0.27414   0.28282   0.28393
+ Alpha virt. eigenvalues --    0.28450   0.29666   0.30682   0.32989   0.34811
+ Alpha virt. eigenvalues --    0.35305   0.35447   0.37564   0.37816   0.38957
+ Alpha virt. eigenvalues --    0.40308   0.41162   0.41918   0.42504   0.42926
+ Alpha virt. eigenvalues --    0.43775   0.44361   0.45521   0.45640   0.47157
+ Alpha virt. eigenvalues --    0.48557   0.49575   0.49739   0.51339   0.52020
+ Alpha virt. eigenvalues --    0.53177   0.53394   0.54161   0.55250   0.55356
+ Alpha virt. eigenvalues --    0.55803   0.56425   0.56634   0.56958   0.57733
+ Alpha virt. eigenvalues --    0.59064   0.60230   0.60826   0.61807   0.63226
+ Alpha virt. eigenvalues --    0.64886   0.66653   0.67283   0.68557   0.69329
+ Alpha virt. eigenvalues --    0.70013   0.70427   0.70663   0.72931   0.75700
+ Alpha virt. eigenvalues --    0.76118   0.76332   0.81251   0.82922   0.84482
+ Alpha virt. eigenvalues --    0.86911   0.88960   0.90063   0.91792   0.93504
+ Alpha virt. eigenvalues --    0.93848   0.95084   1.00458   1.00837   1.02362
+ Alpha virt. eigenvalues --    1.02694   1.03152   1.03656   1.06167   1.06974
+ Alpha virt. eigenvalues --    1.07184   1.08744   1.09834   1.11643   1.13457
+ Alpha virt. eigenvalues --    1.14101   1.14960   1.15058   1.16788   1.18671
+ Alpha virt. eigenvalues --    1.20692   1.21885   1.25600   1.27441   1.32984
+ Alpha virt. eigenvalues --    1.33739   1.35172   1.35851   1.36190   1.37277
+ Alpha virt. eigenvalues --    1.38095   1.39584   1.44444   1.47333   1.47468
+ Alpha virt. eigenvalues --    1.51977   1.55313   1.56715   1.56856   1.59523
+ Alpha virt. eigenvalues --    1.60454   1.61546   1.62174   1.62429   1.63129
+ Alpha virt. eigenvalues --    1.65508   1.65672   1.67111   1.69643   1.70015
+ Alpha virt. eigenvalues --    1.70138   1.70842   1.70981   1.71885   1.72118
+ Alpha virt. eigenvalues --    1.72530   1.76358   1.76640   1.79205   1.82377
+ Alpha virt. eigenvalues --    1.85367   1.85421   1.86083   1.90378   1.90697
+ Alpha virt. eigenvalues --    1.91301   1.94474   1.94782   1.96888   1.97354
+ Alpha virt. eigenvalues --    2.00265   2.01973   2.03080   2.03876   2.04465
+ Alpha virt. eigenvalues --    2.05553   2.07841   2.10599   2.13423   2.13721
+ Alpha virt. eigenvalues --    2.14867   2.17048   2.17877   2.22613   2.23004
+ Alpha virt. eigenvalues --    2.23835   2.27213   2.28707   2.30111   2.33196
+ Alpha virt. eigenvalues --    2.35433   2.37028   2.37074   2.38757   2.40596
+ Alpha virt. eigenvalues --    2.40844   2.43853   2.43934   2.46092   2.46417
+ Alpha virt. eigenvalues --    2.47956   2.48424   2.49659   2.50201   2.50837
+ Alpha virt. eigenvalues --    2.53768   2.56359   2.57308   2.58530   2.60523
+ Alpha virt. eigenvalues --    2.60852   2.62180   2.64829   2.66988   2.67504
+ Alpha virt. eigenvalues --    2.68499   2.68678   2.69205   2.71253   2.71448
+ Alpha virt. eigenvalues --    2.71534   2.73668   2.78918   2.79314   2.81562
+ Alpha virt. eigenvalues --    2.83200   2.83681   2.85922   2.86154   2.90258
+ Alpha virt. eigenvalues --    2.91205   2.91324   2.96433   2.98236   2.99282
+ Alpha virt. eigenvalues --    3.01549   3.01856   3.02254   3.03690   3.05929
+ Alpha virt. eigenvalues --    3.07840   3.08222   3.08711   3.10061   3.11723
+ Alpha virt. eigenvalues --    3.13334   3.13790   3.17946   3.18609   3.19730
+ Alpha virt. eigenvalues --    3.22542   3.23459   3.24309   3.25209   3.25222
+ Alpha virt. eigenvalues --    3.27171   3.28998   3.30399   3.30759   3.33157
+ Alpha virt. eigenvalues --    3.33833   3.33964   3.34497   3.34800   3.36466
+ Alpha virt. eigenvalues --    3.36879   3.37636   3.39177   3.40341   3.40535
+ Alpha virt. eigenvalues --    3.42726   3.44114   3.45581   3.46716   3.47757
+ Alpha virt. eigenvalues --    3.48871   3.53437   3.54754   3.56083   3.56132
+ Alpha virt. eigenvalues --    3.58736   3.58782   3.60474   3.62248   3.64696
+ Alpha virt. eigenvalues --    3.65464   3.67500   3.76411   3.77421   3.78645
+ Alpha virt. eigenvalues --    3.78914   3.82678   3.84858   3.85263   3.87537
+ Alpha virt. eigenvalues --    3.94160   3.94818   4.03384   4.03614   4.04896
+ Alpha virt. eigenvalues --    4.07701   4.09097   4.09609   4.12996   4.15050
+ Alpha virt. eigenvalues --    4.15301   4.17372   4.19683   4.20132   4.32250
+ Alpha virt. eigenvalues --    4.33781   4.36255   4.41605   4.45216   4.48821
+ Alpha virt. eigenvalues --    4.49019   4.50349   4.51025   4.51146   4.54401
+ Alpha virt. eigenvalues --    4.56573   4.57124   4.57602   4.59097   4.70970
+ Alpha virt. eigenvalues --    4.76712   4.76886   4.77743   4.86863   4.87566
+ Alpha virt. eigenvalues --    4.90931   4.91656   5.02052   5.10662   5.12665
+ Alpha virt. eigenvalues --    5.18999   5.22363   5.26072   5.27475   5.29032
+ Alpha virt. eigenvalues --    5.46142   5.66565   5.71192   5.84686   5.84777
+ Alpha virt. eigenvalues --    5.90986   6.12581   6.17432   6.27514   6.56879
+ Alpha virt. eigenvalues --    6.71820   6.78264   6.81211   6.85075   6.92951
+ Alpha virt. eigenvalues --    6.96351   7.29412   7.38493   7.42915   8.33102
+ Alpha virt. eigenvalues --   22.23414  22.23679  22.46869  22.47297  22.56750
+ Alpha virt. eigenvalues --   22.61166  22.97307  22.97652  43.93950  44.27385
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  C    4.924873   0.643178  -0.058617  -0.044273   0.002694  -0.000700
+     2  C    0.643178   5.077167   0.266067   0.317464  -0.057965   0.011822
+     3  C   -0.058617   0.266067   4.968591  -0.067426   0.018935  -0.000337
+     4  C   -0.044273   0.317464  -0.067426   4.774280   0.232149  -0.022701
+     5  O    0.002694  -0.057965   0.018935   0.232149   8.083486   0.006022
+     6  O   -0.000700   0.011822  -0.000337  -0.022701   0.006022   8.083488
+     7  C    0.000042  -0.001600  -0.001553   0.002921  -0.022701   0.232144
+     8  C   -0.000009  -0.000731   0.000424  -0.001601   0.011822  -0.057955
+     9  C    0.000000  -0.000009  -0.000008   0.000042  -0.000700   0.002696
+    10  C   -0.000008   0.000423  -0.000011  -0.001551  -0.000337   0.018925
+    11  H    0.413169  -0.041718   0.008469  -0.009505  -0.000115   0.000008
+    12  H    0.410238  -0.036875  -0.010984   0.008590  -0.000171   0.000010
+    13  H    0.001311  -0.037836   0.393621   0.005179  -0.002796  -0.000068
+    14  H   -0.005467  -0.042905   0.412219   0.007034   0.000630  -0.000001
+    15  H   -0.002880  -0.030606   0.415072  -0.010873   0.005544  -0.000378
+    16  H   -0.007499  -0.040062   0.015338   0.408092  -0.031178   0.002510
+    17  H    0.005221  -0.021146  -0.028472   0.418165  -0.059391  -0.001983
+    18  H    0.000008   0.001171  -0.000126  -0.001297   0.002509  -0.031180
+    19  H   -0.000023  -0.004083   0.000509   0.006949  -0.001983  -0.059393
+    20  H   -0.000000   0.000001  -0.000000   0.000003   0.000008  -0.000115
+    21  H   -0.000000   0.000000   0.000000  -0.000001   0.000010  -0.000171
+    22  H   -0.000000  -0.000015   0.000007   0.000346  -0.000378   0.005546
+    23  H    0.000002  -0.000050  -0.000005  -0.000178  -0.000068  -0.002794
+    24  H   -0.000000   0.000003   0.000000   0.000017  -0.000001   0.000629
+               7          8          9         10         11         12
+     1  C    0.000042  -0.000009   0.000000  -0.000008   0.413169   0.410238
+     2  C   -0.001600  -0.000731  -0.000009   0.000423  -0.041718  -0.036875
+     3  C   -0.001553   0.000424  -0.000008  -0.000011   0.008469  -0.010984
+     4  C    0.002921  -0.001601   0.000042  -0.001551  -0.009505   0.008590
+     5  O   -0.022701   0.011822  -0.000700  -0.000337  -0.000115  -0.000171
+     6  O    0.232144  -0.057955   0.002696   0.018925   0.000008   0.000010
+     7  C    4.774287   0.317459  -0.044275  -0.067425   0.000003  -0.000001
+     8  C    0.317459   5.077151   0.643183   0.266077   0.000001   0.000000
+     9  C   -0.044275   0.643183   4.924859  -0.058617  -0.000000  -0.000000
+    10  C   -0.067425   0.266077  -0.058617   4.968593  -0.000000   0.000000
+    11  H    0.000003   0.000001  -0.000000  -0.000000   0.528948  -0.026528
+    12  H   -0.000001   0.000000  -0.000000   0.000000  -0.026528   0.532366
+    13  H   -0.000179  -0.000050   0.000002  -0.000005  -0.000350   0.000177
+    14  H    0.000017   0.000003  -0.000000   0.000000   0.000282   0.002692
+    15  H    0.000346  -0.000015  -0.000000   0.000007  -0.000276   0.000114
+    16  H   -0.001297   0.001171   0.000008  -0.000126   0.004751   0.000171
+    17  H    0.006949  -0.004083  -0.000023   0.000509  -0.000173  -0.000414
+    18  H    0.408091  -0.040058  -0.007499   0.015337   0.000001  -0.000000
+    19  H    0.418168  -0.021144   0.005222  -0.028474  -0.000003  -0.000000
+    20  H   -0.009506  -0.041717   0.413169   0.008468   0.000000   0.000000
+    21  H    0.008591  -0.036876   0.410238  -0.010984   0.000000  -0.000000
+    22  H   -0.010871  -0.030614  -0.002880   0.415078   0.000000  -0.000000
+    23  H    0.005172  -0.037831   0.001311   0.393620  -0.000000  -0.000000
+    24  H    0.007036  -0.042903  -0.005466   0.412217   0.000000   0.000000
+              13         14         15         16         17         18
+     1  C    0.001311  -0.005467  -0.002880  -0.007499   0.005221   0.000008
+     2  C   -0.037836  -0.042905  -0.030606  -0.040062  -0.021146   0.001171
+     3  C    0.393621   0.412219   0.415072   0.015338  -0.028472  -0.000126
+     4  C    0.005179   0.007034  -0.010873   0.408092   0.418165  -0.001297
+     5  O   -0.002796   0.000630   0.005544  -0.031178  -0.059391   0.002509
+     6  O   -0.000068  -0.000001  -0.000378   0.002510  -0.001983  -0.031180
+     7  C   -0.000179   0.000017   0.000346  -0.001297   0.006949   0.408091
+     8  C   -0.000050   0.000003  -0.000015   0.001171  -0.004083  -0.040058
+     9  C    0.000002  -0.000000  -0.000000   0.000008  -0.000023  -0.007499
+    10  C   -0.000005   0.000000   0.000007  -0.000126   0.000509   0.015337
+    11  H   -0.000350   0.000282  -0.000276   0.004751  -0.000173   0.000001
+    12  H    0.000177   0.002692   0.000114   0.000171  -0.000414  -0.000000
+    13  H    0.577208  -0.021901  -0.031174  -0.000205   0.005114  -0.000003
+    14  H   -0.021901   0.550445  -0.019966  -0.000116  -0.000301   0.000000
+    15  H   -0.031174  -0.019966   0.529012  -0.000245   0.000787   0.000252
+    16  H   -0.000205  -0.000116  -0.000245   0.597564  -0.049291  -0.000130
+    17  H    0.005114  -0.000301   0.000787  -0.049291   0.625657   0.000872
+    18  H   -0.000003   0.000000   0.000252  -0.000130   0.000872   0.597563
+    19  H    0.000573  -0.000001  -0.000239   0.000872  -0.003540  -0.049290
+    20  H   -0.000000   0.000000   0.000000   0.000001  -0.000003   0.004751
+    21  H   -0.000000   0.000000  -0.000000  -0.000000  -0.000000   0.000171
+    22  H   -0.000001   0.000000  -0.000000   0.000252  -0.000239  -0.000245
+    23  H    0.000006   0.000000  -0.000001  -0.000003   0.000573  -0.000205
+    24  H    0.000000   0.000000   0.000000   0.000000  -0.000001  -0.000116
+              19         20         21         22         23         24
+     1  C   -0.000023  -0.000000  -0.000000  -0.000000   0.000002  -0.000000
+     2  C   -0.004083   0.000001   0.000000  -0.000015  -0.000050   0.000003
+     3  C    0.000509  -0.000000   0.000000   0.000007  -0.000005   0.000000
+     4  C    0.006949   0.000003  -0.000001   0.000346  -0.000178   0.000017
+     5  O   -0.001983   0.000008   0.000010  -0.000378  -0.000068  -0.000001
+     6  O   -0.059393  -0.000115  -0.000171   0.005546  -0.002794   0.000629
+     7  C    0.418168  -0.009506   0.008591  -0.010871   0.005172   0.007036
+     8  C   -0.021144  -0.041717  -0.036876  -0.030614  -0.037831  -0.042903
+     9  C    0.005222   0.413169   0.410238  -0.002880   0.001311  -0.005466
+    10  C   -0.028474   0.008468  -0.010984   0.415078   0.393620   0.412217
+    11  H   -0.000003   0.000000   0.000000   0.000000  -0.000000   0.000000
+    12  H   -0.000000   0.000000  -0.000000  -0.000000  -0.000000   0.000000
+    13  H    0.000573  -0.000000  -0.000000  -0.000001   0.000006   0.000000
+    14  H   -0.000001   0.000000   0.000000   0.000000   0.000000   0.000000
+    15  H   -0.000239   0.000000  -0.000000  -0.000000  -0.000001   0.000000
+    16  H    0.000872   0.000001  -0.000000   0.000252  -0.000003   0.000000
+    17  H   -0.003540  -0.000003  -0.000000  -0.000239   0.000573  -0.000001
+    18  H   -0.049290   0.004751   0.000171  -0.000245  -0.000205  -0.000116
+    19  H    0.625660  -0.000173  -0.000414   0.000787   0.005115  -0.000301
+    20  H   -0.000173   0.528946  -0.026528  -0.000276  -0.000349   0.000282
+    21  H   -0.000414  -0.026528   0.532367   0.000114   0.000177   0.002692
+    22  H    0.000787  -0.000276   0.000114   0.529013  -0.031176  -0.019965
+    23  H    0.005115  -0.000349   0.000177  -0.031176   0.577209  -0.021899
+    24  H   -0.000301   0.000282   0.002692  -0.019965  -0.021899   0.550441
+ Mulliken charges:
+               1
+     1  C   -0.281260
+     2  C   -0.001696
+     3  C   -0.331713
+     4  C   -0.021825
+     5  O   -0.186024
+     6  O   -0.186024
+     7  C   -0.021819
+     8  C   -0.001702
+     9  C   -0.281251
+    10  C   -0.331715
+    11  H    0.123037
+    12  H    0.120614
+    13  H    0.111374
+    14  H    0.117336
+    15  H    0.145519
+    16  H    0.099423
+    17  H    0.105212
+    18  H    0.099422
+    19  H    0.105207
+    20  H    0.123039
+    21  H    0.120614
+    22  H    0.145517
+    23  H    0.111375
+    24  H    0.117337
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C   -0.037608
+     2  C   -0.001696
+     3  C    0.042517
+     4  C    0.182810
+     5  O   -0.186024
+     6  O   -0.186024
+     7  C    0.182810
+     8  C   -0.001702
+     9  C   -0.037598
+    10  C    0.042514
+ GSVD:  LWork=     -158388 too small for GESVD, short by      782090 words or      782090 for optimal perf.
+ Atomic Valencies and Mayer Atomic Bond Orders:
+               1          2          3          4          5          6
+     1  C    3.931186   1.908673   0.009358   0.026523   0.007560   0.004741
+     2  C    1.908673   3.831672   0.955326   0.987892  -0.014307   0.016645
+     3  C    0.009358   0.955326   3.865975  -0.020226   0.013829   0.001281
+     4  C    0.026523   0.987892  -0.020226   3.943938   0.955417   0.039205
+     5  O    0.007560  -0.014307   0.013829   0.955417   1.861909   0.822247
+     6  O    0.004741   0.016645   0.001281   0.039205   0.822247   1.861905
+     7  C    0.000079  -0.001959  -0.000707   0.016854   0.039204   0.955411
+     8  C    0.000184   0.001951  -0.000444  -0.001959   0.016646  -0.014296
+     9  C    0.000100   0.000184  -0.000009   0.000079   0.004743   0.007564
+    10  C   -0.000009  -0.000444  -0.000043  -0.000706   0.001279   0.013816
+    11  H    0.965318  -0.000296   0.008667  -0.001716   0.000539   0.000173
+    12  H    0.964108   0.004989  -0.004370   0.008760   0.000271   0.000616
+    13  H    0.014740  -0.007434   0.962345   0.005863  -0.000562   0.000001
+    14  H    0.000452  -0.008104   0.978791   0.004304   0.001004   0.000061
+    15  H    0.012954  -0.010244   0.967068  -0.004293   0.007865   0.000845
+    16  H    0.002449  -0.000636   0.006930   0.960825   0.002173   0.004807
+    17  H    0.013665  -0.000064  -0.012014   0.960668  -0.004348   0.001847
+    18  H    0.000031   0.000320   0.000106   0.001150   0.004807   0.002172
+    19  H    0.000199  -0.001015   0.000080   0.005122   0.001846  -0.004350
+    20  H   -0.000007   0.000001  -0.000001   0.000034   0.000173   0.000539
+    21  H    0.000017   0.000023  -0.000025   0.000082   0.000616   0.000271
+    22  H    0.000002   0.000048   0.000016   0.000125   0.000846   0.007867
+    23  H    0.000022   0.000094   0.000009  -0.000072   0.000001  -0.000561
+    24  H    0.000026   0.000029   0.000009   0.000006   0.000061   0.001003
+               7          8          9         10         11         12
+     1  C    0.000079   0.000184   0.000100  -0.000009   0.965318   0.964108
+     2  C   -0.001959   0.001951   0.000184  -0.000444  -0.000296   0.004989
+     3  C   -0.000707  -0.000444  -0.000009  -0.000043   0.008667  -0.004370
+     4  C    0.016854  -0.001959   0.000079  -0.000706  -0.001716   0.008760
+     5  O    0.039204   0.016646   0.004743   0.001279   0.000539   0.000271
+     6  O    0.955411  -0.014296   0.007564   0.013816   0.000173   0.000616
+     7  C    3.943928   0.987889   0.026525  -0.020231   0.000034   0.000082
+     8  C    0.987889   3.831691   1.908676   0.955329   0.000001   0.000023
+     9  C    0.026525   1.908676   3.931192   0.009358  -0.000007   0.000017
+    10  C   -0.020231   0.955329   0.009358   3.865962  -0.000001  -0.000025
+    11  H    0.000034   0.000001  -0.000007  -0.000001   0.978536  -0.000820
+    12  H    0.000082   0.000023   0.000017  -0.000025  -0.000820   0.977838
+    13  H   -0.000072   0.000094   0.000022   0.000009   0.000967   0.000287
+    14  H    0.000006   0.000029   0.000026   0.000009   0.000413   0.002518
+    15  H    0.000125   0.000048   0.000002   0.000016   0.000834   0.000278
+    16  H    0.001150   0.000320   0.000031   0.000106   0.003988   0.000348
+    17  H    0.005123  -0.001015   0.000199   0.000080   0.000448   0.000734
+    18  H    0.960826  -0.000635   0.002448   0.006929  -0.000010  -0.000000
+    19  H    0.960673  -0.000062   0.013663  -0.012014  -0.000003   0.000014
+    20  H   -0.001716  -0.000295   0.965317   0.008666   0.000001  -0.000000
+    21  H    0.008760   0.004989   0.964108  -0.004370  -0.000000   0.000001
+    22  H   -0.004291  -0.010250   0.012954   0.967073   0.000002   0.000002
+    23  H    0.005858  -0.007430   0.014740   0.962343   0.000001   0.000007
+    24  H    0.004304  -0.008103   0.000452   0.978791   0.000004  -0.000002
+              13         14         15         16         17         18
+     1  C    0.014740   0.000452   0.012954   0.002449   0.013665   0.000031
+     2  C   -0.007434  -0.008104  -0.010244  -0.000636  -0.000064   0.000320
+     3  C    0.962345   0.978791   0.967068   0.006930  -0.012014   0.000106
+     4  C    0.005863   0.004304  -0.004293   0.960825   0.960668   0.001150
+     5  O   -0.000562   0.001004   0.007865   0.002173  -0.004348   0.004807
+     6  O    0.000001   0.000061   0.000845   0.004807   0.001847   0.002172
+     7  C   -0.000072   0.000006   0.000125   0.001150   0.005123   0.960826
+     8  C    0.000094   0.000029   0.000048   0.000320  -0.001015  -0.000635
+     9  C    0.000022   0.000026   0.000002   0.000031   0.000199   0.002448
+    10  C    0.000009   0.000009   0.000016   0.000106   0.000080   0.006929
+    11  H    0.000967   0.000413   0.000834   0.003988   0.000448  -0.000010
+    12  H    0.000287   0.002518   0.000278   0.000348   0.000734  -0.000000
+    13  H    0.971389  -0.002456  -0.005730   0.000517   0.002057   0.000002
+    14  H   -0.002456   0.976562  -0.001652   0.000814   0.000325   0.000012
+    15  H   -0.005730  -0.001652   0.969034   0.000038   0.000699   0.000106
+    16  H    0.000517   0.000814   0.000038   0.974320  -0.010008   0.000088
+    17  H    0.002057   0.000325   0.000699  -0.010008   0.958679   0.000271
+    18  H    0.000002   0.000012   0.000106   0.000088   0.000271   0.974320
+    19  H    0.000725   0.000009   0.000063   0.000271  -0.000795  -0.010007
+    20  H    0.000001   0.000004   0.000002  -0.000010  -0.000003   0.003987
+    21  H    0.000007  -0.000002   0.000002  -0.000000   0.000014   0.000348
+    22  H    0.000000   0.000001   0.000006   0.000106   0.000063   0.000038
+    23  H    0.000005  -0.000001   0.000000   0.000002   0.000724   0.000517
+    24  H   -0.000001   0.000000   0.000001   0.000012   0.000009   0.000814
+              19         20         21         22         23         24
+     1  C    0.000199  -0.000007   0.000017   0.000002   0.000022   0.000026
+     2  C   -0.001015   0.000001   0.000023   0.000048   0.000094   0.000029
+     3  C    0.000080  -0.000001  -0.000025   0.000016   0.000009   0.000009
+     4  C    0.005122   0.000034   0.000082   0.000125  -0.000072   0.000006
+     5  O    0.001846   0.000173   0.000616   0.000846   0.000001   0.000061
+     6  O   -0.004350   0.000539   0.000271   0.007867  -0.000561   0.001003
+     7  C    0.960673  -0.001716   0.008760  -0.004291   0.005858   0.004304
+     8  C   -0.000062  -0.000295   0.004989  -0.010250  -0.007430  -0.008103
+     9  C    0.013663   0.965317   0.964108   0.012954   0.014740   0.000452
+    10  C   -0.012014   0.008666  -0.004370   0.967073   0.962343   0.978791
+    11  H   -0.000003   0.000001  -0.000000   0.000002   0.000001   0.000004
+    12  H    0.000014  -0.000000   0.000001   0.000002   0.000007  -0.000002
+    13  H    0.000725   0.000001   0.000007   0.000000   0.000005  -0.000001
+    14  H    0.000009   0.000004  -0.000002   0.000001  -0.000001   0.000000
+    15  H    0.000063   0.000002   0.000002   0.000006   0.000000   0.000001
+    16  H    0.000271  -0.000010  -0.000000   0.000106   0.000002   0.000012
+    17  H   -0.000795  -0.000003   0.000014   0.000063   0.000724   0.000009
+    18  H   -0.010007   0.003987   0.000348   0.000038   0.000517   0.000814
+    19  H    0.958683   0.000448   0.000735   0.000699   0.002058   0.000325
+    20  H    0.000448   0.978535  -0.000820   0.000834   0.000967   0.000413
+    21  H    0.000735  -0.000820   0.977838   0.000278   0.000287   0.002518
+    22  H    0.000699   0.000834   0.000278   0.969035  -0.005731  -0.001652
+    23  H    0.002058   0.000967   0.000287  -0.005731   0.971388  -0.002455
+    24  H    0.000325   0.000413   0.002518  -0.001652  -0.002455   0.976564
+ Lowdin Atomic Charges:
+               1
+     1  C   -0.183657
+     2  C   -0.240304
+     3  C   -0.264837
+     4  C   -0.309868
+     5  O    0.100624
+     6  O    0.100621
+     7  C   -0.309865
+     8  C   -0.240304
+     9  C   -0.183651
+    10  C   -0.264837
+    11  H    0.126511
+    12  H    0.125707
+    13  H    0.129015
+    14  H    0.127911
+    15  H    0.134700
+    16  H    0.127863
+    17  H    0.126334
+    18  H    0.127863
+    19  H    0.126331
+    20  H    0.126512
+    21  H    0.125707
+    22  H    0.134698
+    23  H    0.129015
+    24  H    0.127912
+ Sum of Lowdin charges  =  -0.00000
+ Lowdin atomic charges with hydrogens summed into heavy atoms:
+               1
+     1  C    0.068560
+     2  C   -0.240304
+     3  C    0.126789
+     4  C   -0.055671
+     5  O    0.100624
+     6  O    0.100621
+     7  C   -0.055672
+     8  C   -0.240304
+     9  C    0.068567
+    10  C    0.126789
+    11  H    0.000000
+    12  H    0.000000
+    13  H    0.000000
+    14  H    0.000000
+    15  H    0.000000
+    16  H    0.000000
+    17  H    0.000000
+    18  H    0.000000
+    19  H    0.000000
+    20  H    0.000000
+    21  H    0.000000
+    22  H    0.000000
+    23  H    0.000000
+    24  H    0.000000
+ Sum of Lowdin charges  =  -0.00000
+ Dipole moment from Lowdin charges (Debye):
+    X=    -0.0002    Y=    -0.0000    Z=     0.4977  Tot=     0.4977
+ Electronic spatial extent (au):  <R**2>=           2400.2159
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0001    Y=              0.0002    Z=              1.7903  Tot=              1.7903
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -56.8861   YY=            -59.8314   ZZ=            -65.5456
+   XY=              0.3224   XZ=              0.0000   YZ=             -0.0003
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              3.8683   YY=              0.9230   ZZ=             -4.7913
+   XY=              0.3224   XZ=              0.0000   YZ=             -0.0003
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.0028  YYY=             -0.0014  ZZZ=             -1.2710  XYY=             -0.0007
+  XXY=              0.0005  XXZ=             -1.9687  XZZ=              0.0004  YZZ=              0.0003
+  YYZ=             -6.8296  XYZ=             -9.5056
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=          -2579.2815 YYYY=           -362.2366 ZZZZ=           -203.8726 XXXY=            -29.4492
+ XXXZ=              0.0156 YYYX=              5.8838 YYYZ=              0.0003 ZZZX=             -0.0019
+ ZZZY=             -0.0001 XXYY=           -508.8655 XXZZ=           -531.2549 YYZZ=            -94.6933
+ XXYZ=             -0.0015 YYXZ=             -0.0007 ZZXY=             -2.1740
+ N-N= 5.269968943496D+02 E-N=-2.134795660417D+03  KE= 4.611438039194D+02
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Wed Jul 22 12:16:19 2026, MaxMem= 10737418240 cpu:               9.3 elap:               0.7
+ (Enter /usr/local/g16/l9999.exe)
+
+ Test job not archived.
+ 1\1\GINC-N171\SP\RwB97XD\def2TZVP\C8H14O2\KAPLAN.KFIR\22-Jul-2026\0\\#
+ P guess=mix wb97xd/def2tzvp IOp(2/9=2000,6/80=1) scf=xqc\\540\\0,1\C,0
+ ,-3.567097,-1.309419,-0.075684\C,0,-2.830721,-0.391252,0.555196\C,0,-3
+ .406604,0.857168,1.162476\C,0,-1.344856,-0.576939,0.719084\O,0,-0.7071
+ 11,0.560842,0.17694\O,0,0.665488,0.472804,0.505826\C,0,0.943969,1.5007
+ 97,1.433658\C,0,2.344786,1.289139,1.945571\C,0,3.25664,2.260846,1.8584
+ 02\C,0,2.620195,-0.050976,2.567845\H,0,-3.112484,-2.197523,-0.522618\H
+ ,0,-4.651734,-1.204267,-0.164935\H,0,-3.158665,0.917982,2.235137\H,0,-
+ 4.499139,0.893251,1.055049\H,0,-2.974986,1.749467,0.684587\H,0,-0.9941
+ 32,-1.492997,0.214788\H,0,-1.094905,-0.657085,1.795847\H,0,0.832546,2.
+ 489987,0.958716\H,0,0.225259,1.437664,2.274957\H,0,3.027661,3.217813,1
+ .382027\H,0,4.264225,2.132163,2.262966\H,0,2.486668,-0.852292,1.825597
+ \H,0,1.910059,-0.25281,3.386836\H,0,3.640788,-0.109053,2.969706\\Versi
+ on=EM64L-G16RevC.01\State=1-A\HF=-463.6115888\RMSD=3.234e-09\Dipole=-0
+ .1667426,-0.0509391,0.6824492\Quadrupole=2.2207485,0.9463801,-3.167128
+ 6,0.6719323,1.4635197,0.5006352\PG=C01 [X(C8H14O2)]\\@
+
+
+ NECESSARY EVIL: ONE WE LIKE TOO MUCH TO RELINQUISH.
+ Job cpu time:       0 days  0 hours 34 minutes 49.1 seconds.
+ Elapsed time:       0 days  0 hours  2 minutes 11.8 seconds.
+ File lengths (MBytes):  RWF=     89 Int=      0 D2E=      0 Chk=     10 Scr=      1
+ Normal termination of Gaussian 16 at Wed Jul 22 12:16:19 2026.


### PR DESCRIPTION

## What

Adds `parse_bond_orders()`, returning the Mayer bond order matrix from a Gaussian or Orca log file.

## Why

ARC infers connectivity from interatomic distances alone — `get_bonds_from_dmat()` (`arc/common.py`), covalent radii scaled by 1.2. That heuristic is least reliable exactly where it matters most: IRC endpoints, loose pre-reactive complexes, and stretched or partially formed bonds, where a distance cutoff either fuses two fragments or splits one.

The electronic structure calculation already reports a density-derived bond index. Nothing in ARC read it until now — a repo-wide grep for `mayer|wiberg|nbo` finds only `NBO TRUE` written for Q-Chem `orbitals` jobs, whose output is never parsed back.

## How

- `ESSAdapter.parse_bond_orders()` is **concrete** and returns `None`, following `parse_opt_steps` / `parse_ess_version`. Making it `@abstractmethod` would have forced all nine adapters to implement it; this way the other seven are untouched.
- **Gaussian** — the full N×N matrix under `Atomic Valencies and Mayer Atomic Bond Orders:`, printed in Fortran-style six-column blocks. The last such section in the file is used, which matters for multi-step jobs. The result is symmetrized to absorb print precision.
- **Orca** — printed by default. The `ATOM  NA  ZA  QA  VA  BVA  FA` table gives the atom count and the diagonal, then the sparse pair list `B(  0-O ,  1-C ) :   1.0172` (already 0-indexed). Orca only prints pairs above 0.1 by default, so weaker interactions come back as exactly 0 — stated in the docstring, since it bounds how low a threshold is meaningful downstream.

Return value: a symmetric N×N `np.ndarray` in the log file's atom order, with the diagonal holding the Mayer atomic valence. Gaussian's diagonal and Orca's `VA` column are the same quantity, so the two adapters return the same thing.

## Test data

`arc/testing/bond_orders/` gains one Gaussian and one Orca log. The test additionally covers three Orca logs already in the repo — a TS with two partial bonds, and a formaldehyde opt with a 2.14 C=O — and asserts `None` for logs with no Mayer section.

## Testing

`pytest arc/parser/` — 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Stack** (merge bottom-up; ARC uses merge commits, so GitHub retargets each PR as the one below it lands):

1. #951 — parse Mayer bond orders  ← *this is 1/5*
2. #952 — print them in Gaussian jobs
3. #953 — `mol_from_dft()`
4. #954 — IRC endpoint check
5. #955 — TS bond order check
