### PR TITLE
Fix species copy graph fidelity

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -865,7 +865,10 @@ class ARCSpecies(object):
 
     def from_dict(self, species_dict):
         """
-        A helper function for loading this object from a dictionary in a YAML file for restarting ARC
+        A helper function for loading this object from a dictionary in a YAML file for restarting ARC.
+
+        The 2D graph is taken from the dictionary as-is whenever it was serialized by ``as_dict()``
+        (see ``dict_repr_is_authoritative()``), and is otherwise perceived from the coordinates.
         """
         try:
             self.label = species_dict['label']
@@ -962,9 +965,9 @@ class ARCSpecies(object):
                 self.mol = rmg_mol_from_inchi(inchi)
             elif smiles is not None:
                 self.mol = Molecule(smiles=smiles)
-        # Perceive molecule from xyz coordinates. This also populates the .mol attribute of the Species.
-        # It overrides self.mol generated from adjlist or smiles so xyz and mol will have the same atom order.
-        if self.final_xyz or self.initial_xyz or self.most_stable_conformer or self.conformers or self.ts_guesses:
+        if not dict_repr_is_authoritative(species_dict, mol=self.mol) \
+                and (self.final_xyz or self.initial_xyz or self.most_stable_conformer
+                     or self.conformers or self.ts_guesses):
             self.mol_from_xyz(get_cheap=False)
         if self.mol is not None:
             if 'bond_corrections' not in species_dict and not self.is_ts:
@@ -3392,6 +3395,30 @@ def split_mol(mol: Molecule) -> tuple[list[Molecule], list[list[int]]]:
         molecules.append(Molecule(atoms=[mol.atoms[index] for index in frag_indices]))
         fragments.append(frag_indices)
     return molecules, fragments
