### PR TITLE
Use the frequency log's geometry for the TS normal mode displacement …

### DIFF
--- a/arc/checks/nmd.py
+++ b/arc/checks/nmd.py
@@ -33,7 +33,8 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
     """
     Analyze the normal mode displacement by identifying bonds that break and form
     and comparing them to the expected given reaction.
-    Note that the TS geometry must be in the standard orientation for the normal mode displacement to be relevant.
+    The TS geometry is taken from the frequency job's output file so that it is in the same coordinate frame
+    as the normal mode displacements parsed from that file.
 
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
@@ -58,11 +59,18 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
                 not in reaction.ts_species.ts_checks['warnings']:
             reaction.ts_species.ts_checks['warnings'] += 'Atom map is None; skipped the TS normal mode displacement check; '
         return None
-    ts_xyz = reaction.ts_species.get_xyz()
+    ts_xyz = get_ts_xyz_in_normal_mode_frame(reaction=reaction, job=job)
     n_ts = len(ts_xyz['symbols'])
     n_expected = sum(spc.number_of_atoms for spc in reaction.r_species)
     if n_ts != n_expected:
         return False
+    if not is_ts_atom_order_consistent_with_reactants(reaction=reaction, ts_xyz=ts_xyz):
+        logger.warning(f'The geometry of TS {reaction.ts_species.label} lists its atoms as '
+                       f'{tuple(ts_xyz["symbols"])}, while the reactants of reaction {reaction.label} are ordered '
+                       f'{tuple(reaction.get_reactants_xyz(return_format="dict")["symbols"])}. The forming and '
+                       f'breaking bond indices refer to the reactant order, so they do not describe the intended '
+                       f'atoms of this TS. Skipping the normal mode displacement analysis.')
+        return None
     try:
         freqs, normal_mode_disp = parser.parse_normal_mode_displacement(log_file_path=job.local_path_to_output_file)
     except NotImplementedError:
@@ -92,6 +100,64 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
         if nmd_correct:
             return True
     return False
+
+
+def get_ts_xyz_in_normal_mode_frame(reaction: ARCReaction,
+                                    job: JobAdapter,
+                                    ) -> dict | None:
+    """
+    Get the TS geometry in the coordinate frame in which the normal mode displacements of ``job`` are reported.
+
+    The geometry is taken from the frequency job's output file, the same file the normal mode displacements
+    are parsed from. The TS species geometry is returned instead if the geometry cannot be parsed from that
+    file, or if the parsed geometry's element symbol sequence differs from the TS species' symbol sequence.
+    The parsed geometry is returned when the TS species has no geometry to compare it against, and ``None``
+    is returned only when neither source yields a geometry.
+
+    Args:
+        reaction (ARCReaction): The reaction for which the TS is checked.
+        job (JobAdapter): The frequency job object instance that points to the respective log file.
+
+    Returns:
+        dict | None: The TS Cartesian coordinates.
+    """
+    species_xyz = reaction.ts_species.get_xyz()
+    try:
+        log_xyz = parser.parse_geometry(log_file_path=job.local_path_to_output_file)
+    except Exception as e:
+        logger.warning(f'Could not parse a geometry from {job.local_path_to_output_file}, got:\n{e}\n'
+                       f'Using the geometry of TS {reaction.ts_species.label} for the normal mode '
+                       f'displacement analysis, which may not be in the frame of the normal modes.')
+        log_xyz = None
+    if log_xyz is None or species_xyz is None:
+        return log_xyz if log_xyz is not None else species_xyz
+    if tuple(log_xyz['symbols']) != tuple(species_xyz['symbols']):
+        logger.warning(f'The geometry parsed from {job.local_path_to_output_file} has the element symbol sequence '
+                       f'{tuple(log_xyz["symbols"])}, while the geometry of TS {reaction.ts_species.label} has '
+                       f'{tuple(species_xyz["symbols"])}. Using the TS species geometry for the normal mode '
+                       f'displacement analysis, which may not be in the frame of the normal modes.')
+        return species_xyz
+    return log_xyz
+
+
+def is_ts_atom_order_consistent_with_reactants(reaction: ARCReaction,
+                                               ts_xyz: dict,
+                                               ) -> bool:
+    """
+    Check whether a TS geometry lists its atoms in the element order of the reaction's reactants.
+
+    The forming, breaking and changed bond indices of a reaction are expressed as indices into the
+    concatenated reactant geometry, and are only meaningful for a TS geometry that uses that same order.
+
+    Args:
+        reaction (ARCReaction): The reaction for which the TS is checked.
+        ts_xyz (dict): The TS Cartesian coordinates.
+
+    Returns:
+        bool: Whether the TS and the concatenated reactants have identical element symbol sequences.
+    """
+    r_xyz = reaction.get_reactants_xyz(return_format='dict')
+    return tuple(ts_xyz['symbols']) == tuple(r_xyz['symbols'])
 
 
 def check_bond_directionality(formed_bonds: list[tuple[int, int]],

--- a/arc/checks/nmd_test.py
+++ b/arc/checks/nmd_test.py
@@ -6,12 +6,14 @@ This module contains unit tests for the arc.checks.nmd module
 """
 
 import unittest
