### PR TITLE
Use Mayer bond orders for the IRC endpoint check

### DIFF
--- a/arc/checks/ts.py
+++ b/arc/checks/ts.py
@@ -19,7 +19,7 @@ from arc.common import (ARC_PATH,
                         sum_list_entries,
                         )
 from arc.imports import settings
-from arc.species.converter import check_isomorphism, check_xyz_dict, xyz_from_data, xyz_to_dmat
+from arc.species.converter import check_isomorphism, check_xyz_dict, mol_from_dft, xyz_from_data, xyz_to_dmat
 from arc.species.perceive import perceive_molecule_from_xyz
 from arc.statmech.factory import statmech_factory
 
@@ -497,20 +497,25 @@ def get_rxn_normal_mode_disp_atom_number(rxn_family: str | None = None,
 def check_irc_species_and_rxn(xyz_1: dict,
                               xyz_2: dict,
                               rxn: ARCReaction | None,
+                              log_path_1: str | None = None,
+                              log_path_2: str | None = None,
                               ):
     """
     Check that the two species that result from optimizing the outputs of two IRC runs
     correspond to the desired reactants and products of the corresponding reaction.
 
-    Uses molecular graph isomorphism (including bond orders and resonance structures)
-    when molecule perception succeeds for both endpoints. Falls back to distance-matrix-based
-    bond-list comparison if perception fails for either endpoint or if the expected
-    reactant/product ``Molecule`` objects are unavailable.
+    Uses molecular graph isomorphism (including bond orders and resonance structures).
+    Connectivity is taken from the computed Mayer bond orders when the respective log files are given
+    and contain them, otherwise it is perceived from interatomic distances. Falls back to a
+    distance-matrix-based bond-list comparison if perception fails for either endpoint or if the
+    expected reactant/product ``Molecule`` objects are unavailable.
 
     Args:
         xyz_1 (dict): The coordinates of IRC species 1.
         xyz_2 (dict): The coordinates of IRC species 2.
         rxn (ARCReaction): The corresponding reaction object instance.
+        log_path_1 (str, optional): The path to the log file IRC species 1 was optimized in.
+        log_path_2 (str, optional): The path to the log file IRC species 2 was optimized in.
     """
     if rxn is None:
         return None
@@ -524,8 +529,8 @@ def check_irc_species_and_rxn(xyz_1: dict,
 
     if not any(m is None for m in r_mols + p_mols):
         charge = rxn.charge or 0
-        frags_1 = _perceive_irc_fragments(xyz_1, charge=charge)
-        frags_2 = _perceive_irc_fragments(xyz_2, charge=charge)
+        frags_1 = _perceive_irc_fragments_from_bond_orders(log_path_1) or _perceive_irc_fragments(xyz_1, charge=charge)
+        frags_2 = _perceive_irc_fragments_from_bond_orders(log_path_2) or _perceive_irc_fragments(xyz_2, charge=charge)
         if frags_1 is not None and frags_2 is not None:
             if (_match_fragments_to_species(frags_1, r_mols)
                     and _match_fragments_to_species(frags_2, p_mols)) \
@@ -550,6 +555,35 @@ def check_irc_species_and_rxn(xyz_1: dict,
     if _check_equal_bonds_list(dmat_bonds_1, r_bonds) and _check_equal_bonds_list(dmat_bonds_2, p_bonds) \
             or _check_equal_bonds_list(dmat_bonds_2, r_bonds) and _check_equal_bonds_list(dmat_bonds_1, p_bonds):
         rxn.ts_species.ts_checks['IRC'] = True
+
+
+def _perceive_irc_fragments_from_bond_orders(log_path: str | None,
+                                             charge: int = 0,
+                                             ) -> list[Molecule] | None:
+    """
+    Perceive the molecular fragments of an IRC endpoint using the computed Mayer bond orders.
+
+    This is more reliable than the distance-based criterion used by ``_perceive_irc_fragments()``,
+    since IRC endpoints often have stretched bonds and loosely bound fragments for which
+    interatomic distances are not conclusive.
+
+    Args:
+        log_path (str, optional): The path to the log file of the optimized IRC endpoint.
+        charge (int, optional): The net charge of the full system.
+
+    Returns: list[Molecule] | None
+        A list of perceived ``Molecule`` objects (one per fragment), or ``None`` if ``log_path`` was not
+        given, does not contain Mayer bond orders, or could not be perceived.
+    """
+    if log_path is None or not os.path.isfile(log_path):
+        return None
+    mol, _ = mol_from_dft(log_path, charge=charge)
+    if mol is None:
+        return None
+    fragments = mol.split()
+    for fragment in fragments:
+        fragment.update_multiplicity()
+    return fragments
 
 
 def _perceive_irc_fragments(xyz: dict,

--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -17,7 +17,7 @@ from arc.job.factory import job_factory
 from arc.level import Level
 from arc.parser.parser import parse_normal_mode_displacement, parse_geometry
 from arc.reaction import ARCReaction
-from arc.species.converter import xyz_from_data
+from arc.species.converter import check_isomorphism, xyz_from_data
 from arc.species.species import ARCSpecies, TSGuess
 
 
@@ -682,6 +682,67 @@ class TestTSChecks(unittest.TestCase):
                                      rxn=rxn,
                                      )
         self.assertTrue(rxn.ts_species.ts_checks['IRC'])
+
+    def test_check_irc_species_and_rxn_using_bond_orders(self):
+        """Test that check_irc_species_and_rxn() uses the computed Mayer bond orders when log files are given."""
+        # An isoxazole ring opening, both endpoints were optimized with Orca and hold Mayer bond orders.
+        log_path_1 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C4H5NO2_mayer_orca.out')
+        log_path_2 = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C4H5NO2_isomer_mayer_orca.out')
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='OCc1ccon1')],
+                          p_species=[ARCSpecies(label='P', smiles='OCC1=NC1C=O')])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=parse_geometry(log_path_1),
+                                     xyz_2=parse_geometry(log_path_2),
+                                     rxn=rxn,
+                                     log_path_1=log_path_1,
+                                     log_path_2=log_path_2,
+                                     )
+        self.assertTrue(rxn.ts_species.ts_checks['IRC'])
+
+        # Without the log files, the distance-based perception of the strained three-membered ring of the
+        # product does not reproduce the expected species, and the check fails. This is the case the
+        # bond-order-based perception was added for.
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=parse_geometry(log_path_1),
+                                     xyz_2=parse_geometry(log_path_2),
+                                     rxn=rxn,
+                                     )
+        self.assertFalse(rxn.ts_species.ts_checks['IRC'])
+
+        # The endpoints may also be given in the reverse order.
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=parse_geometry(log_path_2),
+                                     xyz_2=parse_geometry(log_path_1),
+                                     rxn=rxn,
+                                     log_path_1=log_path_2,
+                                     log_path_2=log_path_1,
+                                     )
+        self.assertTrue(rxn.ts_species.ts_checks['IRC'])
+
+        # A reaction the endpoints do not correspond to must not pass.
+        other_rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='OCc1ccon1')],
+                                p_species=[ARCSpecies(label='P', smiles='OCc1cnoc1')])
+        other_rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        ts.check_irc_species_and_rxn(xyz_1=parse_geometry(log_path_1),
+                                     xyz_2=parse_geometry(log_path_2),
+                                     rxn=other_rxn,
+                                     log_path_1=log_path_1,
+                                     log_path_2=log_path_2,
+                                     )
+        self.assertFalse(other_rxn.ts_species.ts_checks['IRC'])
+
+    def test_perceive_irc_fragments_from_bond_orders(self):
+        """Test the _perceive_irc_fragments_from_bond_orders() function."""
+        log_path = os.path.join(ARC_TESTING_PATH, 'bond_orders', 'C4H5NO2_mayer_orca.out')
+        fragments = ts._perceive_irc_fragments_from_bond_orders(log_path)
+        self.assertEqual(len(fragments), 1)
+        self.assertTrue(check_isomorphism(fragments[0], ARCSpecies(label='S', smiles='OCc1ccon1').mol))
+
+        # A log file without Mayer bond orders, and a nonexistent path, both fall back to ``None``.
+        self.assertIsNone(ts._perceive_irc_fragments_from_bond_orders(
+            os.path.join(ARC_TESTING_PATH, 'irc', 'rxn_1_irc_1.out')))
+        self.assertIsNone(ts._perceive_irc_fragments_from_bond_orders(None))
+        self.assertIsNone(ts._perceive_irc_fragments_from_bond_orders('nonexistent.out'))
 
     def test_check_equal_bonds_list(self):
         """Test the _check_equal_bonds_list() function."""

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -3042,6 +3042,8 @@ class Scheduler(object):
                 check_irc_species_and_rxn(xyz_1=self.output[irc_species_labels[0]]['paths']['geo'],
                                           xyz_2=self.output[irc_species_labels[1]]['paths']['geo'],
                                           rxn=self.rxn_dict.get(self.species_dict[ts_label].rxn_index, None),
+                                          log_path_1=self.output[irc_species_labels[0]]['paths']['geo'],
+                                          log_path_2=self.output[irc_species_labels[1]]['paths']['geo'],
                                           )
 
     def check_scan_job(self,

--- a/arc/testing/bond_orders/C4H5NO2_isomer_mayer_orca.out
+++ b/arc/testing/bond_orders/C4H5NO2_isomer_mayer_orca.out
@@ -1,0 +1,6282 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Cooperlake SINGLE_THREADED
+        Core in use  :  Cooperlake
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+NOTE: MaxCore=9800 MB was set to SCF,MP2,MDCI,CIPSI,MRCI and CIS
+      => If you want to overwrite this, your respective input block should be placed after the MaxCore statement
+
+
+***************************************
+The coordinates will be read from file: geom.xyz
+***************************************
+
+
+Your calculation utilizes the geometrical counterpoise correction gCP
+Please cite in your paper:
+H.Kruse, S. Grimme J.Chem.Phys., 136, (2012), 154101 
+   
+
+Your calculation utilizes the atom-pairwise dispersion correction
+based on EEQ partial charges (D4)
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-mTZVPP
+   Stefan Grimme, Andreas Hansen, Sebastian Ehlert, and Jan-Michael Mewes 
+   J. Chem. Phys. 154, 064103 (2021). DOI: 10.1063/5.0040021
+
+----- AuxJ basis set information -----
+Your calculation utilizes the basis: def2-mTZVPP/J
+   Stefan Grimme, Andreas Hansen, Sebastian Ehlert, and Jan-Michael Mewes 
+   J. Chem. Phys. 154, 000000 (2021). DOI: 10.1063/5.0040021
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Using LibXC functional ID 497 : Re-regularized SCAN exchange by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 498 : Re-regularized SCAN correlation by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 497 : Re-regularized SCAN exchange by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+Using LibXC functional ID 498 : Re-regularized SCAN correlation by Furness et al
+[ 1]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020)
+[ 2]  J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020)
+
+WARNING: Geometry Optimization
+  ===> : Switching off AutoStart
+         For restart on a previous wavefunction, please use MOREAD
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = input.in
+|  1> ! r2SCAN-3c Opt TightSCF
+|  2> %maxcore 9800
+|  3> %pal nprocs 30 end
+|  4> * xyzfile 0 1 geom.xyz
+|  5> 
+|  6>                          ****END OF INPUT****
+================================================================================
+
+                       *****************************
+                       * Geometry Optimization Run *
+                       *****************************
+
+Geometry optimization settings:
+Update method            Update   .... BFGS
+Choice of coordinates    CoordSys .... (2022) Redundant Internals
+Initial Hessian          InHess   .... Almloef's Model
+Max. no of cycles        MaxIter  .... 50
+
+Convergence Tolerances:
+Energy Change            TolE     ....  5.0000e-06 Eh
+Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+Strict Convergence                .... False
+
+------------------------------------------------------------------------------
+                        ORCA OPTIMIZATION COORDINATE SETUP
+------------------------------------------------------------------------------
+
+The optimization will be done in redundant internal coordinates (2022)
+Making redundant internal coordinates   ...  (2022 redundants) done
+Evaluating the initial hessian          ...  (Almloef) done
+Evaluating the coordinates              ...  done
+Calculating the B-matrix                .... done
+Calculating the G-matrix                .... done
+Diagonalizing the G-matrix              .... done
+The first mode is                       ....   23
+The number of degrees of freedom        ....   30
+
+    -----------------------------------------------------------------
+                    Redundant Internal Coordinates
+
+
+    -----------------------------------------------------------------
+         Definition                    Initial Value    Approx d2E/dq
+    -----------------------------------------------------------------
+      1. B(C   1,O   0)                  1.3994         0.540675   
+      2. B(C   2,C   1)                  1.4854         0.440115   
+      3. B(N   3,C   2)                  1.2477         0.943859   
+      4. B(C   5,O   4)                  1.2093         1.087043   
+      5. B(C   6,N   3)                  1.5301         0.334522   
+      6. B(C   6,C   5)                  1.4905         0.431925   
+      7. B(C   6,C   2)                  1.4563         0.489784   
+      8. B(H   7,O   0)                  0.9659         0.508759   
+      9. B(H   8,C   1)                  1.0946         0.354021   
+     10. B(H   9,C   1)                  1.1020         0.344544   
+     11. B(H  10,C   5)                  1.1102         0.334290   
+     12. B(H  11,C   6)                  1.0909         0.358969   
+     13. A(C   1,O   0,H   7)          108.5627         0.360199   
+     14. A(C   2,C   1,H   8)          108.2135         0.332274   
+     15. A(H   8,C   1,H   9)          107.1735         0.288064   
+     16. A(C   2,C   1,H   9)          107.4454         0.330785   
+     17. A(O   0,C   1,H   9)          113.1748         0.340228   
+     18. A(O   0,C   1,C   2)          113.1972         0.396024   
+     19. A(O   0,C   1,H   8)          107.3773         0.341776   
+     20. A(C   1,C   2,C   6)          148.3240         0.391722   
+     21. A(C   1,C   2,N   3)          143.2102         0.437288   
+     22. A(N   3,C   2,C   6)           68.4228         0.445821   
+     23. A(C   2,N   3,C   6)           62.2613         0.413627   
+     24. A(O   4,C   5,C   6)          122.9445         0.447077   
+     25. A(C   6,C   5,H  10)          115.6113         0.328118   
+     26. A(O   4,C   5,H  10)          121.4415         0.381246   
+     27. A(C   2,C   6,N   3)           49.3159         0.371156   
+     28. A(C   5,C   6,H  11)          117.1663         0.332004   
+     29. A(N   3,C   6,H  11)          116.6478         0.316460   
+     30. A(C   2,C   6,H  11)          121.1968         0.339018   
+     31. A(N   3,C   6,C   5)          116.0096         0.363241   
+     32. A(C   2,C   6,C   5)          118.3817         0.390437   
+     33. D(H   8,C   1,O   0,H   7)    174.1837         0.023259   
+     34. D(H   9,C   1,O   0,H   7)    -67.7489         0.023259   
+     35. D(C   2,C   1,O   0,H   7)     54.8154         0.023259   
+     36. D(N   3,C   2,C   1,H   9)    123.5927         0.014293   
+     37. D(N   3,C   2,C   1,O   0)     -2.1019         0.014293   
+     38. D(C   6,C   2,C   1,H   8)     62.8312         0.014293   
+     39. D(C   6,C   2,C   1,O   0)   -178.2821         0.014293   
+     40. D(N   3,C   2,C   1,H   8)   -120.9886         0.014293   
+     41. D(C   6,N   3,C   2,C   1)   -177.8441         0.071730   
+     42. D(H  11,C   6,C   2,N   3)    -99.8388         0.017697   
+     43. D(H  11,C   6,C   2,C   1)     77.7023         0.017697   
+     44. D(C   5,C   6,C   2,N   3)    101.1181         0.017697   
+     45. D(C   5,C   6,C   2,C   1)    -81.3408         0.017697   
+     46. D(C   5,C   6,N   3,C   2)   -106.1422         0.009031   
+     47. D(N   3,C   6,C   5,H  10)   -144.7425         0.013775   
+     48. D(N   3,C   6,C   2,C   1)    177.5411         0.017697   
+     49. D(N   3,C   6,C   5,O   4)     35.8566         0.013775   
+     50. D(C   2,C   6,C   5,H  10)    159.3703         0.013775   
+     51. D(C   2,C   6,C   5,O   4)    -20.0306         0.013775   
+     52. D(H  11,C   6,C   5,O   4)   -179.9172         0.013775   
+     53. D(H  11,C   6,N   3,C   2)    109.4426         0.009031   
+    -----------------------------------------------------------------
+
+Number of atoms                         .... 12
+Number of degrees of freedom            .... 53
+
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   1            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.517539    0.690240   -0.164245
+  C     -1.532055   -0.160789    0.348388
+  C     -0.216198   -0.003206   -0.322462
+  N      0.373299    0.611653   -1.234162
+  O      1.978487    1.117414    1.168652
+  C      2.165532    0.110113    0.526273
+  C      1.171275   -0.428244   -0.444909
+  H     -2.576794    0.552458   -1.118455
+  H     -1.407424    0.084205    1.407949
+  H     -1.806660   -1.226501    0.290944
+  H      3.098570   -0.481605    0.635614
+  H      1.436869   -1.345080   -0.972961
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.757459    1.304364   -0.310377
+   1 C     6.0000    0    12.011   -2.895165   -0.303847    0.658357
+   2 C     6.0000    0    12.011   -0.408554   -0.006058   -0.609365
+   3 N     7.0000    0    14.007    0.705432    1.155857   -2.332228
+   4 O     8.0000    0    15.999    3.738798    2.111606    2.208432
+   5 C     6.0000    0    12.011    4.092262    0.208083    0.994513
+   6 C     6.0000    0    12.011    2.213389   -0.809264   -0.840756
+   7 H     1.0000    0     1.008   -4.869434    1.043995   -2.113574
+   8 H     1.0000    0     1.008   -2.659647    0.159125    2.660638
+   9 H     1.0000    0     1.008   -3.414093   -2.317751    0.549805
+  10 H     1.0000    0     1.008    5.855448   -0.910101    1.201136
+  11 H     1.0000    0     1.008    2.715288   -2.541832   -1.838630
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.399363921910     0.00000000     0.00000000
+ C      2   1   0     1.485379901063   113.19720638     0.00000000
+ N      3   2   1     1.247699324453   143.21016005   357.89813399
+ O      3   2   1     2.880251649735   118.84735198   111.84721825
+ C      5   3   2     1.209252453041    61.23318725   132.70654202
+ C      3   2   1     1.456272762386   148.32398377   181.71794236
+ H      1   2   3     0.965926035176   108.56272179    54.81536216
+ H      2   1   3     1.094634684281   107.37732808   119.36838671
+ H      2   1   3     1.102020617208   113.17478247   237.43573058
+ H      6   5   3     1.110245317175   121.44147242   190.64299584
+ H      7   3   2     1.090856239979   121.19675241    77.70229700
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.644414574099     0.00000000     0.00000000
+ C      2   1   0     2.806961217840   113.19720638     0.00000000
+ N      3   2   1     2.357810020696   143.21016005   357.89813399
+ O      3   2   1     5.442886814774   118.84735198   111.84721825
+ C      5   3   2     2.285155963021    61.23318725   132.70654202
+ C      3   2   1     2.751956697198   148.32398377   181.71794236
+ H      1   2   3     1.825335672108   108.56272179    54.81536216
+ H      2   1   3     2.068559769982   107.37732808   119.36838671
+ H      2   1   3     2.082517160458   113.17478247   237.43573058
+ H      6   5   3     2.098059590929   121.44147242   190.64299584
+ H      7   3   2     2.061419545040   121.19675241    77.70229700
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   2 Type C   : 11s6p1d contracted to 5s3p1d pattern {62111/411/1}
+ Group   3 Type N   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   4 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   2 Type C   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   3 Type N   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   4 Type H   : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3031
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8073
+          la=0 lb=0:    909 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    276.020095809266 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.537e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59286
+Total number of batches                      ...      934
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4940
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.4 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+  Functional kind                       .... Exchange
+  Functional name                       .... Re-regularized SCAN exchange by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 6
+    Parameter  0 _c1        =  6.670000e-01 : c1 parameter        
+    Parameter  1 _c2        =  8.000000e-01 : c2 parameter        
+    Parameter  2 _d         =  1.240000e+00 : d parameter         
+    Parameter  3 _k1        =  6.500000e-02 : k1 parameter        
+    Parameter  4 _eta       =  1.000000e-03 : eta parameter       
+    Parameter  5 _dp2       =  3.610000e-01 : dp2 parameter       
+  Functional kind                       .... Correlation
+  Functional name                       .... Re-regularized SCAN correlation by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 1
+    Parameter  0 _eta       =  1.000000e-03 : Regularization parameter
+ Gradients option       PostSCFGGA      .... off
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 265
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   52
+ Basis Dimension        Dim             ....  173
+ Nuclear Repulsion      ENuc            ....    276.0200958093 Eh
+
+Convergence Acceleration:
+ AO-DIIS                CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ MO-DIIS                CNVKDIIS        .... off
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....    50
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    24
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold    (grad. norm)   ....   1.000e-05
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   1.000e-02
+   NR start threshold (gradient norm)   ....   1.000e-04
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Quad. conv. algorithm                .... NR
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Pseudo random numbers                .... off
+   Inactive MOs                         .... canonical
+   Orbital update algorithm             .... Taylor
+   Preconditioner                       .... Diag
+   Full preconditioner red. dimension   ....   250
+   COSX micro iterations for RIJONX calc.... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+   Hessian update       SOSCFHessUp     .... L-BFGS
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Making the grid                                    ... done (   0.1 sec)
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+  promolecular density results
+     # of electrons  =     51.996800364
+     EX              =    -44.725271001
+     EC              =     -1.725103749
+     EX+EC           =    -46.450374750
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.7 sec
+Maximum memory used throughout the entire GUESS-calculation: 8.7 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+-------------------------------------------------------------------------------------------
+                                      ORCA LEAN-SCF
+                              memory conserving SCF solver
+-------------------------------------------------------------------------------------------
+
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -360.2900296992831386     0.00e+00  4.64e-03  2.70e-01  2.45e-01  0.700   0.1
+    2    -360.3860055659702653    -9.60e-02  3.23e-03  1.92e-01  9.73e-02  0.700   0.1
+                               ***Turning on AO-DIIS***
+    3    -360.4123968344460422    -2.64e-02  9.78e-04  2.47e-02  2.72e-02  0.700   0.1
+    4    -360.4321279667150861    -1.97e-02  1.76e-03  8.89e-02  1.97e-02  0.000   0.1
+    5    -360.4788094122631605    -4.67e-02  8.07e-04  4.85e-02  5.62e-03  0.000   0.1
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    6    -360.4791411857804064    -3.32e-04  2.44e-04  1.19e-02  2.31e-03     0.1
+               *** Restarting incremental Fock matrix formation ***
+    7    -360.4791634647182832    -2.23e-05  2.08e-04  1.08e-02  6.22e-04     0.1
+    8    -360.4791169169755563     4.65e-05  9.06e-05  3.50e-03  2.24e-03     0.1
+    9    -360.4791738953187519    -5.70e-05  2.23e-05  4.19e-04  1.09e-04     0.1
+   10    -360.4791728271773650     1.07e-06  1.50e-05  2.74e-04  2.06e-04     0.1
+   11    -360.4791743235871877    -1.50e-06  3.66e-06  1.95e-04  2.17e-05     0.1
+   12    -360.4791742921749460     3.14e-08  3.13e-06  1.89e-04  5.24e-05     0.1
+   13    -360.4791743314416976    -3.93e-08  1.05e-06  5.12e-05  3.31e-06     0.1
+   14    -360.4791743318646127    -4.23e-10  4.99e-07  2.11e-05  2.84e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  14 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47917433186461 Eh           -9809.13702 eV
+
+Components:
+Nuclear Repulsion  :        276.02009580926580 Eh            7510.88865 eV
+Electronic Energy  :       -636.49927014113041 Eh          -17320.02567 eV
+One Electron Energy:      -1036.89394337487306 Eh          -28215.31864 eV
+Two Electron Energy:        400.39467323374265 Eh           10895.29296 eV
+
+Virial components:
+Potential Energy   :       -719.57003259996952 Eh          -19580.49604 eV
+Kinetic Energy     :        359.09085826810491 Eh            9771.35902 eV
+Virial Ratio       :          2.00386619718044
+
+DFT components:
+N(Alpha)           :       25.999990622021 electrons
+N(Beta)            :       25.999990622021 electrons
+N(Total)           :       51.999981244042 electrons
+E(X)               :      -45.742258546340 Eh       
+E(C)               :       -1.704702325222 Eh       
+E(XC)              :      -47.446960871561 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    4.2292e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    2.1098e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    4.9914e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    2.3139e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    2.8446e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    4.5038e-06  Tolerance :   1.0000e-05
+
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -18.984049      -516.5822 
+   1   2.0000     -18.953398      -515.7482 
+   2   2.0000     -14.201940      -386.4544 
+   3   2.0000     -10.130354      -275.6609 
+   4   2.0000     -10.124850      -275.5112 
+   5   2.0000     -10.115981      -275.2698 
+   6   2.0000     -10.096222      -274.7322 
+   7   2.0000      -1.027945       -27.9718 
+   8   2.0000      -1.020552       -27.7706 
+   9   2.0000      -0.983950       -26.7746 
+  10   2.0000      -0.724317       -19.7097 
+  11   2.0000      -0.682757       -18.5788 
+  12   2.0000      -0.556011       -15.1298 
+  13   2.0000      -0.547019       -14.8851 
+  14   2.0000      -0.497637       -13.5414 
+  15   2.0000      -0.480325       -13.0703 
+  16   2.0000      -0.456291       -12.4163 
+  17   2.0000      -0.443137       -12.0584 
+  18   2.0000      -0.404621       -11.0103 
+  19   2.0000      -0.385622       -10.4933 
+  20   2.0000      -0.359518        -9.7830 
+  21   2.0000      -0.347867        -9.4659 
+  22   2.0000      -0.306323        -8.3355 
+  23   2.0000      -0.283312        -7.7093 
+  24   2.0000      -0.263097        -7.1592 
+  25   2.0000      -0.230463        -6.2712 
+  26   0.0000      -0.079307        -2.1580 
+  27   0.0000      -0.054979        -1.4961 
+  28   0.0000       0.026258         0.7145 
+  29   0.0000       0.073272         1.9938 
+  30   0.0000       0.089269         2.4291 
+  31   0.0000       0.105995         2.8843 
+  32   0.0000       0.115307         3.1377 
+  33   0.0000       0.130864         3.5610 
+  34   0.0000       0.141923         3.8619 
+  35   0.0000       0.144594         3.9346 
+  36   0.0000       0.158679         4.3179 
+*Only the first 10 virtual orbitals were printed.
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.383085
+   1 C :   -0.250638
+   2 C :    0.287544
+   3 N :   -0.191452
+   4 O :   -0.354977
+   5 C :    0.104983
+   6 C :   -0.129089
+   7 H :    0.315580
+   8 H :    0.175137
+   9 H :    0.152553
+  10 H :    0.111157
+  11 H :    0.162286
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.758806  s :     3.758806
+      pz      :     1.332149  p :     4.613637
+      px      :     1.604566
+      py      :     1.676922
+      dz2     :     0.003295  d :     0.010642
+      dxz     :     0.000919
+      dyz     :     0.002875
+      dx2y2   :     0.000064
+      dxy     :     0.003489
+
+  1 C s       :     3.335126  s :     3.335126
+      pz      :     1.034776  p :     2.850328
+      px      :     0.836863
+      py      :     0.978689
+      dz2     :     0.012726  d :     0.065184
+      dxz     :     0.012311
+      dyz     :     0.005471
+      dx2y2   :     0.022479
+      dxy     :     0.012197
+
+  2 C s       :     3.203794  s :     3.203794
+      pz      :     0.863972  p :     2.433614
+      px      :     0.724835
+      py      :     0.844807
+      dz2     :     0.016555  d :     0.075049
+      dxz     :     0.017728
+      dyz     :     0.009510
+      dx2y2   :     0.016444
+      dxy     :     0.014812
+
+  3 N s       :     3.734468  s :     3.734468
+      pz      :     1.191163  p :     3.415477
+      px      :     1.089118
+      py      :     1.135195
+      dz2     :     0.019372  d :     0.041507
+      dxz     :     0.007503
+      dyz     :    -0.001907
+      dx2y2   :     0.002790
+      dxy     :     0.013749
+
+  4 O s       :     3.845279  s :     3.845279
+      pz      :     1.422520  p :     4.485447
+      px      :     1.735817
+      py      :     1.327110
+      dz2     :     0.006549  d :     0.024251
+      dxz     :     0.002626
+      dyz     :     0.007362
+      dx2y2   :     0.008498
+      dxy     :    -0.000784
+
+  5 C s       :     3.276410  s :     3.276410
+      pz      :     0.799565  p :     2.534028
+      px      :     0.937188
+      py      :     0.797275
+      dz2     :     0.017006  d :     0.084579
+      dxz     :     0.011997
+      dyz     :     0.015080
+      dx2y2   :     0.012335
+      dxy     :     0.028160
+
+  6 C s       :     3.128263  s :     3.128263
+      pz      :     0.987715  p :     2.944563
+      px      :     0.961141
+      py      :     0.995707
+      dz2     :     0.006179  d :     0.056262
+      dxz     :     0.013637
+      dyz     :     0.009979
+      dx2y2   :     0.014117
+      dxy     :     0.012350
+
+  7 H s       :     0.640771  s :     0.640771
+      pz      :     0.022371  p :     0.043649
+      px      :     0.010320
+      py      :     0.010958
+
+  8 H s       :     0.807440  s :     0.807440
+      pz      :     0.011387  p :     0.017423
+      px      :     0.002687
+      py      :     0.003349
+
+  9 H s       :     0.830296  s :     0.830296
+      pz      :     0.003219  p :     0.017150
+      px      :     0.002969
+      py      :     0.010963
+
+ 10 H s       :     0.871313  s :     0.871313
+      pz      :     0.002427  p :     0.017529
+      px      :     0.009949
+      py      :     0.005153
+
+ 11 H s       :     0.819199  s :     0.819199
+      pz      :     0.005335  p :     0.018514
+      px      :     0.003456
+      py      :     0.009723
+
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.558207
+   1 C :    0.049345
+   2 C :    0.192822
+   3 N :   -0.443212
+   4 O :   -0.441262
+   5 C :    0.215853
+   6 C :   -0.009024
+   7 H :    0.274862
+   8 H :    0.207249
+   9 H :    0.180500
+  10 H :    0.156788
+  11 H :    0.174286
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.516813  s :     3.516813
+      pz      :     1.420099  p :     4.784571
+      px      :     1.643471
+      py      :     1.721001
+      dz2     :     0.070941  d :     0.256822
+      dxz     :     0.045306
+      dyz     :     0.029092
+      dx2y2   :     0.060608
+      dxy     :     0.050875
+
+  1 C s       :     2.851593  s :     2.851593
+      pz      :     1.038074  p :     2.959398
+      px      :     0.911174
+      py      :     1.010150
+      dz2     :     0.029848  d :     0.139664
+      dxz     :     0.024084
+      dyz     :     0.010062
+      dx2y2   :     0.048746
+      dxy     :     0.026923
+
+  2 C s       :     2.822009  s :     2.822009
+      pz      :     0.956122  p :     2.838703
+      px      :     0.980668
+      py      :     0.901913
+      dz2     :     0.028974  d :     0.146466
+      dxz     :     0.036379
+      dyz     :     0.021188
+      dx2y2   :     0.031954
+      dxy     :     0.027972
+
+  3 N s       :     3.380156  s :     3.380156
+      pz      :     1.298507  p :     3.683944
+      px      :     1.169162
+      py      :     1.216276
+      dz2     :     0.067785  d :     0.379112
+      dxz     :     0.078664
+      dyz     :     0.089633
+      dx2y2   :     0.067842
+      dxy     :     0.075188
+
+  4 O s       :     3.568553  s :     3.568553
+      pz      :     1.457716  p :     4.645294
+      px      :     1.718344
+      py      :     1.469234
+      dz2     :     0.035046  d :     0.227415
+      dxz     :     0.023599
+      dyz     :     0.065812
+      dx2y2   :     0.043103
+      dxy     :     0.059855
+
+  5 C s       :     2.873213  s :     2.873213
+      pz      :     0.844908  p :     2.726779
+      px      :     0.962356
+      py      :     0.919514
+      dz2     :     0.032766  d :     0.184156
+      dxz     :     0.024524
+      dyz     :     0.038018
+      dx2y2   :     0.026479
+      dxy     :     0.062369
+
+  6 C s       :     2.854824  s :     2.854824
+      pz      :     1.026693  p :     3.040286
+      px      :     0.998554
+      py      :     1.015038
+      dz2     :     0.011713  d :     0.113915
+      dxz     :     0.028783
+      dyz     :     0.019830
+      dx2y2   :     0.029504
+      dxy     :     0.024084
+
+  7 H s       :     0.602188  s :     0.602188
+      pz      :     0.067386  p :     0.122950
+      px      :     0.026575
+      py      :     0.028990
+
+  8 H s       :     0.752545  s :     0.752545
+      pz      :     0.026534  p :     0.040206
+      px      :     0.005777
+      py      :     0.007895
+
+  9 H s       :     0.778822  s :     0.778822
+      pz      :     0.007473  p :     0.040678
+      px      :     0.007144
+      py      :     0.026061
+
+ 10 H s       :     0.803462  s :     0.803462
+      pz      :     0.005453  p :     0.039750
+      px      :     0.023219
+      py      :     0.011078
+
+ 11 H s       :     0.781287  s :     0.781287
+      pz      :     0.013740  p :     0.044427
+      px      :     0.007843
+      py      :     0.022845
+
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.3831     8.0000    -0.3831     1.8661     1.8661    -0.0000
+  1 C      6.2506     6.0000    -0.2506     3.9415     3.9415    -0.0000
+  2 C      5.7125     6.0000     0.2875     3.7074     3.7074    -0.0000
+  3 N      7.1915     7.0000    -0.1915     2.7978     2.7978    -0.0000
+  4 O      8.3550     8.0000    -0.3550     1.9919     1.9919     0.0000
+  5 C      5.8950     6.0000     0.1050     3.9325     3.9325     0.0000
+  6 C      6.1291     6.0000    -0.1291     3.5308     3.5308    -0.0000
+  7 H      0.6844     1.0000     0.3156     0.9008     0.9008     0.0000
+  8 H      0.8249     1.0000     0.1751     0.9456     0.9456    -0.0000
+  9 H      0.8474     1.0000     0.1526     0.9472     0.9472    -0.0000
+ 10 H      0.8888     1.0000     0.1112     0.9646     0.9646     0.0000
+ 11 H      0.8377     1.0000     0.1623     0.9581     0.9581    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-C ) :   1.0335 B(  0-O ,  7-H ) :   0.8871 B(  1-C ,  2-C ) :   0.9187 
+B(  1-C ,  8-H ) :   0.9525 B(  1-C ,  9-H ) :   0.9593 B(  2-C ,  3-N ) :   1.7644 
+B(  2-C ,  4-O ) :   0.1049 B(  2-C ,  6-C ) :   0.9524 B(  3-N ,  6-C ) :   0.8659 
+B(  4-O ,  5-C ) :   1.9311 B(  4-O ,  6-C ) :  -0.1196 B(  5-C ,  6-C ) :   0.9483 
+B(  5-C , 10-H ) :   0.9775 B(  6-C , 11-H ) :   0.8862 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+
+Total time                  ....       1.607 sec
+Sum of individual times     ....       1.586 sec  ( 98.7%)
+
+SCF preparation             ....       0.496 sec  ( 30.9%)
+Fock matrix formation       ....       0.805 sec  ( 50.1%)
+  Startup                   ....       0.015 sec  (  1.9% of F)
+  Split-RI-J                ....       0.149 sec  ( 18.5% of F)
+  XC integration            ....       0.576 sec  ( 71.6% of F)
+    Basis function eval.    ....       0.075 sec  ( 13.0% of XC)
+    Density eval.           ....       0.119 sec  ( 20.7% of XC)
+    XC-Functional eval.     ....       0.044 sec  (  7.7% of XC)
+    XC-Potential eval.      ....       0.124 sec  ( 21.4% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.046 sec  (  2.9%)
+Total Energy calculation    ....       0.025 sec  (  1.6%)
+Population analysis         ....       0.013 sec  (  0.8%)
+Orbital Transformation      ....       0.019 sec  (  1.2%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.108 sec  (  6.7%)
+SOSCF solution              ....       0.073 sec  (  4.5%)
+Finished LeanSCF after   1.6 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 12.9 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+The R2SCAN3C composite method is recognized
+Using three-body term ABC
+Active option DFTDOPT                   ...         5   
+
+-------------------------   ----------------
+Dispersion correction           -0.002884401
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.007049638
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475009094364
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000063782    0.000005340   -0.000012091
+   2   C   :   -0.000057306   -0.000013736    0.000010760
+   3   C   :   -0.000015547   -0.000002583   -0.000009938
+   4   N   :    0.000014707    0.000012887   -0.000044869
+   5   O   :    0.000060033    0.000029047    0.000034754
+   6   C   :    0.000064339   -0.000000616    0.000009848
+   7   C   :    0.000040092   -0.000014868   -0.000011415
+   8   H   :   -0.000024713    0.000008669    0.000008620
+   9   H   :   -0.000033541    0.000001550    0.000013622
+  10   H   :   -0.000031316   -0.000008709    0.000005668
+  11   H   :    0.000028424   -0.000002448    0.000010528
+  12   H   :    0.000018611   -0.000014532   -0.000015487
+
+Difference to translation invariance:
+           :   -0.0000000000   -0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001652550
+RMS gradient                       ...    0.0000275425
+MAX gradient                       ...    0.0000643387
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.005127851   -0.003203661    0.004359372
+   2   C   :   -0.006978754    0.000878615    0.000972603
+   3   C   :    0.003462528   -0.000142262   -0.000807750
+   4   N   :    0.007432406   -0.005465890    0.004370091
+   5   O   :   -0.000447220   -0.002840078   -0.002197500
+   6   C   :    0.003834822    0.002458991    0.002992294
+   7   C   :   -0.010492463    0.005554763   -0.006925184
+   8   H   :    0.000402080   -0.001020621   -0.001155212
+   9   H   :   -0.000863670    0.000346079   -0.001612083
+  10   H   :    0.000264159    0.001750440   -0.000395157
+  11   H   :   -0.001686584    0.001221773    0.000039980
+  12   H   :   -0.000055157    0.000461851    0.000358546
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000300121    0.0000626156    0.0000514802
+
+Norm of the Cartesian gradient     ...    0.0216458381
+RMS gradient                       ...    0.0036076397
+MAX gradient                       ...    0.0104924631
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.190 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.4%)
+RI-J Coulomb gradient       ....       0.057 sec  ( 29.8%)
+XC gradient                 ....       0.095 sec  ( 50.1%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475009094 Eh
+Current gradient norm                   ....     0.021645838 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Evaluating the initial hessian          ....  (Almloef) done
+Projecting the Hessian                  .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.998935824
+Lowest eigenvalues of augmented Hessian:
+ -0.000507048  0.013775479  0.013786740  0.014299222  0.022409467
+Length of the computed step             ....  0.046170930
+The final length of the internal step   ....  0.046170930
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0063420650
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0086385825 RMS(Int)=    0.8627155658
+done
+Storing new coordinates                 .... done
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          RMS gradient        0.0019653908            0.0001000000      NO
+          MAX gradient        0.0078274360            0.0003000000      NO
+          RMS step            0.0063420650            0.0020000000      NO
+          MAX step            0.0222655657            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0118      Max(Angles)    0.45
+          Max(Dihed)        0.72      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.3994 -0.007635  0.0075    1.4068   
+     2. B(C   2,C   1)                1.4854  0.002924 -0.0035    1.4819   
+     3. B(N   3,C   2)                1.2477  0.000015 -0.0003    1.2474   
+     4. B(C   5,O   4)                1.2093 -0.003464  0.0017    1.2109   
+     5. B(C   6,N   3)                1.5301 -0.007827  0.0118    1.5418   
+     6. B(C   6,C   5)                1.4905  0.001983 -0.0024    1.4881   
+     7. B(C   6,C   2)                1.4563 -0.003771  0.0050    1.4612   
+     8. B(H   7,O   0)                0.9659  0.001263 -0.0013    0.9646   
+     9. B(H   8,C   1)                1.0946 -0.001582  0.0024    1.0970   
+    10. B(H   9,C   1)                1.1020 -0.001738  0.0027    1.1047   
+    11. B(H  10,C   5)                1.1102 -0.002064  0.0033    1.1135   
+    12. B(H  11,C   6)                1.0909 -0.000575  0.0008    1.0917   
+    13. A(C   1,O   0,H   7)          108.56 -0.001697    0.27    108.83   
+    14. A(C   2,C   1,H   8)          108.21  0.000882   -0.16    108.05   
+    15. A(H   8,C   1,H   9)          107.17  0.000398   -0.18    106.99   
+    16. A(C   2,C   1,H   9)          107.45  0.000294   -0.04    107.40   
+    17. A(O   0,C   1,H   9)          113.17 -0.000062    0.04    113.22   
+    18. A(O   0,C   1,C   2)          113.20 -0.000988    0.19    113.39   
+    19. A(O   0,C   1,H   8)          107.38 -0.000401    0.12    107.50   
+    20. A(C   1,C   2,C   6)          148.32  0.000339   -0.11    148.22   
+    21. A(C   1,C   2,N   3)          143.21  0.002244   -0.34    142.87   
+    22. A(N   3,C   2,C   6)           68.42 -0.002576    0.45     68.87   
+    23. A(C   2,N   3,C   6)           62.26  0.000605   -0.13     62.13   
+    24. A(O   4,C   5,C   6)          122.94 -0.001764    0.25    123.19   
+    25. A(C   6,C   5,H  10)          115.61  0.001153   -0.17    115.44   
+    26. A(O   4,C   5,H  10)          121.44  0.000608   -0.07    121.37   
+    27. A(C   2,C   6,N   3)           49.32  0.001971   -0.32     48.99   
+    28. A(C   5,C   6,H  11)          117.17  0.000759   -0.04    117.13   
+    29. A(N   3,C   6,H  11)          116.65 -0.000111   -0.02    116.63   
+    30. A(C   2,C   6,H  11)          121.20  0.000168   -0.06    121.14   
+    31. A(N   3,C   6,C   5)          116.01 -0.001429    0.32    116.33   
+    32. A(C   2,C   6,C   5)          118.38 -0.001051    0.05    118.43   
+    33. D(H   8,C   1,O   0,H   7)    174.18  0.000174   -0.35    173.83   
+    34. D(H   9,C   1,O   0,H   7)    -67.75  0.000367   -0.47    -68.22   
+    35. D(C   2,C   1,O   0,H   7)     54.82 -0.000061   -0.34     54.47   
+    36. D(N   3,C   2,C   1,H   9)    123.59 -0.000413   -0.31    123.29   
+    37. D(N   3,C   2,C   1,O   0)     -2.10  0.000133   -0.46     -2.56   
+    38. D(C   6,C   2,C   1,H   8)     62.83  0.000418   -0.72     62.11   
+    39. D(C   6,C   2,C   1,O   0)   -178.28 -0.000097   -0.56   -178.84   
+    40. D(N   3,C   2,C   1,H   8)   -120.99  0.000647   -0.62   -121.61   
+    41. D(C   6,N   3,C   2,C   1)   -177.84 -0.000112   -0.05   -177.90   
+    42. D(H  11,C   6,C   2,N   3)    -99.84 -0.000634    0.13    -99.71   
+    43. D(H  11,C   6,C   2,C   1)     77.70 -0.000401    0.18     77.88   
+    44. D(C   5,C   6,C   2,N   3)    101.12 -0.000400    0.28    101.40   
+    45. D(C   5,C   6,C   2,C   1)    -81.34 -0.000167    0.33    -81.01   
+    46. D(C   5,C   6,N   3,C   2)   -106.14 -0.000175    0.26   -105.89   
+    47. D(N   3,C   6,C   5,H  10)   -144.74  0.000702    0.24   -144.50   
+    48. D(N   3,C   6,C   2,C   1)    177.54  0.000233    0.05    177.59   
+    49. D(N   3,C   6,C   5,O   4)     35.86  0.001034   -0.56     35.30   
+    50. D(C   2,C   6,C   5,H  10)    159.37 -0.000887    0.50    159.87   
+    51. D(C   2,C   6,C   5,O   4)    -20.03 -0.000555   -0.30    -20.33   
+    52. D(H  11,C   6,C   5,O   4)   -179.92 -0.000225   -0.15   -180.07   
+    53. D(H  11,C   6,N   3,C   2)    109.44  0.000757   -0.14    109.30   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (10.120 %)
+Internal coordinates            :      0.000 s ( 2.249 %)
+B/P matrices and projection     :      0.000 s (19.490 %)
+Hessian update/contruction      :      0.000 s (12.444 %)
+Making the step                 :      0.000 s (17.091 %)
+Converting the step to Cartesian:      0.000 s ( 3.448 %)
+Storing new data                :      0.000 s ( 1.799 %)
+Checking convergence            :      0.000 s ( 0.150 %)
+Final printing                  :      0.000 s (32.984 %)
+Total time                      :      0.001 s
+
+Time for energy+gradient        :      5.651 s
+Time for complete geometry iter :      6.602 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   2            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.523678    0.693812   -0.164722
+  C     -1.530674   -0.162203    0.345523
+  C     -0.218077   -0.005415   -0.324134
+  N      0.363789    0.609407   -1.240326
+  O      1.981679    1.121575    1.169495
+  C      2.164695    0.109686    0.529997
+  C      1.175147   -0.430181   -0.441435
+  H     -2.584969    0.565735   -1.118828
+  H     -1.401249    0.079007    1.407818
+  H     -1.805278   -1.230678    0.288210
+  H      3.103218   -0.480355    0.634514
+  H      1.442757   -1.349730   -0.965485
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.769060    1.311115   -0.311279
+   1 C     6.0000    0    12.011   -2.892554   -0.306519    0.652945
+   2 C     6.0000    0    12.011   -0.412105   -0.010233   -0.612525
+   3 N     7.0000    0    14.007    0.687461    1.151611   -2.343876
+   4 O     8.0000    0    15.999    3.744830    2.119469    2.210025
+   5 C     6.0000    0    12.011    4.090680    0.207277    1.001549
+   6 C     6.0000    0    12.011    2.220706   -0.812924   -0.834191
+   7 H     1.0000    0     1.008   -4.884884    1.069084   -2.114279
+   8 H     1.0000    0     1.008   -2.647976    0.149301    2.660390
+   9 H     1.0000    0     1.008   -3.411481   -2.325645    0.544639
+  10 H     1.0000    0     1.008    5.864232   -0.907739    1.199057
+  11 H     1.0000    0     1.008    2.726416   -2.550621   -1.824503
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.406829647538     0.00000000     0.00000000
+ C      2   1   0     1.481868515976   113.38692779     0.00000000
+ N      3   2   1     1.247389267439   142.86807486   357.43558757
+ O      3   2   1     2.887898731457   118.83380282   111.62771161
+ C      5   3   2     1.210938137489    61.04569886   132.47211319
+ C      3   2   1     1.461251886428   148.21762524   181.16008793
+ H      1   2   3     0.964613796281   108.83232978    54.47426211
+ H      2   1   3     1.096996664157   107.49982929   119.36070608
+ H      2   1   3     1.104686421173   113.21911195   237.31010988
+ H      6   5   3     1.113507368710   121.37306434   189.96590156
+ H      7   3   2     1.091703062085   121.13792639    77.88329782
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.658522750928     0.00000000     0.00000000
+ C      2   1   0     2.800325661675   113.38692779     0.00000000
+ N      3   2   1     2.357224097852   142.86807486   357.43558757
+ O      3   2   1     5.457337704953   118.83380282   111.62771161
+ C      5   3   2     2.288341444976    61.04569886   132.47211319
+ C      3   2   1     2.761365878025   148.21762524   181.16008793
+ H      1   2   3     1.822855899973   108.83232978    54.47426211
+ H      2   1   3     2.073023265082   107.49982929   119.36070608
+ H      2   1   3     2.087554799878   113.21911195   237.31010988
+ H      6   5   3     2.104223974965   121.37306434   189.96590156
+ H      7   3   2     2.063019806903   121.13792639    77.88329782
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3030
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8065
+          la=0 lb=0:    908 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.544811422135 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.543e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59293
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4792804685519059     0.00e+00  1.97e-04  5.70e-03  3.94e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4794459484456866    -1.65e-04  1.12e-04  3.66e-03  4.41e-04     0.1
+    3    -360.4794483081302587    -2.36e-06  4.68e-05  9.87e-04  1.18e-03     0.1
+    4    -360.4794552423730920    -6.93e-06  5.31e-05  2.00e-03  5.94e-04     0.1
+    5    -360.4794579484640735    -2.71e-06  2.59e-05  8.60e-04  2.32e-04     0.1
+    6    -360.4794596502812283    -1.70e-06  1.44e-05  2.70e-04  1.05e-04     0.1
+    7    -360.4794599298659250    -2.80e-07  7.19e-06  1.17e-04  5.24e-05     0.1
+    8    -360.4794600563466247    -1.26e-07  5.63e-06  2.34e-04  3.89e-05     0.1
+    9    -360.4794600875668493    -3.12e-08  4.65e-06  2.88e-04  2.15e-05     0.1
+   10    -360.4794600887930756    -1.23e-09  2.09e-06  9.98e-05  3.34e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47946008879308 Eh           -9809.14480 eV
+
+Components:
+Nuclear Repulsion  :        275.54481142213535 Eh            7497.95551 eV
+Electronic Energy  :       -636.02427151092843 Eh          -17307.10030 eV
+One Electron Energy:      -1035.95455776042991 Eh          -28189.75666 eV
+Two Electron Energy:        399.93028624950142 Eh           10882.65635 eV
+
+Virial components:
+Potential Energy   :       -719.52638966696395 Eh          -19579.30846 eV
+Kinetic Energy     :        359.04692957817088 Eh            9770.16366 eV
+Virial Ratio       :          2.00398981412348
+
+DFT components:
+N(Alpha)           :       25.999990505325 electrons
+N(Beta)            :       25.999990505325 electrons
+N(Total)           :       51.999981010651 electrons
+E(X)               :      -45.731141674002 Eh       
+E(C)               :       -1.704018360469 Eh       
+E(XC)              :      -47.435160034471 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    1.2262e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    9.9777e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    2.0875e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    3.2497e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    3.3387e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    4.8406e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.0 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002882114
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006982419
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475359783927
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000063439    0.000005442   -0.000011943
+   2   C   :   -0.000057489   -0.000013778    0.000010787
+   3   C   :   -0.000015548   -0.000002694   -0.000010027
+   4   N   :    0.000014325    0.000012640   -0.000045037
+   5   O   :    0.000060079    0.000029218    0.000034893
+   6   C   :    0.000064367   -0.000000602    0.000010020
+   7   C   :    0.000039956   -0.000014770   -0.000011506
+   8   H   :   -0.000024614    0.000008604    0.000008522
+   9   H   :   -0.000033486    0.000001431    0.000013481
+  10   H   :   -0.000031164   -0.000008519    0.000005655
+  11   H   :    0.000028413   -0.000002419    0.000010511
+  12   H   :    0.000018599   -0.000014554   -0.000015355
+
+Difference to translation invariance:
+           :   -0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000    0.0000000000    0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651447
+RMS gradient                       ...    0.0000275241
+MAX gradient                       ...    0.0000643671
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.001565856   -0.000775349    0.000506213
+   2   C   :   -0.002999580    0.000519954    0.000380798
+   3   C   :    0.000729877   -0.000091436    0.000887246
+   4   N   :    0.004225809   -0.003063037    0.002354857
+   5   O   :   -0.000354971   -0.000305210   -0.001107397
+   6   C   :    0.001596671   -0.000189447    0.002678840
+   7   C   :   -0.005588712    0.003786283   -0.005539451
+   8   H   :   -0.000179922   -0.000209292    0.000046204
+   9   H   :    0.000035836    0.000196117   -0.000051492
+  10   H   :    0.000348718   -0.000072615   -0.000244484
+  11   H   :    0.000146236    0.000549155   -0.000208317
+  12   H   :    0.000474180   -0.000345125    0.000296981
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000033353    0.0000746105    0.0000330668
+
+Norm of the Cartesian gradient     ...    0.0116362965
+RMS gradient                       ...    0.0019393828
+MAX gradient                       ...    0.0055887116
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.177 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.009 sec  (  5.0%)
+RI-J Coulomb gradient       ....       0.054 sec  ( 30.7%)
+XC gradient                 ....       0.085 sec  ( 48.0%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475359784 Eh
+Current gradient norm                   ....     0.011636297 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.993521500
+Lowest eigenvalues of augmented Hessian:
+ -0.000384761  0.013497435  0.013785210  0.015345649  0.022266421
+Length of the computed step             ....  0.114385354
+The final length of the internal step   ....  0.114385354
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0157120367
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0164983408 RMS(Int)=    0.8591512173
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000194897
+Previously predicted energy change      ....    -0.000254064
+Actually observed energy change         ....    -0.000350690
+Ratio of predicted to observed change   ....     1.380317199
+New trust radius                        ....     0.300000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0003506896            0.0000050000      NO
+          RMS gradient        0.0008855930            0.0001000000      NO
+          MAX gradient        0.0042598411            0.0003000000      NO
+          RMS step            0.0157120367            0.0020000000      NO
+          MAX step            0.0559773810            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0167      Max(Angles)    0.71
+          Max(Dihed)        3.21      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4068 -0.001776  0.0067    1.4135   
+     2. B(C   2,C   1)                1.4819  0.001409 -0.0046    1.4773   
+     3. B(N   3,C   2)                1.2474  0.000246 -0.0007    1.2467   
+     4. B(C   5,O   4)                1.2109 -0.000786  0.0015    1.2124   
+     5. B(C   6,N   3)                1.5418 -0.004260  0.0167    1.5585   
+     6. B(C   6,C   5)                1.4881  0.001834 -0.0049    1.4832   
+     7. B(C   6,C   2)                1.4613 -0.001056  0.0052    1.4665   
+     8. B(H   7,O   0)                0.9646 -0.000005 -0.0007    0.9639   
+     9. B(H   8,C   1)                1.0970 -0.000004  0.0012    1.0982   
+    10. B(H   9,C   1)                1.1047 -0.000004  0.0014    1.1061   
+    11. B(H  10,C   5)                1.1135 -0.000187  0.0022    1.1157   
+    12. B(H  11,C   6)                1.0917  0.000264 -0.0002    1.0915   
+    13. A(C   1,O   0,H   7)          108.83 -0.000029    0.15    108.98   
+    14. A(C   2,C   1,H   8)          108.05 -0.000060   -0.05    108.00   
+    15. A(H   8,C   1,H   9)          106.99  0.000181   -0.20    106.80   
+    16. A(C   2,C   1,H   9)          107.40 -0.000323    0.10    107.50   
+    17. A(O   0,C   1,H   9)          113.22  0.000260   -0.06    113.16   
+    18. A(O   0,C   1,C   2)          113.39 -0.000083    0.14    113.52   
+    19. A(O   0,C   1,H   8)          107.50  0.000033    0.05    107.55   
+    20. A(C   1,C   2,C   6)          148.22  0.000625   -0.25    147.97   
+    21. A(C   1,C   2,N   3)          142.87  0.001143   -0.45    142.41   
+    22. A(N   3,C   2,C   6)           68.87 -0.001767    0.71     69.58   
+    23. A(C   2,N   3,C   6)           62.13  0.000751   -0.27     61.87   
+    24. A(O   4,C   5,C   6)          123.19 -0.001353    0.42    123.61   
+    25. A(C   6,C   5,H  10)          115.44  0.000957   -0.35    115.09   
+    26. A(O   4,C   5,H  10)          121.37  0.000394   -0.12    121.25   
+    27. A(C   2,C   6,N   3)           48.99  0.001016   -0.44     48.55   
+    28. A(C   5,C   6,H  11)          117.13  0.000103    0.03    117.15   
+    29. A(N   3,C   6,H  11)          116.63  0.000238   -0.28    116.34   
+    30. A(C   2,C   6,H  11)          121.14  0.000338   -0.08    121.06   
+    31. A(N   3,C   6,C   5)          116.33 -0.000598    0.21    116.54   
+    32. A(C   2,C   6,C   5)          118.44 -0.000641    0.25    118.68   
+    33. D(H   8,C   1,O   0,H   7)    173.83 -0.000007   -0.72    173.11   
+    34. D(H   9,C   1,O   0,H   7)    -68.22  0.000390   -0.97    -69.18   
+    35. D(C   2,C   1,O   0,H   7)     54.47  0.000096   -0.78     53.70   
+    36. D(N   3,C   2,C   1,H   9)    123.29  0.000110   -0.65    122.64   
+    37. D(N   3,C   2,C   1,O   0)     -2.56  0.000077   -0.74     -3.30   
+    38. D(C   6,C   2,C   1,H   8)     62.11  0.000117   -1.16     60.95   
+    39. D(C   6,C   2,C   1,O   0)   -178.84  0.000067   -1.05   -179.89   
+    40. D(N   3,C   2,C   1,H   8)   -121.61  0.000127   -0.85   -122.46   
+    41. D(C   6,N   3,C   2,C   1)   -177.90 -0.000017   -0.17   -178.07   
+    42. D(H  11,C   6,C   2,N   3)    -99.71 -0.000543    0.54    -99.17   
+    43. D(H  11,C   6,C   2,C   1)     77.88 -0.000502    0.73     78.61   
+    44. D(C   5,C   6,C   2,N   3)    101.40  0.000058   -0.06    101.33   
+    45. D(C   5,C   6,C   2,C   1)    -81.01  0.000099    0.12    -80.89   
+    46. D(C   5,C   6,N   3,C   2)   -105.89  0.000139   -0.06   -105.94   
+    47. D(N   3,C   6,C   5,H  10)   -144.50  0.000904   -3.21   -147.71   
+    48. D(N   3,C   6,C   2,C   1)    177.59  0.000041    0.19    177.78   
+    49. D(N   3,C   6,C   5,O   4)     35.30  0.000074    1.84     37.14   
+    50. D(C   2,C   6,C   5,H  10)    159.87  0.000062   -2.82    157.05   
+    51. D(C   2,C   6,C   5,O   4)    -20.33 -0.000768    2.23    -18.10   
+    52. D(H  11,C   6,C   5,O   4)    179.93 -0.000249    1.68    181.61   
+    53. D(H  11,C   6,N   3,C   2)    109.31  0.000507    0.00    109.31   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 8.748 %)
+Internal coordinates            :      0.000 s ( 1.968 %)
+B/P matrices and projection     :      0.000 s (14.489 %)
+Hessian update/contruction      :      0.001 s (33.024 %)
+Making the step                 :      0.000 s (11.700 %)
+Converting the step to Cartesian:      0.000 s ( 2.898 %)
+Storing new data                :      0.000 s ( 1.531 %)
+Checking convergence            :      0.000 s ( 0.656 %)
+Final printing                  :      0.000 s (24.822 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      4.531 s
+Time for complete geometry iter :      5.421 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   3            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.526575    0.695311   -0.159883
+  C     -1.524183   -0.164446    0.344107
+  C     -0.219309   -0.008019   -0.330620
+  N      0.346537    0.604630   -1.257207
+  O      1.977067    1.123103    1.174665
+  C      2.169288    0.124023    0.515216
+  C      1.180964   -0.429190   -0.442343
+  H     -2.587931    0.579352   -1.114862
+  H     -1.387203    0.074098    1.407317
+  H     -1.800691   -1.233999    0.289568
+  H      3.087151   -0.494237    0.656582
+  H      1.452244   -1.349968   -0.961912
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.774535    1.313947   -0.302135
+   1 C     6.0000    0    12.011   -2.880288   -0.310757    0.650269
+   2 C     6.0000    0    12.011   -0.414433   -0.015154   -0.624781
+   3 N     7.0000    0    14.007    0.654860    1.142586   -2.375776
+   4 O     8.0000    0    15.999    3.736114    2.122358    2.219794
+   5 C     6.0000    0    12.011    4.099360    0.234370    0.973616
+   6 C     6.0000    0    12.011    2.231699   -0.811051   -0.835908
+   7 H     1.0000    0     1.008   -4.890480    1.094817   -2.106784
+   8 H     1.0000    0     1.008   -2.621434    0.140025    2.659443
+   9 H     1.0000    0     1.008   -3.402814   -2.331921    0.547204
+  10 H     1.0000    0     1.008    5.833871   -0.933973    1.240760
+  11 H     1.0000    0     1.008    2.744343   -2.551069   -1.817751
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.413498544820     0.00000000     0.00000000
+ C      2   1   0     1.477302328023   113.52385580     0.00000000
+ N      3   2   1     1.246628947401   142.41361758   356.69632435
+ O      3   2   1     2.892988884704   118.31683907   111.57211388
+ C      5   3   2     1.212428785529    60.99888133   133.62096367
+ C      3   2   1     1.466502957464   147.97060645   180.10721798
+ H      1   2   3     0.963948338261   108.97807929    53.69891833
+ H      2   1   3     1.098216813671   107.54918622   119.41427209
+ H      2   1   3     1.106063718549   113.16019385   237.11877793
+ H      6   5   3     1.115662697836   121.20919508   194.23076562
+ H      7   3   2     1.091501809572   121.05435611    78.61179273
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.671125140406     0.00000000     0.00000000
+ C      2   1   0     2.791696816967   113.52385580     0.00000000
+ N      3   2   1     2.355787301206   142.41361758   356.69632435
+ O      3   2   1     5.466956700569   118.31683907   111.57211388
+ C      5   3   2     2.291158361533    60.99888133   133.62096367
+ C      3   2   1     2.771288964193   147.97060645   180.10721798
+ H      1   2   3     1.821598366561   108.97807929    53.69891833
+ H      2   1   3     2.075329013507   107.54918622   119.41427209
+ H      2   1   3     2.090157514724   113.16019385   237.11877793
+ H      6   5   3     2.108296956741   121.20919508   194.23076562
+ H      7   3   2     2.062639494770   121.05435611    78.61179273
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3030
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8067
+          la=0 lb=0:    908 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.176173897448 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.550e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59287
+Total number of batches                      ...      931
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -360.4785236224744267     0.00e+00  1.00e-04  2.01e-03  1.12e-02  0.700   0.1
+    2    -360.4787545402444948    -2.31e-04  9.63e-05  2.09e-03  8.55e-03  0.700   0.1
+                               ***Turning on AO-DIIS***
+    3    -360.4789309707302891    -1.76e-04  7.87e-05  1.68e-03  6.15e-03  0.700   0.1
+    4    -360.4790559647946111    -1.25e-04  1.96e-04  3.74e-03  4.36e-03  0.000   0.1
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    5    -360.4793511195929341    -2.95e-04  1.61e-05  2.79e-04  2.15e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    6    -360.4793517756857000    -6.56e-07  2.31e-05  3.45e-04  1.46e-04     0.1
+    7    -360.4793512579423123     5.18e-07  1.19e-05  3.25e-04  3.52e-04     0.1
+    8    -360.4793522106100454    -9.53e-07  1.01e-05  2.18e-04  5.28e-05     0.1
+    9    -360.4793522132847556    -2.67e-09  3.89e-06  6.15e-05  2.70e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   9 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47935221328476 Eh           -9809.14186 eV
+
+Components:
+Nuclear Repulsion  :        275.17617389744794 Eh            7487.92437 eV
+Electronic Energy  :       -635.65552611073258 Eh          -17297.06623 eV
+One Electron Energy:      -1035.21696499115546 Eh          -28169.68574 eV
+Two Electron Energy:        399.56143888042283 Eh           10872.61951 eV
+
+Virial components:
+Potential Energy   :       -719.49509157745433 Eh          -19578.45679 eV
+Kinetic Energy     :        359.01573936416958 Eh            9769.31493 eV
+Virial Ratio       :          2.00407673728095
+
+DFT components:
+N(Alpha)           :       25.999989345560 electrons
+N(Beta)            :       25.999989345560 electrons
+N(Total)           :       51.999978691120 electrons
+E(X)               :      -45.722378332785 Eh       
+E(C)               :       -1.703386886344 Eh       
+E(XC)              :      -47.425765219129 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    2.6747e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    6.1511e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    3.8903e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    2.1476e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    2.7038e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    5.3269e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.2 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.1 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002881696
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006933418
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475300491030
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000063115    0.000005481   -0.000011698
+   2   C   :   -0.000057670   -0.000013787    0.000010821
+   3   C   :   -0.000015491   -0.000002774   -0.000010236
+   4   N   :    0.000013623    0.000012185   -0.000045547
+   5   O   :    0.000060199    0.000029356    0.000035422
+   6   C   :    0.000064484   -0.000000316    0.000009851
+   7   C   :    0.000039768   -0.000014474   -0.000011784
+   8   H   :   -0.000024517    0.000008496    0.000008564
+   9   H   :   -0.000033405    0.000001329    0.000013483
+  10   H   :   -0.000031062   -0.000008474    0.000005708
+  11   H   :    0.000028542   -0.000002505    0.000010713
+  12   H   :    0.000018645   -0.000014517   -0.000015297
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000   -0.0000000000    0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001652677
+RMS gradient                       ...    0.0000275446
+MAX gradient                       ...    0.0000644844
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :   -0.001489370    0.001303368   -0.002041953
+   2   C   :    0.001312327    0.000010061   -0.000669285
+   3   C   :   -0.002624189   -0.000346352    0.002072914
+   4   N   :    0.000851486    0.000026033    0.000571071
+   5   O   :   -0.001677326   -0.000659875    0.002493988
+   6   C   :    0.003991205    0.003553664   -0.006459126
+   7   C   :   -0.001091241   -0.000685168   -0.000134101
+   8   H   :   -0.000562765    0.000330065    0.000711276
+   9   H   :    0.000604459   -0.000042774    0.000760338
+  10   H   :    0.000356596   -0.001027605   -0.000023440
+  11   H   :   -0.000481109   -0.001860450    0.002282756
+  12   H   :    0.000809927   -0.000600966    0.000435562
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000169562    0.0000608109    0.0000451453
+
+Norm of the Cartesian gradient     ...    0.0108262966
+RMS gradient                       ...    0.0018043828
+MAX gradient                       ...    0.0064591261
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.246 sec
+
+Densities                   ....       0.001 sec  (  0.3%)
+One electron gradient       ....       0.010 sec  (  4.2%)
+RI-J Coulomb gradient       ....       0.075 sec  ( 30.3%)
+XC gradient                 ....       0.128 sec  ( 52.0%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475300491 Eh
+Current gradient norm                   ....     0.010826297 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.995529405
+Lowest eigenvalues of augmented Hessian:
+ -0.000503179  0.013278145  0.013779417  0.021340956  0.022680944
+Length of the computed step             ....  0.094876277
+The final length of the internal step   ....  0.094876277
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0130322589
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0143466648 RMS(Int)=    1.2166867321
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000253854
+Previously predicted energy change      ....    -0.000194897
+Actually observed energy change         ....     0.000059293
+Ratio of predicted to observed change   ....     0.304226273
+New trust radius                        ....     0.200000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change       0.0000592929            0.0000050000      NO
+          RMS gradient        0.0009867888            0.0001000000      NO
+          MAX gradient        0.0029250642            0.0003000000      NO
+          RMS step            0.0130322589            0.0020000000      NO
+          MAX step            0.0503866344            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0050      Max(Angles)    0.27
+          Max(Dihed)        2.89      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4135  0.002925 -0.0006    1.4129   
+     2. B(C   2,C   1)                1.4773 -0.000836 -0.0007    1.4766   
+     3. B(N   3,C   2)                1.2466  0.000419 -0.0004    1.2462   
+     4. B(C   5,O   4)                1.2124  0.001078 -0.0001    1.2123   
+     5. B(C   6,N   3)                1.5585 -0.000391  0.0050    1.5636   
+     6. B(C   6,C   5)                1.4832  0.000521 -0.0021    1.4810   
+     7. B(C   6,C   2)                1.4665  0.001698  0.0001    1.4666   
+     8. B(H   7,O   0)                0.9639 -0.000707  0.0005    0.9645   
+     9. B(H   8,C   1)                1.0982  0.000801 -0.0008    1.0974   
+    10. B(H   9,C   1)                1.1061  0.000905 -0.0010    1.1051   
+    11. B(H  10,C   5)                1.1157  0.000925 -0.0008    1.1149   
+    12. B(H  11,C   6)                1.0915  0.000501 -0.0008    1.0907   
+    13. A(C   1,O   0,H   7)          108.98  0.001112   -0.11    108.87   
+    14. A(C   2,C   1,H   8)          108.00 -0.000755    0.11    108.11   
+    15. A(H   8,C   1,H   9)          106.80 -0.000026   -0.02    106.78   
+    16. A(C   2,C   1,H   9)          107.50 -0.000666    0.13    107.63   
+    17. A(O   0,C   1,H   9)          113.16  0.000341   -0.10    113.06   
+    18. A(O   0,C   1,C   2)          113.52  0.000779   -0.06    113.46   
+    19. A(O   0,C   1,H   8)          107.55  0.000237   -0.06    107.49   
+    20. A(C   1,C   2,C   6)          147.97  0.000999   -0.16    147.81   
+    21. A(C   1,C   2,N   3)          142.41 -0.000176   -0.10    142.31   
+    22. A(N   3,C   2,C   6)           69.58 -0.000824    0.27     69.85   
+    23. A(C   2,N   3,C   6)           61.86  0.000820   -0.15     61.71   
+    24. A(O   4,C   5,C   6)          123.56 -0.000814    0.20    123.77   
+    25. A(C   6,C   5,H  10)          115.04  0.000304   -0.13    114.91   
+    26. A(O   4,C   5,H  10)          121.21  0.000147   -0.03    121.18   
+    27. A(C   2,C   6,N   3)           48.56  0.000004   -0.12     48.44   
+    28. A(C   5,C   6,H  11)          117.15 -0.000730    0.11    117.26   
+    29. A(N   3,C   6,H  11)          116.34  0.000292   -0.11    116.24   
+    30. A(C   2,C   6,H  11)          121.05  0.000624   -0.14    120.92   
+    31. A(N   3,C   6,C   5)          116.55 -0.000211    0.14    116.68   
+    32. A(C   2,C   6,C   5)          118.68  0.000360    0.00    118.69   
+    33. D(H   8,C   1,O   0,H   7)    173.11 -0.000073   -0.41    172.71   
+    34. D(H   9,C   1,O   0,H   7)    -69.18  0.000247   -0.52    -69.70   
+    35. D(C   2,C   1,O   0,H   7)     53.70  0.000236   -0.47     53.23   
+    36. D(N   3,C   2,C   1,H   9)    122.64  0.000493   -0.32    122.32   
+    37. D(N   3,C   2,C   1,O   0)     -3.30  0.000013   -0.25     -3.56   
+    38. D(C   6,C   2,C   1,H   8)     60.95 -0.000193   -0.44     60.51   
+    39. D(C   6,C   2,C   1,O   0)   -179.89  0.000070   -0.48   -180.37   
+    40. D(N   3,C   2,C   1,H   8)   -122.46 -0.000250   -0.22   -122.68   
+    41. D(C   6,N   3,C   2,C   1)   -178.07 -0.000011   -0.12   -178.19   
+    42. D(H  11,C   6,C   2,N   3)    -99.17  0.000082    0.10    -99.07   
+    43. D(H  11,C   6,C   2,C   1)     78.61  0.000024    0.25     78.86   
+    44. D(C   5,C   6,C   2,N   3)    101.33 -0.000575    0.14    101.47   
+    45. D(C   5,C   6,C   2,C   1)    -80.89 -0.000633    0.28    -80.60   
+    46. D(C   5,C   6,N   3,C   2)   -105.94 -0.000654    0.13   -105.81   
+    47. D(N   3,C   6,C   5,H  10)   -147.71 -0.002706    2.80   -144.91   
+    48. D(N   3,C   6,C   2,C   1)    177.78 -0.000058    0.14    177.92   
+    49. D(N   3,C   6,C   5,O   4)     37.14  0.002132   -2.02     35.13   
+    50. D(C   2,C   6,C   5,H  10)    157.05 -0.002726    2.89    159.93   
+    51. D(C   2,C   6,C   5,O   4)    -18.10  0.002112   -1.92    -20.03   
+    52. D(H  11,C   6,C   5,O   4)   -178.40  0.001214   -1.84   -180.23   
+    53. D(H  11,C   6,N   3,C   2)    109.31  0.000621   -0.13    109.18   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (11.682 %)
+Internal coordinates            :      0.000 s ( 1.460 %)
+B/P matrices and projection     :      0.000 s (13.343 %)
+Hessian update/contruction      :      0.001 s (28.751 %)
+Making the step                 :      0.000 s (13.494 %)
+Converting the step to Cartesian:      0.000 s ( 3.273 %)
+Storing new data                :      0.000 s ( 1.964 %)
+Checking convergence            :      0.000 s ( 0.604 %)
+Final printing                  :      0.001 s (25.327 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      5.297 s
+Time for complete geometry iter :      6.163 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   4            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.524759    0.697207   -0.159126
+  C     -1.526797   -0.168000    0.342658
+  C     -0.221129   -0.011542   -0.328931
+  N      0.344800    0.602839   -1.253775
+  O      1.985208    1.131396    1.167219
+  C      2.161436    0.115501    0.529515
+  C      1.179415   -0.434012   -0.433339
+  H     -2.577898    0.590202   -1.116155
+  H     -1.393141    0.064675    1.406715
+  H     -1.808516   -1.234873    0.282297
+  H      3.098786   -0.478552    0.636192
+  H      1.449955   -1.354183   -0.952645
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.771104    1.317531   -0.300704
+   1 C     6.0000    0    12.011   -2.885228   -0.317474    0.647529
+   2 C     6.0000    0    12.011   -0.417873   -0.021811   -0.621590
+   3 N     7.0000    0    14.007    0.651577    1.139200   -2.369291
+   4 O     8.0000    0    15.999    3.751499    2.138029    2.205725
+   5 C     6.0000    0    12.011    4.084522    0.218266    1.000639
+   6 C     6.0000    0    12.011    2.228772   -0.820164   -0.818892
+   7 H     1.0000    0     1.008   -4.871522    1.115319   -2.109227
+   8 H     1.0000    0     1.008   -2.632655    0.122219    2.658306
+   9 H     1.0000    0     1.008   -3.417599   -2.333571    0.533464
+  10 H     1.0000    0     1.008    5.855858   -0.904333    1.202228
+  11 H     1.0000    0     1.008    2.740017   -2.559035   -1.800237
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.412904648416     0.00000000     0.00000000
+ C      2   1   0     1.476577115690   113.46260801     0.00000000
+ N      3   2   1     1.246224071555   142.30957913   356.44266151
+ O      3   2   1     2.900464868707   118.67080812   110.97879789
+ C      5   3   2     1.212338584432    60.59623966   132.31156227
+ C      3   2   1     1.466596735584   147.80982941   179.62952080
+ H      1   2   3     0.964457673454   108.86763348    53.23025216
+ H      2   1   3     1.097369672433   107.49066886   119.47697912
+ H      2   1   3     1.105090767043   113.06182882   237.06813902
+ H      6   5   3     1.114857042265   121.22469335   190.08758991
+ H      7   3   2     1.090680790206   120.91719156    78.85754379
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.670002838851     0.00000000     0.00000000
+ C      2   1   0     2.790326364269   113.46260801     0.00000000
+ N      3   2   1     2.355022196739   142.30957913   356.44266151
+ O      3   2   1     5.481084262916   118.67080812   110.97879789
+ C      5   3   2     2.290987906162    60.59623966   132.31156227
+ C      3   2   1     2.771466179157   147.80982941   179.62952080
+ H      1   2   3     1.822560870586   108.86763348    53.23025216
+ H      2   1   3     2.073728148568   107.49066886   119.47697912
+ H      2   1   3     2.088318902837   113.06182882   237.06813902
+ H      6   5   3     2.106774488355   121.22469335   190.08758991
+ H      7   3   2     2.061087993019   120.91719156    78.85754379
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8064
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.179199621893 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.550e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.002 sec
+Total time needed                          ...    0.005 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59291
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -360.4789669854812360     0.00e+00  7.65e-05  1.70e-03  1.31e-02  0.700   0.1
+    2    -360.4791379742901540    -1.71e-04  7.37e-05  1.57e-03  9.99e-03  0.700   0.1
+                               ***Turning on AO-DIIS***
+    3    -360.4792691996684084    -1.31e-04  5.90e-05  1.21e-03  7.20e-03  0.700   0.1
+    4    -360.4793624698311874    -9.33e-05  1.48e-04  3.01e-03  5.11e-03  0.000   0.1
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    5    -360.4795825303231709    -2.20e-04  1.29e-05  1.90e-04  2.01e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    6    -360.4795829952191184    -4.65e-07  2.63e-05  1.22e-03  1.37e-04     0.1
+    7    -360.4795824728709590     5.22e-07  1.33e-05  7.22e-04  2.87e-04     0.1
+    8    -360.4795833473927473    -8.75e-07  6.25e-06  1.45e-04  3.64e-05     0.1
+    9    -360.4795833609040869    -1.35e-08  3.00e-06  1.56e-04  1.34e-05     0.1
+   10    -360.4795833659142659    -5.01e-09  2.22e-06  5.40e-05  1.95e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  10 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47958336591427 Eh           -9809.14815 eV
+
+Components:
+Nuclear Repulsion  :        275.17919962189302 Eh            7488.00670 eV
+Electronic Energy  :       -635.65878298780729 Eh          -17297.15486 eV
+One Electron Energy:      -1035.21888957812439 Eh          -28169.73811 eV
+Two Electron Energy:        399.56010659031710 Eh           10872.58325 eV
+
+Virial components:
+Potential Energy   :       -719.50202442408295 Eh          -19578.64544 eV
+Kinetic Energy     :        359.02244105816868 Eh            9769.49729 eV
+Virial Ratio       :          2.00405863851700
+
+DFT components:
+N(Alpha)           :       25.999990096271 electrons
+N(Beta)            :       25.999990096271 electrons
+N(Total)           :       51.999980192542 electrons
+E(X)               :      -45.723753890437 Eh       
+E(C)               :       -1.703400877134 Eh       
+E(XC)              :      -47.427154767570 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    5.0102e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    5.4042e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    2.2172e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    2.0120e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.9501e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.0417e-04  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.3 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.2 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002881539
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006945454
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475519450541
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000062945    0.000005711   -0.000011871
+   2   C   :   -0.000057598   -0.000013787    0.000010636
+   3   C   :   -0.000015629   -0.000002906   -0.000010213
+   4   N   :    0.000013494    0.000012018   -0.000045312
+   5   O   :    0.000060343    0.000029592    0.000035113
+   6   C   :    0.000064517   -0.000000442    0.000010204
+   7   C   :    0.000039665   -0.000014489   -0.000011646
+   8   H   :   -0.000024543    0.000008473    0.000008602
+   9   H   :   -0.000033411    0.000001276    0.000013509
+  10   H   :   -0.000031010   -0.000008486    0.000005610
+  11   H   :    0.000028467   -0.000002350    0.000010523
+  12   H   :    0.000018651   -0.000014610   -0.000015153
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651056
+RMS gradient                       ...    0.0000275176
+MAX gradient                       ...    0.0000645167
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :   -0.001067796    0.001082110   -0.001127245
+   2   C   :    0.001663329   -0.000280184   -0.000557887
+   3   C   :   -0.002370036    0.000300007    0.001950556
+   4   N   :   -0.000668725    0.000231169   -0.000300015
+   5   O   :    0.000164878    0.001047573    0.000242127
+   6   C   :   -0.000972821   -0.001750815    0.000340913
+   7   C   :    0.001849074   -0.000090721   -0.001370018
+   8   H   :   -0.000378888    0.000132758    0.000242665
+   9   H   :    0.000312417   -0.000124560    0.000233490
+  10   H   :    0.000242835   -0.000362590    0.000032009
+  11   H   :    0.000580650    0.000069143   -0.000206860
+  12   H   :    0.000645083   -0.000253888    0.000520266
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000241054    0.0000951881    0.0000252982
+
+Norm of the Cartesian gradient     ...    0.0054010381
+RMS gradient                       ...    0.0009001730
+MAX gradient                       ...    0.0023700364
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.200 sec
+
+Densities                   ....       0.001 sec  (  0.3%)
+One electron gradient       ....       0.009 sec  (  4.3%)
+RI-J Coulomb gradient       ....       0.067 sec  ( 33.4%)
+XC gradient                 ....       0.094 sec  ( 47.2%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475519451 Eh
+Current gradient norm                   ....     0.005401038 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.200
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999844655
+Lowest eigenvalues of augmented Hessian:
+ -0.000048477  0.013372723  0.013779187  0.021267000  0.022670743
+Length of the computed step             ....  0.017628457
+The final length of the internal step   ....  0.017628457
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0024214548
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0031602626 RMS(Int)=    0.0024209305
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000024246
+Previously predicted energy change      ....    -0.000253854
+Actually observed energy change         ....    -0.000218960
+Ratio of predicted to observed change   ....     0.862540614
+New trust radius                        ....     0.300000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0002189595            0.0000050000      NO
+          RMS gradient        0.0005278802            0.0001000000      NO
+          MAX gradient        0.0020816326            0.0003000000      NO
+          RMS step            0.0024214548            0.0020000000      NO
+          MAX step            0.0068099160            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0036      Max(Angles)    0.17
+          Max(Dihed)        0.30      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4129  0.002082 -0.0025    1.4104   
+     2. B(C   2,C   1)                1.4766 -0.001269  0.0021    1.4787   
+     3. B(N   3,C   2)                1.2462  0.000108  0.0001    1.2463   
+     4. B(C   5,O   4)                1.2123  0.000982 -0.0006    1.2118   
+     5. B(C   6,N   3)                1.5636  0.000732 -0.0036    1.5600   
+     6. B(C   6,C   5)                1.4810 -0.000139  0.0011    1.4821   
+     7. B(C   6,C   2)                1.4666  0.001636 -0.0024    1.4642   
+     8. B(H   7,O   0)                0.9645 -0.000233  0.0002    0.9647   
+     9. B(H   8,C   1)                1.0974  0.000236 -0.0003    1.0971   
+    10. B(H   9,C   1)                1.1051  0.000287 -0.0004    1.1047   
+    11. B(H  10,C   5)                1.1149  0.000432 -0.0007    1.1141   
+    12. B(H  11,C   6)                1.0907  0.000126  0.0000    1.0907   
+    13. A(C   1,O   0,H   7)          108.87  0.000653   -0.09    108.77   
+    14. A(C   2,C   1,H   8)          108.11 -0.000455    0.08    108.19   
+    15. A(H   8,C   1,H   9)          106.78 -0.000064    0.06    106.85   
+    16. A(C   2,C   1,H   9)          107.63 -0.000340    0.02    107.65   
+    17. A(O   0,C   1,H   9)          113.06  0.000205   -0.03    113.03   
+    18. A(O   0,C   1,C   2)          113.46  0.000460   -0.08    113.38   
+    19. A(O   0,C   1,H   8)          107.49  0.000137   -0.03    107.46   
+    20. A(C   1,C   2,C   6)          147.81  0.000585   -0.02    147.79   
+    21. A(C   1,C   2,N   3)          142.31 -0.000392    0.13    142.44   
+    22. A(N   3,C   2,C   6)           69.85 -0.000195   -0.11     69.74   
+    23. A(C   2,N   3,C   6)           61.71  0.000504   -0.00     61.71   
+    24. A(O   4,C   5,C   6)          123.81  0.000129   -0.09    123.73   
+    25. A(C   6,C   5,H  10)          114.96  0.000046    0.06    115.02   
+    26. A(O   4,C   5,H  10)          121.22 -0.000174    0.04    121.27   
+    27. A(C   2,C   6,N   3)           48.44 -0.000309    0.11     48.55   
+    28. A(C   5,C   6,H  11)          117.26 -0.000599    0.08    117.34   
+    29. A(N   3,C   6,H  11)          116.23  0.000480   -0.09    116.15   
+    30. A(C   2,C   6,H  11)          120.92  0.000435   -0.03    120.89   
+    31. A(N   3,C   6,C   5)          116.68  0.000350   -0.17    116.52   
+    32. A(C   2,C   6,C   5)          118.69  0.000037    0.04    118.72   
+    33. D(H   8,C   1,O   0,H   7)    172.71  0.000001   -0.09    172.62   
+    34. D(H   9,C   1,O   0,H   7)    -69.70  0.000129   -0.05    -69.75   
+    35. D(C   2,C   1,O   0,H   7)     53.23  0.000197   -0.11     53.12   
+    36. D(N   3,C   2,C   1,H   9)    122.32  0.000266    0.12    122.43   
+    37. D(N   3,C   2,C   1,O   0)     -3.56 -0.000065    0.20     -3.36   
+    38. D(C   6,C   2,C   1,H   8)     60.51 -0.000074    0.16     60.67   
+    39. D(C   6,C   2,C   1,O   0)    179.63  0.000072    0.12    179.75   
+    40. D(N   3,C   2,C   1,H   8)   -122.68 -0.000211    0.24   -122.44   
+    41. D(C   6,N   3,C   2,C   1)   -178.19  0.000051   -0.04   -178.24   
+    42. D(H  11,C   6,C   2,N   3)    -99.07 -0.000187    0.05    -99.02   
+    43. D(H  11,C   6,C   2,C   1)     78.86 -0.000297    0.11     78.96   
+    44. D(C   5,C   6,C   2,N   3)    101.47  0.000339   -0.21    101.26   
+    45. D(C   5,C   6,C   2,C   1)    -80.60  0.000229   -0.16    -80.76   
+    46. D(C   5,C   6,N   3,C   2)   -105.81  0.000305   -0.20   -106.01   
+    47. D(N   3,C   6,C   5,H  10)   -144.91  0.000291   -0.15   -145.07   
+    48. D(N   3,C   6,C   2,C   1)    177.93 -0.000110    0.06    177.98   
+    49. D(N   3,C   6,C   5,O   4)     35.13 -0.000543    0.30     35.43   
+    50. D(C   2,C   6,C   5,H  10)    159.93  0.000531   -0.23    159.70   
+    51. D(C   2,C   6,C   5,O   4)    -20.02 -0.000304    0.22    -19.80   
+    52. D(H  11,C   6,C   5,O   4)    179.77 -0.000004   -0.01    179.76   
+    53. D(H  11,C   6,N   3,C   2)    109.18  0.000155    0.05    109.23   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s (15.153 %)
+Internal coordinates            :      0.000 s ( 1.934 %)
+B/P matrices and projection     :      0.000 s (16.658 %)
+Hessian update/contruction      :      0.000 s (17.464 %)
+Making the step                 :      0.000 s (12.789 %)
+Converting the step to Cartesian:      0.000 s ( 2.203 %)
+Storing new data                :      0.000 s ( 1.397 %)
+Checking convergence            :      0.000 s ( 0.591 %)
+Final printing                  :      0.001 s (31.650 %)
+Total time                      :      0.002 s
+
+Time for energy+gradient        :      5.417 s
+Time for complete geometry iter :      6.276 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   5            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.523011    0.695451   -0.158739
+  C     -1.527670   -0.168143    0.343907
+  C     -0.220320   -0.011225   -0.328903
+  N      0.348245    0.603545   -1.251992
+  O      1.984319    1.131245    1.165939
+  C      2.162198    0.116673    0.527689
+  C      1.177683   -0.433794   -0.433792
+  H     -2.573032    0.587637   -1.116053
+  H     -1.395598    0.065663    1.407607
+  H     -1.809819   -1.234491    0.283149
+  H      3.097235   -0.479103    0.637562
+  H      1.447129   -1.352800   -0.955748
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.767800    1.314212   -0.299974
+   1 C     6.0000    0    12.011   -2.886877   -0.317743    0.649890
+   2 C     6.0000    0    12.011   -0.416344   -0.021212   -0.621537
+   3 N     7.0000    0    14.007    0.658088    1.140534   -2.365922
+   4 O     8.0000    0    15.999    3.749820    2.137744    2.203305
+   5 C     6.0000    0    12.011    4.085961    0.220480    0.997188
+   6 C     6.0000    0    12.011    2.225499   -0.819752   -0.819748
+   7 H     1.0000    0     1.008   -4.862326    1.110473   -2.109034
+   8 H     1.0000    0     1.008   -2.637298    0.124085    2.659992
+   9 H     1.0000    0     1.008   -3.420062   -2.332849    0.535074
+  10 H     1.0000    0     1.008    5.852926   -0.905373    1.204818
+  11 H     1.0000    0     1.008    2.734678   -2.556422   -1.806102
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410372784097     0.00000000     0.00000000
+ C      2   1   0     1.478668666365   113.37963124     0.00000000
+ N      3   2   1     1.246314904270   142.43795886   356.64302670
+ O      3   2   1     2.898314021342   118.66488257   111.02222996
+ C      5   3   2     1.211759372642    60.65688231   132.39068862
+ C      3   2   1     1.464232803805   147.79182350   179.74882977
+ H      1   2   3     0.964662948990   108.77408095    53.12065819
+ H      2   1   3     1.097071555538   107.45855847   119.49975761
+ H      2   1   3     1.104716194379   113.02928678   237.13092886
+ H      6   5   3     1.114143729432   121.26347760   190.44426874
+ H      7   3   2     1.090693512597   120.88482561    78.96249302
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.665218308680     0.00000000     0.00000000
+ C      2   1   0     2.794278822240   113.37963124     0.00000000
+ N      3   2   1     2.355193845694   142.43795886   356.64302670
+ O      3   2   1     5.477019750441   118.66488257   111.02222996
+ C      5   3   2     2.289893354505    60.65688231   132.39068862
+ C      3   2   1     2.766998995495   147.79182350   179.74882977
+ H      1   2   3     1.822948785131   108.77408095    53.12065819
+ H      2   1   3     2.073164789282   107.45855847   119.49975761
+ H      2   1   3     2.087611063084   113.02928678   237.13092886
+ H      6   5   3     2.105426522452   121.26347760   190.44426874
+ H      7   3   2     2.061112034853   120.88482561    78.96249302
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8065
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.310421249251 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.555e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59291
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796066248980537     0.00e+00  7.27e-05  1.64e-03  1.31e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796267633224147    -2.01e-05  3.85e-05  9.43e-04  1.61e-04     0.1
+    3    -360.4796269609860815    -1.98e-07  1.84e-05  3.38e-04  4.09e-04     0.1
+    4    -360.4796279251078772    -9.64e-07  1.78e-05  6.21e-04  2.00e-04     0.1
+    5    -360.4796281524654091    -2.27e-07  9.44e-06  2.83e-04  9.00e-05     0.1
+    6    -360.4796284166039300    -2.64e-07  6.08e-06  1.10e-04  2.96e-05     0.1
+    7    -360.4796284488657534    -3.23e-08  2.75e-06  5.16e-05  1.81e-05     0.1
+    8    -360.4796284696498674    -2.08e-08  2.10e-06  8.29e-05  1.37e-05     0.1
+    9    -360.4796284733556035    -3.71e-09  1.61e-06  9.99e-05  7.44e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   9 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47962847335560 Eh           -9809.14938 eV
+
+Components:
+Nuclear Repulsion  :        275.31042124925119 Eh            7491.57743 eV
+Electronic Energy  :       -635.79004972260668 Eh          -17300.72680 eV
+One Electron Energy:      -1035.47929577096124 Eh          -28176.82412 eV
+Two Electron Energy:        399.68924604835451 Eh           10876.09732 eV
+
+Virial components:
+Potential Energy   :       -719.51309460777316 Eh          -19578.94668 eV
+Kinetic Energy     :        359.03346613441761 Eh            9769.79730 eV
+Virial Ratio       :          2.00402793186526
+
+DFT components:
+N(Alpha)           :       25.999990136771 electrons
+N(Beta)            :       25.999990136771 electrons
+N(Total)           :       51.999980273542 electrons
+E(X)               :      -45.726725636219 Eh       
+E(C)               :       -1.703582820042 Eh       
+E(XC)              :      -47.430308456261 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    3.7057e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    9.9862e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.6051e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.1527e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    7.4418e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.8467e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+Finished LeanSCF after   0.9 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.3 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002882097
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006964208
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475546362390
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000063040    0.000005718   -0.000011928
+   2   C   :   -0.000057534   -0.000013833    0.000010675
+   3   C   :   -0.000015645   -0.000002884   -0.000010191
+   4   N   :    0.000013632    0.000012106   -0.000045280
+   5   O   :    0.000060327    0.000029572    0.000035042
+   6   C   :    0.000064511   -0.000000421    0.000010140
+   7   C   :    0.000039725   -0.000014543   -0.000011607
+   8   H   :   -0.000024608    0.000008472    0.000008643
+   9   H   :   -0.000033442    0.000001285    0.000013537
+  10   H   :   -0.000031041   -0.000008511    0.000005629
+  11   H   :    0.000028471   -0.000002358    0.000010538
+  12   H   :    0.000018643   -0.000014601   -0.000015199
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651567
+RMS gradient                       ...    0.0000275261
+MAX gradient                       ...    0.0000645108
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000018197    0.000250449   -0.000129626
+   2   C   :    0.000099386   -0.000070732   -0.000256901
+   3   C   :   -0.000749450    0.000215526    0.000916654
+   4   N   :    0.000419718   -0.000388371    0.000259226
+   5   O   :    0.000035469    0.000222058    0.000037748
+   6   C   :   -0.000065933   -0.000492672    0.000148503
+   7   C   :   -0.000178745    0.000424595   -0.001371173
+   8   H   :   -0.000148897   -0.000086930    0.000053041
+   9   H   :    0.000000176   -0.000008590    0.000054554
+  10   H   :    0.000085790   -0.000047383   -0.000023735
+  11   H   :    0.000095740    0.000093737   -0.000004179
+  12   H   :    0.000388549   -0.000111687    0.000315886
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000212773    0.0001006532    0.0000306459
+
+Norm of the Cartesian gradient     ...    0.0021780117
+RMS gradient                       ...    0.0003630019
+MAX gradient                       ...    0.0013711730
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.215 sec
+
+Densities                   ....       0.001 sec  (  0.3%)
+One electron gradient       ....       0.009 sec  (  4.0%)
+RI-J Coulomb gradient       ....       0.071 sec  ( 33.0%)
+XC gradient                 ....       0.105 sec  ( 48.6%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475546362 Eh
+Current gradient norm                   ....     0.002178012 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.300
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999873084
+Lowest eigenvalues of augmented Hessian:
+ -0.000010518  0.013705084  0.013791880  0.020635909  0.022617842
+Length of the computed step             ....  0.015933620
+The final length of the internal step   ....  0.015933620
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0021886511
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0025366957 RMS(Int)=    0.0021875908
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000005260
+Previously predicted energy change      ....    -0.000024246
+Actually observed energy change         ....    -0.000026912
+Ratio of predicted to observed change   ....     1.109939473
+New trust radius                        ....     0.450000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000269118            0.0000050000      NO
+          RMS gradient        0.0001621753            0.0001000000      NO
+          MAX gradient        0.0004742640            0.0003000000      NO
+          RMS step            0.0021886511            0.0020000000      NO
+          MAX step            0.0067159000            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0016      Max(Angles)    0.14
+          Max(Dihed)        0.38      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4104  0.000222 -0.0002    1.4102   
+     2. B(C   2,C   1)                1.4787 -0.000194  0.0003    1.4790   
+     3. B(N   3,C   2)                1.2463  0.000090 -0.0002    1.2461   
+     4. B(C   5,O   4)                1.2118  0.000201 -0.0001    1.2117   
+     5. B(C   6,N   3)                1.5600 -0.000403  0.0016    1.5616   
+     6. B(C   6,C   5)                1.4821  0.000098 -0.0004    1.4818   
+     7. B(C   6,C   2)                1.4642  0.000474 -0.0006    1.4637   
+     8. B(H   7,O   0)                0.9647 -0.000033  0.0000    0.9647   
+     9. B(H   8,C   1)                1.0971  0.000049 -0.0001    1.0970   
+    10. B(H   9,C   1)                1.1047  0.000025 -0.0000    1.1047   
+    11. B(H  10,C   5)                1.1141  0.000030 -0.0000    1.1141   
+    12. B(H  11,C   6)                1.0907  0.000039 -0.0001    1.0906   
+    13. A(C   1,O   0,H   7)          108.77  0.000086   -0.03    108.75   
+    14. A(C   2,C   1,H   8)          108.19 -0.000058    0.03    108.22   
+    15. A(H   8,C   1,H   9)          106.85 -0.000007    0.00    106.85   
+    16. A(C   2,C   1,H   9)          107.65 -0.000078    0.03    107.68   
+    17. A(O   0,C   1,H   9)          113.03  0.000061   -0.03    112.99   
+    18. A(O   0,C   1,C   2)          113.38  0.000087   -0.03    113.35   
+    19. A(O   0,C   1,H   8)          107.46 -0.000014   -0.00    107.46   
+    20. A(C   1,C   2,C   6)          147.79  0.000362   -0.09    147.70   
+    21. A(C   1,C   2,N   3)          142.44  0.000003   -0.01    142.42   
+    22. A(N   3,C   2,C   6)           69.74 -0.000366    0.11     69.85   
+    23. A(C   2,N   3,C   6)           61.71  0.000321   -0.08     61.63   
+    24. A(O   4,C   5,C   6)          123.72 -0.000028    0.03    123.75   
+    25. A(C   6,C   5,H  10)          115.01  0.000112   -0.05    114.97   
+    26. A(O   4,C   5,H  10)          121.26 -0.000083    0.01    121.27   
+    27. A(C   2,C   6,N   3)           48.55  0.000045   -0.03     48.52   
+    28. A(C   5,C   6,H  11)          117.34 -0.000277    0.09    117.43   
+    29. A(N   3,C   6,H  11)          116.15  0.000257   -0.14    116.01   
+    30. A(C   2,C   6,H  11)          120.88  0.000286   -0.08    120.81   
+    31. A(N   3,C   6,C   5)          116.52  0.000026   -0.05    116.47   
+    32. A(C   2,C   6,C   5)          118.72 -0.000075    0.08    118.80   
+    33. D(H   8,C   1,O   0,H   7)    172.62  0.000081   -0.36    172.26   
+    34. D(H   9,C   1,O   0,H   7)    -69.75  0.000099   -0.38    -70.13   
+    35. D(C   2,C   1,O   0,H   7)     53.12  0.000111   -0.38     52.74   
+    36. D(N   3,C   2,C   1,H   9)    122.43  0.000056   -0.06    122.38   
+    37. D(N   3,C   2,C   1,O   0)     -3.36 -0.000025   -0.02     -3.37   
+    38. D(C   6,C   2,C   1,H   8)     60.67  0.000024   -0.21     60.46   
+    39. D(C   6,C   2,C   1,O   0)    179.75  0.000020   -0.20    179.55   
+    40. D(N   3,C   2,C   1,H   8)   -122.44 -0.000022   -0.02   -122.46   
+    41. D(C   6,N   3,C   2,C   1)   -178.24  0.000012   -0.10   -178.34   
+    42. D(H  11,C   6,C   2,N   3)    -99.02 -0.000155    0.15    -98.87   
+    43. D(H  11,C   6,C   2,C   1)     78.96 -0.000190    0.27     79.23   
+    44. D(C   5,C   6,C   2,N   3)    101.26  0.000113   -0.14    101.12   
+    45. D(C   5,C   6,C   2,C   1)    -80.76  0.000078   -0.02    -80.77   
+    46. D(C   5,C   6,N   3,C   2)   -106.01  0.000110   -0.13   -106.14   
+    47. D(N   3,C   6,C   5,H  10)   -145.07  0.000108   -0.06   -145.13   
+    48. D(N   3,C   6,C   2,C   1)    177.98 -0.000034    0.12    178.10   
+    49. D(N   3,C   6,C   5,O   4)     35.43 -0.000085    0.12     35.55   
+    50. D(C   2,C   6,C   5,H  10)    159.70  0.000064   -0.03    159.67   
+    51. D(C   2,C   6,C   5,O   4)    -19.80 -0.000128    0.15    -19.65   
+    52. D(H  11,C   6,C   5,O   4)    179.76  0.000018   -0.09    179.68   
+    53. D(H  11,C   6,N   3,C   2)    109.23  0.000200   -0.01    109.22   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 8.348 %)
+Internal coordinates            :      0.000 s ( 0.840 %)
+B/P matrices and projection     :      0.002 s (60.138 %)
+Hessian update/contruction      :      0.000 s ( 8.471 %)
+Making the step                 :      0.000 s ( 6.026 %)
+Converting the step to Cartesian:      0.000 s ( 1.087 %)
+Storing new data                :      0.000 s ( 0.692 %)
+Checking convergence            :      0.000 s ( 0.272 %)
+Final printing                  :      0.001 s (14.102 %)
+Total time                      :      0.004 s
+
+Time for energy+gradient        :      5.019 s
+Time for complete geometry iter :      6.302 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   6            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.522607    0.694807   -0.157686
+  C     -1.527660   -0.169389    0.344093
+  C     -0.220502   -0.012362   -0.329725
+  N      0.347129    0.602695   -1.252978
+  O      1.984236    1.133142    1.164457
+  C      2.161979    0.118158    0.527013
+  C      1.177163   -0.434626   -0.432233
+  H     -2.568573    0.591544   -1.115743
+  H     -1.395344    0.063596    1.407882
+  H     -1.810927   -1.235372    0.282615
+  H      3.096263   -0.478496    0.638172
+  H      1.446202   -1.353038   -0.955239
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.767036    1.312994   -0.297984
+   1 C     6.0000    0    12.011   -2.886860   -0.320099    0.650242
+   2 C     6.0000    0    12.011   -0.416688   -0.023361   -0.623090
+   3 N     7.0000    0    14.007    0.655979    1.138928   -2.367785
+   4 O     8.0000    0    15.999    3.749663    2.141327    2.200504
+   5 C     6.0000    0    12.011    4.085549    0.223287    0.995910
+   6 C     6.0000    0    12.011    2.224517   -0.821324   -0.816802
+   7 H     1.0000    0     1.008   -4.853900    1.117857   -2.108449
+   8 H     1.0000    0     1.008   -2.636818    0.120179    2.660511
+   9 H     1.0000    0     1.008   -3.422157   -2.334514    0.534065
+  10 H     1.0000    0     1.008    5.851089   -0.904227    1.205970
+  11 H     1.0000    0     1.008    2.732926   -2.556872   -1.805140
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410154385298     0.00000000     0.00000000
+ C      2   1   0     1.478969972427   113.35393410     0.00000000
+ N      3   2   1     1.246152007568   142.42352614   356.62681331
+ O      3   2   1     2.899245830167   118.63696708   110.92765042
+ C      5   3   2     1.211659226079    60.62337149   132.37787472
+ C      3   2   1     1.463653850212   147.69981559   179.54543190
+ H      1   2   3     0.964701521134   108.74774114    52.73587604
+ H      2   1   3     1.097012312815   107.45774887   119.52371645
+ H      2   1   3     1.104689435577   112.99437724   237.13757580
+ H      6   5   3     1.114108928540   121.27466112   190.54957860
+ H      7   3   2     1.090595201958   120.80417557    79.23159771
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.664805594761     0.00000000     0.00000000
+ C      2   1   0     2.794848208181   113.35393410     0.00000000
+ N      3   2   1     2.354886015539   142.42352614   356.62681331
+ O      3   2   1     5.478780613929   118.63696708   110.92765042
+ C      5   3   2     2.289704104928    60.62337149   132.37787472
+ C      3   2   1     2.765904931760   147.69981559   179.54543190
+ H      1   2   3     1.823021675920   108.74774114    52.73587604
+ H      2   1   3     2.073052836760   107.45774887   119.52371645
+ H      2   1   3     2.087560496276   112.99437724   237.13757580
+ H      6   5   3     2.105360758298   121.27466112   190.54957860
+ H      7   3   2     2.060926254669   120.80417557    79.23159771
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8065
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.318725928233 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.559e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59293
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796280323707265     0.00e+00  5.03e-05  1.28e-03  9.22e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796380737157619    -1.00e-05  2.56e-05  7.18e-04  8.89e-05     0.1
+    3    -360.4796383208449129    -2.47e-07  1.41e-05  3.78e-04  2.60e-04     0.1
+    4    -360.4796384783964527    -1.58e-07  1.39e-05  4.19e-04  1.52e-04     0.1
+    5    -360.4796387790086669    -3.01e-07  4.28e-06  6.87e-05  2.13e-05     0.1
+    6    -360.4796387691158657     9.89e-09  2.75e-06  5.08e-05  2.50e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47963876911587 Eh           -9809.14966 eV
+
+Components:
+Nuclear Repulsion  :        275.31872592823328 Eh            7491.80341 eV
+Electronic Energy  :       -635.79836469734914 Eh          -17300.95307 eV
+One Electron Energy:      -1035.49344994780267 Eh          -28177.20927 eV
+Two Electron Energy:        399.69508525045353 Eh           10876.25621 eV
+
+Virial components:
+Potential Energy   :       -719.51465800077949 Eh          -19578.98922 eV
+Kinetic Energy     :        359.03501923166357 Eh            9769.83956 eV
+Virial Ratio       :          2.00402361736341
+
+DFT components:
+N(Alpha)           :       25.999990097124 electrons
+N(Beta)            :       25.999990097124 electrons
+N(Total)           :       51.999980194247 electrons
+E(X)               :      -45.726977948216 Eh       
+E(C)               :       -1.703569918743 Eh       
+E(XC)              :      -47.430547866959 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -9.8928e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    5.0821e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    2.7520e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.2391e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    2.5009e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    5.0479e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+Finished LeanSCF after   1.2 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.4 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002882333
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006966852
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475554250862
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000062990    0.000005789   -0.000011953
+   2   C   :   -0.000057512   -0.000013868    0.000010670
+   3   C   :   -0.000015672   -0.000002918   -0.000010208
+   4   N   :    0.000013585    0.000012040   -0.000045288
+   5   O   :    0.000060357    0.000029637    0.000035023
+   6   C   :    0.000064533   -0.000000380    0.000010145
+   7   C   :    0.000039695   -0.000014529   -0.000011604
+   8   H   :   -0.000024647    0.000008436    0.000008677
+   9   H   :   -0.000033444    0.000001258    0.000013553
+  10   H   :   -0.000031027   -0.000008513    0.000005630
+  11   H   :    0.000028482   -0.000002345    0.000010545
+  12   H   :    0.000018642   -0.000014607   -0.000015189
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651595
+RMS gradient                       ...    0.0000275266
+MAX gradient                       ...    0.0000645326
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000105120    0.000146430    0.000008912
+   2   C   :    0.000051667   -0.000078528   -0.000162780
+   3   C   :   -0.000256741    0.000199646    0.000438297
+   4   N   :    0.000215955   -0.000262049    0.000202037
+   5   O   :    0.000040509    0.000037653    0.000080208
+   6   C   :   -0.000048046   -0.000092403   -0.000145831
+   7   C   :   -0.000183365    0.000200243   -0.000692534
+   8   H   :   -0.000086699   -0.000109884    0.000020888
+   9   H   :   -0.000080135   -0.000007307    0.000024725
+  10   H   :    0.000002743    0.000008770   -0.000015797
+  11   H   :   -0.000001326    0.000006928    0.000056520
+  12   H   :    0.000240318   -0.000049499    0.000185355
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000134682    0.0001111469    0.0000367209
+
+Norm of the Cartesian gradient     ...    0.0011144908
+RMS gradient                       ...    0.0001857485
+MAX gradient                       ...    0.0006925342
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.202 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.009 sec  (  4.5%)
+RI-J Coulomb gradient       ....       0.061 sec  ( 30.2%)
+XC gradient                 ....       0.103 sec  ( 50.6%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475554251 Eh
+Current gradient norm                   ....     0.001114491 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.450
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999699168
+Lowest eigenvalues of augmented Hessian:
+ -0.000008392  0.010737622  0.013764551  0.014835647  0.022551705
+Length of the computed step             ....  0.024534377
+The final length of the internal step   ....  0.024534377
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0033700558
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0037503110 RMS(Int)=    0.0033682190
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000004199
+Previously predicted energy change      ....    -0.000005260
+Actually observed energy change         ....    -0.000007888
+Ratio of predicted to observed change   ....     1.499665007
+New trust radius                        ....     0.450000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000078885            0.0000050000      NO
+          RMS gradient        0.0000859691            0.0001000000      YES
+          MAX gradient        0.0002686507            0.0003000000      YES
+          RMS step            0.0033700558            0.0020000000      NO
+          MAX step            0.0113000532            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0024      Max(Angles)    0.19
+          Max(Dihed)        0.65      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4102  0.000001 -0.0001    1.4101   
+     2. B(C   2,C   1)                1.4790 -0.000051  0.0003    1.4792   
+     3. B(N   3,C   2)                1.2462 -0.000004 -0.0002    1.2460   
+     4. B(C   5,O   4)                1.2117  0.000068 -0.0001    1.2116   
+     5. B(C   6,N   3)                1.5616 -0.000269  0.0024    1.5640   
+     6. B(C   6,C   5)                1.4818 -0.000027 -0.0004    1.4814   
+     7. B(C   6,C   2)                1.4637  0.000188 -0.0006    1.4630   
+     8. B(H   7,O   0)                0.9647 -0.000002  0.0000    0.9647   
+     9. B(H   8,C   1)                1.0970  0.000011 -0.0001    1.0970   
+    10. B(H   9,C   1)                1.1047 -0.000008  0.0000    1.1047   
+    11. B(H  10,C   5)                1.1141  0.000001 -0.0000    1.1141   
+    12. B(H  11,C   6)                1.0906  0.000012 -0.0001    1.0905   
+    13. A(C   1,O   0,H   7)          108.75 -0.000023   -0.02    108.73   
+    14. A(C   2,C   1,H   8)          108.22  0.000052    0.01    108.23   
+    15. A(H   8,C   1,H   9)          106.85 -0.000014    0.00    106.85   
+    16. A(C   2,C   1,H   9)          107.68  0.000024    0.02    107.70   
+    17. A(O   0,C   1,H   9)          112.99 -0.000000   -0.03    112.96   
+    18. A(O   0,C   1,C   2)          113.35 -0.000014   -0.02    113.34   
+    19. A(O   0,C   1,H   8)          107.46 -0.000046    0.02    107.48   
+    20. A(C   1,C   2,C   6)          147.70  0.000209   -0.13    147.57   
+    21. A(C   1,C   2,N   3)          142.42 -0.000020   -0.02    142.41   
+    22. A(N   3,C   2,C   6)           69.85 -0.000189    0.15     70.00   
+    23. A(C   2,N   3,C   6)           61.63  0.000166   -0.10     61.53   
+    24. A(O   4,C   5,C   6)          123.75  0.000072    0.02    123.77   
+    25. A(C   6,C   5,H  10)          114.97  0.000009   -0.04    114.93   
+    26. A(O   4,C   5,H  10)          121.27 -0.000081    0.03    121.30   
+    27. A(C   2,C   6,N   3)           48.52  0.000023   -0.04     48.47   
+    28. A(C   5,C   6,H  11)          117.43 -0.000175    0.13    117.56   
+    29. A(N   3,C   6,H  11)          116.01  0.000150   -0.19    115.82   
+    30. A(C   2,C   6,H  11)          120.80  0.000181   -0.12    120.68   
+    31. A(N   3,C   6,C   5)          116.47  0.000003   -0.06    116.41   
+    32. A(C   2,C   6,C   5)          118.80 -0.000030    0.10    118.90   
+    33. D(H   8,C   1,O   0,H   7)    172.26  0.000104   -0.63    171.63   
+    34. D(H   9,C   1,O   0,H   7)    -70.13  0.000057   -0.63    -70.76   
+    35. D(C   2,C   1,O   0,H   7)     52.74  0.000078   -0.65     52.09   
+    36. D(N   3,C   2,C   1,H   9)    122.38 -0.000011   -0.02    122.35   
+    37. D(N   3,C   2,C   1,O   0)     -3.37 -0.000020    0.02     -3.36   
+    38. D(C   6,C   2,C   1,H   8)     60.46  0.000032   -0.30     60.16   
+    39. D(C   6,C   2,C   1,O   0)    179.55  0.000002   -0.28    179.27   
+    40. D(N   3,C   2,C   1,H   8)   -122.46  0.000011   -0.01   -122.47   
+    41. D(C   6,N   3,C   2,C   1)   -178.34  0.000005   -0.16   -178.50   
+    42. D(H  11,C   6,C   2,N   3)    -98.87 -0.000077    0.19    -98.69   
+    43. D(H  11,C   6,C   2,C   1)     79.23 -0.000094    0.38     79.61   
+    44. D(C   5,C   6,C   2,N   3)    101.12  0.000037   -0.18    100.94   
+    45. D(C   5,C   6,C   2,C   1)    -80.77  0.000020    0.01    -80.76   
+    46. D(C   5,C   6,N   3,C   2)   -106.14  0.000038   -0.17   -106.31   
+    47. D(N   3,C   6,C   5,H  10)   -145.13 -0.000030    0.10   -145.02   
+    48. D(N   3,C   6,C   2,C   1)    178.10 -0.000017    0.19    178.29   
+    49. D(N   3,C   6,C   5,O   4)     35.55  0.000016    0.09     35.64   
+    50. D(C   2,C   6,C   5,H  10)    159.67 -0.000050    0.15    159.82   
+    51. D(C   2,C   6,C   5,O   4)    -19.65 -0.000005    0.13    -19.51   
+    52. D(H  11,C   6,C   5,O   4)    179.68  0.000036   -0.16    179.51   
+    53. D(H  11,C   6,N   3,C   2)    109.22  0.000135   -0.03    109.19   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 9.397 %)
+Internal coordinates            :      0.000 s ( 0.919 %)
+B/P matrices and projection     :      0.002 s (57.150 %)
+Hessian update/contruction      :      0.000 s ( 8.427 %)
+Making the step                 :      0.000 s ( 7.074 %)
+Converting the step to Cartesian:      0.000 s ( 1.124 %)
+Storing new data                :      0.000 s ( 0.741 %)
+Checking convergence            :      0.000 s ( 0.281 %)
+Final printing                  :      0.001 s (14.811 %)
+Total time                      :      0.004 s
+
+Time for energy+gradient        :      5.039 s
+Time for complete geometry iter :      5.894 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   7            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.522679    0.693672   -0.156432
+  C     -1.527843   -0.171157    0.344229
+  C     -0.221024   -0.014154   -0.330822
+  N      0.345626    0.601429   -1.254124
+  O      1.983748    1.135646    1.162467
+  C      2.161361    0.119521    0.527003
+  C      1.176349   -0.436105   -0.429826
+  H     -2.562147    0.598117   -1.115609
+  H     -1.394621    0.060861    1.408064
+  H     -1.812090   -1.236843    0.282016
+  H      3.096046   -0.476511    0.637847
+  H      1.444634   -1.353815   -0.954186
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.767173    1.310849   -0.295614
+   1 C     6.0000    0    12.011   -2.887206   -0.323440    0.650498
+   2 C     6.0000    0    12.011   -0.417674   -0.026748   -0.625163
+   3 N     7.0000    0    14.007    0.653138    1.136536   -2.369952
+   4 O     8.0000    0    15.999    3.748740    2.146060    2.196745
+   5 C     6.0000    0    12.011    4.084380    0.225862    0.995892
+   6 C     6.0000    0    12.011    2.222978   -0.824120   -0.812253
+   7 H     1.0000    0     1.008   -4.841757    1.130277   -2.108195
+   8 H     1.0000    0     1.008   -2.635452    0.115010    2.660855
+   9 H     1.0000    0     1.008   -3.424353   -2.337295    0.532933
+  10 H     1.0000    0     1.008    5.850679   -0.900474    1.205356
+  11 H     1.0000    0     1.008    2.729963   -2.558340   -1.803150
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410066595648     0.00000000     0.00000000
+ C      2   1   0     1.479229837616   113.33845655     0.00000000
+ N      3   2   1     1.246002426418   142.40736784   356.64187968
+ O      3   2   1     2.900511898988   118.59812212   110.80444994
+ C      5   3   2     1.211557061562    60.58926087   132.31609921
+ C      3   2   1     1.463043018340   147.57159198   179.26952781
+ H      1   2   3     0.964732092997   108.73141668    52.08843216
+ H      2   1   3     1.096962024323   107.47557009   119.54000311
+ H      2   1   3     1.104696065095   112.96285046   237.15232486
+ H      6   5   3     1.114081045235   121.29924024   190.45464730
+ H      7   3   2     1.090468875493   120.67976041    79.60623861
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.664639696366     0.00000000     0.00000000
+ C      2   1   0     2.795339282220   113.33845655     0.00000000
+ N      3   2   1     2.354603348131   142.40736784   356.64187968
+ O      3   2   1     5.481173137267   118.59812212   110.80444994
+ C      5   3   2     2.289511041971    60.58926087   132.31609921
+ C      3   2   1     2.764750626808   147.57159198   179.26952781
+ H      1   2   3     1.823079448369   108.73141668    52.08843216
+ H      2   1   3     2.072957805282   107.47557009   119.54000311
+ H      2   1   3     2.087573024250   112.96285046   237.15232486
+ H      6   5   3     2.105308066488   121.29924024   190.45464730
+ H      7   3   2     2.060687532246   120.67976041    79.60623861
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8064
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.317959857095 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.564e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59288
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.7 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796193021531394     0.00e+00  7.55e-05  2.19e-03  1.46e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796428512151465    -2.35e-05  3.81e-05  1.01e-03  1.28e-04     0.1
+    3    -360.4796435033508146    -6.52e-07  2.13e-05  5.43e-04  3.83e-04     0.1
+    4    -360.4796437294293696    -2.26e-07  2.07e-05  5.99e-04  2.38e-04     0.1
+    5    -360.4796444926591334    -7.63e-07  5.97e-06  1.02e-04  2.84e-05     0.1
+    6    -360.4796444743016650     1.84e-08  3.80e-06  8.76e-05  4.09e-05     0.1
+    7    -360.4796445305458406    -5.62e-08  2.39e-06  1.50e-04  6.94e-06     0.1
+    8    -360.4796445312345554    -6.89e-10  1.53e-06  9.74e-05  1.66e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   8 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47964453123456 Eh           -9809.14982 eV
+
+Components:
+Nuclear Repulsion  :        275.31795985709476 Eh            7491.78256 eV
+Electronic Energy  :       -635.79760438832932 Eh          -17300.93238 eV
+One Electron Energy:      -1035.49083002584507 Eh          -28177.13798 eV
+Two Electron Energy:        399.69322563751575 Eh           10876.20561 eV
+
+Virial components:
+Potential Energy   :       -719.51539718685717 Eh          -19579.00934 eV
+Kinetic Energy     :        359.03575265562262 Eh            9769.85952 eV
+Virial Ratio       :          2.00402158243276
+
+DFT components:
+N(Alpha)           :       25.999990062194 electrons
+N(Beta)            :       25.999990062194 electrons
+N(Total)           :       51.999980124387 electrons
+E(X)               :      -45.726980889582 Eh       
+E(C)               :       -1.703540855612 Eh       
+E(XC)              :      -47.430521745195 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    6.8871e-10  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    9.7448e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.5308e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    2.0808e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.6573e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    1.9669e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+Finished LeanSCF after   0.9 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.4 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002882662
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006968243
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475558949424
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000062897    0.000005909   -0.000011994
+   2   C   :   -0.000057476   -0.000013911    0.000010659
+   3   C   :   -0.000015711   -0.000002972   -0.000010230
+   4   N   :    0.000013524    0.000011945   -0.000045289
+   5   O   :    0.000060390    0.000029732    0.000034992
+   6   C   :    0.000064563   -0.000000334    0.000010172
+   7   C   :    0.000039643   -0.000014513   -0.000011595
+   8   H   :   -0.000024715    0.000008372    0.000008719
+   9   H   :   -0.000033443    0.000001223    0.000013566
+  10   H   :   -0.000031009   -0.000008515    0.000005629
+  11   H   :    0.000028493   -0.000002316    0.000010543
+  12   H   :    0.000018636   -0.000014620   -0.000015171
+
+Difference to translation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651445
+RMS gradient                       ...    0.0000275241
+MAX gradient                       ...    0.0000645635
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000136645    0.000056516    0.000087314
+   2   C   :   -0.000060055   -0.000050262   -0.000000218
+   3   C   :    0.000228549    0.000061393   -0.000025741
+   4   N   :   -0.000056837    0.000004208   -0.000045221
+   5   O   :    0.000070563   -0.000071933    0.000009910
+   6   C   :   -0.000108476    0.000115377   -0.000123632
+   7   C   :   -0.000008754   -0.000032895    0.000087118
+   8   H   :   -0.000018565   -0.000099408   -0.000007340
+   9   H   :   -0.000110700   -0.000022979   -0.000001397
+  10   H   :   -0.000042417    0.000034938   -0.000007898
+  11   H   :   -0.000048652   -0.000020185    0.000013964
+  12   H   :    0.000018697    0.000025228    0.000013141
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000339024    0.0001207730    0.0000308850
+
+Norm of the Cartesian gradient     ...    0.0004326910
+RMS gradient                       ...    0.0000721152
+MAX gradient                       ...    0.0002285494
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.192 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.1%)
+RI-J Coulomb gradient       ....       0.062 sec  ( 32.1%)
+XC gradient                 ....       0.089 sec  ( 46.4%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475558949 Eh
+Current gradient norm                   ....     0.000432691 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.450
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999969437
+Lowest eigenvalues of augmented Hessian:
+ -0.000000972  0.008640442  0.013871757  0.014299599  0.022537301
+Length of the computed step             ....  0.007818510
+The final length of the internal step   ....  0.007818510
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0010739550
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0009624994 RMS(Int)=    0.0010739784
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000000486
+Previously predicted energy change      ....    -0.000004199
+Actually observed energy change         ....    -0.000004699
+Ratio of predicted to observed change   ....     1.119054947
+New trust radius                        ....     0.675000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000046986            0.0000050000      YES
+          RMS gradient        0.0000547929            0.0001000000      YES
+          MAX gradient        0.0001358359            0.0003000000      YES
+          RMS step            0.0010739550            0.0020000000      YES
+          MAX step            0.0040564950            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0003      Max(Angles)    0.03
+          Max(Dihed)        0.23      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4101 -0.000136  0.0001    1.4101   
+     2. B(C   2,C   1)                1.4792  0.000120 -0.0001    1.4791   
+     3. B(N   3,C   2)                1.2460 -0.000010 -0.0000    1.2460   
+     4. B(C   5,O   4)                1.2116 -0.000065  0.0000    1.2116   
+     5. B(C   6,N   3)                1.5640  0.000012  0.0003    1.5643   
+     6. B(C   6,C   5)                1.4814 -0.000110  0.0001    1.4815   
+     7. B(C   6,C   2)                1.4630 -0.000075 -0.0000    1.4630   
+     8. B(H   7,O   0)                0.9647  0.000020 -0.0000    0.9647   
+     9. B(H   8,C   1)                1.0970 -0.000022  0.0000    1.0970   
+    10. B(H   9,C   1)                1.1047 -0.000022  0.0000    1.1047   
+    11. B(H  10,C   5)                1.1141 -0.000028  0.0000    1.1141   
+    12. B(H  11,C   6)                1.0905 -0.000024  0.0000    1.0905   
+    13. A(C   1,O   0,H   7)          108.73 -0.000098    0.01    108.74   
+    14. A(C   2,C   1,H   8)          108.23  0.000125   -0.02    108.21   
+    15. A(H   8,C   1,H   9)          106.85 -0.000022    0.00    106.86   
+    16. A(C   2,C   1,H   9)          107.70  0.000077   -0.01    107.69   
+    17. A(O   0,C   1,H   9)          112.96 -0.000021    0.00    112.96   
+    18. A(O   0,C   1,C   2)          113.34 -0.000109    0.01    113.35   
+    19. A(O   0,C   1,H   8)          107.48 -0.000040    0.01    107.49   
+    20. A(C   1,C   2,C   6)          147.57  0.000033   -0.03    147.55   
+    21. A(C   1,C   2,N   3)          142.41 -0.000065    0.01    142.42   
+    22. A(N   3,C   2,C   6)           70.00  0.000032    0.02     70.02   
+    23. A(C   2,N   3,C   6)           61.53 -0.000036   -0.01     61.52   
+    24. A(O   4,C   5,C   6)          123.77  0.000130   -0.02    123.76   
+    25. A(C   6,C   5,H  10)          114.93 -0.000086    0.01    114.93   
+    26. A(O   4,C   5,H  10)          121.30 -0.000045    0.01    121.31   
+    27. A(C   2,C   6,N   3)           48.47  0.000004   -0.01     48.47   
+    28. A(C   5,C   6,H  11)          117.56 -0.000029    0.03    117.59   
+    29. A(N   3,C   6,H  11)          115.82  0.000002   -0.03    115.79   
+    30. A(C   2,C   6,H  11)          120.68  0.000011   -0.02    120.66   
+    31. A(N   3,C   6,C   5)          116.41  0.000006   -0.01    116.40   
+    32. A(C   2,C   6,C   5)          118.89  0.000025    0.01    118.90   
+    33. D(H   8,C   1,O   0,H   7)    171.63  0.000089   -0.23    171.40   
+    34. D(H   9,C   1,O   0,H   7)    -70.76  0.000024   -0.22    -70.98   
+    35. D(C   2,C   1,O   0,H   7)     52.09  0.000026   -0.22     51.87   
+    36. D(N   3,C   2,C   1,H   9)    122.35 -0.000061    0.07    122.42   
+    37. D(N   3,C   2,C   1,O   0)     -3.36 -0.000016    0.06     -3.29   
+    38. D(C   6,C   2,C   1,H   8)     60.16  0.000020   -0.03     60.13   
+    39. D(C   6,C   2,C   1,O   0)    179.27 -0.000012   -0.02    179.25   
+    40. D(N   3,C   2,C   1,H   8)   -122.47  0.000017    0.06   -122.41   
+    41. D(C   6,N   3,C   2,C   1)   -178.50  0.000000   -0.05   -178.55   
+    42. D(H  11,C   6,C   2,N   3)    -98.69  0.000005    0.02    -98.66   
+    43. D(H  11,C   6,C   2,C   1)     79.61  0.000000    0.08     79.69   
+    44. D(C   5,C   6,C   2,N   3)    100.94 -0.000010   -0.02    100.92   
+    45. D(C   5,C   6,C   2,C   1)    -80.76 -0.000014    0.03    -80.73   
+    46. D(C   5,C   6,N   3,C   2)   -106.31 -0.000030   -0.02   -106.33   
+    47. D(N   3,C   6,C   5,H  10)   -145.02 -0.000037    0.07   -144.95   
+    48. D(N   3,C   6,C   2,C   1)    178.29 -0.000004    0.06    178.35   
+    49. D(N   3,C   6,C   5,O   4)     35.64  0.000028    0.04     35.68   
+    50. D(C   2,C   6,C   5,H  10)    159.82 -0.000049    0.08    159.91   
+    51. D(C   2,C   6,C   5,O   4)    -19.51  0.000016    0.05    -19.46   
+    52. D(H  11,C   6,C   5,O   4)    179.51 -0.000005    0.01    179.53   
+    53. D(H  11,C   6,N   3,C   2)    109.19  0.000014   -0.01    109.18   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.001 s (10.797 %)
+Internal coordinates            :      0.000 s ( 0.824 %)
+B/P matrices and projection     :      0.003 s (55.732 %)
+Hessian update/contruction      :      0.000 s ( 7.774 %)
+Making the step                 :      0.000 s ( 6.321 %)
+Converting the step to Cartesian:      0.000 s ( 0.923 %)
+Storing new data                :      0.000 s ( 0.667 %)
+Checking convergence            :      0.000 s ( 0.275 %)
+Final printing                  :      0.001 s (16.647 %)
+Total time                      :      0.005 s
+
+Time for energy+gradient        :      5.109 s
+Time for complete geometry iter :      6.034 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   8            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.523191    0.692970   -0.156396
+  C     -1.527793   -0.171344    0.344259
+  C     -0.221252   -0.014475   -0.331153
+  N      0.345408    0.601259   -1.254311
+  O      1.982788    1.135434    1.162765
+  C      2.161070    0.119469    0.527218
+  C      1.176109   -0.436458   -0.429609
+  H     -2.560780    0.599657   -1.115860
+  H     -1.393873    0.061168    1.407911
+  H     -1.811660   -1.237185    0.282627
+  H      3.096363   -0.475767    0.637451
+  H      1.444171   -1.354070   -0.954275
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.768140    1.309524   -0.295545
+   1 C     6.0000    0    12.011   -2.887110   -0.323794    0.650556
+   2 C     6.0000    0    12.011   -0.418105   -0.027353   -0.625788
+   3 N     7.0000    0    14.007    0.652727    1.136215   -2.370305
+   4 O     8.0000    0    15.999    3.746927    2.145659    2.197307
+   5 C     6.0000    0    12.011    4.083830    0.225763    0.996299
+   6 C     6.0000    0    12.011    2.222524   -0.824786   -0.811843
+   7 H     1.0000    0     1.008   -4.839173    1.133187   -2.108669
+   8 H     1.0000    0     1.008   -2.634039    0.115591    2.660567
+   9 H     1.0000    0     1.008   -3.423542   -2.337940    0.534087
+  10 H     1.0000    0     1.008    5.851277   -0.899070    1.204607
+  11 H     1.0000    0     1.008    2.729087   -2.558821   -1.803318
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410146440053     0.00000000     0.00000000
+ C      2   1   0     1.479134874184   113.35288389     0.00000000
+ N      3   2   1     1.245974805313   142.41555372   356.70612908
+ O      3   2   1     2.900322437277   118.56155233   110.83249818
+ C      5   3   2     1.211564086252    60.60411521   132.32494176
+ C      3   2   1     1.463003581923   147.54581388   179.24911739
+ H      1   2   3     0.964723375253   108.74278249    51.86794133
+ H      2   1   3     1.096974136769   107.48843266   119.52811575
+ H      2   1   3     1.104714802168   112.96479400   237.15425078
+ H      6   5   3     1.114104757032   121.30869642   190.39338046
+ H      7   3   2     1.090478321622   120.65596094    79.68529705
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.664790580424     0.00000000     0.00000000
+ C      2   1   0     2.795159827340   113.35288389     0.00000000
+ N      3   2   1     2.354551151808   142.41555372   356.70612908
+ O      3   2   1     5.480815106521   118.56155233   110.83249818
+ C      5   3   2     2.289524316711    60.60411521   132.32494176
+ C      3   2   1     2.764676102780   147.54581388   179.24911739
+ H      1   2   3     1.823062974221   108.74278249    51.86794133
+ H      2   1   3     2.072980694487   107.48843266   119.52811575
+ H      2   1   3     2.087608432187   112.96479400   237.15425078
+ H      6   5   3     2.105352875289   121.30869642   190.39338046
+ H      7   3   2     2.060705382843   120.65596094    79.68529705
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8063
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.318811383537 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.564e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59289
+Total number of batches                      ...      932
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796423720018197     0.00e+00  2.17e-05  6.62e-04  3.30e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796440940077105    -1.72e-06  9.62e-06  1.86e-04  3.35e-05     0.1
+    3    -360.4796441832364167    -8.92e-08  6.44e-06  3.40e-04  3.44e-05     0.1
+    4    -360.4796441569229160     2.63e-08  5.12e-06  2.49e-04  5.34e-05     0.1
+    5    -360.4796442052033285    -4.83e-08  1.89e-06  4.51e-05  1.10e-05     0.1
+    6    -360.4796441996231238     5.58e-09  1.18e-06  1.50e-05  1.78e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47964419962312 Eh           -9809.14981 eV
+
+Components:
+Nuclear Repulsion  :        275.31881138353657 Eh            7491.80573 eV
+Electronic Energy  :       -635.79845558315969 Eh          -17300.95554 eV
+One Electron Energy:      -1035.49173581052355 Eh          -28177.16263 eV
+Two Electron Energy:        399.69328022736386 Eh           10876.20709 eV
+
+Virial components:
+Potential Energy   :       -719.51499467355575 Eh          -19578.99838 eV
+Kinetic Energy     :        359.03535047393262 Eh            9769.84858 eV
+Virial Ratio       :          2.00402270618696
+
+DFT components:
+N(Alpha)           :       25.999990049752 electrons
+N(Beta)            :       25.999990049752 electrons
+N(Total)           :       51.999980099504 electrons
+E(X)               :      -45.726841368997 Eh       
+E(C)               :       -1.703532961622 Eh       
+E(XC)              :      -47.430374330619 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -5.5802e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.4999e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.1766e-06  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    6.0639e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.7777e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    3.2896e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.5 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002882842
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006967311
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475559730722
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000062868    0.000005938   -0.000012006
+   2   C   :   -0.000057460   -0.000013908    0.000010659
+   3   C   :   -0.000015714   -0.000002980   -0.000010236
+   4   N   :    0.000013517    0.000011934   -0.000045291
+   5   O   :    0.000060386    0.000029738    0.000035006
+   6   C   :    0.000064570   -0.000000330    0.000010180
+   7   C   :    0.000039629   -0.000014512   -0.000011596
+   8   H   :   -0.000024741    0.000008348    0.000008726
+   9   H   :   -0.000033437    0.000001224    0.000013561
+  10   H   :   -0.000031013   -0.000008521    0.000005630
+  11   H   :    0.000028497   -0.000002309    0.000010541
+  12   H   :    0.000018634   -0.000014623   -0.000015173
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651347
+RMS gradient                       ...    0.0000275224
+MAX gradient                       ...    0.0000645695
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000087407    0.000060696    0.000035960
+   2   C   :   -0.000025513   -0.000038133    0.000032283
+   3   C   :    0.000237841    0.000043313   -0.000098122
+   4   N   :   -0.000124868    0.000017948   -0.000028451
+   5   O   :    0.000047308   -0.000048014   -0.000008413
+   6   C   :   -0.000073430    0.000108393   -0.000037809
+   7   C   :    0.000006178   -0.000051977    0.000146792
+   8   H   :   -0.000027027   -0.000070102   -0.000000177
+   9   H   :   -0.000075628   -0.000024721   -0.000005554
+  10   H   :   -0.000020441    0.000021307   -0.000011044
+  11   H   :   -0.000015779   -0.000030041   -0.000004973
+  12   H   :   -0.000016046    0.000011331   -0.000020493
+
+Difference to translation invariance:
+           :   -0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000278811    0.0001188949    0.0000302353
+
+Norm of the Cartesian gradient     ...    0.0004037506
+RMS gradient                       ...    0.0000672918
+MAX gradient                       ...    0.0002378407
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.185 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.6%)
+RI-J Coulomb gradient       ....       0.053 sec  ( 28.5%)
+XC gradient                 ....       0.086 sec  ( 46.5%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475559731 Eh
+Current gradient norm                   ....     0.000403751 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.675
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999870904
+Lowest eigenvalues of augmented Hessian:
+ -0.000001556  0.004471147  0.013155053  0.014076390  0.022475944
+Length of the computed step             ....  0.016069897
+The final length of the internal step   ....  0.016069897
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0022073701
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0020924629 RMS(Int)=    0.0022076750
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000000778
+Previously predicted energy change      ....    -0.000000486
+Actually observed energy change         ....    -0.000000781
+Ratio of predicted to observed change   ....     1.607277429
+New trust radius                        ....     0.450000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000007813            0.0000050000      YES
+          RMS gradient        0.0000396089            0.0001000000      YES
+          MAX gradient        0.0000878728            0.0003000000      YES
+          RMS step            0.0022073701            0.0020000000      NO
+          MAX step            0.0084807140            0.0040000000      NO
+          ........................................................
+          Max(Bonds)      0.0002      Max(Angles)    0.06
+          Max(Dihed)        0.49      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+The optimization has not yet converged - more geometry cycles are needed
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+                            (Angstroem and degrees)
+
+        Definition                    Value    dE/dq     Step     New-Value
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4101 -0.000059  0.0001    1.4102   
+     2. B(C   2,C   1)                1.4791  0.000078 -0.0002    1.4789   
+     3. B(N   3,C   2)                1.2460 -0.000054  0.0001    1.2460   
+     4. B(C   5,O   4)                1.2116 -0.000051  0.0000    1.2116   
+     5. B(C   6,N   3)                1.5643  0.000053  0.0001    1.5644   
+     6. B(C   6,C   5)                1.4815 -0.000046  0.0002    1.4816   
+     7. B(C   6,C   2)                1.4630 -0.000085  0.0000    1.4630   
+     8. B(H   7,O   0)                0.9647  0.000010 -0.0000    0.9647   
+     9. B(H   8,C   1)                1.0970 -0.000022  0.0001    1.0970   
+    10. B(H   9,C   1)                1.1047 -0.000014  0.0000    1.1048   
+    11. B(H  10,C   5)                1.1141  0.000003 -0.0000    1.1141   
+    12. B(H  11,C   6)                1.0905 -0.000004 -0.0000    1.0905   
+    13. A(C   1,O   0,H   7)          108.74 -0.000050    0.02    108.76   
+    14. A(C   2,C   1,H   8)          108.21  0.000085   -0.06    108.15   
+    15. A(H   8,C   1,H   9)          106.86 -0.000015    0.01    106.87   
+    16. A(C   2,C   1,H   9)          107.69  0.000043   -0.02    107.66   
+    17. A(O   0,C   1,H   9)          112.96 -0.000009    0.01    112.97   
+    18. A(O   0,C   1,C   2)          113.35 -0.000074    0.03    113.39   
+    19. A(O   0,C   1,H   8)          107.49 -0.000023    0.02    107.51   
+    20. A(C   1,C   2,C   6)          147.55  0.000001   -0.03    147.51   
+    21. A(C   1,C   2,N   3)          142.42 -0.000066    0.03    142.45   
+    22. A(N   3,C   2,C   6)           70.02  0.000065    0.00     70.02   
+    23. A(C   2,N   3,C   6)           61.52 -0.000046   -0.00     61.51   
+    24. A(O   4,C   5,C   6)          123.75  0.000088   -0.04    123.71   
+    25. A(C   6,C   5,H  10)          114.93 -0.000073    0.03    114.96   
+    26. A(O   4,C   5,H  10)          121.31 -0.000015    0.01    121.32   
+    27. A(C   2,C   6,N   3)           48.47 -0.000019    0.00     48.47   
+    28. A(C   5,C   6,H  11)          117.59 -0.000005    0.04    117.62   
+    29. A(N   3,C   6,H  11)          115.79 -0.000016   -0.02    115.77   
+    30. A(C   2,C   6,H  11)          120.66 -0.000019   -0.02    120.63   
+    31. A(N   3,C   6,C   5)          116.40  0.000017   -0.02    116.38   
+    32. A(C   2,C   6,C   5)          118.90  0.000032   -0.01    118.90   
+    33. D(H   8,C   1,O   0,H   7)    171.40  0.000066   -0.49    170.91   
+    34. D(H   9,C   1,O   0,H   7)    -70.98  0.000028   -0.45    -71.43   
+    35. D(C   2,C   1,O   0,H   7)     51.87  0.000021   -0.45     51.42   
+    36. D(N   3,C   2,C   1,H   9)    122.42 -0.000042    0.18    122.60   
+    37. D(N   3,C   2,C   1,O   0)     -3.29 -0.000011    0.16     -3.13   
+    38. D(C   6,C   2,C   1,H   8)     60.13  0.000010   -0.00     60.13   
+    39. D(C   6,C   2,C   1,O   0)    179.25 -0.000007    0.01    179.26   
+    40. D(N   3,C   2,C   1,H   8)   -122.41  0.000006    0.15   -122.26   
+    41. D(C   6,N   3,C   2,C   1)   -178.55  0.000002   -0.08   -178.63   
+    42. D(H  11,C   6,C   2,N   3)    -98.66  0.000017    0.01    -98.65   
+    43. D(H  11,C   6,C   2,C   1)     79.69  0.000012    0.11     79.80   
+    44. D(C   5,C   6,C   2,N   3)    100.92 -0.000010   -0.02    100.90   
+    45. D(C   5,C   6,C   2,C   1)    -80.73 -0.000014    0.08    -80.65   
+    46. D(C   5,C   6,N   3,C   2)   -106.33 -0.000026   -0.00   -106.33   
+    47. D(N   3,C   6,C   5,H  10)   -144.95 -0.000026    0.15   -144.81   
+    48. D(N   3,C   6,C   2,C   1)    178.35 -0.000004    0.10    178.45   
+    49. D(N   3,C   6,C   5,O   4)     35.68  0.000004    0.10     35.78   
+    50. D(C   2,C   6,C   5,H  10)    159.91 -0.000017    0.15    160.06   
+    51. D(C   2,C   6,C   5,O   4)    -19.46  0.000013    0.10    -19.36   
+    52. D(H  11,C   6,C   5,O   4)    179.53 -0.000010    0.09    179.61   
+    53. D(H  11,C   6,N   3,C   2)    109.18 -0.000017   -0.01    109.16   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 9.617 %)
+Internal coordinates            :      0.000 s ( 0.750 %)
+B/P matrices and projection     :      0.002 s (57.219 %)
+Hessian update/contruction      :      0.000 s ( 9.081 %)
+Making the step                 :      0.000 s ( 6.268 %)
+Converting the step to Cartesian:      0.000 s ( 0.911 %)
+Storing new data                :      0.000 s ( 0.643 %)
+Checking convergence            :      0.000 s ( 0.348 %)
+Final printing                  :      0.001 s (15.055 %)
+Total time                      :      0.004 s
+
+Time for energy+gradient        :      4.719 s
+Time for complete geometry iter :      5.909 s
+
+         *************************************************************
+         *                GEOMETRY OPTIMIZATION CYCLE   9            *
+         *************************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.524363    0.691318   -0.156478
+  C     -1.527679   -0.171498    0.344415
+  C     -0.221713   -0.014942   -0.331751
+  N      0.345317    0.601018   -1.254609
+  O      1.980203    1.134258    1.163909
+  C      2.160366    0.119112    0.527535
+  C      1.175678   -0.436989   -0.429766
+  H     -2.558104    0.602247   -1.116473
+  H     -1.392259    0.062598    1.407591
+  H     -1.810505   -1.237755    0.284496
+  H      3.096934   -0.474262    0.636592
+  H      1.443483   -1.354446   -0.954833
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.770355    1.306401   -0.295701
+   1 C     6.0000    0    12.011   -2.886894   -0.324084    0.650851
+   2 C     6.0000    0    12.011   -0.418976   -0.028236   -0.626919
+   3 N     7.0000    0    14.007    0.652555    1.135760   -2.370867
+   4 O     8.0000    0    15.999    3.742041    2.143437    2.199468
+   5 C     6.0000    0    12.011    4.082499    0.225089    0.996896
+   6 C     6.0000    0    12.011    2.221710   -0.825790   -0.812140
+   7 H     1.0000    0     1.008   -4.834116    1.138082   -2.109828
+   8 H     1.0000    0     1.008   -2.630987    0.118293    2.659961
+   9 H     1.0000    0     1.008   -3.421358   -2.339019    0.537619
+  10 H     1.0000    0     1.008    5.852357   -0.896225    1.202984
+  11 H     1.0000    0     1.008    2.727788   -2.559533   -1.804374
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410221332076     0.00000000     0.00000000
+ C      2   1   0     1.478938123160   113.38700022     0.00000000
+ N      3   2   1     1.246032128458   142.44715338   356.86533726
+ O      3   2   1     2.899325726466   118.47271986   110.93108405
+ C      5   3   2     1.211590677675    60.65135172   132.37446833
+ C      3   2   1     1.463021738008   147.51396988   179.26031006
+ H      1   2   3     0.964708451589   108.76468624    51.41644756
+ H      2   1   3     1.097032704013   107.51233645   119.49370236
+ H      2   1   3     1.104756286220   112.97371001   237.15177079
+ H      6   5   3     1.114067597826   121.32241741   190.29186889
+ H      7   3   2     1.090478287336   120.63264005    79.79743041
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.664932105838     0.00000000     0.00000000
+ C      2   1   0     2.794788021789   113.38700022     0.00000000
+ N      3   2   1     2.354659476852   142.44715338   356.86533726
+ O      3   2   1     5.478931596052   118.47271986   110.93108405
+ C      5   3   2     2.289574567218    60.65135172   132.37446833
+ C      3   2   1     2.764710412808   147.51396988   179.26031006
+ H      1   2   3     1.823034772582   108.76468624    51.41644756
+ H      2   1   3     2.073091370540   107.51233645   119.49370236
+ H      2   1   3     2.087686825685   112.97371001   237.15177079
+ H      6   5   3     2.105282654566   121.32241741   190.29186889
+ H      7   3   2     2.060705318052   120.63264005    79.79743041
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8064
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.329690459556 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.566e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.004 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59287
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+Occupation numbers will be reassigned to an Aufbau configuration
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.5 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796344578222715     0.00e+00  4.38e-05  1.09e-03  1.17e-04     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796428396755346    -8.38e-06  1.95e-05  3.49e-04  1.05e-04     0.1
+    3    -360.4796433643525688    -5.25e-07  7.72e-06  4.42e-04  4.15e-05     0.1
+    4    -360.4796432843631919     8.00e-08  5.44e-06  3.12e-04  8.91e-05     0.1
+    5    -360.4796433901420869    -1.06e-07  1.48e-06  2.58e-05  1.06e-05     0.1
+    6    -360.4796433850666517     5.08e-09  9.58e-07  1.73e-05  1.69e-05     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47964338506665 Eh           -9809.14978 eV
+
+Components:
+Nuclear Repulsion  :        275.32969045955633 Eh            7492.10177 eV
+Electronic Energy  :       -635.80933384462310 Eh          -17301.25155 eV
+One Electron Energy:      -1035.51270223741631 Eh          -28177.73316 eV
+Two Electron Energy:        399.70336839279327 Eh           10876.48160 eV
+
+Virial components:
+Potential Energy   :       -719.51425062033422 Eh          -19578.97814 eV
+Kinetic Energy     :        359.03460723526763 Eh            9769.82835 eV
+Virial Ratio       :          2.00402478234877
+
+DFT components:
+N(Alpha)           :       25.999990053439 electrons
+N(Beta)            :       25.999990053439 electrons
+N(Total)           :       51.999980106878 electrons
+E(X)               :      -45.726685953951 Eh       
+E(C)               :       -1.703531855548 Eh       
+E(XC)              :      -47.430217809499 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -5.0754e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    1.7315e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    9.5847e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.1560e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    1.6897e-05  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    2.1726e-05  Tolerance :   1.0000e-05
+
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+Finished LeanSCF after   0.8 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.6 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+-------------------------   ----------------
+Dispersion correction           -0.002883289
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006966016
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475560658026
+-------------------------   --------------------
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                         ORCA SCF GRADIENT CALCULATION
+------------------------------------------------------------------------------
+
+Nuc. rep. gradient        (SHARK) ... done (  0.0 sec)
+HCore & Overlap gradient  (SHARK) ... done (  0.0 sec)
+Split-RIJ-J gradient      (SHARK) ... done (  0.1 sec)
+XC gradient                       ... done (  0.1 sec)
+Dispersion correction             ... done (  0.0 sec)
+
+-------------------
+DISPERSION GRADIENT
+-------------------
+
+   1   O   :   -0.000062817    0.000005991   -0.000012033
+   2   C   :   -0.000057427   -0.000013894    0.000010669
+   3   C   :   -0.000015712   -0.000002987   -0.000010244
+   4   N   :    0.000013518    0.000011930   -0.000045302
+   5   O   :    0.000060366    0.000029730    0.000035048
+   6   C   :    0.000064578   -0.000000329    0.000010187
+   7   C   :    0.000039614   -0.000014516   -0.000011600
+   8   H   :   -0.000024799    0.000008300    0.000008740
+   9   H   :   -0.000033426    0.000001233    0.000013545
+  10   H   :   -0.000031031   -0.000008535    0.000005637
+  11   H   :    0.000028503   -0.000002296    0.000010538
+  12   H   :    0.000018632   -0.000014627   -0.000015184
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000   -0.0000000000
+
+Difference to rotation invariance:
+           :    0.0000000000   -0.0000000000   -0.0000000000
+
+Norm of the Dispersion gradient    ...    0.0001651211
+RMS gradient                       ...    0.0000275202
+MAX gradient                       ...    0.0000645783
+gCP correction                   ... done
+
+------------------
+CARTESIAN GRADIENT
+------------------
+
+   1   O   :    0.000022752    0.000039819   -0.000029460
+   2   C   :   -0.000042483    0.000007042    0.000055533
+   3   C   :    0.000121453   -0.000053066   -0.000068562
+   4   N   :   -0.000090474    0.000056739   -0.000064640
+   5   O   :   -0.000015506   -0.000009601   -0.000044850
+   6   C   :    0.000054097    0.000036170    0.000087765
+   7   C   :    0.000009216   -0.000032195    0.000150336
+   8   H   :   -0.000035649   -0.000015132    0.000008490
+   9   H   :    0.000003947   -0.000014192   -0.000003451
+  10   H   :    0.000032178   -0.000010532   -0.000016646
+  11   H   :    0.000005534   -0.000010962   -0.000027470
+  12   H   :   -0.000065065    0.000005910   -0.000047044
+
+Difference to translation invariance:
+           :    0.0000000000    0.0000000000    0.0000000000
+
+Difference to rotation invariance:
+           :   -0.0000325726    0.0001162592    0.0000328361
+
+Norm of the Cartesian gradient     ...    0.0003072054
+RMS gradient                       ...    0.0000512009
+MAX gradient                       ...    0.0001503361
+
+-------
+TIMINGS
+-------
+
+Total SCF gradient time     ....        0.192 sec
+
+Densities                   ....       0.001 sec  (  0.4%)
+One electron gradient       ....       0.008 sec  (  4.3%)
+RI-J Coulomb gradient       ....       0.062 sec  ( 32.3%)
+XC gradient                 ....       0.089 sec  ( 46.4%)
+
+Maximum memory used throughout the entire SCFGRAD-calculation: 27.3 MB
+------------------------------------------------------------------------------
+                         ORCA GEOMETRY RELAXATION STEP
+------------------------------------------------------------------------------
+
+Reading the OPT-File                    .... done
+Getting information on internals        .... done
+Copying old internal coords+grads       .... done
+Making the new internal coordinates     .... (2022 redundants) done
+Validating the new internal coordinates .... (2022 redundants) done
+Calculating the B-matrix                .... done
+Calculating the G,G- and P matrices     .... done
+Transforming gradient to internals      .... done
+Projecting the internal gradient        .... done
+Number of atoms                         ....  12
+Number of internal coordinates          ....  53
+Current Energy                          ....  -360.475560658 Eh
+Current gradient norm                   ....     0.000307205 Eh/bohr
+Maximum allowed component of the step   ....  0.300
+Current trust radius                    ....  0.450
+Updating the Hessian (BFGS)             .... done
+Forming the augmented Hessian           .... done
+Diagonalizing the augmented Hessian     .... done
+Last element of RFO vector              ....  0.999984610
+Lowest eigenvalues of augmented Hessian:
+ -0.000000312  0.003777272  0.012891895  0.014068352  0.022391736
+Length of the computed step             ....  0.005548039
+The final length of the internal step   ....  0.005548039
+Converting the step to Cartesian space:
+ Initial RMS(Int)=    0.0007620818
+Transforming coordinates:
+ Iter   0:  RMS(Cart)=    0.0008313779 RMS(Int)=    0.0007621026
+done
+Storing new coordinates                 .... done
+The predicted energy change is          ....    -0.000000156
+Previously predicted energy change      ....    -0.000000778
+Actually observed energy change         ....    -0.000000927
+Ratio of predicted to observed change   ....     1.191722074
+New trust radius                        ....     0.675000000
+
+                                .--------------------.
+          ----------------------|Geometry convergence|-------------------------
+          Item                value                   Tolerance       Converged
+          ---------------------------------------------------------------------
+          Energy change      -0.0000009273            0.0000050000      YES
+          RMS gradient        0.0000270619            0.0001000000      YES
+          MAX gradient        0.0000750000            0.0003000000      YES
+          RMS step            0.0007620818            0.0020000000      YES
+          MAX step            0.0028351119            0.0040000000      YES
+          ........................................................
+          Max(Bonds)      0.0002      Max(Angles)    0.02
+          Max(Dihed)        0.16      Max(Improp)    0.00
+          ---------------------------------------------------------------------
+
+                    ***********************HURRAY********************
+                    ***        THE OPTIMIZATION HAS CONVERGED     ***
+                    *************************************************
+
+
+    ---------------------------------------------------------------------------
+                         Redundant Internal Coordinates
+
+                          --- Optimized Parameters ---  
+                            (Angstroem and degrees)
+
+        Definition                    OldVal   dE/dq     Step     FinalVal
+    ----------------------------------------------------------------------------
+     1. B(C   1,O   0)                1.4102  0.000034 -0.0000    1.4102   
+     2. B(C   2,C   1)                1.4789  0.000018 -0.0001    1.4788   
+     3. B(N   3,C   2)                1.2460 -0.000012  0.0000    1.2461   
+     4. B(C   5,O   4)                1.2116 -0.000029  0.0000    1.2116   
+     5. B(C   6,N   3)                1.5644  0.000075 -0.0002    1.5642   
+     6. B(C   6,C   5)                1.4816  0.000048  0.0000    1.4817   
+     7. B(C   6,C   2)                1.4630 -0.000057  0.0001    1.4631   
+     8. B(H   7,O   0)                0.9647 -0.000004 -0.0000    0.9647   
+     9. B(H   8,C   1)                1.0970 -0.000008  0.0000    1.0971   
+    10. B(H   9,C   1)                1.1048  0.000003  0.0000    1.1048   
+    11. B(H  10,C   5)                1.1141  0.000008 -0.0000    1.1141   
+    12. B(H  11,C   6)                1.0905  0.000001  0.0000    1.0905   
+    13. A(C   1,O   0,H   7)          108.76  0.000029    0.00    108.77   
+    14. A(C   2,C   1,H   8)          108.15 -0.000005   -0.02    108.13   
+    15. A(H   8,C   1,H   9)          106.87  0.000004    0.00    106.87   
+    16. A(C   2,C   1,H   9)          107.66 -0.000035    0.00    107.66   
+    17. A(O   0,C   1,H   9)          112.97  0.000023    0.00    112.97   
+    18. A(O   0,C   1,C   2)          113.39  0.000005    0.01    113.40   
+    19. A(O   0,C   1,H   8)          107.51  0.000008    0.00    107.52   
+    20. A(C   1,C   2,C   6)          147.51 -0.000027    0.00    147.51   
+    21. A(C   1,C   2,N   3)          142.45 -0.000030    0.01    142.46   
+    22. A(N   3,C   2,C   6)           70.02  0.000057   -0.02     70.01   
+    23. A(C   2,N   3,C   6)           61.51 -0.000047    0.01     61.52   
+    24. A(O   4,C   5,C   6)          123.71 -0.000031   -0.01    123.70   
+    25. A(C   6,C   5,H  10)          114.96 -0.000008    0.01    114.98   
+    26. A(O   4,C   5,H  10)          121.32  0.000040   -0.00    121.32   
+    27. A(C   2,C   6,N   3)           48.47 -0.000011    0.00     48.47   
+    28. A(C   5,C   6,H  11)          117.62  0.000034   -0.00    117.62   
+    29. A(N   3,C   6,H  11)          115.77 -0.000042    0.01    115.78   
+    30. A(C   2,C   6,H  11)          120.63 -0.000055    0.01    120.64   
+    31. A(N   3,C   6,C   5)          116.38  0.000015    0.00    116.38   
+    32. A(C   2,C   6,C   5)          118.90  0.000026   -0.02    118.88   
+    33. D(H   8,C   1,O   0,H   7)    170.91  0.000012   -0.16    170.75   
+    34. D(H   9,C   1,O   0,H   7)    -71.43  0.000035   -0.16    -71.59   
+    35. D(C   2,C   1,O   0,H   7)     51.42  0.000010   -0.15     51.27   
+    36. D(N   3,C   2,C   1,H   9)    122.60  0.000004    0.07    122.67   
+    37. D(N   3,C   2,C   1,O   0)     -3.13 -0.000003    0.06     -3.07   
+    38. D(C   6,C   2,C   1,H   8)     60.13 -0.000007    0.03     60.16   
+    39. D(C   6,C   2,C   1,O   0)    179.26  0.000002    0.03    179.29   
+    40. D(N   3,C   2,C   1,H   8)   -122.26 -0.000012    0.06   -122.20   
+    41. D(C   6,N   3,C   2,C   1)   -178.63  0.000004   -0.02   -178.65   
+    42. D(H  11,C   6,C   2,N   3)    -98.65  0.000021   -0.01    -98.66   
+    43. D(H  11,C   6,C   2,C   1)     79.80  0.000016    0.01     79.81   
+    44. D(C   5,C   6,C   2,N   3)    100.90 -0.000004    0.02    100.92   
+    45. D(C   5,C   6,C   2,C   1)    -80.65 -0.000008    0.04    -80.61   
+    46. D(C   5,C   6,N   3,C   2)   -106.33 -0.000021    0.02   -106.31   
+    47. D(N   3,C   6,C   5,H  10)   -144.81  0.000011    0.03   -144.78   
+    48. D(N   3,C   6,C   2,C   1)    178.45 -0.000004    0.02    178.47   
+    49. D(N   3,C   6,C   5,O   4)     35.78 -0.000010    0.04     35.81   
+    50. D(C   2,C   6,C   5,H  10)    160.06  0.000013    0.03    160.09   
+    51. D(C   2,C   6,C   5,O   4)    -19.36 -0.000008    0.03    -19.32   
+    52. D(H  11,C   6,C   5,O   4)    179.61 -0.000014    0.06    179.67   
+    53. D(H  11,C   6,N   3,C   2)    109.16 -0.000044    0.01    109.17   
+    ----------------------------------------------------------------------------
+
+Geometry step timings:
+Preparation and reading OPT file:      0.000 s ( 9.599 %)
+Internal coordinates            :      0.000 s ( 0.851 %)
+B/P matrices and projection     :      0.002 s (56.182 %)
+Hessian update/contruction      :      0.000 s ( 9.147 %)
+Making the step                 :      0.000 s ( 6.434 %)
+Converting the step to Cartesian:      0.000 s ( 0.904 %)
+Storing new data                :      0.000 s ( 0.691 %)
+Checking convergence            :      0.000 s ( 0.292 %)
+Final printing                  :      0.001 s (15.847 %)
+Total time                      :      0.004 s
+                 *******************************************************
+                 *** FINAL ENERGY EVALUATION AT THE STATIONARY POINT ***
+                 ***               (AFTER    9 CYCLES)               ***
+                 *******************************************************
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  O     -2.524747    0.690680   -0.156573
+  C     -1.527595   -0.171458    0.344538
+  C     -0.221865   -0.015002   -0.331914
+  N      0.345323    0.600960   -1.254706
+  O      1.979099    1.133533    1.164591
+  C      2.160021    0.118934    0.527511
+  C      1.175598   -0.437029   -0.430186
+  H     -2.557153    0.602805   -1.116721
+  H     -1.391742    0.063435    1.407513
+  H     -1.810099   -1.237857    0.285472
+  H      3.096972   -0.473861    0.636321
+  H      1.443549   -1.354479   -0.955219
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 O     8.0000    0    15.999   -4.771081    1.305196   -0.295881
+   1 C     6.0000    0    12.011   -2.886736   -0.324009    0.651083
+   2 C     6.0000    0    12.011   -0.419264   -0.028350   -0.627227
+   3 N     7.0000    0    14.007    0.652566    1.135649   -2.371051
+   4 O     8.0000    0    15.999    3.739954    2.142068    2.200758
+   5 C     6.0000    0    12.011    4.081848    0.224752    0.996852
+   6 C     6.0000    0    12.011    2.221558   -0.825865   -0.812933
+   7 H     1.0000    0     1.008   -4.832319    1.139136   -2.110297
+   8 H     1.0000    0     1.008   -2.630012    0.119874    2.659814
+   9 H     1.0000    0     1.008   -3.420591   -2.339212    0.539464
+  10 H     1.0000    0     1.008    5.852428   -0.895468    1.202472
+  11 H     1.0000    0     1.008    2.727912   -2.559594   -1.805102
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     1.410215571866     0.00000000     0.00000000
+ C      2   1   0     1.478849890998   113.39688575     0.00000000
+ N      3   2   1     1.246056165248   142.46191777   356.92539145
+ O      3   2   1     2.898775837022   118.43514798   110.98422556
+ C      5   3   2     1.211616888576    60.66855757   132.40836329
+ C      3   2   1     1.463101833737   147.51496726   179.28893038
+ H      1   2   3     0.964705234253   108.76754039    51.26652985
+ H      2   1   3     1.097062603615   107.51570712   119.48116548
+ H      2   1   3     1.104764576442   112.97375468   237.14327033
+ H      6   5   3     1.114056635671   121.31951213   190.28415604
+ H      7   3   2     1.090491673163   120.64422943    79.80597839
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ O      0   0   0     0.000000000000     0.00000000     0.00000000
+ C      1   0   0     2.664921220618     0.00000000     0.00000000
+ C      2   1   0     2.794621287165   113.39688575     0.00000000
+ N      3   2   1     2.354704899804   142.46191777   356.92539145
+ O      3   2   1     5.477892455600   118.43514798   110.98422556
+ C      5   3   2     2.289624098642    60.66855757   132.40836329
+ C      3   2   1     2.764861771801   147.51496726   179.28893038
+ H      1   2   3     1.823028692699   108.76754039    51.26652985
+ H      2   1   3     2.073147872600   107.51570712   119.48116548
+ H      2   1   3     2.087702491933   112.97375468   237.14327033
+ H      6   5   3     2.105261939095   121.31951213   190.28415604
+ H      7   3   2     2.060730613600   120.64422943    79.80597839
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   2 Type C   : 11s6p1d contracted to 5s3p1d pattern {62111/411/1}
+ Group   3 Type N   : 11s6p2d contracted to 5s3p2d pattern {62111/411/11}
+ Group   4 Type H   : 4s1p contracted to 2s1p pattern {31/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 4 groups of distinct atoms
+
+ Group   1 Type O   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   2 Type C   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   3 Type N   : 8s3p3d contracted to 6s3p3d pattern {311111/111/111}
+ Group   4 Type H   : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0O    basis set group =>   1
+Atom   1C    basis set group =>   2
+Atom   2C    basis set group =>   2
+Atom   3N    basis set group =>   3
+Atom   4O    basis set group =>   1
+Atom   5C    basis set group =>   2
+Atom   6C    basis set group =>   2
+Atom   7H    basis set group =>   4
+Atom   8H    basis set group =>   4
+Atom   9H    basis set group =>   4
+Atom  10H    basis set group =>   4
+Atom  11H    basis set group =>   4
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...     12
+Number of basis functions                   ...    173
+Number of shells                            ...     81
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...    265
+   # of shells in Aux-J                     ...    109
+   Maximum angular momentum in Aux-J        ...      2
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 81
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...      3321
+Shell pairs after pre-screening             ...      3029
+Total number of primitive shell pairs       ...     12104
+Primitive shell pairs kept                  ...      8065
+          la=0 lb=0:    907 shell pairs
+          la=1 lb=0:   1070 shell pairs
+          la=1 lb=1:    335 shell pairs
+          la=2 lb=0:    414 shell pairs
+          la=2 lb=1:    250 shell pairs
+          la=2 lb=2:     53 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=    275.338440353942 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.566e-04
+Time for diagonalization                   ...    0.002 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.001 sec
+Total time needed                          ...    0.005 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    59287
+Total number of batches                      ...      933
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4941
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.3 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.6 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+  Functional kind                       .... Exchange
+  Functional name                       .... Re-regularized SCAN exchange by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 6
+    Parameter  0 _c1        =  6.670000e-01 : c1 parameter        
+    Parameter  1 _c2        =  8.000000e-01 : c2 parameter        
+    Parameter  2 _d         =  1.240000e+00 : d parameter         
+    Parameter  3 _k1        =  6.500000e-02 : k1 parameter        
+    Parameter  4 _eta       =  1.000000e-03 : eta parameter       
+    Parameter  5 _dp2       =  3.610000e-01 : dp2 parameter       
+  Functional kind                       .... Correlation
+  Functional name                       .... Re-regularized SCAN correlation by Furness et al
+  Functional family                     .... MGGA
+  Functional refs                              
+    [ 0] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 8208-8215 (2020), doi: 10.1021/acs.jpclett.0c02405
+    [ 1] J. W. Furness, A. D. Kaplan, J. Ning, J. P. Perdew, and J. Sun.,  J. Phys. Chem. Lett. 11, 9248-9248 (2020), doi: 10.1021/acs.jpclett.0c03077
+  Functional external parameters        .... 1
+    Parameter  0 _eta       =  1.000000e-03 : Regularization parameter
+ Gradients option       PostSCFGGA      .... off
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 265
+
+
+General Settings:
+ Integral files         IntName         .... input
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....   52
+ Basis Dimension        Dim             ....  173
+ Nuclear Repulsion      ENuc            ....    275.3384403539 Eh
+
+Convergence Acceleration:
+ AO-DIIS                CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ MO-DIIS                CNVKDIIS        .... off
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....     1
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    24
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold    (grad. norm)   ....   1.000e-05
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   1.000e-02
+   NR start threshold (gradient norm)   ....   1.000e-04
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Quad. conv. algorithm                .... NR
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Pseudo random numbers                .... off
+   Inactive MOs                         .... canonical
+   Orbital update algorithm             .... Taylor
+   Preconditioner                       .... Diag
+   Full preconditioner red. dimension   ....   250
+   COSX micro iterations for RIJONX calc.... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+   Hessian update       SOSCFHessUp     .... L-BFGS
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: input.gbw
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+Occupation numbers will be reassigned to an Aufbau configuration
+MOs were renormalized
+MOs were reorthogonalized (Cholesky)
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+Finished Guess after   0.3 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.5 MB
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+-------------------------------------------------------------------------------------------
+                                      ORCA LEAN-SCF
+                              memory conserving SCF solver
+-------------------------------------------------------------------------------------------
+
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    1    -360.4796418559216136     0.00e+00  1.57e-05  3.40e-04  6.89e-05     0.1
+               *** Restarting incremental Fock matrix formation ***
+    2    -360.4796432773756578    -1.42e-06  7.55e-06  1.19e-04  6.18e-05     0.1
+    3    -360.4796433422984592    -6.49e-08  5.09e-06  1.45e-04  7.39e-05     0.1
+    4    -360.4796433191135065     2.32e-08  4.21e-06  7.64e-05  7.64e-05     0.1
+    5    -360.4796433816148920    -6.25e-08  8.05e-07  3.45e-05  3.91e-06     0.1
+    6    -360.4796433788754939     2.74e-09  6.16e-07  3.43e-05  4.03e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   6 CYCLES          *
+               *****************************************************
+
+             **** ENERGY FILE WAS UPDATED (input.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :       -360.47964337887549 Eh           -9809.14978 eV
+
+Components:
+Nuclear Repulsion  :        275.33844035394202 Eh            7492.33987 eV
+Electronic Energy  :       -635.81808373281751 Eh          -17301.48965 eV
+One Electron Energy:      -1035.52995006587935 Eh          -28178.20249 eV
+Two Electron Energy:        399.71186633306189 Eh           10876.71284 eV
+
+Virial components:
+Potential Energy   :       -719.51420329821826 Eh          -19578.97685 eV
+Kinetic Energy     :        359.03455991934271 Eh            9769.82706 eV
+Virial Ratio       :          2.00402491464849
+
+DFT components:
+N(Alpha)           :       25.999990086115 electrons
+N(Beta)            :       25.999990086115 electrons
+N(Total)           :       51.999980172229 electrons
+E(X)               :      -45.726677679319 Eh       
+E(C)               :       -1.703539662575 Eh       
+E(XC)              :      -47.430217341894 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -2.7394e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    3.4343e-05  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    6.1561e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    4.8516e-04  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    4.0297e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    6.5096e-06  Tolerance :   1.0000e-05
+
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000     -18.983777      -516.5748 
+   1   2.0000     -18.953666      -515.7555 
+   2   2.0000     -14.204797      -386.5322 
+   3   2.0000     -10.130881      -275.6753 
+   4   2.0000     -10.126233      -275.5488 
+   5   2.0000     -10.117608      -275.3141 
+   6   2.0000     -10.098639      -274.7979 
+   7   2.0000      -1.024700       -27.8835 
+   8   2.0000      -1.018580       -27.7170 
+   9   2.0000      -0.979260       -26.6470 
+  10   2.0000      -0.725776       -19.7494 
+  11   2.0000      -0.688006       -18.7216 
+  12   2.0000      -0.555759       -15.1230 
+  13   2.0000      -0.548090       -14.9143 
+  14   2.0000      -0.496985       -13.5236 
+  15   2.0000      -0.477932       -13.0052 
+  16   2.0000      -0.455855       -12.4044 
+  17   2.0000      -0.442698       -12.0464 
+  18   2.0000      -0.404061       -10.9951 
+  19   2.0000      -0.384710       -10.4685 
+  20   2.0000      -0.359331        -9.7779 
+  21   2.0000      -0.348298        -9.4777 
+  22   2.0000      -0.308654        -8.3989 
+  23   2.0000      -0.282995        -7.7007 
+  24   2.0000      -0.264600        -7.2001 
+  25   2.0000      -0.231528        -6.3002 
+  26   0.0000      -0.081949        -2.2300 
+  27   0.0000      -0.055321        -1.5054 
+  28   0.0000       0.024724         0.6728 
+  29   0.0000       0.071771         1.9530 
+  30   0.0000       0.080084         2.1792 
+  31   0.0000       0.105448         2.8694 
+  32   0.0000       0.114152         3.1062 
+  33   0.0000       0.130082         3.5397 
+  34   0.0000       0.141639         3.8542 
+  35   0.0000       0.143117         3.8944 
+  36   0.0000       0.158148         4.3034 
+*Only the first 10 virtual orbitals were printed.
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 O :   -0.387958
+   1 C :   -0.246687
+   2 C :    0.299239
+   3 N :   -0.204798
+   4 O :   -0.354932
+   5 C :    0.103461
+   6 C :   -0.128146
+   7 H :    0.315266
+   8 H :    0.175331
+   9 H :    0.152816
+  10 H :    0.110776
+  11 H :    0.165632
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 O s       :     3.761870  s :     3.761870
+      pz      :     1.331714  p :     4.615491
+      px      :     1.604056
+      py      :     1.679721
+      dz2     :     0.003666  d :     0.010596
+      dxz     :     0.001173
+      dyz     :     0.002231
+      dx2y2   :     0.000088
+      dxy     :     0.003438
+
+  1 C s       :     3.332800  s :     3.332800
+      pz      :     1.034361  p :     2.849891
+      px      :     0.838209
+      py      :     0.977320
+      dz2     :     0.012484  d :     0.063997
+      dxz     :     0.012208
+      dyz     :     0.005193
+      dx2y2   :     0.021996
+      dxy     :     0.012115
+
+  2 C s       :     3.197927  s :     3.197927
+      pz      :     0.860686  p :     2.427329
+      px      :     0.725839
+      py      :     0.840803
+      dz2     :     0.016890  d :     0.075505
+      dxz     :     0.017984
+      dyz     :     0.009746
+      dx2y2   :     0.016353
+      dxy     :     0.014532
+
+  3 N s       :     3.748227  s :     3.748227
+      pz      :     1.187301  p :     3.414141
+      px      :     1.091507
+      py      :     1.135333
+      dz2     :     0.018965  d :     0.042430
+      dxz     :     0.008063
+      dyz     :    -0.001141
+      dx2y2   :     0.003083
+      dxy     :     0.013460
+
+  4 O s       :     3.845857  s :     3.845857
+      pz      :     1.420377  p :     4.485112
+      px      :     1.738375
+      py      :     1.326359
+      dz2     :     0.006404  d :     0.023964
+      dxz     :     0.002441
+      dyz     :     0.007554
+      dx2y2   :     0.008391
+      dxy     :    -0.000826
+
+  5 C s       :     3.274501  s :     3.274501
+      pz      :     0.799021  p :     2.537417
+      px      :     0.938824
+      py      :     0.799572
+      dz2     :     0.016843  d :     0.084621
+      dxz     :     0.011813
+      dyz     :     0.015136
+      dx2y2   :     0.012361
+      dxy     :     0.028468
+
+  6 C s       :     3.128359  s :     3.128359
+      pz      :     0.988300  p :     2.946327
+      px      :     0.962094
+      py      :     0.995933
+      dz2     :     0.005939  d :     0.053460
+      dxz     :     0.012919
+      dyz     :     0.009376
+      dx2y2   :     0.013299
+      dxy     :     0.011927
+
+  7 H s       :     0.640876  s :     0.640876
+      pz      :     0.022615  p :     0.043858
+      px      :     0.010276
+      py      :     0.010966
+
+  8 H s       :     0.807321  s :     0.807321
+      pz      :     0.011367  p :     0.017348
+      px      :     0.002690
+      py      :     0.003291
+
+  9 H s       :     0.830104  s :     0.830104
+      pz      :     0.003217  p :     0.017080
+      px      :     0.002987
+      py      :     0.010876
+
+ 10 H s       :     0.871852  s :     0.871852
+      pz      :     0.002388  p :     0.017372
+      px      :     0.009887
+      py      :     0.005096
+
+ 11 H s       :     0.815811  s :     0.815811
+      pz      :     0.005342  p :     0.018557
+      px      :     0.003464
+      py      :     0.009750
+
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 O :   -0.557505
+   1 C :    0.048631
+   2 C :    0.188658
+   3 N :   -0.434269
+   4 O :   -0.442613
+   5 C :    0.213226
+   6 C :   -0.012027
+   7 H :    0.273961
+   8 H :    0.207086
+   9 H :    0.181438
+  10 H :    0.157215
+  11 H :    0.176201
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 O s       :     3.520733  s :     3.520733
+      pz      :     1.420266  p :     4.785106
+      px      :     1.642695
+      py      :     1.722144
+      dz2     :     0.069830  d :     0.251667
+      dxz     :     0.044255
+      dyz     :     0.027632
+      dx2y2   :     0.059292
+      dxy     :     0.050657
+
+  1 C s       :     2.853519  s :     2.853519
+      pz      :     1.040040  p :     2.961137
+      px      :     0.912628
+      py      :     1.008469
+      dz2     :     0.029279  d :     0.136712
+      dxz     :     0.023897
+      dyz     :     0.009387
+      dx2y2   :     0.047527
+      dxy     :     0.026622
+
+  2 C s       :     2.821421  s :     2.821421
+      pz      :     0.961944  p :     2.842188
+      px      :     0.980870
+      py      :     0.899374
+      dz2     :     0.029855  d :     0.147733
+      dxz     :     0.036979
+      dyz     :     0.021728
+      dx2y2   :     0.031706
+      dxy     :     0.027465
+
+  3 N s       :     3.390417  s :     3.390417
+      pz      :     1.302044  p :     3.675557
+      px      :     1.160907
+      py      :     1.212606
+      dz2     :     0.067771  d :     0.368295
+      dxz     :     0.076988
+      dyz     :     0.087909
+      dx2y2   :     0.063835
+      dxy     :     0.071792
+
+  4 O s       :     3.570398  s :     3.570398
+      pz      :     1.455471  p :     4.646738
+      px      :     1.721468
+      py      :     1.469799
+      dz2     :     0.034716  d :     0.225477
+      dxz     :     0.022543
+      dyz     :     0.065142
+      dx2y2   :     0.043148
+      dxy     :     0.059928
+
+  5 C s       :     2.871540  s :     2.871540
+      pz      :     0.844085  p :     2.730806
+      px      :     0.964102
+      py      :     0.922619
+      dz2     :     0.032461  d :     0.184428
+      dxz     :     0.024208
+      dyz     :     0.038059
+      dx2y2   :     0.026702
+      dxy     :     0.062998
+
+  6 C s       :     2.861749  s :     2.861749
+      pz      :     1.027111  p :     3.042450
+      px      :     1.000834
+      py      :     1.014505
+      dz2     :     0.011227  d :     0.107829
+      dxz     :     0.027161
+      dyz     :     0.018404
+      dx2y2   :     0.027865
+      dxy     :     0.023172
+
+  7 H s       :     0.602462  s :     0.602462
+      pz      :     0.068331  p :     0.123576
+      px      :     0.026510
+      py      :     0.028736
+
+  8 H s       :     0.752816  s :     0.752816
+      pz      :     0.026580  p :     0.040098
+      px      :     0.005791
+      py      :     0.007726
+
+  9 H s       :     0.778075  s :     0.778075
+      pz      :     0.007426  p :     0.040488
+      px      :     0.007167
+      py      :     0.025895
+
+ 10 H s       :     0.803455  s :     0.803455
+      pz      :     0.005316  p :     0.039330
+      px      :     0.023050
+      py      :     0.010964
+
+ 11 H s       :     0.779109  s :     0.779109
+      pz      :     0.013738  p :     0.044690
+      px      :     0.007859
+      py      :     0.023093
+
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 O      8.3880     8.0000    -0.3880     1.8663     1.8663    -0.0000
+  1 C      6.2467     6.0000    -0.2467     3.9413     3.9413    -0.0000
+  2 C      5.7008     6.0000     0.2992     3.7032     3.7032     0.0000
+  3 N      7.2048     7.0000    -0.2048     2.7933     2.7933     0.0000
+  4 O      8.3549     8.0000    -0.3549     1.9923     1.9923     0.0000
+  5 C      5.8965     6.0000     0.1035     3.9425     3.9425     0.0000
+  6 C      6.1281     6.0000    -0.1281     3.5243     3.5243     0.0000
+  7 H      0.6847     1.0000     0.3153     0.9016     0.9016     0.0000
+  8 H      0.8247     1.0000     0.1753     0.9452     0.9452     0.0000
+  9 H      0.8472     1.0000     0.1528     0.9472     0.9472     0.0000
+ 10 H      0.8892     1.0000     0.1108     0.9647     0.9647     0.0000
+ 11 H      0.8344     1.0000     0.1656     0.9569     0.9569    -0.0000
+
+  Mayer bond orders larger than 0.100000
+B(  0-O ,  1-C ) :   1.0289 B(  0-O ,  7-H ) :   0.8874 B(  1-C ,  2-C ) :   0.9271 
+B(  1-C ,  8-H ) :   0.9507 B(  1-C ,  9-H ) :   0.9559 B(  2-C ,  3-N ) :   1.7625 
+B(  2-C ,  4-O ) :   0.1022 B(  2-C ,  6-C ) :   0.9430 B(  3-N ,  6-C ) :   0.8539 
+B(  4-O ,  5-C ) :   1.9290 B(  4-O ,  6-C ) :  -0.1180 B(  5-C ,  6-C ) :   0.9605 
+B(  5-C , 10-H ) :   0.9769 B(  6-C , 11-H ) :   0.8867 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.995 sec
+Sum of individual times     ....       0.964 sec  ( 96.9%)
+
+SCF preparation             ....       0.490 sec  ( 49.3%)
+Fock matrix formation       ....       0.355 sec  ( 35.7%)
+  Startup                   ....       0.008 sec  (  2.2% of F)
+  Split-RI-J                ....       0.068 sec  ( 19.1% of F)
+  XC integration            ....       0.252 sec  ( 70.9% of F)
+    Basis function eval.    ....       0.031 sec  ( 12.4% of XC)
+    Density eval.           ....       0.053 sec  ( 21.1% of XC)
+    XC-Functional eval.     ....       0.019 sec  (  7.4% of XC)
+    XC-Potential eval.      ....       0.050 sec  ( 19.7% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.015 sec  (  1.5%)
+Total Energy calculation    ....       0.012 sec  (  1.2%)
+Population analysis         ....       0.020 sec  (  2.0%)
+Orbital Transformation      ....       0.011 sec  (  1.1%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.013 sec  (  1.4%)
+SOSCF solution              ....       0.048 sec  (  4.8%)
+Finished LeanSCF after   1.0 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 13.7 MB
+
+
+-------------------------------------------------------------------------------
+                          DFT DISPERSION CORRECTION                            
+                                                                               
+                                DFTD4 V3.4.0                                   
+-------------------------------------------------------------------------------
+The R2SCAN3C composite method is recognized
+Using three-body term ABC
+Active option DFTDOPT                   ...         5   
+
+-------------------------   ----------------
+Dispersion correction           -0.002883476
+-------------------------   ----------------
+
+------------------   -----------------
+gCP correction             0.006965971
+------------------   -----------------
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY      -360.475560883767
+-------------------------   --------------------
+
+                                *** OPTIMIZATION RUN DONE ***
+
+
+
+           ************************************************************
+           *        Program running with 30 parallel MPI-processes    *
+           *              working on a common directory               *
+           ************************************************************
+
+------------------------------------------------------------------------------
+                              ORCA PROPERTY CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                 ... input.gbw
+Number of atoms                         ...     12
+Number of basis functions               ...    173
+Max core memory                         ...   9800 MB
+
+Electric properties:
+Dipole moment                           ... YES
+Quadrupole moment                       ...  NO
+Static polarizability (Dipole/Dipole)   ...  NO
+Static polarizability (Dipole/Quad.)    ...  NO
+Static polarizability (Quad./Quad.)     ...  NO
+Static polarizability (Velocity)        ...  NO
+
+Atomic electric properties:
+Dipole moment                           ...  NO
+Quadrupole moment                       ...  NO
+Static polarizability                   ...  NO
+
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.265664     0.555421     0.002529
+
+General magnetic properties:
+Magnetizability                         ...  NO
+
+EPR properties:
+g-Tensor (aka g-matrix)                 ...  NO
+Zero-Field splitting spin-orbit         ...  NO
+Zero-field splitting spin-spin          ...  NO
+Hyperfine couplings                     ...  NO (   0 nuclei)
+Quadrupole couplings                    ...  NO (   0 nuclei)
+Contact density                         ...  NO (   0 nuclei)
+
+NMR properties:
+Chemical shifts                         ...  NO (   0 nuclei)
+Spin-rotation constants                 ...  NO (   0 nuclei)
+Spin-spin couplings                     ...  NO (   0 nuclei,    0 pairs)
+
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+
+Properties with geometric perturbations:
+SCF Hessian                             ...  NO
+IR spectrum                             ...  NO
+VCD spectrum                            ...  NO
+X-ray spectroscopy properties:
+SCF XES/XAS/RIXS spectra                ...  NO
+
+
+-------------
+DIPOLE MOMENT
+-------------
+
+Method             : SCF
+Type of density    : Electron Density
+Multiplicity       :   1
+Irrep              :   0
+Energy             :  -360.4796433788754939 Eh
+Relativity type    : 
+Basis              : AO
+                                X                 Y                 Z
+Electronic contribution:      1.433010497       1.992901855      -0.543221907
+Nuclear contribution   :     -1.813702799      -3.610334451       0.243127694
+                        -----------------------------------------
+Total Dipole Moment    :     -0.380692302      -1.617432596      -0.300094213
+                        -----------------------------------------
+Magnitude (a.u.)       :      1.688511584
+Magnitude (Debye)      :      4.291855367
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:             0.206334             0.052199             0.048020 
+Rotational constants in MHz :          6185.733141          1564.891312          1439.600563 
+
+Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.461358    -0.860762    -1.377429 
+x,y,z [Debye]:    -1.172679    -2.187882    -3.501145 
+
+ 
+
+Dipole moment calculation done in   0.0 sec 
+
+Maximum memory used throughout the entire PROP-calculation: 6.5 MB
+
+--------------------------------
+SUGGESTED CITATIONS FOR THIS RUN
+--------------------------------
+
+Below you find a list of papers that are relevant to this ORCA run
+We neither can nor want to force you to cite these papers, but we appreciate if you do
+You receive ORCA, which is the product of decades of hard work by many enthusiastic individuals, for free
+The only thing we kindly ask in return is that you cite our papers,
+We deeply appreciate it, if you show your appreciation for ORCA by not just citing the generic ORCA reference.
+
+Please note that relegating all ORCA citations to the supporting information does *not* help us.
+SI sections are not indexed - citations you put there will not count into any citation statistics
+But we need these citations in order to attract the funding resources that allow us to do what we are doing
+
+Therefore, if you are a happy ORCA user, please consider citing a few of the papers listed below in the main body of your paper
+
+In addition to the list printed below, the program has created the file input.bibtex that contains the list in bibtex format
+You can import this file easily into all common literature databanks and citation aid programs
+
+
+List of essential papers. We consider these as the minimum necessary citations
+
+  1. Neese,F.
+     Software update: the ORCA program system, version 5.0
+     WIRES Comput. Molec. Sci., 2022 12(1)e1606
+     doi.org/10.1002/wcms.1606
+  2. Grimme,S.; Hansen,A.; Ehlert,S.; Mewes,J.
+     r2SCAN-3c: A 'Swiss army knife' composite electronic-structure method
+     J. Chem. Phys., 2021 154 064103
+     doi.org/10.1063/5.0040021
+
+List of papers to cite with high priority. The work reported in these papers was absolutely
+necessary for this run to complete.
+Our perspective: the developers of density functionals and basis sets usually get cited in chemistry papers
+Good! But without the algorithms to do something with them, the functionals or basis sets would not do anything.
+Hence, in our opinion, the algorithm design and method developments papers are equally worthy of getting cited
+
+  1. Neese,F.
+     An improvement of the resolution of the identity approximation for the formation of the Coulomb matrix
+     J. Comp. Chem., 2003 24(14)1740-1747
+     doi.org/10.1002/jcc.10318
+  2. Neese,F.
+     The SHARK Integral Generation and Digestion System
+     J. Comp. Chem., 2022  1-16
+     doi.org/10.1002/jcc.26942
+  3. Lehtola,S.; Steigemann,C.; Oliveira,M.; Marques,M.
+     Recent developments in Libxc - A comprehensive library of functionals for density functional theory
+     Software X, 2018 7 
+     doi.org/10.1016/j.softx.2017.11.002
+  4. Caldeweyher,E.; Bannwarth,C.; Grimme,S.
+     Extension of the D3 dispersion coefficient model
+     J. Chem. Phys., 2017 147 034112-XXXX
+     doi.org/10.1063/1.4993215
+  5. Caldeweyher,E.; Ehlert,S.; Hansen,A.; Neugebauer,H.; Spicher,S.; Bannwarth,C.; Grimme,S.
+     A generally applicable atomic-charge dependent London dispersion correction
+     J. Chem. Phys., 2019 150 154122-XXXX
+     doi.org/10.1063/1.5090222
+  6. Caldeweyher,E.; Mewes,J.; Ehlert,S.; Grimme,S.
+     Extension and evaluation of the D4 London-dispersion model for periodic systems
+     Phys. Chem. Chem. Phys., 2020 22(16)8499-8512
+     doi.org/10.1039/D0CP00502A
+
+List of suggested additional citations. These are papers that are important in the 'surrounding' of 
+of this run, or papers that preceded the highly important papers. If you like your results we are grateful for a citation.
+
+  1. Neese,F.
+     The ORCA program system
+     WIRES Comput. Molec. Sci., 2012 2(1)73-78
+     doi.org/10.1002/wcms.81
+  2. Neese,F.
+     Software update: the ORCA program system, version 4.0
+     WIRES Comput. Molec. Sci., 2018 8(1)1-6
+     doi.org/10.1002/wcms.1327
+  3. Neese,F.; Wennmohs,F.; Becker,U.; Riplinger,C.
+     The ORCA quantum chemistry program package
+     J. Chem. Phys., 2020 152 Art. No. L224108
+     doi.org/10.1063/5.0004608
+
+List of optional additional citations
+
+  1. Neese,F.
+     Approximate second-order SCF convergence for spin unrestricted wavefunctions
+     Chem. Phys. Lett., 2000 325(1-3)93-98
+     doi.org/10.1016/s0009-2614(00)00662-x
+
+Timings for individual modules:
+
+Sum of individual times          ...       50.097 sec (=   0.835 min)
+Startup calculation              ...       12.499 sec (=   0.208 min)  24.9 %
+SCF iterations                   ...       26.184 sec (=   0.436 min)  52.3 %
+Property calculations            ...        0.905 sec (=   0.015 min)   1.8 %
+SCF Gradient evaluation          ...       10.476 sec (=   0.175 min)  20.9 %
+Geometry relaxation              ...        0.033 sec (=   0.001 min)   0.1 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 59 seconds 980 msec


### PR DESCRIPTION
**Stack 4/5** — based on #953. This is the payoff of the stack.

## What

`check_irc_species_and_rxn()` takes optional `log_path_1` / `log_path_2` and prefers connectivity derived from the computed Mayer bond orders. The existing distance-based perception and the bond-list comparison remain as ordered fallbacks.

No new plumbing was needed in the scheduler: `check_irc_species()` already passes `output[label]['paths']['geo']`, which *is* the path to the log file of the IRC endpoint's re-optimization job.

## Why it matters — measured, not asserted

For a real isoxazole → 2H-azirine ring opening, with both endpoints optimized in Orca and both logs added as fixtures:

| path | verdict |
| --- | --- |
| distance-based (today) | `False` |
| Mayer bond orders | `True` |

The distance heuristic mis-perceives the strained three-membered ring of the product, so a correct TS would have been rejected. Both verdicts are pinned as assertions in the test, so the contrast is a regression guard rather than a claim in a description.

## Behaviour when bond orders are unavailable

Unchanged. Older logs, an ESS that does not report a Mayer analysis, a `None` path or a nonexistent file all fall through to exactly today's code path. The existing `test_check_irc_species_and_rxn` passes untouched.

## Why the endpoints' opt logs and not the IRC logs

Gaussian prints the Mayer block at the final population analysis, so an `opt` log has it for the converged geometry while an `irc` log may not have it per point. ARC already re-optimizes both IRC endpoints as `IRC_<label>_1/2` species in `spawn_post_irc_jobs()`, so those logs are the natural source and are already tracked.

## Conflict note

#937 and #938 also touch `arc/checks/ts.py` and `arc/checks/ts_test.py` around the IRC check. Whichever lands first, this will need a rebase — the changes are adjacent rather than contradictory.

## Testing

`pytest arc/checks/` — 50 passed, 2 failed. Both failures are the pre-existing `test_check_rxn_e0` / `test_compute_rxn_e0`, which fail identically on `main` (Arkane cannot import `pybel` in `rmg_env` here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
