### PR TITLE
Populate final_xyz for monoatomic species given an explicit geometry

### DIFF
--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -877,6 +877,38 @@ H       1.12853146   -0.86793870    0.06973060"""
         rxn_2.check_done_opt_r_n_p()
         self.assertEqual(rxn_2.done_opt_r_n_p, False)
 
+    def test_check_done_opt_r_n_p_with_atomic_species_given_xyz(self):
+        """
+        Test that an atomic reactant given an explicit geometry does not block TS search.
+
+        Replays the Scheduler.__init__ sequence: rebind r_species/p_species to the run's own
+        ARCSpecies objects, then check_atom_balance() and check_done_opt_r_n_p().
+        """
+        xyz = {'symbols': ('H',), 'isotopes': (1,), 'coords': ((0.0, 0.0, 0.0),)}
+        rxn = ARCReaction(reactants=['CH4', 'H'], products=['CH3', 'H2'],
+                          r_species=[ARCSpecies(label='CH4', smiles='C'),
+                                     ARCSpecies(label='H', smiles='[H]')],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]'),
+                                     ARCSpecies(label='H2', smiles='[H][H]')])
+        species_list = [ARCSpecies(label='CH4', smiles='C'),
+                        ARCSpecies(label='H', smiles='[H]', xyz=xyz),
+                        ARCSpecies(label='CH3', smiles='[CH3]'),
+                        ARCSpecies(label='H2', smiles='[H][H]')]
+        rxn.r_species, rxn.p_species = list(), list()
+        for spc in species_list:
+            if spc.label in rxn.reactants:
+                rxn.r_species.append(spc)
+            if spc.label in rxn.products:
+                rxn.p_species.append(spc)
+        rxn.check_atom_balance()
+        rxn.check_done_opt_r_n_p()
+        self.assertFalse(rxn.done_opt_r_n_p)
+        for spc in species_list:
+            if not spc.is_monoatomic():
+                spc.final_xyz = spc.get_xyz(generate=True)
+        rxn.check_done_opt_r_n_p()
+        self.assertTrue(rxn.done_opt_r_n_p)
+
     def tests_white_space_in_reaction_label(self):
         """Test that an extra white space in the reaction label does not confuse ARC."""
         hno = ARCSpecies(label='HNO', smiles='N=O')

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -556,6 +556,7 @@ class ARCSpecies(object):
         self.set_mol_list()
         if self.is_ts and not any(value is not None for key, value in self.ts_checks.items() if key != 'warnings'):
             self.populate_ts_checks()
+        self._set_final_xyz_for_monoatomic()
 
     def __str__(self) -> str:
         """Return a string representation of the object"""
@@ -579,6 +580,20 @@ class ARCSpecies(object):
 
     def __hash__(self):
         return hash(self.label)
+
+    def _set_final_xyz_for_monoatomic(self) -> None:
+        """
+        Set ``final_xyz`` for a monoatomic species.
+
+        An atom has nothing to optimize, so ARC never runs an opt job for it and
+        ``final_xyz`` is simply the geometry it was given. Any geometry already on
+        the species is used as-is; otherwise a conformer is generated, which also
+        sets ``initial_xyz`` and ``cheap_conformer``. TSs and polyatomic species
+        are left untouched.
+        """
+        if self.is_ts or self.final_xyz is not None or not self.is_monoatomic():
+            return
+        self.final_xyz = self.get_xyz(generate=True)
 
     @property
     def number_of_atoms(self):

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -283,6 +283,71 @@ class TestARCSpecies(unittest.TestCase):
         n_rad = ARCSpecies(label='N', smiles='[N]')
         self.assertTrue(n_rad.is_monoatomic())
 
+    def test_set_final_xyz_for_monoatomic_generates_a_geometry(self):
+        """Test that a monoatomic species gets a final_xyz at initialization."""
+        for label, smiles in [('H', '[H]'), ('O', '[O]'), ('Cl', '[Cl]')]:
+            spc = ARCSpecies(label=label, smiles=smiles)
+            self.assertIsNotNone(spc.final_xyz)
+            self.assertEqual(spc.final_xyz['symbols'], (label,))
+            self.assertEqual(spc.final_xyz['coords'], ((0.0, 0.0, 0.0),))
+            self.assertEqual(spc.initial_xyz, spc.final_xyz)
+            self.assertEqual(spc.cheap_conformer, spc.final_xyz)
+
+    def test_set_final_xyz_for_monoatomic_preserves_user_xyz(self):
+        """Test that a user-supplied monoatomic geometry is used as-is, from any input route."""
+        xyz = {'symbols': ('O',), 'isotopes': (16,), 'coords': ((1.5, -2.5, 3.5),)}
+        adjlist = """multiplicity 3
+1 O u2 p2 c0"""
+        for kwargs in [{'smiles': '[O]', 'xyz': xyz}, {'adjlist': adjlist, 'xyz': xyz}, {'xyz': xyz}]:
+            spc = ARCSpecies(label='O', **kwargs)
+            self.assertEqual(spc.final_xyz['coords'], ((1.5, -2.5, 3.5),))
+            self.assertIsNone(spc.initial_xyz)
+
+    def test_set_final_xyz_for_monoatomic_from_adjlist(self):
+        """Test that a monoatomic species given only an adjlist gets a final_xyz."""
+        adjlist = """multiplicity 3
+1 O u2 p2 c0"""
+        spc = ARCSpecies(label='O', adjlist=adjlist)
+        self.assertEqual(spc.final_xyz, {'symbols': ('O',), 'isotopes': (16,), 'coords': ((0.0, 0.0, 0.0),)})
+
+    def test_set_final_xyz_for_monoatomic_from_species_dict(self):
+        """Test that a monoatomic species restored from a dictionary gets a final_xyz."""
+        xyz_dict = {'label': 'tst_atom_1', 'xyz': 'C 0.1 0.5 0.0'}
+        initial_xyz_dict = {'label': 'tst_atom_2', 'initial_xyz': 'C 0.2 0.5 0.0'}
+        final_xyz_dict = {'label': 'tst_atom_3', 'final_xyz': 'C 0.3 0.5 0.0'}
+        conformers_dict = {'label': 'tst_atom_4', 'xyz': ['C 0.4 0.5 0.0', 'C 0.5 0.5 0.0']}
+        smiles_dict = {'label': 'tst_atom_5', 'smiles': '[H]'}
+
+        spc1 = ARCSpecies(species_dict=xyz_dict)
+        spc2 = ARCSpecies(species_dict=initial_xyz_dict)
+        spc3 = ARCSpecies(species_dict=final_xyz_dict)
+        spc4 = ARCSpecies(species_dict=conformers_dict)
+        spc5 = ARCSpecies(species_dict=smiles_dict)
+
+        self.assertEqual(spc1.final_xyz, {'coords': ((0.1, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertIsNone(spc1.initial_xyz)
+        self.assertEqual(spc2.final_xyz, {'coords': ((0.2, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertEqual(spc3.final_xyz, {'coords': ((0.3, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertEqual(spc4.final_xyz, {'coords': ((0.4, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertEqual(spc5.final_xyz, {'coords': ((0.0, 0.0, 0.0),), 'isotopes': (1,), 'symbols': ('H',)})
+
+    def test_set_final_xyz_for_monoatomic_feeds_get_xyz_without_generating(self):
+        """Test that run_sp_job's get_xyz(generate=False) call returns a geometry for a standalone atom."""
+        self.assertEqual(ARCSpecies(label='H', smiles='[H]').get_xyz(generate=False),
+                         {'symbols': ('H',), 'isotopes': (1,), 'coords': ((0.0, 0.0, 0.0),)})
+        xyz = {'symbols': ('O',), 'isotopes': (16,), 'coords': ((1.5, -2.5, 3.5),)}
+        self.assertEqual(ARCSpecies(label='O', smiles='[O]', xyz=xyz).get_xyz(generate=False), xyz)
+
+    def test_set_final_xyz_for_monoatomic_skips_ts(self):
+        """Test that a TS is not assigned a monoatomic final_xyz."""
+        ts = ARCSpecies(label='TS0', is_ts=True, smiles='[H]')
+        self.assertIsNone(ts.final_xyz)
+
+    def test_set_final_xyz_for_monoatomic_ignores_polyatomic(self):
+        """Test that a polyatomic species is unaffected."""
+        for smiles in ['C', '[H][H]', 'O']:
+            self.assertIsNone(ARCSpecies(label='spc', smiles=smiles).final_xyz)
+
     def test_is_diatomic(self):
         """Test the is_diatomic() method."""
         self.assertFalse(self.spc1.is_diatomic())
