### PR TITLE
Recover ARC thermo when Arkane's thermo-library save fails (A+A reactions)

### DIFF
--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -32,8 +32,9 @@ from arc.common import (NUMBER_BY_SYMBOL,
                         sort_two_lists_by_the_first,
                         )
 from arc.checks.common import TS_IRC_FAILED_MARKER, get_ts_validation_comment
-from arc.exceptions import InputError
+from arc.exceptions import InputError, InvalidAdjacencyListError
 from arc.level import Level
+from arc.molecule.molecule import Molecule
 from arc.parser.parser import parse_trajectory
 from arc.species.converter import (check_xyz_dict,
                                    get_xyz_radius,
@@ -766,6 +767,40 @@ def save_irc_traj_animation(irc_f_path, irc_r_path, out_path):
             f.write(' Normal termination of Gaussian 16\n')
 
 
+def _get_thermo_lib_duplicate(adjlist: str,
+                              written: list,
+                              ) -> str | None:
+    """
+    Return the label of an already written thermo library entry that RMG would reject
+    ``adjlist`` as a duplicate of, or ``None`` if there is none.
+
+    Applies the same test as ``rmgpy.data.thermo.ThermoLibrary.load_entry``: an isomorphic
+    molecule with an equal multiplicity. An adjacency list that cannot be parsed is reported
+    as not a duplicate, leaving the entry to be written as it was before this check existed.
+
+    Args:
+        adjlist (str): The adjacency list of the candidate entry.
+        written (list): Entries are (label, adjacency list) tuples already written.
+
+    Returns:
+        str | None: The label of the matching entry, or ``None``.
+    """
+    try:
+        mol = Molecule().from_adjacency_list(adjlist)
+    except (ValueError, InvalidAdjacencyListError):
+        logger.warning(f'Could not parse an adjacency list while checking the thermo library for '
+                       f'duplicates:\n{adjlist}')
+        return None
+    for label, written_adjlist in written:
+        try:
+            written_mol = Molecule().from_adjacency_list(written_adjlist)
+        except (ValueError, InvalidAdjacencyListError):
+            continue
+        if mol.multiplicity == written_mol.multiplicity and mol.is_isomorphic(written_mol):
+            return label
+    return None
+
+
 def save_thermo_lib(species_list: list,
                     path: str,
                     name: str,
@@ -773,6 +808,14 @@ def save_thermo_lib(species_list: list,
                     ) -> None:
     """
     Save an RMG thermo library of all species.
+
+    A species is written only if it has thermo data and ``include_in_thermo_lib`` is ``True``.
+    A species whose adjacency list and multiplicity match an already written entry is skipped
+    with a warning, because ``rmgpy.data.thermo.ThermoLibrary.load_entry`` raises
+    ``DatabaseError`` on such a pair and the whole library would then fail to load. This applies
+    to a reaction whose two reactants are the same species, which reaches this function as two
+    separately labeled entries. Skipping affects the library file only; every species keeps its
+    own computed thermo everywhere else it is reported.
 
     Args:
         species_list (list): Entries are ARCSpecies objects to be saved in the library.
@@ -788,15 +831,23 @@ shortDesc = ""
 longDesc = \"\"\"\n{lib_long_desc}\n\"\"\"\n
 """
     species_dict = dict()
+    written = list()
     if not len(species_list) or not any(spc.thermo for spc in species_list):
         logger.warning('No species to save in the thermo library.')
         return
 
     for i, spc in enumerate(species_list):
         if spc.thermo.data and spc.include_in_thermo_lib:
-            if spc.label not in species_dict:
-                adjlist = spc.adjlist or spc.mol_list[0].copy(deep=True).to_adjacency_list()
-                species_dict[spc.label] = adjlist
+            adjlist = species_dict.get(spc.label) \
+                or spc.adjlist or spc.mol_list[0].copy(deep=True).to_adjacency_list()
+            duplicate_of = _get_thermo_lib_duplicate(adjlist, written)
+            if duplicate_of is not None:
+                logger.warning(f'Species {spc.label} has the same adjacency list and multiplicity as '
+                               f'{duplicate_of}, which is already in the thermo library. Omitting '
+                               f'{spc.label} from the library, RMG cannot load a library containing both.')
+                continue
+            species_dict[spc.label] = adjlist
+            written.append((spc.label, adjlist))
             spc.long_thermo_description += (
                 f'\nExternal symmetry: {spc.external_symmetry}, '
                 f'optical isomers: {spc.optical_isomers}\n'

--- a/arc/plotter_test.py
+++ b/arc/plotter_test.py
@@ -7,12 +7,112 @@ This module contains unit tests for the plotter functions
 
 import os
 import shutil
+import subprocess
+import tempfile
 import unittest
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file, safe_copy_file
 from arc.species.converter import str_to_xyz
 from arc.species.species import ARCSpecies
+
+
+OH_ADJLIST = """1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}"""
+
+OH_NASA = ("NASA(polynomials=[NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, "
+           "-6.45157e-13, 2675.74, 1.48391], Tmin=(10,'K'), Tmax=(974.045,'K')), "
+           "NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, "
+           "1.92114], Tmin=(974.045,'K'), Tmax=(3000,'K'))], Tmin=(10,'K'), Tmax=(3000,'K'))")
+
+
+def _rmg_env_available() -> bool:
+    """Check whether the rmg_env conda environment is available."""
+    try:
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', '-c', 'import rmgpy'],
+                                capture_output=True, timeout=60)
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+RMG_ENV = _rmg_env_available()
+
+
+def _make_oh_species(label: str) -> ARCSpecies:
+    """Return an OH ARCSpecies carrying enough computed thermo to be written to a library."""
+    spc = ARCSpecies(label=label, smiles='[OH]', multiplicity=2)
+    spc.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.97""")
+    spc.external_symmetry, spc.optical_isomers = 1, 1
+    spc.thermo.data = OH_NASA
+    spc.thermo.H298, spc.thermo.S298 = 30.93, 178.17
+    return spc
+
+
+class TestSaveThermoLibDuplicates(unittest.TestCase):
+    """
+    A reaction whose two reactants are the same species reaches save_thermo_lib as two separately
+    labeled entries with identical adjacency lists. RMG refuses to load a library containing both.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='test_thermo_lib_')
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+    def _lib_path(self, name='aa_project'):
+        return os.path.join(self.tmp_dir, 'thermo', f'{name}.py')
+
+    def test_identical_species_written_once(self):
+        """The A+A duplicate is omitted from the library; the distinct species are both kept."""
+        r1, r2 = _make_oh_species('R1'), _make_oh_species('R2')
+        p1 = ARCSpecies(label='P1', smiles='O', multiplicity=1)
+        p1.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.24""")
+        p1.external_symmetry, p1.optical_isomers = 2, 1
+        p1.thermo.data = OH_NASA
+        p1.thermo.H298, p1.thermo.S298 = -240.63, 188.62
+        plotter.save_thermo_lib([r1, r2, p1], path=self.tmp_dir, name='aa_project', lib_long_desc='test')
+        with open(self._lib_path(), 'r') as f:
+            content = f.read()
+        self.assertIn('label = "R1"', content)
+        self.assertNotIn('label = "R2"', content)
+        self.assertIn('label = "P1"', content)
+        self.assertEqual(content.count('entry('), 2)
+
+    def test_distinct_species_all_written(self):
+        """Regression: species that are not duplicates are all written."""
+        a = _make_oh_species('A')
+        b = ARCSpecies(label='B', smiles='O', multiplicity=1)
+        b.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.24""")
+        b.external_symmetry, b.optical_isomers = 2, 1
+        b.thermo.data = OH_NASA
+        b.thermo.H298, b.thermo.S298 = -240.63, 188.62
+        plotter.save_thermo_lib([a, b], path=self.tmp_dir, name='distinct', lib_long_desc='test')
+        with open(self._lib_path('distinct'), 'r') as f:
+            content = f.read()
+        self.assertEqual(content.count('entry('), 2)
+        self.assertIn('label = "A"', content)
+        self.assertIn('label = "B"', content)
+
+    @unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+    def test_generated_library_loads_in_rmg(self):
+        """The generated library must actually load with RMG, not merely look right."""
+        r1, r2 = _make_oh_species('R1'), _make_oh_species('R2')
+        plotter.save_thermo_lib([r1, r2], path=self.tmp_dir, name='aa_project', lib_long_desc='test')
+        loader = os.path.join(self.tmp_dir, 'load_lib.py')
+        with open(loader, 'w') as f:
+            f.write('import sys\n'
+                    'from rmgpy.data.thermo import ThermoLibrary\n'
+                    'from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit\n'
+                    'local_context = {"ThermoData": ThermoData, "Wilhoit": Wilhoit,\n'
+                    '                 "NASAPolynomial": NASAPolynomial, "NASA": NASA}\n'
+                    'lib = ThermoLibrary()\n'
+                    f'lib.load({self._lib_path()!r}, local_context, {{}})\n'
+                    'sys.stdout.write("LOADED %d\\n" % len(lib.entries))\n')
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', loader],
+                                capture_output=True, text=True, timeout=300)
+        self.assertEqual(result.returncode, 0,
+                         f'RMG could not load the generated thermo library:\n{result.stdout}\n{result.stderr}')
+        self.assertIn('LOADED 1', result.stdout)
 
 
 class TestPlotter(unittest.TestCase):

