### PR TITLE
Fix the Cython build with setuptools 84 (unhashable Extension)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import sys
 import os
-from collections import OrderedDict
 
 try:
     from setuptools import setup, find_packages
@@ -59,9 +58,6 @@ ext_modules = [
 if 'main' in sys.argv:
     # This is for `python setup.py build_ext main`
     sys.argv.remove('main')
-    ext_modules.extend(ext_modules)
-
-ext_modules = list(OrderedDict.fromkeys(ext_modules))
 
 
 setup(


### PR DESCRIPTION
Fixes the scheduled CI failure in [run 31349161224](https://github.com/ReactionMechanismGenerator/ARC/actions/runs/31349161224/job/93336632698), where `make compile` dies before compiling anything:

```
Compiling ARC's Cython module (arc.molecule)…
python setup.py build_ext main --inplace --build-temp .
Traceback (most recent call last):
  File "setup.py", line 64, in <module>
    ext_modules = list(OrderedDict.fromkeys(ext_modules))
TypeError: unhashable type: 'Extension'
make: *** [Makefile:130: compile] Error 1
```

## Cause

`arc_env` now resolves to **setuptools 84.0.0**, which makes `setuptools.extension.Extension` unhashable. `OrderedDict.fromkeys()` needs hashable keys, so the de-duplication on line 64 raises.

This is environment drift, not a code change — nothing in ARC moved. It reproduces on any machine that resolves setuptools ≥ 84 and passes on older ones, which is why it surfaced on the nightly schedule rather than on a PR.

## Fix

The two lines involved were a no-op that only existed to undo each other:

```python
if 'main' in sys.argv:
    sys.argv.remove('main')
    ext_modules.extend(ext_modules)      # duplicates every extension

ext_modules = list(OrderedDict.fromkeys(ext_modules))   # removes the duplicates again
```

`extend` appends the *same objects*, so with identity hashing `fromkeys` strips exactly what `extend` added and the list comes back unchanged. Verified explicitly — with 4 extensions the list goes 4 → 8 → 4 and compares equal to the original.

Both lines are removed. The `sys.argv.remove('main')` stays, since it is what lets `python setup.py build_ext main --inplace` work (the form the Makefile uses); without it setuptools rejects `main` as an unknown command.

Note that removing only line 64 would have been a real bug: every extension would then be compiled twice.

## Verification

- Executed `setup.py`'s prologue with `Extension.__hash__` forced to `None` to emulate setuptools 84: fails with the exact CI `TypeError` before the change, and after it yields 15 unique extensions with `main` correctly stripped from `argv`.
- Ran the actual `python setup.py build_ext main --inplace --build-temp .` locally — all 15 modules build and are copied into the tree.
- `pytest arc/molecule/ arc/species/converter_test.py` against the rebuilt extensions — 651 passed.

## Follow-up worth considering separately

CI does not pin setuptools, so the version can move under the project again. If that is a concern, pinning it in the environment file would be the durable fix; this PR deliberately only removes the dependency on hashability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
