### PR TITLE
Fix Molpro parse_geometry: raises on every log, and returned Bohr coordinates

### DIFF
--- a/arc/parser/adapters/molpro.py
+++ b/arc/parser/adapters/molpro.py
@@ -8,8 +8,8 @@ import numpy as np
 import pandas as pd
 import re
 
-from arc.common import SYMBOL_BY_NUMBER
-from arc.constants import E_h_kJmol
+from arc.common import NUMBER_BY_SYMBOL, SYMBOL_BY_NUMBER
+from arc.constants import E_h_kJmol, bohr_to_angstrom
 from arc.species.converter import xyz_from_data
 from arc.parser.adapter import ESSAdapter
 from arc.parser.factory import register_ess_adapter
@@ -51,9 +51,10 @@ class MolproParser(ESSAdapter, ABC):
     def parse_geometry(self) -> dict[str, tuple] | None:
         """
         Parse the xyz geometry from an ESS log file.
+        The ``ATOMIC COORDINATES`` block is reported by Molpro in Bohr and is converted to Angstrom.
 
         Returns: dict[str, tuple] | None
-            The cartesian geometry.
+            The cartesian geometry in Angstrom.
         """
         lines = _get_lines_from_file(self.log_file_path)
         coords = []
@@ -78,24 +79,27 @@ class MolproParser(ESSAdapter, ABC):
                 if coords:
                     return xyz_from_data(coords=np.array(coords), numbers=np.array(numbers))
 
-        # Fallback to input geometry
-        for line in lines:
+        for i, line in enumerate(lines):
             if 'ATOMIC COORDINATES' in line:
                 coords = []
                 numbers = []
-                for _ in range(3):  # Skip header lines
-                    line = next(lines)
-                while line.strip() and 'Bond' not in line:
-                    parts = line.split()
-                    if len(parts) >= 5:
+                reading = False
+                j = i + 1
+                while j < len(lines):
+                    parts = lines[j].split()
+                    if len(parts) >= 6 and parts[0].isdigit():
                         try:
-                            atom_symbol = parts[1].capitalize()
-                            atomic_number = next(k for k, v in SYMBOL_BY_NUMBER.items() if v == atom_symbol)
-                            numbers.append(atomic_number)
-                            coords.append([float(parts[2]), float(parts[3]), float(parts[4])])
-                        except (ValueError, StopIteration):
+                            atomic_number = NUMBER_BY_SYMBOL[parts[1].capitalize()]
+                            xyz_bohr = [float(parts[3]), float(parts[4]), float(parts[5])]
+                        except (ValueError, KeyError):
+                            j += 1
                             continue
-                    line = next(lines)
+                        numbers.append(atomic_number)
+                        coords.append([coord * bohr_to_angstrom for coord in xyz_bohr])
+                        reading = True
+                    elif reading:
+                        break
+                    j += 1
                 if coords:
                     return xyz_from_data(coords=np.array(coords), numbers=np.array(numbers))
         return None

--- a/arc/parser/parser_test.py
+++ b/arc/parser/parser_test.py
@@ -16,6 +16,7 @@ from arc.common import ARC_TESTING_PATH, almost_equal_coords, get_element_mass, 
 from arc.parser.adapters.gaussian import parse_ic_info, parse_ic_values
 from arc.species import ARCSpecies
 from arc.species.converter import str_to_xyz, xyz_to_str
+from arc.species.vectors import calculate_distance
 
 
 class TestParser(unittest.TestCase):