--- a/arc/scripts/save_arkane_thermo.py
+++ b/arc/scripts/save_arkane_thermo.py
@@ -5,7 +5,9 @@
 A standalone script to read an Arknane thermo job and save in the same folder a YAML file with the thermo data.
 """
 
+import ast
 import os
+import sys
 
 from common import save_yaml_file
 
@@ -48,32 +50,95 @@ def _extract_cp(thermo_data):
         return None
 
 
+def _iter_thermo_calls(content):
+    """Return the :class:`ast.Call` node of each ``thermo(...)`` call in ``content``.
+
+    Selects calls to the bare name ``thermo`` only, so the ``thermo=`` keyword nested inside each
+    call is not mistaken for one. If ``content`` is not parseable Python, a message is written to
+    stderr and an empty list is returned.
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError as e:
+        sys.stderr.write(f'Could not parse an Arkane output.py as Python: {e}\n')
+        return []
+    return [node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'thermo']
+
+
+def _load_thermo_entries_from_output_py(output_path, local_context):
+    """Reconstruct a ``{label: NASA}`` mapping directly from an Arkane ``output.py``.
+
+    Used as a fallback when ``RMG_libraries/thermo.py`` is absent because Arkane's
+    ``save_thermo_lib`` crashed *after* writing ``output.py`` (e.g. it rejects the two
+    identical reactants of an A+A reaction such as OH + OH, or a singlet-carbene
+    multiplicity clash). ``output.py`` holds one ``thermo(label=..., thermo=NASA(...))``
+    call per species; each is evaluated with the real rmgpy thermo classes in scope —
+    exactly the context Arkane itself uses to read these files back — so no thermo data
+    is lost to the library-save failure. A block that fails to evaluate is reported on
+    stderr and the remaining blocks are still parsed.
+    """
+    with open(output_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    entries = dict()
+
+    def _capture(label=None, thermo=None, *args, **kwargs):
+        if label is not None:
+            entries[label] = thermo
+
+    eval_context = dict(local_context)
+    eval_context['thermo'] = _capture
+    for node in _iter_thermo_calls(content):
+        try:
+            eval(compile(ast.Expression(body=node), '<arkane_output>', 'eval'), eval_context)
+        except Exception as e:
+            sys.stderr.write(f'Could not parse an Arkane thermo() block from {output_path}: {e}\n')
+    return entries
+
+
 def main():
     """
     Run this script from an Arkane project folder.
     In ARC this is under calcs/statmech/thermo.
-    It loads the RMG thermo library, extracts H298, S298, NASA polynomial coefficients, and
-    tabulated Cp data, saving the results in a YAML file.
+    It loads the computed thermo (from the RMG thermo library Arkane wrote, or — when
+    that library save failed — straight from ``output.py``), extracts H298, S298, NASA
+    polynomial coefficients, and tabulated Cp data, saving the results in a YAML file.
+    A species whose thermo cannot be evaluated is reported on stderr and skipped, so the
+    remaining species are still written.
     """
-    thermo_lib_path = os.path.join(os.getcwd(), 'RMG_libraries', 'thermo.py')
-    if not os.path.isfile(thermo_lib_path):
-        return
-    result = dict()
+    cwd = os.getcwd()
+    thermo_lib_path = os.path.join(cwd, 'RMG_libraries', 'thermo.py')
+    output_path = os.path.join(cwd, 'output.py')
     local_context = {'ThermoData': ThermoData,
                      'Wilhoit': Wilhoit,
                      'NASAPolynomial': NASAPolynomial,
                      'NASA': NASA}
-    global_context = {}
-    library = ThermoLibrary()
-    library.load(thermo_lib_path, local_context, global_context)
-    for entry in library.entries.values():
-        thermo_data = entry.data
-        H298 = thermo_data.get_enthalpy(RT) / 1000.0
-        S298 = thermo_data.get_entropy(RT)
-        data = str(thermo_data)
-        nasa_low, nasa_high = _extract_nasa(thermo_data)
-        cp_data = _extract_cp(thermo_data)
-        result[entry.label] = {
+    entries = dict()
+    if os.path.isfile(thermo_lib_path):
+        library = ThermoLibrary()
+        library.load(thermo_lib_path, local_context, {})
+        for entry in library.entries.values():
+            entries[entry.label] = entry.data
+    elif os.path.isfile(output_path):
+        entries = _load_thermo_entries_from_output_py(output_path, local_context)
+    else:
+        return
+    result = dict()
+    for label, thermo_data in entries.items():
+        if thermo_data is None:
+            continue
+        try:
+            H298 = thermo_data.get_enthalpy(RT) / 1000.0
+            S298 = thermo_data.get_entropy(RT)
+            data = str(thermo_data)
+            nasa_low, nasa_high = _extract_nasa(thermo_data)
+            cp_data = _extract_cp(thermo_data)
+        except Exception as e:
+            sys.stderr.write(f'Could not evaluate the computed thermo of {label}: {e}\n')
+            continue
+        result[label] = {
             'H298': H298,
             'S298': S298,
             'data': data,
@@ -82,7 +147,7 @@ def main():
             'cp_data': cp_data,
         }
     if result:
-        result_path = os.path.join(os.getcwd(), 'thermo.yaml')
+        result_path = os.path.join(cwd, 'thermo.yaml')
         save_yaml_file(path=result_path, content=result)
 
 

--- a/arc/scripts/save_arkane_thermo_test.py
+++ b/arc/scripts/save_arkane_thermo_test.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for arc/scripts/save_arkane_thermo.py.
+
+The output.py-fallback path reconstructs NASA thermo objects with the real rmgpy thermo
+classes, so these tests require rmgpy (the rmg_env). Run them as a plain script (NOT via
+pytest): rmg_env's Python 3.9 cannot import the ``arc`` package that pytest pulls in for a
+file inside ``arc/scripts/`` (arc.common uses ``X | None`` PEP 604 annotations). As a script,
+only the standalone module + ``common`` are imported:
+
+    conda run -n rmg_env python arc/scripts/save_arkane_thermo_test.py
+
+Under arc_env pytest the file collects and skips cleanly (no rmgpy), so CI is unaffected.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import rmgpy.thermo
+    HAS_RMG = True
+except ImportError:
+    HAS_RMG = False
+
+
+OUTPUT_PY_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                              'testing', 'statmech', 'thermo_aa', 'output.py')
+
+with open(OUTPUT_PY_PATH, 'r') as _f:
+    OUTPUT_PY = _f.read()
+
+
+@unittest.skipUnless(HAS_RMG, 'requires rmgpy (rmg_env)')
+class TestOutputPyThermoFallback(unittest.TestCase):
+    """The output.py fallback recovers thermo when RMG_libraries/thermo.py is absent."""
+
+    def test_iter_thermo_calls_finds_each_block(self):
+        """One node per species; the nested thermo= keyword is not mistaken for a call."""
+        import ast
+        import save_arkane_thermo as sat
+        calls = sat._iter_thermo_calls(OUTPUT_PY)
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(all(isinstance(c, ast.Call) for c in calls))
+        self.assertTrue(all(c.func.id == 'thermo' for c in calls))
+
+    def test_iter_thermo_calls_tolerates_parens_in_strings(self):
+        """An unbalanced parenthesis inside a string literal does not drop the block."""
+        import save_arkane_thermo as sat
+        content = ("thermo(\n"
+                   "    label = 'X',\n"
+                   "    thermo = NASA(\n"
+                   "        polynomials = [],\n"
+                   "        comment = 'fitted using ( an unbalanced paren',\n"
+                   "    ),\n"
+                   ")\n")
+        self.assertEqual(len(sat._iter_thermo_calls(content)), 1)
+
+    def test_iter_thermo_calls_reports_unparseable_file(self):
+        """A file that is not valid Python yields no blocks rather than raising."""
+        import save_arkane_thermo as sat
+        self.assertEqual(sat._iter_thermo_calls('thermo(label = ,,,)'), [])
+
+    def test_one_bad_entry_does_not_lose_the_others(self):
+        """A species whose thermo cannot be evaluated is skipped; the rest still reach thermo.yaml."""
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        broken = OUTPUT_PY + """
+thermo(
+    label = 'Broken',
+    thermo = NASA(
+        polynomials = [],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+    ),
+)
+"""
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'output.py'), 'w') as f:
+                f.write(broken)
+            try:
+                os.chdir(d)
+                sat.main()
+                content = read_yaml_file(os.path.join(d, 'thermo.yaml'))
+            finally:
+                os.chdir(cwd)
+        self.assertEqual(set(content), {'R1', 'R2', 'P1'})
+
+    def test_load_thermo_entries_from_output_py(self):
+        import save_arkane_thermo as sat
+        from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit
+        local_context = {'ThermoData': ThermoData, 'Wilhoit': Wilhoit,
+                         'NASAPolynomial': NASAPolynomial, 'NASA': NASA}
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'output.py')
+            with open(path, 'w') as f:
+                f.write(OUTPUT_PY)
+            entries = sat._load_thermo_entries_from_output_py(path, local_context)
+        self.assertEqual(set(entries), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            self.assertIsInstance(entries[label], NASA)
+        self.assertAlmostEqual(entries['R1'].get_enthalpy(298.15), entries['R2'].get_enthalpy(298.15))
+
+    def test_main_writes_thermo_yaml_from_output_py(self):
+        """With output.py present but no RMG_libraries/thermo.py, main() still writes thermo.yaml
+        for every species (including the duplicate R2), carrying the real thermochemistry.
+
+        P1 is H2O and is checked against JANAF reference values rather than against whatever the
+        code emits: dHf(298.15 K) = -241.8 kJ/mol, S(298.15 K) = 188.8 J/(mol*K), and, from the
+        high-temperature polynomial, H(2000 K) - H(298.15 K) = 72.79 kJ/mol and
+        S(2000 K) = 264.77 J/(mol*K). Tolerances are loose so the assertions test the
+        reconstruction rather than the level of theory, and never rely on exact floats.
+
+        R1/R2 are OH, whose S(298.15 K) is deliberately not compared to the accepted
+        183.7 J/(mol*K) because the fixture's electronic partition function omits the 2-Pi
+        spin-orbit structure. What is asserted for them is the A+A invariant: two blocks for the
+        same species must reconstruct to the same thermo.
+        """
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            output_path = os.path.join(d, 'output.py')
+            with open(output_path, 'w') as f:
+                f.write(OUTPUT_PY)
+            try:
+                os.chdir(d)
+                sat.main()
+                yaml_path = os.path.join(d, 'thermo.yaml')
+                self.assertTrue(os.path.isfile(yaml_path), 'thermo.yaml must be written from output.py')
+                content = read_yaml_file(yaml_path)
+            finally:
+                os.chdir(cwd)
+            entries = sat._load_thermo_entries_from_output_py(
+                output_path, {'ThermoData': ThermoData, 'Wilhoit': Wilhoit,
+                              'NASAPolynomial': NASAPolynomial, 'NASA': NASA})
+        self.assertEqual(set(content), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            entry = content[label]
+            self.assertIsNotNone(entry['H298'])
+            self.assertIsNotNone(entry['S298'])
+            self.assertIsNotNone(entry['data'])
+            self.assertIsNotNone(entry['nasa_low'])
+            self.assertIsNotNone(entry['nasa_high'])
+            self.assertEqual(len(entry['nasa_low']['coeffs']), 7)
+        self.assertAlmostEqual(content['R1']['H298'], content['R2']['H298'])
+        self.assertAlmostEqual(content['R1']['S298'], content['R2']['S298'])
+        self.assertEqual(content['R1']['nasa_low'], content['R2']['nasa_low'])
+        self.assertEqual(content['R1']['nasa_high'], content['R2']['nasa_high'])
+        self.assertAlmostEqual(content['P1']['H298'], -241.8, delta=3.0)
+        self.assertAlmostEqual(content['P1']['S298'], 188.8, delta=2.0)
+        self.assertLess(content['P1']['H298'], content['R1']['H298'])
+        self.assertTrue(all(cp['cp_j_mol_k'] > 0 for cp in content['P1']['cp_data']))
+        h_increment = (entries['P1'].get_enthalpy(2000.0) - entries['P1'].get_enthalpy(298.15)) / 1000.0
+        self.assertAlmostEqual(h_increment, 72.79, delta=3.0)
+        self.assertAlmostEqual(entries['P1'].get_entropy(2000.0), 264.77, delta=3.0)
+        self.assertGreater(content['P1']['nasa_high']['tmax_k'], 2000.0)
+
+    def test_library_path_takes_precedence(self):
+        """When RMG_libraries/thermo.py exists, main() uses it (happy path), not output.py."""
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        library_py = '''#!/usr/bin/env python
+name = "test"
+shortDesc = ""
+longDesc = """"""
+entry(
+    index = 0,
+    label = "OnlyFromLibrary",
+    molecule = """
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin=(10, 'K'), Tmax=(3000, 'K'),
+    ),
+)
+'''
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, 'RMG_libraries'))
+            with open(os.path.join(d, 'RMG_libraries', 'thermo.py'), 'w') as f:
+                f.write(library_py)
+            with open(os.path.join(d, 'output.py'), 'w') as f:
+                f.write(OUTPUT_PY)
+            try:
+                os.chdir(d)
+                sat.main()
+                content = read_yaml_file(os.path.join(d, 'thermo.yaml'))
+            finally:
+                os.chdir(cwd)
+        self.assertIn('OnlyFromLibrary', content)
+        self.assertNotIn('R1', content)
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/scripts_test.py
+++ b/arc/scripts_test.py
@@ -8,6 +8,7 @@ These tests call the scripts as subprocesses in rmg_env (matching production usa
 Tests are skipped if rmg_env is not available.
 """
 
+import math
 import os
 import shutil
 import subprocess
@@ -30,6 +31,20 @@ def _rmg_env_available() -> bool:
 
 
 RMG_ENV = _rmg_env_available()
+
+R_J_MOL_K = 8.314462618
+
+
+def _nasa_enthalpy(coeffs: list, t: float) -> float:
+    """Return H(T) in J/mol from the 7 NASA coefficients of a single temperature range."""
+    a1, a2, a3, a4, a5, a6, _ = coeffs
+    return R_J_MOL_K * t * (a1 + a2 * t / 2 + a3 * t ** 2 / 3 + a4 * t ** 3 / 4 + a5 * t ** 4 / 5 + a6 / t)
+
+
+def _nasa_entropy(coeffs: list, t: float) -> float:
+    """Return S(T) in J/(mol*K) from the 7 NASA coefficients of a single temperature range."""
+    a1, a2, a3, a4, a5, _, a7 = coeffs
+    return R_J_MOL_K * (a1 * math.log(t) + a2 * t + a3 * t ** 2 / 2 + a4 * t ** 3 / 3 + a5 * t ** 4 / 4 + a7)
 
 
 @unittest.skipUnless(RMG_ENV, 'rmg_env not available')
@@ -115,6 +130,61 @@ class TestSaveArkaneThermo(unittest.TestCase):
             self.assertGreater(len(cp), 0)
             self.assertIn('temperature_k', cp[0])
             self.assertIn('cp_j_mol_k', cp[0])
+
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestSaveArkaneThermoOutputPyFallback(unittest.TestCase):
+    """
+    The motivating scenario end to end: Arkane's save_thermo_lib crashed on the two identical
+    reactants of an A+A reaction, so it left output.py behind but never wrote
+    RMG_libraries/thermo.py. Running the real script must still produce thermo.yaml for every
+    species, including both duplicates.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='test_aa_reload_')
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+        src = os.path.join(ARC_TESTING_PATH, 'statmech', 'thermo_aa', 'output.py')
+        shutil.copy(src, os.path.join(self.tmp_dir, 'output.py'))
+        self.assertFalse(os.path.isdir(os.path.join(self.tmp_dir, 'RMG_libraries')))
+
+    def _run_script(self):
+        script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', script],
+                                capture_output=True, text=True, cwd=self.tmp_dir, timeout=300)
+        self.assertEqual(result.returncode, 0, f'Script failed: {result.stderr}')
+        yaml_path = os.path.join(self.tmp_dir, 'thermo.yaml')
+        self.assertTrue(os.path.isfile(yaml_path),
+                        'thermo.yaml must be recovered from output.py when the library is absent')
+        return read_yaml_file(yaml_path)
+
+    def test_both_duplicates_recover_their_own_thermo(self):
+        """R1 and R2 are the same species submitted twice; each recovers thermo from its own block."""
+        data = self._run_script()
+        self.assertEqual(set(data), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            self.assertIsNotNone(data[label]['H298'])
+            self.assertIsNotNone(data[label]['S298'])
+            self.assertIsNotNone(data[label]['nasa_low'])
+            self.assertIsNotNone(data[label]['nasa_high'])
+        self.assertAlmostEqual(data['R1']['H298'], data['R2']['H298'])
+        self.assertAlmostEqual(data['R1']['S298'], data['R2']['S298'])
+
+    def test_recovered_values_match_reference_thermochemistry(self):
+        """P1 is H2O; the recovered values are checked against JANAF, at 298 K and at 2000 K.
+
+        The high-temperature check evaluates the serialized nasa_high coefficients, which is what
+        ARC consumers use up to 3000 K, so a reload that corrupted them cannot pass.
+        """
+        data = self._run_script()
+        self.assertAlmostEqual(data['P1']['H298'], -241.8, delta=3.0)
+        self.assertAlmostEqual(data['P1']['S298'], 188.8, delta=2.0)
+        nasa_high = data['P1']['nasa_high']
+        self.assertGreaterEqual(nasa_high['tmax_k'], 3000.0)
+        h_2000 = _nasa_enthalpy(nasa_high['coeffs'], 2000.0) / 1000.0
+        s_2000 = _nasa_entropy(nasa_high['coeffs'], 2000.0)
+        self.assertAlmostEqual(h_2000 - data['P1']['H298'], 72.79, delta=3.0)
+        self.assertAlmostEqual(s_2000, 264.77, delta=3.0)
 
 
 if __name__ == '__main__':

--- a/arc/testing/statmech/thermo_aa/output.py
+++ b/arc/testing/statmech/thermo_aa/output.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+conformer(
+    label = 'R1',
+    E0 = (22.2577, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(17.0027, 'amu')),
+        LinearRotor(inertia=(0.904473, 'amu*angstrom^2'), symmetry=1),
+        HarmonicOscillator(frequencies=([3675.45], 'cm^-1')),
+    ],
+    spin_multiplicity = 2,
+    optical_isomers = 1,
+)
+
+conformer(
+    label = 'R2',
+    E0 = (22.2577, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(17.0027, 'amu')),
+        LinearRotor(inertia=(0.904473, 'amu*angstrom^2'), symmetry=1),
+        HarmonicOscillator(frequencies=([3675.45], 'cm^-1')),
+    ],
+    spin_multiplicity = 2,
+    optical_isomers = 1,
+)
+
+conformer(
+    label = 'P1',
+    E0 = (-250.574, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(18.0106, 'amu')),
+        NonlinearRotor(inertia=([0.611436, 1.17966, 1.7911], 'amu*angstrom^2'), symmetry=2),
+        HarmonicOscillator(frequencies=([1615.43, 3782.01, 3887.1], 'cm^-1')),
+    ],
+    spin_multiplicity = 1,
+    optical_isomers = 1,
+)
+
+thermo(
+    label = 'R1',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (22.2464, 'kJ/mol'), Cp0 = (29.1007, 'J/(mol*K)'), CpInf = (37.4151, 'J/(mol*K)'),
+    ),
+)
+
+thermo(
+    label = 'R2',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (22.2464, 'kJ/mol'), Cp0 = (29.1007, 'J/(mol*K)'), CpInf = (37.4151, 'J/(mol*K)'),
+    ),
+)
+
+thermo(
+    label = 'P1',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.00485, -0.000245998, 8.95339e-07, 1.40307e-09, -1.18107e-12, -30136.7, -0.104547],
+                           Tmin=(10, 'K'), Tmax=(772.675, 'K')),
+            NASAPolynomial(coeffs=[3.50315, 0.00113242, 5.85407e-07, -3.70913e-10, 5.33992e-14, -30022.8, 2.42188],
+                           Tmin=(772.675, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (-250.569, 'kJ/mol'), Cp0 = (33.2579, 'J/(mol*K)'), CpInf = (58.2013, 'J/(mol*K)'),
+    ),
+)


