### PR TITLE
Fix KeyError on deleted IRC species in save_project_info_file

### DIFF
--- a/arc/main.py
+++ b/arc/main.py
@@ -673,6 +673,9 @@ class ARC(object):
     def save_project_info_file(self):
         """
         Save a project info file.
+
+        Species that are absent from ``self.output`` (e.g., an IRC species deleted mid-run)
+        are logged and are not listed in the info file nor in the accompanying YAML file.
         """
         self.execution_time = time_lapse(t0=self.t0)
         path = os.path.join(self.project_directory, f'{self.project}.info')
@@ -706,7 +709,13 @@ class ARC(object):
             txt += 'NOT using bond additivity corrections for thermo\n'
         txt += f'\nUsing the following ESS settings: {self.ess_settings}\n'
         txt += '\nConsidered the following species and TSs:\n'
+        unreported_labels = [species.label for species in self.species if species.label not in self.output]
+        if unreported_labels:
+            logger.warning(f'The following species are missing from the output dictionary and will not be '
+                           f'reported in {self.project}.info nor in {self.project}_info.yml: {unreported_labels}')
         for species in self.species:
+            if species.label not in self.output:
+                continue
             descriptor = 'TS' if species.is_ts else 'Species'
             failed = '' if self.output[species.label]['convergence'] else ' (Failed!)'
             txt += f'{descriptor} {species.label}{failed} (run time: {species.run_time})\n'
@@ -727,7 +736,7 @@ class ARC(object):
         if os.path.exists(path):
             os.remove(path)
         for species in self.species:
-            if not species.is_ts:
+            if not species.is_ts and species.label in self.output:
                 spc_dict = dict()
                 spc_dict['label'] = species.label
                 spc_dict['success'] = self.output[species.label]['convergence']

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -12,6 +12,7 @@ import subprocess
 import tempfile
 import unittest
 from unittest import mock
+from unittest.mock import patch
 
 from arc.common import ARC_PATH, get_logger
 from arc.exceptions import InputError
@@ -20,7 +21,9 @@ from arc.job.adapters.gaussian import GaussianAdapter
 from arc.job.ssh import SSHClient
 from arc.level import Level
 from arc.main import ARC, process_adaptive_levels
-from arc.species.species import ARCSpecies
+from arc.scheduler import Scheduler
+from arc.species.converter import str_to_xyz
+from arc.species.species import ARCSpecies, TSGuess
 
 servers = settings['servers']
 
@@ -205,6 +208,88 @@ class TestARC(unittest.TestCase):
         job_type_expected = {'conf_opt': False, 'conf_sp': False, 'opt': True, 'freq': True, 'sp': True, 'rotors': False,
                              'orbitals': False, 'bde': True, 'onedmin': False, 'fine': True, 'irc': False}
         self.assertEqual(arc1.job_types, job_type_expected)