@@ -1878,11 +1943,12 @@ H       1.32129900    0.71837500    0.38017700
                                                            'Number was not determined, default value is 2')
 
     def test_xyz_from_dict(self):
-        """Test correctly assigning xyz from dictionary"""
-        species_dict1 = {'label': 'tst_spc_1', 'xyz': 'C 0.1 0.5 0.0'}
-        species_dict2 = {'label': 'tst_spc_2', 'initial_xyz': 'C 0.2 0.5 0.0'}
-        species_dict3 = {'label': 'tst_spc_3', 'final_xyz': 'C 0.3 0.5 0.0'}
-        species_dict4 = {'label': 'tst_spc_4', 'xyz': ['C 0.4 0.5 0.0', 'C 0.5 0.5 0.0']}
+        """Test correctly assigning xyz from a dictionary for a polyatomic species"""
+        species_dict1 = {'label': 'tst_spc_1', 'xyz': 'C 0.1 0.5 0.0\nH 1.2 0.5 0.0'}
+        species_dict2 = {'label': 'tst_spc_2', 'initial_xyz': 'C 0.2 0.5 0.0\nH 1.3 0.5 0.0'}
+        species_dict3 = {'label': 'tst_spc_3', 'final_xyz': 'C 0.3 0.5 0.0\nH 1.4 0.5 0.0'}
+        species_dict4 = {'label': 'tst_spc_4', 'xyz': ['C 0.4 0.5 0.0\nH 1.5 0.5 0.0',
+                                                       'C 0.5 0.5 0.0\nH 1.6 0.5 0.0']}
 
         spc1 = ARCSpecies(species_dict=species_dict1)
         spc2 = ARCSpecies(species_dict=species_dict2)