### PR DESCRIPTION
## What a user sees go wrong

Run any reaction whose two reactants are the **same species** — `OH + OH <=> H2O + O` — and:

- `output.yml` reports `thermo: null` for **every** species in the run, reactants and products alike.
- The project thermo library comes out **empty**.
- `arc.log` shows Arkane ran fine, then a `DatabaseError` traceback at the very end.

Arkane had **already computed** the full NASA polynomials. They are sitting in `calcs/statmech/thermo/output.py`. ARC just never picked them up, so a completed, expensive job reported nothing.

## Why

- Arkane's `save_thermo_lib` keys thermo-library entries by adjacency list + multiplicity and raises `DatabaseError` on a duplicate. Two identical reactants = a duplicate.
- It is the **second-to-last statement of `Arkane.execute()`** — it runs **after** `output.py` is written and **before** `RMG_libraries/thermo.py` is.
- `save_arkane_thermo.py` guarded on exactly that missing library file and returned early:
  ```python
  if not os.path.isfile(thermo_lib_path):
      return
  ```
- No `thermo.yaml` → `parse_arkane_thermo_output` leaves `spc.thermo` unset → null thermo everywhere.

One duplicate species loses thermo for the **whole run**, because the library save is all-or-nothing.

## The fix

**1. Reload from `output.py`.** When `RMG_libraries/thermo.py` is absent, reconstruct each species' thermo straight from `output.py` and write `thermo.yaml` exactly as the library path would.