+import math
 import os
 import shutil
 
 import numpy as np
 
 import arc.checks.nmd as nmd
+from arc.checks.ts import check_ts
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_coords
 from arc.job.factory import job_factory
 from arc.level import Level
@@ -20,6 +22,7 @@ from arc.parser.parser import parse_normal_mode_displacement
 from arc.reaction import ARCReaction
 from arc.species.species import ARCSpecies
 from arc.species.converter import check_xyz_dict
+from arc.species.vectors import rotate_vector
 
 
 class TestNMD(unittest.TestCase):
@@ -56,19 +59,19 @@ class TestNMD(unittest.TestCase):
                          H      -0.34927558    0.98159583   -0.32768232
                          H      -0.02233792   -0.04887375    1.09087665
                          H       1.02216551   -0.15844188   -0.35067554"""
-        oh_xyz = """O       0.48890387    0.00000000    0.00000000
-                    H      -0.48890387    0.00000000    0.00000000"""
-        ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
-                     H       1.06690511   -0.17519582    0.05416493
-                     H      -0.68531716   -0.83753536   -0.02808565
-                     H      -0.38158795    1.01273118   -0.02607927"""
-        h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
-                     H      -0.76330345   -0.19953755    0.00000000
-                     H       0.76363177   -0.19827735    0.00000000"""
+        cls.oh_xyz = """O       0.48890387    0.00000000    0.00000000
+                        H      -0.48890387    0.00000000    0.00000000"""
+        cls.ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
+                         H       1.06690511   -0.17519582    0.05416493
+                         H      -0.68531716   -0.83753536   -0.02808565
+                         H      -0.38158795    1.01273118   -0.02607927"""
+        cls.h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
+                         H      -0.76330345   -0.19953755    0.00000000
+                         H       0.76363177   -0.19827735    0.00000000"""
         cls.rxn_1 = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=cls.ch4_xyz),
-                                           ARCSpecies(label='OH', smiles='[OH]', xyz=oh_xyz)],
-                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=ch3_xyz),
-                                           ARCSpecies(label='H2O', smiles='O', xyz=h2o_xyz)])
+                                           ARCSpecies(label='OH', smiles='[OH]', xyz=cls.oh_xyz)],
+                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=cls.ch3_xyz),
+                                           ARCSpecies(label='H2O', smiles='O', xyz=cls.h2o_xyz)])
         cls.ts_1_xyz = check_xyz_dict("""C                    -1.212192   -0.010161    0.000000
                                          H                     0.010122    0.150115    0.000001
                                          H                    -1.460491   -0.555461   -0.907884
@@ -353,6 +356,124 @@ class TestNMD(unittest.TestCase):
         rxn_6.ts_species.populate_ts_checks()
         valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn_6, job=self.generic_job, amplitude=1)
         self.assertTrue(valid)