+
+    def test_save_project_info_file_skips_deleted_species(self):
+        """Test that a species present in self.species but absent from self.output (e.g., an IRC
+        endpoint species deleted mid-run) is omitted from the project info file and from the
+        accompanying YAML file, instead of raising a KeyError."""
+        arc0 = ARC(project='arc_info_test', species=[ARCSpecies(label='tst_spc', smiles='C')],
+                   level_of_theory='b3lyp/6-31g', bac_type=None, compute_thermo=False,
+                   freq_scale_factor=1.0, calc_freq_factor=False, job_types=self.job_types1,
+                   ess_settings={'gaussian': ['local']})
+        self.addCleanup(shutil.rmtree, arc0.project_directory, ignore_errors=True)
+        arc0.species.append(ARCSpecies(label='IRC_TS0_1', smiles='O'))
+        arc0.output = {'tst_spc': {'convergence': True}}
+        arc0.save_project_info_file()
+        with open(os.path.join(arc0.project_directory, f'{arc0.project}.info'), 'r') as f:
+            content = f.read()
+        self.assertIn('tst_spc', content)
+        self.assertNotIn('IRC_TS0_1', content)
+        with open(os.path.join(arc0.project_directory, f'{arc0.project}_info.yml'), 'r') as f:
+            yml_content = f.read()
+        self.assertIn('tst_spc', yml_content)
+        self.assertNotIn('IRC_TS0_1', yml_content)
+
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_save_project_info_file_after_a_scheduler_deleted_an_irc_species(self, mock_run_opt):
+        """Test that an ARC run whose Scheduler abandoned a TS guess, and thereby deleted the IRC
+        species spawned for it, can still write its project info files. Wires a real ARC to a real
+        Scheduler the way ARC.execute does, so it covers the shared species list rather than a
+        stand-in for it."""
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+        ts_spc = ARCSpecies(label='TS0', is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0,
+                            compute_thermo=False)
+        ts_spc.ts_guesses = [
+            TSGuess(index=0, method='heuristics', success=True, energy=100.0, xyz=ts_xyz,
+                    execution_time='0:00:01'),
+            TSGuess(index=1, method='heuristics', success=True, energy=110.0, xyz=ts_xyz,
+                    execution_time='0:00:01'),
+        ]
+        ts_spc.ts_guesses[0].opt_xyz = ts_xyz
+        ts_spc.ts_guesses[0].imaginary_freqs = [-500.0]
+        ts_spc.ts_guesses[1].opt_xyz = ts_xyz
+        ts_spc.ts_guesses[1].imaginary_freqs = [-400.0]
+        ts_spc.chosen_ts = 0
+        ts_spc.chosen_ts_list = [0]
+        ts_spc.ts_guesses_exhausted = False
+
+        arc0 = ARC(project='arc_info_e2e_test', species=[ts_spc], level_of_theory='b3lyp/6-31g',
+                   bac_type=None, compute_thermo=False, freq_scale_factor=1.0,
+                   calc_freq_factor=False, job_types=self.job_types1,
+                   ess_settings={'gaussian': ['local']})
+        self.addCleanup(shutil.rmtree, arc0.project_directory, ignore_errors=True)
+        sched = Scheduler(project=arc0.project, species_list=arc0.species,
+                          ess_settings=arc0.ess_settings, opt_level=arc0.opt_level,
+                          freq_level=arc0.freq_level, sp_level=arc0.sp_level,
+                          ts_guess_level=arc0.ts_guess_level,
+                          project_directory=arc0.project_directory, testing=True,
+                          job_types=arc0.job_types)
+        self.assertIs(arc0.species, sched.species_list)
+
+        irc_label = 'IRC_TS0_1'
+        sched.species_dict[irc_label] = ARCSpecies(label=irc_label, xyz=ts_xyz,
+                                                   compute_thermo=False, irc_label='TS0')
+        sched.species_list.append(sched.species_dict[irc_label])
+        sched.unique_species_labels.append(irc_label)
+        sched.initialize_output_dict(label=irc_label)
+        ts_spc.irc_label = irc_label
+        self.assertIn(irc_label, [spc.label for spc in arc0.species])
+
+        sched.switch_ts('TS0')
+        arc0.output = sched.output
+        arc0.save_project_info_file()
+
+        self.assertNotIn(irc_label, [spc.label for spc in arc0.species])
+        with open(os.path.join(arc0.project_directory, f'{arc0.project}.info'), 'r') as f:
+            content = f.read()
+        self.assertIn('TS0', content)
+        self.assertNotIn(irc_label, content)
+        with open(os.path.join(arc0.project_directory, f'{arc0.project}_info.yml'), 'r') as f:
+            yml_content = f.read()
+        self.assertNotIn('IRC_TS0_1', yml_content)
 
     def test_check_project_name(self):
         """Test project name invalidity"""

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -4033,6 +4033,10 @@ class Scheduler(object):
         """
         Delete all jobs of a species/TS.
 
+        If the species is a TS, the IRC species it spawned are deleted as well. They are removed
+        from ``self.species_list`` in-place (slice assignment), so the removal is seen through
+        every reference to that list object, including ``ARC.species``, which is the same object.
+
         Args:
             label (str): The species label.
         """