- Every job has already written `output.py` by the time `save_thermo_lib` runs, so each species' **own** thermo is recovered — nothing is inferred from another species.
- Blocks are located with `ast.parse`, walking `Call` nodes named `thermo`, then evaluated with the real rmgpy thermo classes in scope — the same context Arkane itself uses to read these files back.
- Recovers from **any** `save_thermo_lib` failure, not only A+A.
- Happy path untouched: when the library file exists it is used and `output.py` is not read. Covered by a test that passes before and after.

**2. Write each library entry once.** This is required *by* the reload, not optional alongside it: once both A+A duplicates carry thermo, `save_thermo_lib` emits two entries whose adjacency list and multiplicity match, and `rmgpy`'s `ThermoLibrary.load_entry` refuses the file:

```
DatabaseError: Adjacency list and multiplicity of R2 matches that of existing
molecule R1 in thermo library. Please correct your library.
```

Before the fix the library was *empty*; after the reload alone it would be *unloadable*. `plotter.save_thermo_lib` now applies the **same isomorphic + equal-multiplicity test RMG applies** and omits the later entry with a warning.

- This is a **library-file uniqueness** constraint, not a claim about thermochemical identity.
- It changes the library file **only**. Every species keeps its own computed thermo in `output.yml` and everywhere else it is reported.

