### PR TITLE
Perceive connectivity from Mayer bond orders (mol_from_dft)

### DIFF
--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -1571,6 +1571,68 @@ def update_molecule(mol: Molecule, to_single_bonds: bool = False) -> Molecule:
     return new_mol
 
 
+def mol_from_dft(log_file_path: str,
+                 charge: int | None = None,
+                 multiplicity: int | None = None,
+                 bond_order_threshold: float = 0.5,
+                 ) -> tuple[Molecule | None, Molecule | None]:
+    """
+    Perceive a Molecule from an electronic structure software output file,
+    inferring connectivity from the computed Mayer bond orders rather than from interatomic distances.
+
+    This is more reliable than a distance-based criterion whenever bond lengths are not conclusive,
+    e.g., for IRC endpoints, van der Waals complexes, and stretched or partially formed bonds.
+    Requires a log file that contains a Mayer population analysis: Orca prints it by default,
+    Gaussian requires ``IOp(6/80=1)`` in the route section (which ARC adds to all of its Gaussian jobs).
+
+    Args:
+        log_file_path (str): The path to the ESS log file.
+        charge (int, optional): The net charge of the species. Defaults to 0.
+        multiplicity (int, optional): The spin multiplicity of the species. Inferred if not given.
+        bond_order_threshold (float, optional): The minimal Mayer bond order for considering two atoms bonded.
+                                                Note that Orca only prints bond orders above 0.1.
+
+    Returns: tuple[Molecule | None, Molecule | None]
+        The perceived molecule with its respective bond orders, and a copy of it in which all of the
+        Mayer-derived bonds are single bonds. Both preserve the atom order of the log file, and may consist
+        of several disconnected fragments (use ``.split()`` to separate them).
+        The first entry is ``None`` if the molecule could not be perceived, both entries are ``None``
+        if the log file does not contain Mayer bond orders.
+    """
+    from arc.parser.parser import parse_bond_orders, parse_geometry
+    bond_orders_matrix = parse_bond_orders(log_file_path)
+    xyz = parse_geometry(log_file_path)
+    if bond_orders_matrix is None or xyz is None:
+        return None, None
+    symbols, coords = xyz['symbols'], xyz['coords']
+    if len(symbols) != bond_orders_matrix.shape[0]:
+        logger.error(f'The number of atoms ({len(symbols)}) does not match the bond order matrix dimension '
+                     f'({bond_orders_matrix.shape[0]}) in {log_file_path}.')
+        return None, None
+    bonds, bond_orders = list(), dict()
+    for i in range(len(symbols)):
+        for j in range(i + 1, len(symbols)):
+            if bond_orders_matrix[i, j] > bond_order_threshold:
+                bonds.append((i, j))
+                bond_orders[(i, j)] = float(bond_orders_matrix[i, j])
+
+    single_bond_mol = Molecule(atoms=[Atom(element=symbol, coords=np.array(coord, np.float64))
+                                      for symbol, coord in zip(symbols, coords)])
+    for i, j in bonds:
+        single_bond_mol.add_bond(Bond(single_bond_mol.atoms[i], single_bond_mol.atoms[j], order=1))
+    single_bond_mol.update_atomtypes(raise_exception=False)
+
+    mol = perceive_molecule_from_xyz(xyz,
+                                     charge=charge,
+                                     multiplicity=multiplicity,
+                                     bonds=bonds,
+                                     bond_orders=bond_orders,
+                                     )
+    if mol is not None:
+        single_bond_mol.multiplicity = mol.multiplicity
+    return mol, single_bond_mol
+
+
 def s_bonds_mol_from_xyz(xyz: dict) -> Molecule | None:
     """
     Create a single bonded molecule from xyz using RMG's connect_the_dots() method.

--- a/arc/species/converter_test.py
+++ b/arc/species/converter_test.py
@@ -20,6 +20,7 @@ import arc.species.converter as converter
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords, almost_equal_coords_lists, almost_equal_lists
 from arc.exceptions import ConverterError
 from arc.molecule.molecule import Molecule
+from arc.parser.parser import parse_geometry
 from arc.species.converter import order_mol_by_atom_map
 from arc.species.perceive import perceive_molecule_from_xyz
 from arc.species.species import ARCSpecies
@@ -3522,6 +3523,60 @@ R1=1.0912"""
         conf, rd_mol = converter.rdkit_conf_from_mol(mol=mol, xyz=self.xyz5['dict'])
         self.assertTrue(conf.Is3D())
         self.assertEqual(rd_mol.GetNumAtoms(), 5)
