### PR TITLE
Add a TS bond order check

### DIFF
--- a/arc/checks/ts.py
+++ b/arc/checks/ts.py
@@ -9,7 +9,10 @@ import numpy as np
 from typing import TYPE_CHECKING
 
 from arc.parser import parser
-from arc.checks.nmd import analyze_ts_normal_mode_displacement
+from arc.checks.nmd import (analyze_ts_normal_mode_displacement,
+                            find_equivalent_atoms,
+                            get_eq_formed_and_broken_bonds,
+                            )
 from arc.common import (ARC_PATH,
                         convert_list_index_0_to_1,
                         extremum_list,
@@ -18,6 +21,7 @@ from arc.common import (ARC_PATH,
                         read_yaml_file,
                         sum_list_entries,
                         )
+from arc.exceptions import ReactionError
 from arc.imports import settings
 from arc.species.converter import check_isomorphism, check_xyz_dict, mol_from_dft, xyz_from_data, xyz_to_dmat
 from arc.species.perceive import perceive_molecule_from_xyz
@@ -34,6 +38,11 @@ logger = get_logger()
 
 MAX_IRC_FRAGMENTS_FOR_CHARGE_SEARCH = 4
 LOWEST_MAJOR_TS_FREQ, HIGHEST_MAJOR_TS_FREQ = settings['LOWEST_MAJOR_TS_FREQ'], settings['HIGHEST_MAJOR_TS_FREQ']
+# The Mayer bond order range within which a bond is considered partially formed at a TS.
+TS_PARTIAL_BOND_MIN, TS_PARTIAL_BOND_MAX = 0.15, 0.85
+# TS checks that are reported but do not determine whether a TS is accepted. The bond order thresholds
+# above are heuristic, and an early or a late TS may legitimately fall outside of them.
+NON_BLOCKING_TS_CHECKS = ['BO']
 
 
 def check_ts(reaction: ARCReaction,
@@ -60,7 +69,7 @@ def check_ts(reaction: ARCReaction,
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
         job (JobAdapter, optional): The frequency job object instance.
-        checks (list[str], optional): Specific checks to run. Optional values: 'energy', 'NMD', 'IRC', 'rotors'.
+        checks (list[str], optional): Specific checks to run. Optional values: 'energy', 'NMD', 'BO', 'IRC', 'rotors'.
         rxn_zone_atom_indices (list[int], optional): The 0-indices of atoms identified by the normal mode displacement
                                                      as the reaction zone. Automatically determined if not given.
         species_dict (dict, optional): The Scheduler species dictionary.
@@ -74,8 +83,8 @@ def check_ts(reaction: ARCReaction,
     """
     checks = checks or list()
     for entry in checks:
-        if entry not in ['energy', 'NMD', 'IRC', 'rotors']:
-            raise ValueError(f"Requested checks could be 'energy', 'IRC', 'NMD', or 'rotors', got:\n{checks}")
+        if entry not in ['energy', 'NMD', 'BO', 'IRC', 'rotors']:
+            raise ValueError(f"Requested checks could be 'energy', 'IRC', 'NMD', 'BO', or 'rotors', got:\n{checks}")
 
     if 'energy' in checks:
         if not reaction.ts_species.ts_checks['E0']:
@@ -97,6 +106,10 @@ def check_ts(reaction: ARCReaction,
             logger.warning(f'Skipping failed normal mode displacement check for TS {reaction.ts_species.label}')
             reaction.ts_species.ts_checks['NMD'] = True
 
+    # Use .get(), a TS restarted from a project that predates this check has no 'BO' key.
+    if 'BO' in checks and not reaction.ts_species.ts_checks.get('BO'):
+        check_bond_orders(reaction, job=job, verbose=verbose)
+
     if 'rotors' in checks or (ts_passed_checks(species=reaction.ts_species, exemptions=['E0', 'warnings', 'IRC'])
                               and job is not None):
         invalidate_rotors_with_both_pivots_in_a_reactive_zone(reaction, job,
@@ -109,6 +122,7 @@ def ts_passed_checks(species: ARCSpecies,
                      ) -> bool:
     """
     Check whether the TS species passes all checks other than ones specified in ``exemptions``.
+    The checks listed in ``NON_BLOCKING_TS_CHECKS`` are always exempted.
 
     Args:
         species (ARCSpecies): The TS species.
@@ -118,7 +132,7 @@ def ts_passed_checks(species: ARCSpecies,
     Returns:
         bool: Whether the TS species passed all checks.
     """
-    exemptions = exemptions or list()
+    exemptions = (exemptions or list()) + NON_BLOCKING_TS_CHECKS
     for check, value in species.ts_checks.items():
         if check not in exemptions and not value and not (check == 'e_elect' and species.ts_checks['E0']):
             if verbose:
@@ -301,6 +315,77 @@ def check_normal_mode_displacement(reaction: ARCReaction,
                                                                                job=job,
                                                                                amplitude=amplitude,
                                                                                )
+
+
+def check_bond_orders(reaction: ARCReaction,
+                      job: 'JobAdapter | None' = None,
+                      verbose: bool = True,
+                      ) -> None:
+    """
+    Check that the computed Mayer bond orders at the TS geometry are consistent with the reaction.
+
+    At a transition state the bonds that are formed and broken are only partially formed, so their bond
+    orders are expected to be significantly lower than a single bond, yet not negligible. Unlike the normal
+    mode displacement check, this considers the electron density at the TS geometry alone, and does not
+    depend on the imaginary mode. Populates the ``'BO'`` entry of the ``TS.ts_checks`` dictionary.
+
+    This check only rejects a TS on positive evidence: if the bond orders cannot be determined
+    (e.g., the ESS did not report them, or the reaction has no atom map), the check passes with a warning.
+    Its result is currently reported but not acted upon: ``'BO'`` is listed in ``NON_BLOCKING_TS_CHECKS``,
+    and unlike a failed NMD check it does not trigger a TS switch.
+
+    Args:
+        reaction (ARCReaction): The reaction for which the TS is checked.
+        job (JobAdapter, optional): The frequency job object instance.
+        verbose (bool, optional): Whether to log findings.
+    """
+    ts_species = reaction.ts_species
+
+    def pass_with_warning(message: str) -> None:
+        ts_species.ts_checks['BO'] = True
+        if message not in ts_species.ts_checks.get('warnings', ''):
+            ts_species.ts_checks['warnings'] = ts_species.ts_checks.get('warnings', '') + message
+        if verbose:
+            logger.info(f'Skipping the bond order check for TS {ts_species.label}: {message}')
+
+    if job is None:
+        pass_with_warning('Could not check bond orders, no frequency job; ')
+        return
+    bond_orders = parser.parse_bond_orders(log_file_path=job.local_path_to_output_file)
+    if bond_orders is None:
+        pass_with_warning('Could not parse Mayer bond orders; ')
+        return
+    if bond_orders.shape[0] != sum(spc.number_of_atoms for spc in reaction.r_species):
+        pass_with_warning('The number of atoms in the TS does not match the reactants; ')
+        return
+    try:
+        formed_bonds, broken_bonds = reaction.get_formed_and_broken_bonds()
+        changed_bonds = reaction.get_changed_bonds()
+    except (ReactionError, ValueError, IndexError):
+        pass_with_warning('Could not determine the formed and broken bonds; ')
+        return
+    if not formed_bonds and not broken_bonds:
+        pass_with_warning('The reaction has no formed or broken bonds; ')
+        return
+
+    r_eq_atoms, _ = find_equivalent_atoms(reaction=reaction, reactant_only=True)
+    options = get_eq_formed_and_broken_bonds(formed_bonds=formed_bonds,
+                                             broken_bonds=broken_bonds,
+                                             changed_bonds=changed_bonds,
+                                             r_eq_atoms=r_eq_atoms,
+                                             ) or [(formed_bonds, broken_bonds, changed_bonds)]
+    for eq_formed_bonds, eq_broken_bonds, _ in options:
+        if all(TS_PARTIAL_BOND_MIN <= bond_orders[i, j] <= TS_PARTIAL_BOND_MAX
+               for i, j in eq_formed_bonds + eq_broken_bonds):
+            ts_species.ts_checks['BO'] = True
+            return
+    ts_species.ts_checks['BO'] = False
+    if verbose:
+        logger.info(f'TS {ts_species.label} did not pass the bond order check. No assignment of the bonds '
+                    f'expected to change has all of its Mayer bond orders between {TS_PARTIAL_BOND_MIN} and '
+                    f'{TS_PARTIAL_BOND_MAX}. For the atom-mapped assignment they are:\n'
+                    f'formed: {[(bond, round(float(bond_orders[bond[0], bond[1]]), 4)) for bond in formed_bonds]}\n'
+                    f'broken: {[(bond, round(float(bond_orders[bond[0], bond[1]]), 4)) for bond in broken_bonds]}')
 
 
 def determine_changing_bond(bond: tuple[int, ...],

--- a/arc/checks/ts_test.py
+++ b/arc/checks/ts_test.py
@@ -683,6 +683,48 @@ class TestTSChecks(unittest.TestCase):
                                      )
         self.assertTrue(rxn.ts_species.ts_checks['IRC'])
 
+    def test_check_bond_orders(self):
+        """Test the check_bond_orders() function."""
+        # The Orca TS of CH4 + OH <=> CH3 + H2O. The migrating H atom has Mayer bond orders of 0.62 to C
+        # and 0.36 to O, both partial. Note that the atom map assigns a different, equivalent, methane H
+        # atom, so this only passes when equivalent atoms are considered.
+        path_1 = os.path.join(ARC_TESTING_PATH, 'freq', 'orca_neg_freq_ts.out')
+        self.job1.local_path_to_output_file = path_1
+        rxn_1 = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'), ARCSpecies(label='CH4', smiles='C')],
+                            p_species=[ARCSpecies(label='H2O', smiles='O'), ARCSpecies(label='CH3', smiles='[CH3]')])
+        rxn_1.ts_species = ARCSpecies(label='TS', is_ts=True, xyz=parse_geometry(path_1))
+        rxn_1.ts_species.populate_ts_checks()
+        self.assertIsNone(rxn_1.ts_species.ts_checks['BO'])
+        ts.check_bond_orders(rxn_1, job=self.job1)
+        self.assertTrue(rxn_1.ts_species.ts_checks['BO'])
+        self.assertEqual(rxn_1.ts_species.ts_checks['warnings'], '')
+
+        # An optimized formaldehyde geometry is not the TS of CH2O <=> H2 + CO: the H-H bond that should be
+        # forming has a Mayer bond order of 0, and the C-H bonds that should be breaking are still 0.89.
+        path_2 = os.path.join(ARC_TESTING_PATH, 'orca_example_opt.log')
+        self.job1.local_path_to_output_file = path_2
+        rxn_2 = ARCReaction(r_species=[ARCSpecies(label='CH2O', smiles='C=O', xyz=parse_geometry(path_2))],
+                            p_species=[ARCSpecies(label='H2', smiles='[H][H]'),
+                                       ARCSpecies(label='CO', smiles='[C-]#[O+]')])
+        rxn_2.ts_species = ARCSpecies(label='TS', is_ts=True, xyz=parse_geometry(path_2))
+        rxn_2.ts_species.populate_ts_checks()
+        ts.check_bond_orders(rxn_2, job=self.job1)
+        self.assertFalse(rxn_2.ts_species.ts_checks['BO'])
+
+        # The check must never block a TS when the bond orders are unavailable.
+        self.job1.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'composite',
+                                                           'TS_intra_H_migration_CBS-QB3.out')
+        self.rxn_2a.ts_species.populate_ts_checks()
+        ts.check_bond_orders(self.rxn_2a, job=self.job1)
+        self.assertTrue(self.rxn_2a.ts_species.ts_checks['BO'])
+        self.assertIn('Could not parse Mayer bond orders', self.rxn_2a.ts_species.ts_checks['warnings'])
+
+        self.rxn_2a.ts_species.populate_ts_checks()
+        ts.check_bond_orders(self.rxn_2a, job=None)
+        self.assertTrue(self.rxn_2a.ts_species.ts_checks['BO'])
+        self.assertIn('no frequency job', self.rxn_2a.ts_species.ts_checks['warnings'])
+        self.rxn_2a.ts_species.populate_ts_checks()
+
     def test_check_irc_species_and_rxn_using_bond_orders(self):
         """Test that check_irc_species_and_rxn() uses the computed Mayer bond orders when log files are given."""
         # An isoxazole ring opening, both endpoints were optimized with Orca and hold Mayer bond orders.

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2714,7 +2714,7 @@ class Scheduler(object):
             if self.species_dict[label].rxn_index in self.rxn_dict.keys():
                 check_ts(reaction=self.rxn_dict[self.species_dict[label].rxn_index],
                          job=job,
-                         checks=['NMD'],
+                         checks=['NMD', 'BO'],
                          skip_nmd=self.skip_nmd,
                          )
             if self.species_dict[label].ts_checks['NMD'] is False:

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -2223,7 +2223,7 @@ class ARCSpecies(object):
     def populate_ts_checks(self):
         """Populate (or restart) the .ts_checks attribute with default (``None``) values."""
         if self.is_ts:
-            keys = ['E0', 'e_elect', 'IRC', 'freq', 'NMD']
+            keys = ['E0', 'e_elect', 'IRC', 'freq', 'NMD', 'BO']
             self.ts_checks = {key: None for key in keys}
             self.ts_checks['warnings'] = ''
 


### PR DESCRIPTION
**Stack 5/5** — based on #954.

## What

`check_bond_orders()` — a TS check that uses the electron density at the TS geometry alone, independent of the imaginary mode.

Every bond in `get_formed_and_broken_bonds()` must have a Mayer bond order inside `[TS_PARTIAL_BOND_MIN, TS_PARTIAL_BOND_MAX]` = `[0.15, 0.85]`: partially formed, neither fully bonded nor absent. Populates `ts_checks['BO']`.

Symmetry-equivalent atoms are handled by reusing NMD's `find_equivalent_atoms()` and `get_eq_formed_and_broken_bonds()`. That is not decoration — for CH4 + OH the atom map picks a different, equivalent methane hydrogen than the one actually in transit, so the check only passes once the equivalent assignments are tried.

## Validated on

- **CH4 + OH ⇌ CH3 + H2O**, Orca TS already in the repo: the migrating H has Mayer orders of 0.62 to C and 0.36 to O → **passes**.
- **An optimized formaldehyde geometry offered as the TS of CH2O ⇌ H2 + CO**: the H–H that should be forming is 0.00 and the two C–H that should be breaking are 0.89 → **rejected**.

## Deliberately non-blocking — please push back if you disagree

`'BO'` is listed in the new `NON_BLOCKING_TS_CHECKS`, which `ts_passed_checks()` always exempts, and a failed BO does **not** trigger `switch_ts()` the way a failed NMD does.

The reasoning: the thresholds are heuristic, and an early or late TS can legitimately place a breaking bond above 0.85 — a strongly exothermic abstraction is the obvious case. Rejecting real TSs on an uncalibrated band is worse than reporting the verdict and leaving it visible in `ts_checks`. Promoting it to a gate is removing one list entry, once the band has been checked against a body of known-good TSs.

The check can only ever reject on positive evidence. No Mayer data in the log, no atom map, no formed or broken bonds — each passes with a note appended to `ts_checks['warnings']`.

## Restart safety

A TS restored from a project predating this PR has no `'BO'` key, because `populate_ts_checks()` does not re-run once any check has a value. `check_ts()` therefore reads it with `.get()`, and `ts_passed_checks()` iterates whatever keys exist, so the missing key is simply exempt. Old projects neither crash nor stall.

## Conflict note

Same as #954 — #937 and #938 also touch `arc/checks/ts.py` and `ts_test.py`.

## Testing

`pytest arc/checks/ arc/species/species_test.py` — 129 passed, 2 failed (the pre-existing Arkane `pybel` failures, identical on `main`).

Full suite for the whole stack: **2513 passed, 14 failed**. All 14 were reproduced on `main` in the same environment — torchani not installed, no xtb binary, and Arkane's `pybel` import in `rmg_env`. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