## What is deliberately *not* here

An earlier revision of this PR also deduplicated species **before** the Arkane input was written, collapsing isomorphic same-multiplicity species into one block and copying the representative's thermo onto the other. **That has been removed.** It skipped a real calculation and assigned one species' thermodynamics to another, and ARC's `Molecule` is a 2D graph with no stereochemistry and no geometry — so it collapsed *cis*/*trans*-2-butene, *cis*/*trans*-1,2-dimethylcyclohexane, R/S enantiomers, and two distinct conformers of the same SMILES submitted as separate species. Errors of 3.1× to 17.3× in K_eq, with the sign set by list order, and it fired project-wide rather than only on A+A.

Its only real benefit was suppressing a stderr traceback. Since `save_thermo_lib` runs after `output.py` is written, the reload above already recovers every one of those cases correctly.

## Verification

- `arc/plotter_test.py`, `arc/scripts_test.py`, `arc/statmech/`, `arc/processor_test.py`, `arc/output_test.py` — **158 passed, 7 skipped**.
- `arc/scripts/save_arkane_thermo_test.py` — 7 passed under `rmg_env`; skips cleanly under `arc_env` pytest.

**Every new test was proven to fail on unfixed `main`.** With only `plotter.py` reverted:

```
FAILED TestSaveThermoLibDuplicates::test_generated_library_loads_in_rmg
  rmgpy.exceptions.DatabaseError: Adjacency list and multiplicity of R2 matches
  that of existing molecule R1 in thermo library. Please correct your library.
FAILED TestSaveThermoLibDuplicates::test_identical_species_written_once
  AssertionError: 'label = "R2"' unexpectedly found in ...
```