@@ -1891,23 +1957,28 @@ H       1.32129900    0.71837500    0.38017700
 
         self.assertIsNone(spc1.initial_xyz)
         self.assertIsNone(spc1.final_xyz)
-        self.assertEqual(spc1.conformers, [{'coords': ((0.1, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)}])
+        self.assertEqual(spc1.conformers, [{'coords': ((0.1, 0.5, 0.0), (1.2, 0.5, 0.0)),
+                                            'isotopes': (12, 1), 'symbols': ('C', 'H')}])
         self.assertEqual(spc1.conformer_energies, [None])
 
-        self.assertEqual(spc2.initial_xyz, {'coords': ((0.2, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertEqual(spc2.initial_xyz, {'coords': ((0.2, 0.5, 0.0), (1.3, 0.5, 0.0)),
+                                            'isotopes': (12, 1), 'symbols': ('C', 'H')})
         self.assertIsNone(spc2.final_xyz)
         self.assertEqual(spc2.conformers, [])
         self.assertEqual(spc2.conformer_energies, [])
 
         self.assertIsNone(spc3.initial_xyz)
-        self.assertEqual(spc3.final_xyz, {'coords': ((0.3, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)})
+        self.assertEqual(spc3.final_xyz, {'coords': ((0.3, 0.5, 0.0), (1.4, 0.5, 0.0)),
+                                          'isotopes': (12, 1), 'symbols': ('C', 'H')})
         self.assertEqual(spc3.conformers, [])
         self.assertEqual(spc3.conformer_energies, [])
 
         self.assertIsNone(spc4.initial_xyz)
         self.assertIsNone(spc4.final_xyz)
-        self.assertEqual(spc4.conformers, [{'coords': ((0.4, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)},
-                                           {'coords': ((0.5, 0.5, 0.0),), 'isotopes': (12,), 'symbols': ('C',)}])
+        self.assertEqual(spc4.conformers, [{'coords': ((0.4, 0.5, 0.0), (1.5, 0.5, 0.0)),
+                                            'isotopes': (12, 1), 'symbols': ('C', 'H')},
+                                           {'coords': ((0.5, 0.5, 0.0), (1.6, 0.5, 0.0)),
+                                            'isotopes': (12, 1), 'symbols': ('C', 'H')}])
         self.assertEqual(spc4.conformer_energies, [None, None])
 
     def test_mol_from_xyz(self):


### PR DESCRIPTION
## Symptom

**A monoatomic species given an explicit geometry silently blocks TS search for its reaction, forever.**

- Give `[H]`, `[O]`, `[Cl]` an `xyz` in the input and the reaction it participates in never dispatches a TS-guess job.
- Nothing raises, nothing warns, nothing appears in the log. The run just completes with no TS.
- Separately, a standalone atom that participates in no reaction gets its sp job submitted with `xyz=None`.

This was not motivated by an observed benchmark failure; it was found while reading the dispatch gate. The benchmark generator emits `label` + `smiles` + `multiplicity` with no xyz, **and every one of its atoms is a reactant or a product**. That second half is what saves it, not the input shape: `Scheduler.__init__` calls `check_atom_balance()` on every reaction participant, which populates `final_xyz` for a bare atom before either gate is read. A bare SMILES-only atom that is *not* in any reaction does trigger bug (b) — see below.

## What breaks

`ARCSpecies.final_xyz` is only ever populated for an atom as a side effect of someone calling `get_xyz(generate=True)`, which routes through `get_cheap_conformer()` (`species.py:1211-1214`). But `get_xyz()` short-circuits on the first geometry it finds (`species.py:1258`):

```python
xyz = self.final_xyz or self.initial_xyz or self.most_stable_conformer or conf or self.cheap_conformer
```

So an atom that **already has** a geometry never reaches `get_cheap_conformer()`, and `final_xyz` stays `None`.

**(a) TS dispatch is blocked.** `ARCReaction.check_done_opt_r_n_p()` gates TS-search dispatch on every reactant and product having a non-`None` `final_xyz`. One atom with `final_xyz is None` pins `done_opt_r_n_p` to `False` for the rest of the run.

Replaying the exact `Scheduler.__init__` sequence on unpatched `main`:

```
smiles only              H.final_xyz set: True  -> TS DISPATCHES
smiles + user xyz        H.final_xyz set: False -> TS BLOCKED FOREVER
xyz only                 H.final_xyz set: False -> TS BLOCKED FOREVER
```

The smiles-only case is fine, and that is worth being explicit about: `Scheduler.__init__` calls `rxn.check_atom_balance()` (`scheduler.py:432`) immediately before `rxn.check_done_opt_r_n_p()` (`:433`), in the same unconditional loop iteration as the `r_species`/`p_species` rebind (`:372-377`). `check_atom_balance()` calls `get_xyz(generate=True)` on every rebound reactant and product, which populates `final_xyz` for a *bare* atom. Only an atom that already carries a geometry slips through.

**(b) sp job submitted with no geometry.** A standalone atom in no reaction never enters that loop, so `scheduler.py:469` (`if species.is_monoatomic():`) → `run_sp_job()` → `get_xyz(generate=False)` (`scheduler.py:1575`) returns `None`. This fires for the bare SMILES-only atom too — participation in a reaction, not the input shape, is what avoids it:

```
UNFIXED main: ARCSpecies(label='H', smiles='[H]').get_xyz(generate=False) -> None
WITH FIX:     ARCSpecies(label='H', smiles='[H]').get_xyz(generate=False)
              -> {'symbols': ('H',), 'isotopes': (1,), 'coords': ((0.0, 0.0, 0.0),)}
```

## What the fix does

`ARCSpecies.__init__` now populates `final_xyz` for a monoatomic species:

```python
if self.is_ts or self.final_xyz is not None or not self.is_monoatomic():
    return
self.final_xyz = self.get_xyz(generate=True)
```

- Delegates to `get_xyz(generate=True)` rather than reimplementing the lookup, so geometry precedence and conformer generation stay in exactly one place.
- Guarded by the existing `is_monoatomic()` predicate, which also covers the `mol_list`/adjlist and xyz-only routes that an open-coded `len(self.mol.atoms) != 1` check would miss.
- TSs and polyatomic species are untouched. No behavioural change for anything with more than one atom.

Note `is_monoatomic()` returns `None` when it cannot tell; `not None` is `True`, so an undetermined species correctly bails out.

**Two consequences that are not just `final_xyz`, stated explicitly:**

1. **`initial_xyz` and `cheap_conformer` are also written, but only for a *bare* atom.** When no geometry is supplied, `get_xyz(generate=True)` reaches `get_cheap_conformer()`, which does `self.initial_xyz = self.final_xyz = self.cheap_conformer` (`species.py:1214`). When a geometry *is* supplied the short-circuit returns it and only `final_xyz` is set. The asymmetry is inherited from `get_cheap_conformer()`, not introduced here; both behaviours are now asserted in `species_test.py`.
2. **The call site is `__init__`, outside the `if species_dict is None or self.yml_path is not None:` block**, so it applies to the restart (`species_dict=`) and YAML routes as well as to kwargs. That is deliberate — a restart-loaded atom has the same gate problem — and it is covered by `test_set_final_xyz_for_monoatomic_from_species_dict`.

## How it was verified

**Reaction-level regression test** in `arc/reaction/reaction_test.py`, next to the existing `test_check_done_opt_r_n_p`. It replays the full scheduler sequence — rebind, `check_atom_balance()`, `check_done_opt_r_n_p()` — with an atomic reactant given an explicit xyz. Including `check_atom_balance()` is the load-bearing part: omit it and the test passes on unfixed `main` while guarding nothing. `done_opt_r_n_p` is asserted `False` after the first call as well, because the flag is sticky (`if not self.done_opt_r_n_p:`) and without that assertion a premature `True` would be indistinguishable from correct behaviour.

**Species-level tests** in `arc/species/species_test.py` cover the SMILES, adjlist, xyz-only, `species_dict=` and `get_xyz(generate=False)` routes, plus the TS and polyatomic negative guards.

Against unfixed `origin/main`, the new assertions fail:

```
FAILED arc/reaction/reaction_test.py::TestARCReaction::test_check_done_opt_r_n_p_with_atomic_species_given_xyz
FAILED arc/species/species_test.py::TestARCSpecies::test_set_final_xyz_for_monoatomic_generates_a_geometry
FAILED arc/species/species_test.py::TestARCSpecies::test_set_final_xyz_for_monoatomic_preserves_user_xyz
FAILED arc/species/species_test.py::TestARCSpecies::test_set_final_xyz_for_monoatomic_from_adjlist
FAILED arc/species/species_test.py::TestARCSpecies::test_set_final_xyz_for_monoatomic_from_species_dict
FAILED arc/species/species_test.py::TestARCSpecies::test_set_final_xyz_for_monoatomic_feeds_get_xyz_without_generating
```

## Blast radius

The risk is not that monoatomic code paths change — they key off `is_monoatomic()` / `number_of_atoms`, never `final_xyz` (`scheduler.py:469`, `:1306`, `:3031`, `:3425`). The risk is the converse: **generic `final_xyz` branches that a monoatomic species now newly enters.** Every `final_xyz` read in `arc/` was audited for that. Exactly one is reached that was not reached before:

- `scheduler.py:459` — `if not self.job_types['opt'] and species.final_xyz is not None: … output[...]['job_types']['opt'] = True`. This now fires for a bare atom, which is correct: an atom has nothing to optimize, so declaring opt converged is the right answer.

The semantic worry — that `final_xyz` conventionally means "post-opt" and this populates it in `__init__` — does not land, because `get_cheap_conformer()` on `main` already does `self.initial_xyz = self.final_xyz = self.cheap_conformer` for a monoatomic species (`species.py:1214`). "`final_xyz` = a generated atom geometry with no opt run" is pre-existing convention; this PR only extends it to the case where the geometry came from the user.

## `test_xyz_from_dict`

Its four fixtures were one-atom (`'C 0.1 0.5 0.0'` — atomic carbon) only by accident, so they collided with the new behaviour. They are now two-atom and the `assertIsNone(final_xyz)` assertions are restored unchanged, so that test still proves the invariant it exists for: input geometry is not promoted to `final_xyz` for a polyatomic species.

The one-atom coverage was **not** dropped — all four dicts are restored, with corrected (non-`None`) expectations, in the new `test_set_final_xyz_for_monoatomic_from_species_dict`, together with a fifth SMILES-only dict. Splitting them keeps each test asserting one invariant instead of two contradictory ones.

## Reuse

Searched by behaviour before writing — "where does a single-atom species get its coordinates", "what already assigns a geometry when opt is skipped" — plus direct searches for `monoatomic` / `single_atom` / `len(atoms) == 1` and every branch on `final_xyz`.

- `is_monoatomic()` — reused as the guard.
- `get_xyz(generate=True)` — reused as the whole implementation, which transitively reuses `get_cheap_conformer()` and `conformers.generate_monoatomic_conformer()` rather than duplicating either.

**A pre-existing defect whose blast radius this PR widens, disclosed rather than fixed here:** `generate_monoatomic_conformer()` builds its xyz from the element symbol only, so it always returns the most common isotope. On `main`, `ARCSpecies(label='D', smiles='[2H]')` leaves `final_xyz`, `initial_xyz` and `cheap_conformer` all `None`; with this PR it gets `isotopes: (1,)` at construction, despite `mol.atoms[0].element.isotope == 2`. So this is not merely "inherited" — the defective value is now materialised earlier and for species that would never have triggered it. It replaces "no geometry at all" (which is bug (b)) with "a geometry carrying the wrong isotope, for isotopologues only", so it is not a regression relative to the bug being fixed, but it deserves its own fix in that one function, where it will fix every caller at once.