@@ -754,6 +755,22 @@ H      -1.69381305    0.40788834    0.90078104"""
                                      (-0.624513, 0.203027, -0.807493), (0.59, -0.871703, -0.0),
                                      (0.659027, -1.754591, -0.0))}
         self.assertTrue(almost_equal_coords(xyz_5, expected_xyz_5))
+
+    def test_parse_geometry_molpro(self):
+        """Test parse_geometry() of a Molpro log file"""
+        path = os.path.join(ARC_TESTING_PATH, 'freq', 'CH2O_freq_molpro.out')
+        xyz = parser.parse_geometry(log_file_path=path)
+        self.assertIsInstance(xyz, dict)
+        self.assertEqual(xyz['symbols'], ('O', 'C', 'H', 'H'))
+        self.assertEqual(len(xyz['coords']), 4)
+
+    def test_parse_geometry_molpro_is_in_angstrom(self):
+        """Test that parse_geometry() converts the Molpro Bohr coordinates to Angstrom"""
+        path = os.path.join(ARC_TESTING_PATH, 'freq', 'CH2O_freq_molpro.out')
+        xyz = parser.parse_geometry(log_file_path=path)
+        self.assertAlmostEqual(calculate_distance(coords=xyz, atoms=[0, 1]), 1.2116, places=3)
+        self.assertAlmostEqual(calculate_distance(coords=xyz, atoms=[1, 2]), 1.1031, places=3)
+        self.assertAlmostEqual(calculate_distance(coords=xyz, atoms=[1, 3]), 1.1031, places=3)
 
     def test_parse_geometry_for_ts(self):
         """Test parse_geometry() for Transition States"""


### PR DESCRIPTION
## What breaks

- **`parse_geometry()` is unusable for Molpro — it raises on every Molpro log.** The `ATOMIC COORDINATES` branch called `next(lines)` on the *list* returned by `_get_lines_from_file()`:
  ```
  TypeError: 'list' object is not an iterator
  ```
- This is not caught anywhere. `make_parser()` calls the adapter method unguarded, so the `TypeError` propagates straight out of `parser.parse_geometry()` into its callers (`arc/scheduler.py` in ~8 places, `arc/job/trsh.py:657`, `arc/job/pipe/pipe_run.py:627`).
- It also shadows the generic XYZ fallback: `parse_xyz_from_file` only runs when the adapter returns `None`, and an adapter that raises never returns anything.
- **Two further defects sat behind the raise, both of which silently return a *wrong* geometry rather than failing:**
  - The `ATOMIC COORDINATES` block is printed by Molpro in **Bohr**, and nothing converted it. Every coordinate was off by a factor of ~1.89.
  - The columns are `NR ATOM CHARGE X Y Z`, so the coordinates start at index **3**. The code read indices 2, 3, 4 — i.e. it took the nuclear **charge** as the x coordinate and dropped z entirely.
- Net effect for CH2O: a "C=O bond" of **1.609 Å** instead of 1.212 Å, from numbers that are partly a charge and partly Bohr.
- This matters now because the NMD path is starting to call `parse_geometry()` behind an `except Exception` guard — which would absorb the raise and, once the raise is fixed, would happily consume a silently-Bohr geometry. Fixing the raise without the units would be worse than the status quo.

## What the fix does

- Locates the atom lines by **content** (`NR` is an integer and the row has 6+ fields) instead of a fixed "skip 3 header lines" offset, and stops at the first non-atom line after the block — so no `next()` on a list, and no dependence on Molpro's blank-line layout.
- Reads the coordinate columns at indices 3, 4, 5.
- Scales them by **`arc.constants.bohr_to_angstrom`** — the constant the other adapters already use. Nothing hard-coded.
- Resolves the element via **`arc.common.NUMBER_BY_SYMBOL`** instead of an open-coded linear scan of `SYMBOL_BY_NUMBER` (`next(k for k, v in ... if v == symbol)`). The two dicts are exact inverses (verified over all 118 entries), so this is behaviour-preserving.
- Scope: only the `ATOMIC COORDINATES` branch is touched. The `Current geometry` branch above it is left exactly as it was — see "Not fixed here".

## How it was verified

- **Both defects have a test that fails on unfixed code.**
  - `test_parse_geometry_molpro` on `main`:
    ```
    FAILED arc/parser/parser_test.py::TestParser::test_parse_geometry_molpro
      - TypeError: 'list' object is not an iterator
    ```
  - `test_parse_geometry_molpro_is_in_angstrom` with the iteration fixed but the conversion removed:
    ```
    AssertionError: 2.289539337158203 != 1.2116 within 3 places
    ```
    2.2895 is exactly the Bohr value Molpro prints for that bond, so the check discriminates Bohr from Ångström cleanly.
  - And with the conversion present but the original column indices retained:
    ```
    AssertionError: 1.6087325811386108 != 1.2116 within 3 places
    ```
- **Physical check against Molpro's own numbers.** Every Molpro log prints `Bond lengths in Bohr (Angstrom)` a few lines below the coordinate block, which is an independent reference. Parsed vs. printed:

  | fixture | bond | parsed | Molpro's printed Å |
  |---|---|---|---|
  | `freq/CH2O_freq_molpro.out` | C=O | 1.2116 | 1.211572060 |
  | | C–H | 1.1031 | 1.103052416 |
  | `sp/mehylamine_CCSD(T).out` | N–C | 1.4582 | 1.458164546 |
  | | C–H | 1.0928 | 1.092770789 |
  | | N–H | 1.0120 | 1.011957409 |
  | `sp/ONHO(T)_sp_CCSD(T).out` | O–N | 1.3133 | 1.313290573 |
  | | N–H | 1.0221 | 1.022089640 |

  Distances are compared with a tolerance (`assertAlmostEqual(..., places=3)`), not as byte-exact float goldens.
- `arc/parser/parser_test.py` passes in full (34 tests) with the fix.

## What I searched for

Before writing anything, I looked for machinery ARC already has, by behaviour rather than by the name I'd have given it:

- *"does ARC already convert atomic coordinates from Bohr to Ångström?"* → `arc/constants.py::bohr_to_angstrom` (`a0 * 1e10`), already imported and used inline by `arc/parser/adapters/orca.py`, `xtb.py`, `qchem.py`, `gaussian.py` and `yaml.py`. Reused it; did not add a helper, since inline multiplication by the shared constant is the established idiom across the adapters and there is no wrapper to reuse.
- *"element symbol → atomic number"* → `arc/common.py::NUMBER_BY_SYMBOL`, sibling of the `SYMBOL_BY_NUMBER` the code was scanning. Both come from the same `read_element_dicts()`.
- *"distance between two atoms of an xyz dict"* for the test → `arc/species/vectors.py::calculate_distance`, which takes the xyz dict directly. No hand-rolled `np.linalg.norm`.
- I also checked whether any adapter already solved this in a shape worth reusing. Only three adapters convert a geometry at all (`xtb.py:90`, `orca.py:101-103`, and now `molpro.py`), and all three multiply by the constant inline — there is no shared helper to reuse, and at three call sites a wrapper wouldn't earn its indirection. ORCA is the only one that *detects* the unit, by branching on the `(A.U.)` vs `(ANGSTROEM)` tag in the header it matched; that pattern doesn't transfer here, because Molpro's `ATOMIC COORDINATES` header carries no unit tag at all, so the unit is fixed by the format rather than detectable.

## Not fixed here

Two things in the same function are deliberately out of scope, because there is no Molpro **optimization** fixture in `arc/testing/` to verify a change against, and an untested change to a geometry parser is worse than a documented gap:

- The `Current geometry` (optimized, and in Ångström) branch requires `len(parts) >= 5`, but a Molpro xyz-format line has 4 fields and the code reads `parts[1:4]`. The branch can therefore never produce coordinates and always falls through.
- Because it falls through, an `optg` job's geometry comes from the `ATOMIC COORDINATES` fallback — and that loop takes the **first** match in the file, i.e. the *input* geometry, not the optimized one. (ORCA's adapter scans from the end of the file for exactly this reason.)

Both are pre-existing and unchanged by this PR; happy to take them in a follow-up once there's a Molpro `optg` log to test with.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