@@ -4078,7 +4082,7 @@ class Scheduler(object):
                     if irc_label in self.output:
                         del self.output[irc_label]
                     if irc_label in self.species_dict:
-                        self.species_list = [spc for spc in self.species_list if spc.label != irc_label]
+                        self.species_list[:] = [spc for spc in self.species_list if spc.label != irc_label]
                         del self.species_dict[irc_label]
                     if irc_label in self.unique_species_labels:
                         self.unique_species_labels.remove(irc_label)

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -1007,7 +1007,8 @@ H      -1.82570782    0.42754384   -0.56130718"""
 
     @patch('arc.scheduler.Scheduler.run_opt_job')
     def test_switch_ts_cleanup(self, mock_run_opt):
-        """Test that switch_ts resets job_types, convergence, cleans up IRC species, and clears pending pipes."""
+        """Test that switch_ts resets job_types, convergence, clears pending pipes, and cleans up IRC species
+        both from the Scheduler's own state and from the caller's species list object."""
         ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
         H       1.81402049    1.03819414    0.00000000
         H       0.00000000    0.00000000    0.00000000
@@ -1034,8 +1035,9 @@ H      -1.82570782    0.42754384   -0.56130718"""
         project_directory = os.path.join(ARC_PATH, 'Projects',
                                          'arc_project_for_testing_delete_after_usage4')
         self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        caller_species_list = [ts_spc]
         sched = Scheduler(project='test_switch_ts', ess_settings=self.ess_settings,
-                          species_list=[ts_spc],
+                          species_list=caller_species_list,
                           opt_level=Level(repr=default_levels_of_theory['opt']),
                           freq_level=Level(repr=default_levels_of_theory['freq']),
                           sp_level=Level(repr=default_levels_of_theory['sp']),
@@ -1098,6 +1100,9 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertNotIn(irc_label_1, sched.unique_species_labels)
         self.assertNotIn(irc_label_2, sched.unique_species_labels)
         self.assertIsNone(sched.species_dict[ts_label].irc_label)
+
+        self.assertNotIn(irc_label_1, [spc.label for spc in caller_species_list])
+        self.assertNotIn(irc_label_2, [spc.label for spc in caller_species_list])
 
         # Verify job_types reset and convergence cleared.
         self.assertFalse(sched.output[ts_label]['job_types']['opt'])


### PR DESCRIPTION
## What breaks

- A finished ARC run **crashes at the very last step** with `KeyError: 'IRC_TS0_1'`, after every quantum-chemistry job has already completed.
- The traceback points at `ARC.save_project_info_file`. The project summary (`<project>.info`) and the T3 YAML (`<project>_info.yml`) are never written.
- Trigger: any run where a TS guess is abandoned after IRC endpoint species had already been spawned for it.

## Root cause

- When a TS guess is abandoned, `Scheduler.delete_all_species_jobs` deletes the IRC endpoint species it spawned. It removed them from `self.output` and `self.species_dict` correctly.
- It removed them from `self.species_list` by **reassignment**: `self.species_list = [spc for spc in ...]`. That rebinds the scheduler's own attribute only.
- `ARC.species` is the *same list object* — `Scheduler(species_list=self.species)` — and the scheduler mutates it in place when it *appends* the IRC species. So appends were visible to `ARC.species` but removals were not.
- The deleted species therefore stayed in `ARC.species` while being gone from the synced `self.output`, and `save_project_info_file` raised on the lookup.

## What the fix does

**(a) The actual fix — `arc/scheduler.py`.** Remove in place (`self.species_list[:] = [...]`) so removals propagate through the shared list exactly like the appends do. **This alone resolves the reported failure** (verified — see below).

**(b) Defence in depth — `arc/main.py`.** `save_project_info_file` now skips species missing from `self.output` in both of its loops (`.info` and `_info.yml`), and logs the skipped labels. This is *not* required by the bug; (a) already fixes it. It is here because the second loop had the same unguarded lookup, so any future regression of this shape would crash in the same place. The log line matters specifically for `_info.yml`: T3 reads that file to learn which species ARC computed, so a species dropped from it silently is indistinguishable from one that was never requested.

No behaviour change for any species that is still live — the guard only fires for labels the run has already deleted, and there is currently no reachable path that produces one.

## How it was verified

Three tests, each run against the unfixed base first to confirm it genuinely fails:

| test | unfixed base | with (a) only |
|---|---|---|
| `scheduler_test.py::TestScheduler::test_switch_ts_cleanup` | `AssertionError: 'IRC_TS_test_1' unexpectedly found in ['TS_test', 'IRC_TS_test_1', ...]` | passes |
| `main_test.py::TestARC::test_save_project_info_file_after_a_scheduler_deleted_an_irc_species` | `KeyError: 'IRC_TS0_1'` | passes |
| `main_test.py::TestARC::test_save_project_info_file_skips_deleted_species` | `KeyError: 'IRC_TS0_1'` | still fails — this is the test that covers (b) |

The middle row is the end-to-end one: it wires a **real `ARC` to a real `Scheduler`** the way `ARC.execute` does, asserts `arc.species is sched.species_list`, spawns an IRC species, switches the TS guess, and then writes the info files. It is the test that pins the actual invariant; the other two exercise the mechanism on each side.

The third row is what shows (b) is defence in depth rather than part of the bug: with only the `scheduler.py` change applied, the end-to-end path is clean and only the synthetic guard test still fails.

Full runs of `arc/main_test.py`, `arc/scheduler_test.py` and `arc/scheduler_pipe_test.py`: **139 passed**.

The `switch_ts` removal assertion was folded into the existing `test_switch_ts_cleanup`, which already built the identical fixture and asserted removal from every other structure except `species_list` — rather than adding a third near-identical `switch_ts` fixture.

## Reuse check

Per the repo rule, I searched before writing anything new — by behaviour, not by the name I would have picked:

- "does ARC already have a helper that removes a species from a run and keeps `ARC.species` in sync with `Scheduler.species_list`?" — nothing. The only removal helpers are `ARCReaction.remove_dup_species` / `arc/reaction/reaction.py::remove_dup_species`, which deduplicate a reaction's species list and are unrelated.
- Swept for other places that rebuild `species_list` by reassignment (`species_list = [`): the only hits are local variables in `arc/scripts/pipe_worker.py` and `arc/utils/scale.py`, neither of which shares a list with `ARC.species`.
- Swept `arc/main.py` for every `self.output[...]` lookup keyed off an iteration over `self.species`: exactly the two in `save_project_info_file`, both now guarded. `ARC.summary()` iterates `self.output` itself and is not exposed to this.
- Checked the blast radius of a stale `species_list` entry: `save_restart_dict` builds `restart_dict['species']` from `species_dict.values()`, so `save_project_info_file` was the only consumer affected.

No new helper was added.

## Note on this branch's history

This branch was squashed into a single commit. In doing so it **reverts a deliberate test-style change** from the previously pushed commit `8b695602`, which had rewritten the regression test to use `ARC.__new__(ARC)` plus `SimpleNamespace` stand-ins, on the stated grounds that it "runs in ~1s instead of minutes" and removes an RMG dependency. That rationale did not hold up: the full construction measures ~1.6 s once `freq_scale_factor` / `calc_freq_factor` are pinned, so the test here uses real `ARC` and real `ARCSpecies` objects instead. The trade-off is that it does re-introduce an RMG/Arkane import path into a test of pure bookkeeping. The `_info.yml` guard that `8b695602` added is kept.