+
+    def make_ch4_oh_rxn(self, ts_xyz):
+        """A helper for building the CH4 + OH <=> CH3 + H2O reaction with a given TS geometry."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz),
+                                     ARCSpecies(label='H2O', smiles='O', xyz=self.h2o_xyz)])
+        rxn.ts_species = ARCSpecies(label='TS1', is_ts=True, xyz=ts_xyz)
+        return rxn
+
+    def permuted_ts_1_xyz(self):
+        """A helper returning the TS1 geometry reordered so that it no longer follows the reactant order."""
+        order = (5, 6, 0, 1, 2, 3, 4)
+        return {'symbols': tuple(self.ts_1_xyz['symbols'][i] for i in order),
+                'isotopes': tuple(self.ts_1_xyz['isotopes'][i] for i in order),
+                'coords': tuple(self.ts_1_xyz['coords'][i] for i in order)}
+
+    def test_analyze_ts_nmd_uses_the_frame_of_the_freq_log(self):
+        """Test that the NMD analysis uses the geometry of the frequency log rather than the species geometry."""
+        freq_log = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        self.generic_job.local_path_to_output_file = freq_log
+        rotated_coords = tuple(tuple(rotate_vector(point_a=[0.0, 0.0, 0.0],
+                                                   point_b=list(coord),
+                                                   normal=[1.0, 1.0, 1.0],
+                                                   theta=math.pi))
+                               for coord in self.ts_1_xyz['coords'])
+        rotated_xyz = {'symbols': self.ts_1_xyz['symbols'],
+                       'isotopes': self.ts_1_xyz['isotopes'],
+                       'coords': rotated_coords}
+        rxn = self.make_ch4_oh_rxn(ts_xyz=rotated_xyz)
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertTrue(valid)
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertEqual(frame_xyz['symbols'], self.ts_1_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(self.ts_1_xyz['coords']), atol=1e-4)
+
+    def test_get_ts_xyz_in_normal_mode_frame_is_a_no_op_when_the_frames_agree(self):
+        """Test that the NMD analysis is unchanged when the species and the frequency log share a frame."""
+        freq_log = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        self.generic_job.local_path_to_output_file = freq_log
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.ts_1_xyz)
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertEqual(frame_xyz['symbols'], self.ts_1_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(self.ts_1_xyz['coords']), atol=1e-4)
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertTrue(valid)
+
+    def test_get_ts_xyz_in_normal_mode_frame_falls_back_on_a_symbol_mismatch(self):
+        """Test that a symbol sequence mismatch falls back to the species geometry instead of raising."""
+        freq_log = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        self.generic_job.local_path_to_output_file = freq_log
+        permuted_xyz = self.permuted_ts_1_xyz()
+        rxn = self.make_ch4_oh_rxn(ts_xyz=permuted_xyz)
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertEqual(frame_xyz['symbols'], permuted_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(permuted_xyz['coords']), atol=1e-8)
+
+    def test_analyze_ts_nmd_returns_none_when_the_ts_atom_order_differs_from_the_reactants(self):
+        """Test that a TS ordered differently to the reactants yields None rather than a confident verdict."""
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.permuted_ts_1_xyz())
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertIsNone(valid)
+        self.assertFalse(nmd.is_ts_atom_order_consistent_with_reactants(reaction=rxn,
+                                                                        ts_xyz=self.permuted_ts_1_xyz()))
+
+    def test_is_ts_atom_order_consistent_with_reactants(self):
+        """Test that a TS ordered as the concatenated reactants is reported as consistent."""
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.ts_1_xyz)
+        self.assertEqual(rxn.get_reactants_xyz(return_format='dict')['symbols'], self.ts_1_xyz['symbols'])
+        self.assertTrue(nmd.is_ts_atom_order_consistent_with_reactants(reaction=rxn, ts_xyz=self.ts_1_xyz))
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertTrue(valid)
+
+    def test_an_unknown_nmd_verdict_does_not_trigger_a_ts_switch(self):
+        """Test that an unknown NMD verdict does not meet the Scheduler condition for switching a TS guess."""
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.permuted_ts_1_xyz())
+        rxn.ts_species.populate_ts_checks()
+        check_ts(reaction=rxn, job=self.generic_job, checks=['NMD'])
+        self.assertIsNone(rxn.ts_species.ts_checks['NMD'])
+        self.assertIsNot(rxn.ts_species.ts_checks['NMD'], False)
+
+    def test_get_ts_xyz_in_normal_mode_frame_uses_the_log_when_the_species_has_no_geometry(self):
+        """Test that the parsed geometry is used when the TS species has none to compare it against."""
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.ts_1_xyz)
+        rxn.ts_species = ARCSpecies(label='TS1', is_ts=True)
+        self.assertIsNone(rxn.ts_species.get_xyz())
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertIsNotNone(frame_xyz)
+        self.assertEqual(frame_xyz['symbols'], self.ts_1_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(self.ts_1_xyz['coords']), atol=1e-4)
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertTrue(valid)
+
+    def test_get_ts_xyz_in_normal_mode_frame_falls_back_when_the_log_has_no_geometry(self):
+        """Test that a log file with no parsable geometry falls back to the species geometry."""
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'normal_mode', 'HO2', 'output.out')
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.ts_1_xyz)
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertEqual(frame_xyz['symbols'], self.ts_1_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(self.ts_1_xyz['coords']), atol=1e-8)
+
+    def test_get_ts_xyz_in_normal_mode_frame_falls_back_when_parsing_fails(self):
+        """Test that a log file the geometry parser cannot handle falls back to the species geometry."""
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'CH2O_freq_molpro.out')
+        rxn = self.make_ch4_oh_rxn(ts_xyz=self.ts_1_xyz)
+        frame_xyz = nmd.get_ts_xyz_in_normal_mode_frame(reaction=rxn, job=self.generic_job)
+        self.assertEqual(frame_xyz['symbols'], self.ts_1_xyz['symbols'])
+        np.testing.assert_allclose(np.array(frame_xyz['coords']),
+                                   np.array(self.ts_1_xyz['coords']), atol=1e-8)
 
     def test_analyze_ts_normal_mode_displacement_correct_and_incorrect_data(self):
         """Test the analyze_ts_normal_mode_displacement() function with correct and incorrect TSs for iC3H7 <=> nC3H7."""


### PR DESCRIPTION
**Base of a 3-PR stack — review this one first.** Reading order: **#967 → #968 → #970**. All three change the head of `analyze_ts_normal_mode_displacement()`; they are split by *cause*, not by file.

## What breaks

- The TS normal mode displacement (NMD) check accepted or rejected a transition state using a geometry that was not in the same coordinate frame as the normal modes it was compared against.
- The geometry came from the optimization job's `final_xyz`; the modes came from the **frequency** job's log. Gaussian reports modes in that job's own orientation, which is not generally the orientation of the opt geometry.
- Measured over 996 real benchmark frequency jobs: 82% agree to within 1°, but **17.6% differ by ~180°**. These are exact rigid rotations (fit RMSD ~1e-16), not numerical noise.
- Adding a mode vector expressed in one basis to a coordinate expressed in another corrupts the cross term of every displaced bond length, so the rotation-invariance of a bond length does **not** rescue the result.

## What the fix does

- `get_ts_xyz_in_normal_mode_frame()` takes the TS geometry from the frequency job's output file — the same file the displacements are parsed from — so geometry and modes share a frame by construction.
- For Gaussian that resolves to the last `Standard orientation:` block, falling back to `Input orientation:`. Both are right: the fallback only applies when Gaussian suppressed the standard orientation (e.g. under `nosymm`, which ARC's troubleshooting can add), and in that case the frequency analysis is done in the input orientation too.
- Falls back to the TS species geometry when the freq log yields no geometry, or when the parsed geometry's element symbol sequence differs from the species'. Both fallbacks log a warning that the frame may not match.
- The fallback is one-directional. When the **species** has no geometry — `ARCSpecies.get_xyz()` returns `None` for a TS with no `final_xyz`/`initial_xyz`/conformer and no TS guess carrying an `initial_xyz` — the parsed geometry is used rather than discarded. Returning `None` there would hand the caller nothing to measure: it immediately does `len(ts_xyz['symbols'])`.
- `is_ts_atom_order_consistent_with_reactants()` makes the analysis return `None` when the TS atom order differs from the concatenated reactant order. Nothing checked this before: the forming/breaking bond indices are indices into the *reactant* order, so on a mismatch the check silently scored the wrong atoms and still returned a confident verdict.

## Why this shape

- A frame mismatch or an atom-order mismatch is a **missing precondition**, not evidence against the TS — hence `None` (analysis not performed) rather than `False` (TS rejected).
- ARC already pairs a geometry with modes from the same log elsewhere: `arc/job/trsh.py::trsh_negative_freq` parses both from one `log_file` before perturbing along the mode. The NMD check was the outlier, not the precedent.

## How it was verified

- Independently confirmed by the Eckart condition. Modes expressed in their own frame satisfy `Σ mₐ(rₐ − R_com) × dₐ = 0`, and that quantity is frame-dependent, so it is a direct test of whether the pairing is consistent: **73%** of affected jobs exceed 3σ when evaluated in the opt frame, versus **0 of 111** in the freq frame.
- 9 new tests: frames agree, a deliberately rotated geometry, an element symbol mismatch, a log with no geometry, a log that fails to parse, a species with no geometry at all, the atom-order guard (unit and end-to-end), and a scheduler-level test that an unknown (`None`) NMD verdict does not trigger a TS switch.
- `arc/checks/` passes in full — 60 tests.

## Open note for the reviewer

- The line just above the new guard, `if n_ts != n_expected: return False`, is the same class of missing precondition but still returns `False`. It predates this PR and is left alone here; worth deciding whether it should become `None` too.
- `analyze_ts_normal_mode_displacement()` still does not tolerate a `None` geometry, which after this change can only arise when the freq log **and** the species both yield nothing. That `len(ts_xyz['symbols'])` on a possibly-`None` value is unchanged from `main` and is left as-is rather than widened here.

## What I searched for

- Whether ARC already had a helper that resolves a geometry into the frame of a job's parsed modes — searched by behaviour (geometry / frame / orientation reconciliation) rather than by an intended name. `trsh_negative_freq` does it inline for a different purpose; there was no reusable helper to import.
- Confirmed the geometry parse goes through the existing `arc/parser` entry point rather than a new reader, and that the symbol-sequence comparison had no existing equivalent.