+
+
+def dict_repr_is_authoritative(species_dict: dict,
+                               mol: Molecule | None = None,
+                               ) -> bool:
+    """
+    Check whether the 2D graph of a species dictionary supersedes a graph perceived from the coordinates.
+
+    It does when the dictionary carries a ``rmg_mol_to_dict_repr()`` mapping under the 'mol' key,
+    which is written by ``ARCSpecies.as_dict()`` and stores the connectivity, the bond orders,
+    the formal charges, the radical counts and the atom order of an existing object instance.
+    It does not for a structure given as SMILES, InChI, or an adjacency list (including an
+    adjacency list stored under the 'mol' key). It also does not when the atom IDs of ``mol``
+    are not unique, which is how a mapping that ``rmg_mol_from_dict_repr()`` could not decode
+    into a molecule presents itself.
+
+    Args:
+        species_dict (dict): The dictionary representation of an ARCSpecies object instance.
+        mol (Molecule, optional): The graph read from ``species_dict``, if any.
+
+    Returns:
+        bool: Whether the dictionary's 2D graph supersedes a graph perceived from the coordinates.
+    """
+    return isinstance(species_dict.get('mol'), dict) and mol is not None and mol.atom_ids_valid()
 
 
 def rmg_mol_from_dict_repr(representation: dict,

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from arc.common import (ARC_PATH,
                         ARC_TESTING_PATH,
@@ -38,6 +39,7 @@ from arc.species.species import (ARCSpecies,
                                  colliding_atoms,
                                  determine_rotor_symmetry,
                                  determine_rotor_type,
+                                 dict_repr_is_authoritative,
                                  process_run_time,
                                  rmg_mol_from_dict_repr,
                                  rmg_mol_to_dict_repr,
@@ -1561,6 +1563,111 @@ H      -1.67091600   -1.35164600   -0.93286400"""
         self.assertEqual(spc_1_copy.get_xyz()['symbols'], spc_1.get_xyz()['symbols'])
         self.assertEqual(spc_1_copy.mol.to_smiles(), spc_1.mol.to_smiles())
         atom_labels = [atom.label for atom in spc_1_copy.mol.atoms]
+
+    def test_copy_preserves_the_declared_lewis_structure(self):
+        """Test that copy() does not replace a declared graph with a charge-separated perception of the coordinates."""
+        isoxazole_xyz = """C      -1.09437451   -0.03845088    0.00235099
+                           C       0.00327326    0.77917425   -0.06526477
+                           C       1.08963190   -0.10993209    0.01007451
+                           N       0.69216257   -1.38022824    0.11616468
+                           O      -0.69387336   -1.33034168    0.11088427
+                           H      -2.16236830    0.11977522   -0.01175166
+                           H       0.01690055    1.85420986   -0.15530407
+                           H       2.14864790    0.10579356   -0.00715396"""
+        zwitterion_adjlist = """1 C u0 p0 c0 {2,S} {5,D} {6,S}
+                                2 C u0 p0 c0 {1,S} {3,D} {7,S}
+                                3 C u0 p0 c0 {2,D} {4,S} {8,S}
+                                4 N u0 p2 c-1 {3,S} {5,S}
+                                5 O u0 p1 c+1 {1,D} {4,S}
+                                6 H u0 p0 c0 {1,S}
+                                7 H u0 p0 c0 {2,S}
+                                8 H u0 p0 c0 {3,S}"""
+        spc = ARCSpecies(label='isoxazole', smiles='c1ccno1')
+        spc.final_xyz = str_to_xyz(isoxazole_xyz)
+        self.assertEqual(spc.mol.copy(deep=True).to_smiles(), 'c1ccno1')
+        with mock.patch('arc.species.species.perceive_molecule_from_xyz',
+                        side_effect=lambda *args, **kwargs: Molecule().from_adjacency_list(
+                            zwitterion_adjlist, raise_atomtype_exception=False,
+                            raise_charge_exception=False)) as perceive:
+            spc_copy = spc.copy()
+        perceive.assert_not_called()
+        self.assertEqual(spc_copy.mol.copy(deep=True).to_smiles(), 'c1ccno1')
+        self.assertTrue(check_isomorphism(spc.mol, spc_copy.mol))
+        self.assertEqual([atom.charge for atom in spc_copy.mol.atoms], [0] * 8)
+
+    def test_copy_preserves_the_declared_connectivity(self):
+        """
+        Test that copy() does not replace a declared graph with a differently bonded perception of the coordinates.
+
+        The injected ring closure stands in for the one measured in benchmark reaction_018, where a 1.476 A
+        contact in the product geometry closed a fourth ring. It is not a claim about butadiene: the C1...C4
+        distance of the s-trans geometry below is ~3.7 A, and no perception closes that ring.
+        """
+        butadiene_xyz = """C      -1.81799082   -0.22530589   -0.06165892
+                           C      -0.60325740    0.30083878   -0.25569759
+                           C       0.60325739   -0.30083877    0.25569760
+                           C       1.81799082    0.22530592    0.06165897
+                           H      -1.96812252   -1.14370732    0.49678746
+                           H      -2.69975248    0.26231344   -0.46539902
+                           H      -0.51116237    1.22426578   -0.82376453
+                           H       0.51116237   -1.22426580    0.82376450
+                           H       2.69975247   -0.26231341    0.46539906
+                           H       1.96812251    1.14370738   -0.49678738"""
+        cyclobutene_adjlist = """1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+                                 2  C u0 p0 c0 {1,S} {3,D} {7,S}
+                                 3  C u0 p0 c0 {2,D} {4,S} {8,S}
+                                 4  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+                                 5  H u0 p0 c0 {1,S}
+                                 6  H u0 p0 c0 {1,S}
+                                 7  H u0 p0 c0 {2,S}
+                                 8  H u0 p0 c0 {3,S}
+                                 9  H u0 p0 c0 {4,S}
+                                 10 H u0 p0 c0 {4,S}"""
+        spc = ARCSpecies(label='butadiene', smiles='C=CC=C')
+        spc.final_xyz = str_to_xyz(butadiene_xyz)
+        self.assertEqual(len(spc.mol.get_all_edges()), 9)
+        with mock.patch('arc.species.species.perceive_molecule_from_xyz',
+                        side_effect=lambda *args, **kwargs: Molecule().from_adjacency_list(
+                            cyclobutene_adjlist, raise_atomtype_exception=False,
+                            raise_charge_exception=False)) as perceive:
+            spc_copy = spc.copy()
+        perceive.assert_not_called()
+        self.assertEqual(len(spc_copy.mol.get_all_edges()), 9)
+        self.assertEqual(spc_copy.mol.copy(deep=True).to_smiles(), 'C=CC=C')
+        self.assertTrue(check_isomorphism(spc.mol, spc_copy.mol))
+
+    def test_from_dict_perceives_the_graph_of_a_user_specified_structure(self):
+        """Test that from_dict() still perceives the graph when the structure is given as SMILES alongside xyz."""
+        scrambled_ethanol_xyz = """H      -1.42607526    0.68990357   -0.87225712
+                                   C      -0.98261300   -0.04502183    0.00436374
+                                   H      -1.39610270   -1.05737434   -0.02205278
+                                   H      -1.28565463    0.40890627    0.94943929
+                                   C       0.54008765    0.06694671   -0.10188014
+                                   H       0.85567615   -0.38455771   -1.04688865
+                                   H       0.95870245   -0.46330826    0.75955514
+                                   O       0.96361397    1.42484824   -0.03556676
+                                   H       1.91807512    1.45143902   -0.11029272"""
+        species_dict = {'label': 'ethanol', 'smiles': 'CCO', 'multiplicity': 1,
+                        'xyz': scrambled_ethanol_xyz}
+        spc = ARCSpecies(species_dict=species_dict)
+        self.assertEqual([atom.element.symbol for atom in spc.mol.atoms],
+                         list(spc.get_xyz()['symbols']))
+        self.assertTrue(check_isomorphism(spc.mol, Molecule(smiles='CCO')))
+
+    def test_from_dict_perceives_the_graph_without_a_declared_structure(self):
+        """Test that from_dict() still perceives the graph when only coordinates are given."""
+        species_dict = {'label': 'ethanol', 'multiplicity': 1,
+                        'xyz': """C      -0.97459464    0.29181710    0.10303882
+                                  C       0.39565894   -0.35143697    0.10221676
+                                  O       0.30253309   -1.63748590   -0.49196889
+                                  H      -1.68942501   -0.24618907   -0.51173648
+                                  H      -0.93861751    1.30890182   -0.28407958
+                                  H      -1.35943743    0.34098805    1.12546267
+                                  H       0.76858330   -0.46867535    1.12508303
+                                  H       1.10530896    0.26674355   -0.44244914
+                                  H       1.19023282   -2.03119348   -0.44235175"""}
+        spc = ARCSpecies(species_dict=species_dict)
+        self.assertTrue(check_isomorphism(spc.mol, Molecule(smiles='CCO')))
 
     def test_is_water(self):
         """Test the ARCSpecies.is_water() method."""
@@ -3324,6 +3431,39 @@ H      -1.47626400   -0.10694600   -1.88883800"""
         representation = rmg_mol_to_dict_repr(mol)
         new_mol = rmg_mol_from_dict_repr(representation, is_ts=False)
         self.assertEqual(new_mol.to_smiles(), 'CC')
+
+    def test_dict_repr_is_authoritative(self):
+        """Test the dict_repr_is_authoritative() function.
+
+        The ``mol`` argument is the graph decoded from the dictionary, as ``from_dict()`` passes it.
+        """
+        mol = Molecule(smiles='CC')
+        representation = rmg_mol_to_dict_repr(mol)
+        self.assertTrue(dict_repr_is_authoritative({'mol': representation},
+                                                   mol=rmg_mol_from_dict_repr(representation)))
+        self.assertFalse(dict_repr_is_authoritative({'mol': mol.to_adjacency_list()}, mol=mol))
+        self.assertFalse(dict_repr_is_authoritative({'smiles': 'CC'}, mol=mol))
+        self.assertFalse(dict_repr_is_authoritative({'adjlist': mol.to_adjacency_list()}, mol=mol))
+        self.assertFalse(dict_repr_is_authoritative({'mol': representation}, mol=None))
+
+        colliding_mol = Molecule(smiles='CCO')
+        colliding_mol.assign_atom_ids()
+        colliding_mol.atoms[-1].id = colliding_mol.atoms[0].id
+        colliding_repr = rmg_mol_to_dict_repr(colliding_mol)
+        self.assertEqual(colliding_repr['atom_order'][-1], colliding_repr['atom_order'][0])
+        decoded = rmg_mol_from_dict_repr(colliding_repr)
+        self.assertEqual(len(decoded.atoms), 9)
+        self.assertEqual(len(set(id(atom) for atom in decoded.atoms)), 8)
+        self.assertFalse(dict_repr_is_authoritative({'mol': colliding_repr}, mol=decoded))
+
+        degenerate_repr = rmg_mol_to_dict_repr(mol)
+        for atom_dict in degenerate_repr['atoms']:
+            atom_dict['id'] = -1
+            atom_dict['edges'] = {-1: 1.0}
+        degenerate_repr['atom_order'] = [-1] * len(degenerate_repr['atom_order'])
+        degenerate_mol = rmg_mol_from_dict_repr(degenerate_repr, is_ts=True)
+        self.assertEqual(len(set(id(atom) for atom in degenerate_mol.atoms)), 1)
+        self.assertFalse(dict_repr_is_authoritative({'mol': degenerate_repr}, mol=degenerate_mol))
 
     def test_rmg_mol_to_dict_repr(self):
         """Test the rmg_mol_to_dict_repr() function."""

--- a/docs/source/input_reference.rst
+++ b/docs/source/input_reference.rst
@@ -114,6 +114,20 @@ Identity and structure:
 * ``mol`` - RMG Molecule object when using the Python API.
 * ``species_dict`` - dictionary representation used in restarts/API workflows.
 
+.. note::
+
+    When a species is given as a dictionary (a ``species_dict``, or a mapping in the ``species`` list of the
+    input file) whose ``mol`` key holds a serialized graph - the nested mapping of atoms, edges and
+    ``atom_order`` that ARC writes to ``restart.yml``, not an adjacency list string - that graph is used as
+    given and is not re-perceived from the coordinates. This keeps a restarted or copied species identical to
+    the one that was saved, since perception may return a different resonance structure or connectivity for
+    the same coordinates.
+
+    Copying a ``mol`` block out of a restart file and into an input file therefore carries its bond orders,
+    formal charges and atom order into the new run, including into rotor identification, bond corrections and
+    atom mapping, and coordinates that disagree with it are no longer rejected at load time. Give ``smiles``,
+    ``inchi`` or ``adjlist`` instead to have the graph perceived from the coordinates.
+
 Charge, spin, and TS metadata:
 
 * ``charge`` - integer charge.
@@ -146,7 +160,8 @@ Conformers, rotors, and geometry controls:
 * ``external_symmetry`` - external symmetry number.
 * ``optical_isomers`` - number of optical isomers.
 * ``multi_species`` - multi-species label.
-* ``keep_mol`` - preserve the molecule object.
+* ``keep_mol`` - preserve the molecule object, i.e., keep the given 2D graph instead of the one perceived from
+  the coordinates. Not needed for a serialized ``mol`` graph, which is kept regardless (see the note above).
 * ``project_directory`` - species-specific project directory metadata.
 
 Reaction Entries


### PR DESCRIPTION
This pull request introduces a new mechanism for handling species graph perception from input dictionaries, ensuring that serialized 2D molecular graphs are preserved when explicitly provided. This prevents unwanted changes to molecular connectivity or resonance structures during restarts or copy operations. The changes include a new utility function, updates to the main logic in `from_dict`, comprehensive tests, and improved documentation.

**Core logic improvements:**

* Added the `dict_repr_is_authoritative` function to determine if a species dictionary's `mol` key contains a serialized graph that should be used as-is, rather than re-perceiving the structure from coordinates.
* Updated the `from_dict` method in `ARCSpecies` to use `dict_repr_is_authoritative`, so that a provided serialized graph is preserved and not replaced by a graph perceived from coordinates. [[1]](diffhunk://#diff-90a40ffecf9d6d48c85a21031d54d87a791aea24a88edffcb41d4fd1a250c223L850-R853) [[2]](diffhunk://#diff-90a40ffecf9d6d48c85a21031d54d87a791aea24a88edffcb41d4fd1a250c223L950-R955)

**Testing enhancements:**

* Added unit tests for `dict_repr_is_authoritative` and for copy/restart behavior, ensuring that declared molecular graphs are preserved and not overridden by coordinate perception. [[1]](diffhunk://#diff-f9288198240942c0902f0d96c3412743954d9973f48d5c6378f8b586d66365cdR36) [[2]](diffhunk://#diff-f9288198240942c0902f0d96c3412743954d9973f48d5c6378f8b586d66365cdR1418-R1522) [[3]](diffhunk://#diff-f9288198240942c0902f0d96c3412743954d9973f48d5c6378f8b586d66365cdR3124-R3156)

**Documentation updates:**

* Updated `input_reference.rst` to clearly document the new behavior: when a serialized `mol` graph is present in a species dictionary, it is always used as-is, and the `keep_mol` flag is not needed for such cases. [[1]](diffhunk://#diff-0ca5c2788e0070b1b99e20db0cbcd558e1a2688d56fef06d07c2aeb38839a9b8R117-R130) [[2]](diffhunk://#diff-0ca5c2788e0070b1b99e20db0cbcd558e1a2688d56fef06d07c2aeb38839a9b8L149-R164)

**Test infrastructure:**

* Imported `mock` in the test module to enable patching and testing of perception logic.