+
+    def test_mol_from_dft(self):
+        """Test perceiving a molecule from an ESS log file using Mayer bond orders"""
+        # An Orca log file of 3-(hydroxymethyl)isoxazole, an aromatic ring which a distance-based
+        # criterion cannot assign bond orders for.
+        path_1 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C4H5NO2_mayer_orca.out')
+        mol_1, single_bond_mol_1 = converter.mol_from_dft(path_1)
+        self.assertTrue(converter.check_isomorphism(mol_1, Molecule(smiles='OCc1ccon1')))
+        self.assertEqual(mol_1.multiplicity, 1)
+        self.assertEqual(mol_1.get_net_charge(), 0)
+        # The atom order of the log file is preserved.
+        xyz_1 = parse_geometry(path_1)
+        self.assertEqual(tuple(atom.symbol for atom in mol_1.atoms), xyz_1['symbols'])
+        self.assertEqual(tuple(atom.symbol for atom in single_bond_mol_1.atoms), xyz_1['symbols'])
+        # The single bond copy has the same connectivity, with all bond orders set to 1.
+        self.assertEqual(sorted(tuple(sorted((mol_1.atoms.index(bond.atom1), mol_1.atoms.index(bond.atom2))))
+                                for bond in mol_1.get_all_edges()),
+                         sorted(tuple(sorted((single_bond_mol_1.atoms.index(bond.atom1),
+                                              single_bond_mol_1.atoms.index(bond.atom2))))
+                                for bond in single_bond_mol_1.get_all_edges()))
+        self.assertTrue(all(bond.is_single() for bond in single_bond_mol_1.get_all_edges()))
+
+        # A Gaussian log file of di(2-methylallyl) peroxide, the double bonds must be preserved.
+        path_2 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C8H14O2_mayer_gaussian.out')
+        mol_2, single_bond_mol_2 = converter.mol_from_dft(path_2)
+        self.assertTrue(converter.check_isomorphism(mol_2, Molecule(smiles='C=C(C)COOCC(=C)C')))
+        self.assertEqual(len([bond for bond in mol_2.get_all_edges() if bond.is_double()]), 2)
+        self.assertEqual(len(single_bond_mol_2.atoms), 24)
+
+        # A formaldehyde Orca log file, a C=O double bond with a Mayer bond order of 2.14.
+        path_3 = os.path.join(ARC_TESTING_PATH, 'orca_example_opt.log')
+        mol_3, _ = converter.mol_from_dft(path_3)
+        self.assertTrue(converter.check_isomorphism(mol_3, Molecule(smiles='C=O')))
+
+        # An Orca TS log file of CH4 + OH <=> CH3 + H2O. At the TS geometry the migrating H atom has a
+        # Mayer bond order of 0.62 to C and 0.36 to O, so it is perceived as belonging to the methane.
+        path_4 = os.path.join(ARC_TESTING_PATH, 'freq', 'orca_neg_freq_ts.out')
+        mol_4, single_bond_mol_4 = converter.mol_from_dft(path_4)
+        fragments = sorted(mol_4.split(), key=lambda mol: len(mol.atoms))
+        self.assertEqual(len(fragments), 2)
+        self.assertTrue(converter.check_isomorphism(fragments[0], Molecule(smiles='[OH]')))
+        self.assertTrue(converter.check_isomorphism(fragments[1], Molecule(smiles='C')))
+        self.assertEqual(mol_4.multiplicity, 2)
+        # A lower threshold also captures the forming O-H bond. The single bond copy then represents the
+        # bridged TS connectivity, while the perceived molecule cannot (a bivalent H is not a valid
+        # Lewis structure) and falls back to the two separate species.
+        _, single_bond_mol_5 = converter.mol_from_dft(path_4, bond_order_threshold=0.3)
+        self.assertEqual(len(single_bond_mol_5.split()), 1)
+        migrating_h = single_bond_mol_5.atoms[5]
+        self.assertEqual(migrating_h.symbol, 'H')
+        self.assertEqual(sorted(single_bond_mol_5.atoms.index(atom) for atom in migrating_h.edges), [0, 2])
+
+        # A log file without a Mayer population analysis.
+        self.assertEqual(converter.mol_from_dft(os.path.join(ARC_TESTING_PATH, 'opt', 'iC3H7.out')), (None, None))
 
     def test_s_bonds_mol_from_xyz(self):
         """Test creating a molecule with only single bonds from xyz"""