With only `save_arkane_thermo.py` reverted:

```
FAILED TestSaveArkaneThermoOutputPyFallback::test_both_duplicates_recover_their_own_thermo
  AssertionError: False is not true : thermo.yaml must be recovered from output.py
  when the library is absent
FAILED TestSaveArkaneThermoOutputPyFallback::test_recovered_values_match_reference_thermochemistry
  AssertionError: False is not true : thermo.yaml must be recovered from output.py
  when the library is absent
```

`test_library_path_takes_precedence` and `test_distinct_species_all_written` pass **both** before and after — they guard the unchanged paths, so they correctly do not flip.

The end-to-end test runs the **real script as a subprocess** against a fixture directory containing `output.py` and no `RMG_libraries/`, which is exactly the state Arkane leaves behind. Both A+A duplicates come out with their own recovered thermo.

## Thermochemistry the tests assert

Reference values, not whatever the code emits. The recovered product is H₂O, against JANAF:

| Quantity | Reference | Tolerance |
|---|---|---|
| ΔfH°(298.15 K) | −241.8 kJ/mol | 3 kJ/mol |
| S°(298.15 K) | 188.8 J/(mol·K) | 2 J/(mol·K) |
| H(2000 K) − H(298.15 K) | 72.79 kJ/mol | 3 kJ/mol |
| S°(2000 K) | 264.77 J/(mol·K) | 3 J/(mol·K) |