--- a/arc/species/perceive.py
+++ b/arc/species/perceive.py
@@ -34,6 +34,8 @@ def perceive_molecule_from_xyz(
     n_radicals: int | None = None,
     n_fragments: int | None = None,
     single_bond_tolerance: float = 1.20,
+    bonds: list[tuple[int, int]] | None = None,
+    bond_orders: dict[tuple[int, int], float] | None = None,
 ) -> Molecule | None:
     """
     Infer a chemically valid Molecule with localized Lewis structure from Cartesian coordinates.
@@ -41,7 +43,8 @@ def perceive_molecule_from_xyz(
     Workflow:
         (1) Validate the XYZ input (dict or string) and extract symbols/coords.
         (2) Build an initial graph by adding bonds between atoms closer than a scaled
-            single-bond cutoff (`single_bond_tolerance` × reference length).
+            single-bond cutoff (`single_bond_tolerance` × reference length),
+            unless an explicit ``bonds`` list is given.
         (3) Identify connected components (fragments) and drop pure-H fragments.
         (4) If multiple fragments remain:
               • If their count matches `n_fragments`, rebuild using `_combine_fragments`.
@@ -61,7 +64,13 @@ def perceive_molecule_from_xyz(
         n_radicals (int, optional): Number of radical centers. If None, defaults to multiplicity-1.
         n_fragments (int, optional): Expected number of molecular fragments. Defaults to 1.
         single_bond_tolerance (float, optional): Scaling factor for maximum bond length when
-            perceiving connectivity. Default is 1.20.
+            perceiving connectivity. Default is 1.20. Ignored if ``bonds`` is given.
+        bonds (list[tuple[int, int]], optional): An explicit connectivity list of 0-indexed atom pairs,
+            e.g., derived from computed bond orders. If given, it is used as-is instead of perceiving
+            connectivity from interatomic distances, and no inter-fragment bonds are added.
+        bond_orders (dict[tuple[int, int], float], optional): Computed (e.g., Mayer) bond orders keyed by
+            the pairs in ``bonds``. If given, a Lewis structure with the corresponding rounded bond orders
+            is attempted first, and is used if it is chemically valid.
 
     Returns:
         Molecule | None: A perceived Molecule object with atoms, bonds, charges, and multiplicity
@@ -75,16 +84,21 @@ def perceive_molecule_from_xyz(
 
     symbols, coords = xyz_dict["symbols"], xyz_dict["coords"]
 
-    # build the zero‐order graph and find its connected components
-    dmat = distance_matrix(a=np.array(xyz_to_coords_list(xyz_dict)),
-                           b=np.array(xyz_to_coords_list(xyz_dict)))
-    raw_bonds = get_bonds_from_dmat(dmat, symbols, charges=[0] * len(symbols), n_fragments=n_fragments)
+    if bonds is None:
+        # build the zero‐order graph and find its connected components
+        dmat = distance_matrix(a=np.array(xyz_to_coords_list(xyz_dict)),
+                               b=np.array(xyz_to_coords_list(xyz_dict)))
+        raw_bonds = get_bonds_from_dmat(dmat, symbols, charges=[0] * len(symbols), n_fragments=n_fragments)
 
-    bonds: list[tuple[int, int]] = list()
-    for i, j in raw_bonds:
-        maxd = get_single_bond_length(symbols[i], symbols[j]) * (single_bond_tolerance)
-        if dmat[i, j] <= maxd:
-            bonds.append((i, j))
+        bonds = list()
+        for i, j in raw_bonds:
+            maxd = get_single_bond_length(symbols[i], symbols[j]) * (single_bond_tolerance)
+            if dmat[i, j] <= maxd:
+                bonds.append((i, j))
+        given_bonds = False
+    else:
+        bonds = [tuple(sorted(bond)) for bond in bonds]
+        given_bonds = True
 
     # immediately detach into fragments if requested
     atoms0 = [Atom(element=sym, radical_electrons=0, charge=0, lone_pairs=0, coords=np.array(c))
@@ -119,14 +133,21 @@ def perceive_molecule_from_xyz(
 
     # if we expected multiple fragments, hand off to the multi‐frag helper
     if len(fragments) != 1:
-        if len(fragments) == n_fragments:
-            return _combine_fragments(symbols, coords, fragments, charge)
+        # An explicit connectivity list is authoritative, it determines the number of fragments.
+        if len(fragments) == n_fragments or given_bonds:
+            return _combine_fragments(symbols, coords, fragments, charge,
+                                      bonds=bonds if given_bonds else None, bond_orders=bond_orders)
         return None
 
     # otherwise fall back on the existing single‐molecule code
     # (note: symbols, coords, mol0 already built above)
     multiplicity = multiplicity or infer_multiplicity(symbols, charge, n_radicals)
     n_radicals = n_radicals or (multiplicity - 1)
+
+    if bond_orders is not None:
+        rep = _mol_from_computed_bond_orders(mol0, bonds, bond_orders, charge, multiplicity, n_radicals)
+        if rep is not None:
+            return rep
 
     rep = generate_lewis_structure(mol0, charge, multiplicity, n_radicals)
     if rep is None:
@@ -145,11 +166,73 @@ def perceive_molecule_from_xyz(
     return rep
 
 
+def round_bond_order(bond_order: float) -> int:
+    """
+    Convert a computed (e.g., Mayer) bond order into a formal integer bond order.
+
+    Computed bond orders of delocalized bonds fall between the formal values (e.g., ~1.2-1.6 for an
+    aromatic ring), so the thresholds are placed midway between consecutive formal bond orders.
+
+    Args:
+        bond_order (float): The computed bond order.
+
+    Returns: int
+        The corresponding formal bond order, between 1 and 3.
+    """
+    if bond_order >= 2.5:
+        return 3
+    if bond_order >= 1.5:
+        return 2
+    return 1
+
+
+def _mol_from_computed_bond_orders(
+    mol0: Molecule,
+    bonds: list[tuple[int, int]],
+    bond_orders: dict[tuple[int, int], float],
+    charge: int,
+    multiplicity: int,
+    n_radicals: int,
+) -> Molecule | None:
+    """
+    Attempt to build a valid Molecule using computed (e.g., Mayer) bond orders directly.
+
+    This preserves the multiple bonds indicated by the electronic structure calculation instead of
+    searching for a Lewis structure from scratch. Radicals and lone pairs are assigned for the resulting
+    bond orders, and the structure is only returned if it is chemically valid.
+
+    Args:
+        mol0 (Molecule): A single-bonded molecule with the desired connectivity and coordinates.
+        bonds (list[tuple[int, int]]): The 0-indexed atom pairs of ``mol0``.
+        bond_orders (dict[tuple[int, int], float]): Computed bond orders keyed by the pairs in ``bonds``.
+        charge (int): The desired net formal charge.
+        multiplicity (int): The desired spin multiplicity.
+        n_radicals (int): The desired number of radical electrons.
+
+    Returns: Molecule | None
+        The perceived molecule, or ``None`` if the computed bond orders do not yield a valid structure.
+    """
+    mol = mol0.copy(deep=True)
+    for i, j in bonds:
+        order = bond_orders.get((i, j), bond_orders.get((j, i)))
+        if order is None:
+            return None
+        mol.get_bond(mol.atoms[i], mol.atoms[j]).set_order_num(round_bond_order(order))
+    mol.multiplicity = multiplicity
+    adjust_atoms_for_octet(mol, n_radicals)
+    assign_formal_charges(mol)
+    enforce_target_charge(mol, charge)
+    mol.multiplicity = multiplicity
+    return mol if is_mol_valid(mol, charge, multiplicity, n_radicals) else None
+
+
 def _combine_fragments(
     symbols: tuple[str, ...],
     coords: tuple[tuple[float, float, float], ...],
     fragments: list[list[int]],
     total_charge: int,
+    bonds: list[tuple[int, int]] | None = None,
+    bond_orders: dict[tuple[int, int], float] | None = None,
 ) -> Molecule:
     """
     Build disconnected fragments separately, then stitch them into one Molecule with charges distributed.
@@ -171,6 +254,11 @@ def _combine_fragments(
         coords (tuple[tuple[float, float, float], ...]): Cartesian coordinates for all atoms.
         fragments (list[list[int]]): Lists of atom indices, one per fragment.
         total_charge (int): Desired net charge of the combined system.
+        bonds (list[tuple[int, int]], optional): An explicit connectivity list of 0-indexed atom pairs.
+            If given, it is used instead of perceiving connectivity from interatomic distances, and no
+            inter-fragment bonds are added (steps 1 and 5 above are skipped).
+        bond_orders (dict[tuple[int, int], float], optional): Computed bond orders keyed by the pairs
+            in ``bonds``.
 
     Returns:
         Molecule: A reconstructed Molecule with all fragments combined, charges balanced to match
@@ -186,7 +274,12 @@ def _combine_fragments(
     all_idxs = set(range(len(symbols)))
     covered = set().union(*fragments)
     missing = all_idxs - covered
-    if missing:
+    if missing and bonds is not None:
+        # An explicit connectivity list is authoritative, uncovered atoms are separate fragments.
+        for i in sorted(missing):
+            fragments.append([i])
+        nfr = len(fragments)
+    elif missing:
         centroids = list()
         for idxs in fragments:
             pts = [coords[i] for i in idxs]
@@ -207,11 +300,23 @@ def _combine_fragments(
         mult = infer_multiplicity(sub_symbols, charge)
         rad  = mult - 1
         sub_xyz = {"symbols": sub_symbols, "coords": sub_coords}
+        sub_bonds, sub_bond_orders = None, None
+        if bonds is not None:
+            # Re-index the given connectivity into the fragment's local atom order.
+            local_index = {orig: local for local, orig in enumerate(idxs)}
+            sub_bonds = [(local_index[i], local_index[j]) for i, j in bonds
+                         if i in local_index and j in local_index]
+            if bond_orders is not None:
+                sub_bond_orders = {(local_index[i], local_index[j]): order
+                                   for (i, j), order in bond_orders.items()
+                                   if i in local_index and j in local_index}
         return perceive_molecule_from_xyz(sub_xyz,
                                           charge=charge,
                                           multiplicity=mult,
                                           n_radicals=rad,
                                           n_fragments=1,
+                                          bonds=sub_bonds,
+                                          bond_orders=sub_bond_orders,
                                           )
 
     # 2) search over all splits of total_charge into nfr integers (small range)
@@ -274,7 +379,9 @@ def _combine_fragments(
     best_mol.multiplicity = max(sm.multiplicity for sm in submols)
     assign_formal_charges(best_mol)
     enforce_target_charge(best_mol, total_charge)
-    _add_interfragment_bonds(best_mol, fragments, coords)
+    if bonds is None:
+        # A given connectivity list already accounts for all bonds, the fragments are genuinely separate.
+        _add_interfragment_bonds(best_mol, fragments, coords)
 
     # restore original atom order
     idx_map: dict[int, int] = dict()

--- a/arc/species/perceive_test.py
+++ b/arc/species/perceive_test.py
@@ -17,6 +17,7 @@ from arc.species.perceive import (
     get_representative_resonance_structure,
     infer_multiplicity,
     perceive_molecule_from_xyz,
+    round_bond_order,
     validate_xyz,
     xyz_to_str,
 )
@@ -39,6 +40,18 @@ class TestPerceive(unittest.TestCase):
                 (0.0, 0.0, 0.0),
                 (0.96, 0.0, 0.0),
                 (-0.24, 0.93, 0.0),
+            )}
+        # A planar ethene molecule
+        cls.xyz_ethene = {
+            'symbols': ('C', 'C', 'H', 'H', 'H', 'H'),
+            'isotopes': (12, 12, 1, 1, 1, 1),
+            'coords': (
+                (0.0, 0.0, 0.6695),
+                (0.0, 0.0, -0.6695),
+                (0.0, 0.9289, 1.2321),
+                (0.0, -0.9289, 1.2321),
+                (0.0, 0.9289, -1.2321),
+                (0.0, -0.9289, -1.2321),
             )}
         # A single hydrogen atom (radical)
         cls.xyz_h = {
@@ -297,6 +310,54 @@ H      -0.57000001    0.25001318    0.00000000"""
             self.assertEqual(atom.charge, 0)
         # Multiplicity is singlet
         self.assertEqual(mol.multiplicity, 1)
+
+    def test_perceive_with_given_bonds(self):
+        """
+        Test that an explicitly given connectivity list overrides the distance-based perception.
+        """
+        # Only three of methane's four C-H bonds are given, the fourth H atom must remain unbonded.
+        mol = perceive_molecule_from_xyz(self.xyz_methane, bonds=[(0, 1), (0, 2), (0, 3)])
+        self.assertIsInstance(mol, Molecule)
+        self.assertEqual(len(mol.atoms), 5)
+        self.assertEqual(len(mol.get_all_edges()), 3)
+        self.assertEqual(len(mol.atoms[4].edges), 0)
+        # The distance-based perception of the same coordinates does find all four bonds.
+        self.assertEqual(len(perceive_molecule_from_xyz(self.xyz_methane).get_all_edges()), 4)
+
+    def test_perceive_with_given_bond_orders(self):
+        """
+        Test that computed (e.g., Mayer) bond orders are used to assign multiple bonds.
+        """
+        bonds = [(0, 1), (0, 2), (0, 3), (1, 4), (1, 5)]
+        # Mayer bond orders of ethene at the wB97X-D/def2-TZVP level of theory.
+        bond_orders = {(0, 1): 1.9179, (0, 2): 0.9635, (0, 3): 0.9635, (1, 4): 0.9635, (1, 5): 0.9635}
+        mol = perceive_molecule_from_xyz(self.xyz_ethene, bonds=bonds, bond_orders=bond_orders)
+        self.assertIsInstance(mol, Molecule)
+        self.assertEqual(mol.multiplicity, 1)
+        self.assertTrue(mol.get_bond(mol.atoms[0], mol.atoms[1]).is_double())
+        self.assertTrue(all(mol.get_bond(mol.atoms[i], mol.atoms[j]).is_single() for i, j in bonds[1:]))
+        for atom in mol.atoms:
+            self.assertEqual(atom.radical_electrons, 0)
+            self.assertEqual(atom.charge, 0)
+        # A higher computed bond order yields a triple bond.
+        xyz_acetylene = {'symbols': ('C', 'C', 'H', 'H'), 'isotopes': (12, 12, 1, 1),
+                         'coords': ((0.0, 0.0, 0.6015), (0.0, 0.0, -0.6015),
+                                    (0.0, 0.0, 1.6644), (0.0, 0.0, -1.6644))}
+        mol = perceive_molecule_from_xyz(xyz_acetylene,
+                                         bonds=[(0, 1), (0, 2), (1, 3)],
+                                         bond_orders={(0, 1): 2.8557, (0, 2): 0.9349, (1, 3): 0.9349})
+        self.assertTrue(mol.get_bond(mol.atoms[0], mol.atoms[1]).is_triple())
+
+    def test_round_bond_order(self):
+        """
+        Test converting computed bond orders into formal bond orders.
+        """
+        self.assertEqual(round_bond_order(0.62), 1)
+        self.assertEqual(round_bond_order(1.0121), 1)
+        self.assertEqual(round_bond_order(1.203), 1)
+        self.assertEqual(round_bond_order(1.5612), 2)
+        self.assertEqual(round_bond_order(2.1427), 2)
+        self.assertEqual(round_bond_order(2.9), 3)
 
     def test_perceive_water(self):
         """


### PR DESCRIPTION
**Stack 3/5** — based on #952 (which is based on #951). This is the substantive PR of the stack.

## What

```python
mol, single_bond_mol = mol_from_dft(log_file_path, charge=None, multiplicity=None, bond_order_threshold=0.5)
```

in `arc.species.converter`. Both molecules preserve the log file's atom order and may hold several disconnected fragments (use `.split()`).

- **`mol`** — the perceived molecule with its bond orders.
- **`single_bond_mol`** — the same Mayer-derived connectivity with every bond set to order 1. Useful for connectivity-only isomorphism, and available even where no valid Lewis structure exists — e.g. a bridging H at a TS, which is genuinely bivalent in the graph.

Returns `(None, None)` when the log has no Mayer bond orders, so callers can fall back.

## How

`perceive_molecule_from_xyz()` gains two optional arguments, both defaulting to today's behaviour:

- **`bonds`** replaces the distance-matrix step and is authoritative. The fragment count follows from it rather than from `n_fragments`, and `_add_interfragment_bonds()` is suppressed — otherwise genuinely separate fragments would be glued back together by the nearest-atom heuristic.
- **`bond_orders`** seeds multiple bonds through `round_bond_order()` (≥ 2.5 → 3, ≥ 1.5 → 2, else 1; thresholds sit midway between formal bond orders because computed orders of delocalized bonds fall between them). The seeded structure is kept **only if `is_mol_valid()` accepts it**; otherwise the existing `generate_lewis_structure()` A* search runs on the same connectivity.

So the computed bond orders are honoured wherever they are chemically consistent, and can never yield an invalid molecule.

## Results on the fixtures

| log | perceived |
| --- | --- |
| Orca, C4H5NO2 | `OCc1ccon1` — the correct isoxazole Kekulé structure, from Mayer orders of 1.56 (C=N), 1.60 (C=C) and 1.20 (C–C) |
| Gaussian, C8H14O2 | `C=C(C)COOCC(=C)C` — both C=C preserved |
| Orca, formaldehyde | `C=O` (Mayer 2.14) |
| Orca, CH4 + OH TS | `C.[OH]` at the default threshold; at 0.3 the single-bond graph shows the H bridging C and O |

The aromatic ring is the case worth noting: a distance-based criterion has no way to assign those bond orders.

## Implementation note

`converter.py` must import the parser lazily inside the function body — `arc/parser/parser.py` imports `str_to_xyz` from `converter`, so a module-level import is circular. This is the same idiom `str_to_xyz` itself already uses.

## Testing

`pytest arc/species/` — 303 passed. New tests cover `mol_from_dft` against all four logs above, atom-order preservation, the single-bond copy having an identical edge set with all orders 1, and `perceive_molecule_from_xyz(bonds=...)` overriding the distance heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