The 2000 K checks evaluate the **serialized `nasa_high` coefficients**, which is what ARC consumers use out to 3000 K — a reload that corrupted the high-temperature polynomial while leaving 298 K intact cannot pass. No assertion is a byte-exact float.

**Why OH's S° is not asserted.** The fixture's OH recovers S°(298.15 K) ≈ 178.2 against an accepted 183.708 J/(mol·K). The gap is *not* a missing R·ln 2: Arkane has no electronic-mode class, degeneracy enters through `Conformer.spin_multiplicity`, and the value already contains a spin/optical term of exactly 5.7632 = R·ln 2. What is missing is OH's **²Π orbital (Λ = ±1) degeneracy and its spin–orbit structure**: splitting 139.21 cm⁻¹ (θ = 200.29 K), q_el = 2 + 2·exp(−θ/T) = 3.0216 at 298.15 K, S_el = R[ln q + T·dln q/dT] = 11.0825 J/(mol·K); minus the 5.7632 already present leaves 5.3193, giving 183.51 against 183.708. (Adding R·ln 2 gives 183.95 — that near-agreement is coincidental.) The independent check is the heat capacity: fixture Cp₂₉₈(OH) = 29.098 vs JANAF 29.886, a deficit of 0.788 against a computed Schottky Cp_el(298) of 0.840. A temperature-independent degeneracy contributes **exactly zero** to Cp, so the deficit can only be the two-level spin–orbit term. What *is* asserted for OH is the A+A invariant: two blocks for the same species must reconstruct to identical thermo.

## Notes for review

- One commit, six files, no file touched twice.
- Two claims from the first revision of this PR description were **wrong and are withdrawn**: the reloaded `thermo.yaml` is *not* byte-compatible with the library path (`data` differs — RMG's `save_entry` routes the NASA `comment` to `shortDesc` and drops it from the repr, and `spc.thermo.data` is interpolated verbatim into ARC's library; benign today because Arkane leaves `NASA.comment` empty, but the claim was false); and `eval(..., {'__builtins__': {}})` was described as a sandbox — it is trivially escapable via `().__class__` and no longer claimed to be one. The input is a file Arkane just wrote in ARC's own run directory.
- The duplicate check skips the entry in the writer rather than mutating `include_in_thermo_lib` on the species. Mutating would serialize into `restart.yml` and permanently exclude the species on a later restart even once the duplicate is gone.
- `computed_reaction` TCKDB payloads were never affected — they carry no NASA.
