### PR TITLE
Do not discard a TS when the normal mode displacement check cannot be run

### DIFF
--- a/arc/checks/nmd.py
+++ b/arc/checks/nmd.py
@@ -51,7 +51,8 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
         return None
     ts_xyz = reaction.ts_species.get_xyz()
     n_ts = len(ts_xyz['symbols'])
-    n_expected = sum(spc.number_of_atoms for spc in reaction.r_species)
+    n_expected = sum(spc.number_of_atoms * reaction.get_species_count(species=spc, well=0)
+                     for spc in reaction.r_species)
     if n_ts != n_expected:
         return False
     try:
@@ -477,6 +478,37 @@ def get_bond_length_in_reaction(bond: tuple[int, int] | list[int],
     return float(distance)
 
 
+def get_repeated_species_atom_equivalences(reaction: ARCReaction,
+                                           well: int = 0,
+                                           ) -> list[list[int]]:
+    """
+    Build atom-equivalence groups across repeated identical species in a reaction well.
+
+    When a species participates more than once (e.g. OH + OH), ``r_species`` is deduplicated, so the
+    atom map may assign a reactive atom to one copy while the located TS uses the equivalent atom of
+    another copy. For each atom position within such a species, the atoms at that position across all
+    copies are equivalent. Indices follow the expanded (per-occurrence) atom ordering used by the atom
+    map and by ``get_reactants_and_products``.
+
+    Args:
+        reaction (ARCReaction): The reaction.
+        well (int): ``0`` for the reactants well, ``1`` for the products well.
+
+    Returns:
+        list[list[int]]: Equivalence groups (each a list of global atom indices) for repeated species.
+    """
+    species = reaction.r_species if well == 0 else reaction.p_species
+    groups, offset = list(), 0
+    for spc in species:
+        count = reaction.get_species_count(species=spc, well=well)
+        n_atoms = spc.number_of_atoms
+        if count > 1:
+            for pos in range(n_atoms):
+                groups.append([offset + copy_i * n_atoms + pos for copy_i in range(count)])
+        offset += count * n_atoms
+    return groups
+
+
 def find_equivalent_atoms(reaction: ARCReaction,
                           reactant_only: bool = True,
                           ) -> tuple[list[list[int]], list[list[int]]]:
@@ -484,6 +516,8 @@ def find_equivalent_atoms(reaction: ARCReaction,
     Find equivalent atoms in the reactants and products of a reaction.
     This is a tentative function that should be replaced when atom mapping returns a list.
     It is meant to suggest additional atoms that can move instead of the ones selected by the atom map.
+    Reactant equivalences cover both atoms made equivalent within a molecule and atoms at the same
+    position across the copies of a species that participates more than once.
 
     Args:
         reaction (ARCReaction): The reaction for which equivalent atoms are searched.
@@ -501,6 +535,7 @@ def find_equivalent_atoms(reaction: ARCReaction,
                                                                 inc=sum([len(r.mol.atoms) for r in reactants[:i]]),
                                                                 atom_map=None,
                                                                 ))
+    r_eq_atoms.extend(get_repeated_species_atom_equivalences(reaction, well=0))
     if not reactant_only:
         for i, product in enumerate(products):
             p_eq_atoms.extend(identify_equivalent_atoms_in_molecule(molecule=product.mol,

--- a/arc/checks/nmd.py
+++ b/arc/checks/nmd.py
@@ -34,6 +34,9 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
     Analyze the normal mode displacement by identifying bonds that break and form
     and comparing them to the expected given reaction.
     Note that the TS geometry must be in the standard orientation for the normal mode displacement to be relevant.
+    The forming, breaking and changed bonds of the reaction are indexed into the concatenated reactant atoms,
+    where a species participating more than once (e.g. ``A + A``, for which ``r_species`` holds a single entry)
+    contributes its atoms once per occurrence. The TS geometry must span that same set of atoms.
 
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
@@ -46,15 +49,23 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
 
     Returns:
         bool | None: Whether the TS normal mode displacement is consistent with the desired reaction.
+                     ``None`` if the analysis could not be performed, either because no frequency job was
+                     given, because the TS geometry does not span the reactant atoms the bond indices refer
+                     to, or because no normal mode displacements could be parsed from the job's output file.
+                     Only ``False`` marks the TS as inconsistent with the reaction.
     """
     if job is None:
         return None
     ts_xyz = reaction.ts_species.get_xyz()
     n_ts = len(ts_xyz['symbols'])
-    n_expected = sum(spc.number_of_atoms * reaction.get_species_count(species=spc, well=0)
-                     for spc in reaction.r_species)
+    reactants, _ = reaction.get_reactants_and_products(return_copies=False)
+    n_expected = sum(spc.number_of_atoms for spc in reactants)
     if n_ts != n_expected:
-        return False
+        logger.warning(f'The geometry of TS {reaction.ts_species.label} has {n_ts} atoms, while the reactants of '
+                       f'reaction {reaction.label} have {n_expected} atoms in total. The forming, breaking and '
+                       f'changed bonds of the reaction are indexed into the reactant atoms, so they cannot be '
+                       f'applied to this TS geometry. Skipping the normal mode displacement analysis.')
+        return None
     try:
         freqs, normal_mode_disp = parser.parse_normal_mode_displacement(log_file_path=job.local_path_to_output_file)
     except NotImplementedError:

--- a/arc/checks/nmd_test.py
+++ b/arc/checks/nmd_test.py
@@ -8,6 +8,7 @@ This module contains unit tests for the arc.checks.nmd module
 import unittest
 import os
 import shutil
+from unittest.mock import patch
 
 import numpy as np
 
@@ -56,19 +57,19 @@ class TestNMD(unittest.TestCase):
                          H      -0.34927558    0.98159583   -0.32768232
                          H      -0.02233792   -0.04887375    1.09087665
                          H       1.02216551   -0.15844188   -0.35067554"""
-        oh_xyz = """O       0.48890387    0.00000000    0.00000000
-                    H      -0.48890387    0.00000000    0.00000000"""
-        ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
-                     H       1.06690511   -0.17519582    0.05416493
-                     H      -0.68531716   -0.83753536   -0.02808565
-                     H      -0.38158795    1.01273118   -0.02607927"""
-        h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
-                     H      -0.76330345   -0.19953755    0.00000000
-                     H       0.76363177   -0.19827735    0.00000000"""
+        cls.oh_xyz = """O       0.48890387    0.00000000    0.00000000
+                        H      -0.48890387    0.00000000    0.00000000"""
+        cls.ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
+                         H       1.06690511   -0.17519582    0.05416493
+                         H      -0.68531716   -0.83753536   -0.02808565
+                         H      -0.38158795    1.01273118   -0.02607927"""
+        cls.h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
+                         H      -0.76330345   -0.19953755    0.00000000
+                         H       0.76363177   -0.19827735    0.00000000"""
         cls.rxn_1 = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=cls.ch4_xyz),
-                                           ARCSpecies(label='OH', smiles='[OH]', xyz=oh_xyz)],
-                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=ch3_xyz),
-                                           ARCSpecies(label='H2O', smiles='O', xyz=h2o_xyz)])
+                                           ARCSpecies(label='OH', smiles='[OH]', xyz=cls.oh_xyz)],
+                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=cls.ch3_xyz),
+                                           ARCSpecies(label='H2O', smiles='O', xyz=cls.h2o_xyz)])
         cls.ts_1_xyz = check_xyz_dict("""C                    -1.212192   -0.010161    0.000000
                                          H                     0.010122    0.150115    0.000001
                                          H                    -1.460491   -0.555461   -0.907884
@@ -225,6 +226,11 @@ class TestNMD(unittest.TestCase):
                                          H       -1.951439    0.465285   -1.158262""")
         cls.rxn_3.ts_species = ARCSpecies(label='TS3', is_ts=True, xyz=cls.ts_3_xyz)
 
+        cls.ts_oh_oh_xyz = check_xyz_dict("""O      -1.10000000    0.00000000    0.00000000
+                                             H      -0.15000000    0.00000000    0.00000000
+                                             O       1.20000000    0.00000000    0.00000000
+                                             H       1.55000000    0.85000000    0.00000000""")
+
     def test_get_repeated_species_atom_equivalences(self):
         """Repeated identical reactants (e.g. OH + OH) must yield cross-copy atom-equivalence groups
         (the two O's, the two H's) so NMD can try the alternative mapping when the atom map picks one
@@ -237,6 +243,35 @@ class TestNMD(unittest.TestCase):
         groups = nmd.get_repeated_species_atom_equivalences(rxn, well=0)
         self.assertEqual(sorted(sorted(g) for g in groups), [[0, 2], [1, 3]])
         self.assertEqual(nmd.get_repeated_species_atom_equivalences(self.rxn_1, well=0), [])
+
+    def test_analyze_ts_normal_mode_displacement_repeated_reactant(self):
+        """Test that a TS of an A + A reaction is not reported as inconsistent with the reaction."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)],
+                          p_species=[ARCSpecies(label='H2O', smiles='O', xyz=self.h2o_xyz),
+                                     ARCSpecies(label='O', smiles='[O]', multiplicity=3,
+                                                xyz='O 0.00000000 0.00000000 0.00000000')])
+        rxn.ts_species = ARCSpecies(label='TS_OH_OH', is_ts=True, xyz=self.ts_oh_oh_xyz)
+        self.assertEqual(len(rxn.r_species), 1)
+        reactants, _ = rxn.get_reactants_and_products(return_copies=False)
+        self.assertEqual(sum(spc.number_of_atoms for spc in reactants), 4)
+        self.assertEqual(len(rxn.ts_species.get_xyz()['symbols']), 4)
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'CHO_neg_freq.out')
+        with patch.object(nmd.parser, 'parse_normal_mode_displacement', side_effect=NotImplementedError):
+            valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertIsNone(valid)
+
+    def test_analyze_ts_normal_mode_displacement_atom_count_mismatch(self):
+        """Test that a TS spanning a different set of atoms than the reactants is not reported as consistent."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz),
+                                     ARCSpecies(label='H2O', smiles='O', xyz=self.h2o_xyz)])
+        rxn.ts_species = ARCSpecies(label='TS_short', is_ts=True, xyz=self.ch4_xyz)
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertIsNot(valid, True)
+        self.assertIsNone(valid)
 
     def test_analyze_ts_normal_mode_displacement_simple_rxns(self):
         """Test the analyze_ts_normal_mode_displacement() function with simple reactions."""

--- a/arc/checks/nmd_test.py
+++ b/arc/checks/nmd_test.py
@@ -225,6 +225,19 @@ class TestNMD(unittest.TestCase):
                                          H       -1.951439    0.465285   -1.158262""")
         cls.rxn_3.ts_species = ARCSpecies(label='TS3', is_ts=True, xyz=cls.ts_3_xyz)
 
+    def test_get_repeated_species_atom_equivalences(self):
+        """Repeated identical reactants (e.g. OH + OH) must yield cross-copy atom-equivalence groups
+        (the two O's, the two H's) so NMD can try the alternative mapping when the atom map picks one
+        copy's atom but the TS uses the other's. Non-repeated reactions must yield none."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='H2O', smiles='O'),
+                                     ARCSpecies(label='O', smiles='[O]', multiplicity=3)],
+                          reactants=['OH', 'OH'], products=['H2O', 'O'])
+        groups = nmd.get_repeated_species_atom_equivalences(rxn, well=0)
+        self.assertEqual(sorted(sorted(g) for g in groups), [[0, 2], [1, 3]])
+        self.assertEqual(nmd.get_repeated_species_atom_equivalences(self.rxn_1, well=0), [])
+
     def test_analyze_ts_normal_mode_displacement_simple_rxns(self):
         """Test the analyze_ts_normal_mode_displacement() function with simple reactions."""
         # CH4 + OH <=> CH3 + H2O

--- a/arc/job/adapters/ts/autotst_ts.py
+++ b/arc/job/adapters/ts/autotst_ts.py
@@ -211,6 +211,8 @@ class AutoTSTAdapter(JobAdapter):
     def execute_incore(self):
         """
         Execute a job incore.
+        The reverse-direction reaction label repeats each species by the number of times it
+        participates in its well, so a well with a repeated species stays atom-balanced.
         """
         if not AUTOTST_PYTHON or not os.path.isfile(AUTOTST_PYTHON):
             raise FileNotFoundError('AutoTST python executable was not found. '
@@ -230,10 +232,14 @@ class AutoTSTAdapter(JobAdapter):
                                                 multiplicity=rxn.multiplicity,
                                                 )
                 reaction_label_fwd = get_autotst_reaction_string(rxn)
+                rev_reactant_labels = [lbl for lbl in rxn.products
+                                       for _ in range(rxn.get_species_count(label=lbl, well=1))]
+                rev_product_labels = [lbl for lbl in rxn.reactants
+                                      for _ in range(rxn.get_species_count(label=lbl, well=0))]
                 reaction_label_rev = get_autotst_reaction_string(ARCReaction(r_species=rxn.p_species,
                                                                              p_species=rxn.r_species,
-                                                                             reactants=rxn.products,
-                                                                             products=rxn.reactants))
+                                                                             reactants=rev_reactant_labels,
+                                                                             products=rev_product_labels))
 
                 i = 0
                 for reaction_label, direction in zip([reaction_label_fwd, reaction_label_rev], ['F', 'R']):

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -31,6 +31,30 @@ def resolve_neb_level(ts_adapters: list) -> Level | None:
     return None
 
 
+def _thermo_lib_has_isomorph(spc: 'ARCSpecies', species_list: list) -> bool:
+    """
+    Whether ``species_list`` already contains a species with the same molecular identity as ``spc``.
+
+    Arkane keys thermo-library entries by adjacency list + multiplicity and rejects duplicates, so a
+    reaction with identical participants (e.g. OH + OH) must contribute each unique species only once.
+
+    Args:
+        spc (ARCSpecies): The candidate species.
+        species_list (list): Species already collected for the thermo library.
+
+    Returns:
+        bool: ``True`` if an isomorphic, same-multiplicity species is already present.
+    """
+    if spc.mol is None:
+        return False
+    for existing in species_list:
+        if existing.mol is not None \
+                and existing.multiplicity == spc.multiplicity \
+                and existing.mol.is_isomorphic(spc.mol):
+            return True
+    return False
+
+
 def process_arc_project(thermo_adapter: str,
                         kinetics_adapter: str,
                         project: str,
@@ -195,7 +219,7 @@ def process_arc_project(thermo_adapter: str,
                                             )
         statmech_adapter.compute_thermo(e0_only=True)
     for spc in converged_species:
-        if spc.thermo is not None:
+        if spc.thermo is not None and not _thermo_lib_has_isomorph(spc, species_for_thermo_lib):
             species_for_thermo_lib.append(spc)
         plotter.augment_arkane_yml_file_with_mol_repr(spc, output_directory)
     if species_for_thermo_lib:

--- a/arc/reaction/reaction.py
+++ b/arc/reaction/reaction.py
@@ -873,6 +873,8 @@ class ARCReaction(object):
     def get_reactants_xyz(self, return_format='str') -> dict | str:
         """
         Get a combined string/dict representation of the cartesian coordinates of all reactant species.
+        A species participating more than once in the reactant well contributes its atoms once per
+        occurrence.
 
         Args:
             return_format (str): Either ``'dict'`` to return a dict format or ``'str'`` to return a string format.
@@ -885,15 +887,17 @@ class ARCReaction(object):
             Orient the fragments according to the reactive site.
         """
         xyz_dict = dict()
-        if len(self.r_species) == 1:
-            xyz_dict = self.r_species[0].get_xyz()
-        elif len(self.r_species) >= 2:
+        reactants = [spc for spc in self.r_species
+                     for _ in range(self.get_species_count(species=spc, well=0))]
+        if len(reactants) == 1:
+            xyz_dict = reactants[0].get_xyz()
+        elif len(reactants) >= 2:
             xyz_dict = {'symbols': tuple(), 'isotopes': tuple(), 'coords': tuple()}
-            for i, reactant in enumerate(self.r_species):
+            for i, reactant in enumerate(reactants):
                 xyz = translate_to_center_of_mass(reactant.get_xyz())
                 if i:
                     xyz = translate_xyz(xyz_dict=xyz,
-                                        translation=(sum(spc.radius for spc in self.r_species[:i]) * 1.1 * i, 0, 0))
+                                        translation=(sum(spc.radius for spc in reactants[:i]) * 1.1 * i, 0, 0))
                 xyz_dict['symbols'] += xyz['symbols']
                 xyz_dict['isotopes'] += xyz['isotopes']
                 xyz_dict['coords'] += xyz['coords']
@@ -906,6 +910,8 @@ class ARCReaction(object):
         """
         Get a combined string/dict representation of the cartesian coordinates of all product species.
         The resulting coordinates are ordered as the reactants using an atom map.
+        A species participating more than once in the product well contributes its atoms once per
+        occurrence.
 
         Args:
             return_format (str): Either ``'dict'`` to return a dict format or ``'str'`` to return a string format.
@@ -917,15 +923,17 @@ class ARCReaction(object):
         Todo:
             Orient the fragments according to the reactive site.
         """
-        if len(self.p_species) == 1:
-            xyz_dict = self.p_species[0].get_xyz()
+        products = [spc for spc in self.p_species
+                    for _ in range(self.get_species_count(species=spc, well=1))]
+        if len(products) == 1:
+            xyz_dict = products[0].get_xyz()
         else:
             xyz_dict = {'symbols': tuple(), 'isotopes': tuple(), 'coords': tuple()}
-            for i, product in enumerate(self.p_species):
+            for i, product in enumerate(products):
                 xyz = translate_to_center_of_mass(product.get_xyz())
                 if i:
                     xyz = translate_xyz(xyz_dict=xyz,
-                                        translation=(sum(spc.radius for spc in self.p_species[:i]) * 1.1 * i, 0, 0))
+                                        translation=(sum(spc.radius for spc in products[:i]) * 1.1 * i, 0, 0))
                 xyz_dict['symbols'] += xyz['symbols']
                 xyz_dict['isotopes'] += xyz['isotopes']
                 xyz_dict['coords'] += xyz['coords']

--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -602,6 +602,36 @@ class TestARCReaction(unittest.TestCase):
         rxn2 = ARCReaction(r_species=[h2nn, n2h2], p_species=[n2h3, n2h3])
         self.assertEqual(rxn2.get_species_count(label=n2h3.label, well=1), 2)
 
+    def test_get_reactants_xyz_repeated_species(self):
+        """Test that a reactant appearing twice (e.g. OH + OH) contributes all of its atoms,
+        even though r_species holds a single deduplicated entry for it."""
+        oh = ARCSpecies(label='R1', smiles='[OH]',
+                        xyz={'coords': ((0.0, 0.0, 0.109), (0.0, 0.0, -0.868)),
+                             'isotopes': (16, 1), 'symbols': ('O', 'H')})
+        h2o = ARCSpecies(label='P1', smiles='O')
+        o = ARCSpecies(label='P2', smiles='[O]')
+        rxn = ARCReaction(r_species=[oh, oh], p_species=[h2o, o])
+        self.assertEqual(len(rxn.r_species), 1)
+        self.assertEqual(rxn.get_species_count(species=oh, well=0), 2)
+        reactants_xyz = rxn.get_reactants_xyz(return_format='dict')
+        self.assertEqual(len(reactants_xyz['symbols']), 4)
+        self.assertEqual(sorted(reactants_xyz['symbols']), ['H', 'H', 'O', 'O'])
+
+    def test_reverse_reaction_of_repeated_species(self):
+        """Test that the reverse of a reaction with a repeated species (OH + OH <=> H2O + O) stays
+        atom-balanced when its label lists are expanded by get_species_count, as consumers building
+        the reverse reaction from the deduplicated reactants/products lists do."""
+        oh = ARCSpecies(label='R1', smiles='[OH]', multiplicity=2)
+        h2o = ARCSpecies(label='P1', smiles='O', multiplicity=1)
+        o = ARCSpecies(label='P2', smiles='[O]', multiplicity=3)
+        fwd = ARCReaction(label='R1 + R1 <=> P1 + P2', r_species=[oh, oh], p_species=[h2o, o])
+        rev_reactants = [lbl for lbl in fwd.products for _ in range(fwd.get_species_count(label=lbl, well=1))]
+        rev_products = [lbl for lbl in fwd.reactants for _ in range(fwd.get_species_count(label=lbl, well=0))]
+        self.assertEqual(rev_products, ['R1', 'R1'])
+        rev = ARCReaction(r_species=fwd.p_species, p_species=fwd.r_species,
+                          reactants=rev_reactants, products=rev_products)
+        self.assertEqual(rev.label, 'P1 + P2 <=> R1 + R1')
+
     def test_get_reactants_and_products(self):
         """Test getting reactants and products"""
         self.rxn1.remove_dup_species()

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -288,6 +288,69 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertIsNone(self.sched1.species_dict[label].freqs)
         self.assertFalse(os.path.isfile(freq_path))
 
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_check_freq_job_does_not_switch_ts_when_nmd_cannot_be_run(self, mock_switch_ts):
+        """
+        Test that a TS is not discarded when the normal mode displacement check cannot be performed.
+
+        The forming and breaking bond indices are indices into the concatenated reactant atoms, so a
+        TS geometry spanning a different number of atoms cannot be analyzed at all. Reporting that as
+        a failed check calls switch_ts() and throws away a TS that was never examined, and switching
+        to another guess cannot change the atom count that made the analysis impossible.
+        """
+        oh_xyz = str_to_xyz("""O       0.48890387    0.00000000    0.00000000
+H      -0.48890387    0.00000000    0.00000000""")
+        h2o_xyz = str_to_xyz("""O      -0.00032832    0.39781490    0.00000000
+H      -0.76330345   -0.19953755    0.00000000
+H       0.76363177   -0.19827735    0.00000000""")
+        ch4_xyz = str_to_xyz("""C      -0.00000000    0.00000000    0.00000000
+H      -0.65055201   -0.77428020   -0.41251879
+H      -0.34927558    0.98159583   -0.32768232
+H      -0.02233792   -0.04887375    1.09087665
+H       1.02216551   -0.15844188   -0.35067554""")
+        ts_xyz = ch4_xyz
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=ch4_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=oh_xyz)],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=str_to_xyz(
+                              """C       0.00000000    0.00000001   -0.00000000
+H       1.06690511   -0.17519582    0.05416493
+H      -0.68531716   -0.83753536   -0.02808565
+H      -0.38158795    1.01273118   -0.02607927""")),
+                                     ARCSpecies(label='H2O', smiles='O', xyz=h2o_xyz)])
+        ts_label = 'TS_short'
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=3, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=0, method='heuristics', success=True, energy=0.0, xyz=ts_xyz,
+                                     execution_time='0:00:01')]
+        ts_spc.ts_guesses[0].opt_xyz = ts_xyz
+        ts_spc.chosen_ts = 0
+        ts_spc.rxn_index = 0
+        rxn.ts_species = ts_spc
+        rxn.ts_label = ts_label
+
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_nmd_no_switch_ts')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project='test_nmd_no_switch', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.rxn_dict[0] = rxn
+
+        job = job_factory(job_adapter='gaussian', project='test_nmd_no_switch', ess_settings=self.ess_settings,
+                          species=[ts_spc], job_type='freq',
+                          level=Level(repr=default_levels_of_theory['freq']),
+                          project_directory=project_directory, job_num=105)
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'CHO_neg_freq.out')
+        job.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
+        sched.check_freq_job(label=ts_label, job=job)
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['NMD'])
+        mock_switch_ts.assert_not_called()
+
     def test_determine_adaptive_level(self):
         """Test the determine_adaptive_level() method"""
         # adaptive_levels get converted to ``Level`` objects in main, but here we skip main and test Scheduler directly


### PR DESCRIPTION
**A validated transition state for any `A + A` reaction was discarded without ever being examined.**

The TS had converged, had passed its imaginary-frequency check, and was then thrown away by a precondition guard that failed before the normal mode was looked at even once. The scheduler responded by switching to another TS guess, so the reaction burned through its entire guess list — each guess costing a fresh optimisation and frequency job — and ended with no transition state at all.

### The index space

- The atom-count gate in `analyze_ts_normal_mode_displacement()` read the **deduplicated** `r_species`, which holds one entry for a species that participates twice.
- The forming, breaking and changed bond indices, the atom map, `find_equivalent_atoms()` and the TS geometry all live in the **per-occurrence expanded** space produced by `get_reactants_and_products()`.
- For `OH + OH <=> H2O + O` the TS has 4 atoms while the deduplicated reactants report 2, so the gate never matched.

The count is now taken from `get_reactants_and_products()` — the same call `get_bonds()` uses to build the bond indices — so the two agree **by construction** rather than by a parallel re-derivation that can drift.

To be clear about what this part does and does not do: **the two derivations are numerically identical today.** This was verified across six reaction shapes — `A + B`, `A + A`, `A + A + A`, a species appearing in both wells, `A + A -> A + A`, and unimolecular — each compared against the atom count `get_bonds()` actually indexes into. All three agree in every case. The gain here is coupling, not behaviour: `get_reactants_and_products()` is implemented as exactly this expansion, so a re-derivation alongside it agrees only for as long as that implementation stays put.

### A count mismatch is an inability to check, not a verdict

A mismatch means the bond indices cannot be applied to this geometry at all. It now logs a warning naming both counts and returns `None` — the value the function already returns when no frequency job is given and when the normal mode displacements cannot be parsed — instead of `False`.

The reason `False` is wrong is not only that it is harsh:

- `False`'s sole consumer is the scheduler, which responds by calling `switch_ts()` to try a different TS **guess**.
- Every `TSGuess` is validated against the same expanded reactant well by `ARCReaction.check_atom_balance()`, so all guesses for a reaction have the same atom count.
- **The condition is therefore invariant under the remedy.** Switching guesses cannot change the atom count that made the analysis impossible. `False` sends the one signal whose only consumer responds with an action that cannot help, and the cost is the whole guess list plus a TS that was never examined.
- Meanwhile a genuine atom imbalance is already a hard `ReactionError`, raised at reaction construction and again from the scheduler before any of this runs — so a real imbalance never reaches this gate quietly.

`None` does not trigger `switch_ts()`, and `ts_passed_checks()` still treats it as not passed, so the TS is withheld from the checks it must pass without being destroyed. IRC validation remains an independent gate.

Both returns in the function were audited. The count mismatch was the only one that reported an inability to check as a negative verdict; the final `return False`, after every candidate mapping has been tried, is a genuine negative and is unchanged.

### Why this sits on top of the other PR rather than beside it

Ordering matters. The `get_reactants_xyz()`/`get_products_xyz()` expansion in the PR below is a prerequisite for the count fix to be useful — with the count fix present but the expansion absent, any later guard that compares a TS against the concatenated reactant geometry sees an unexpanded reactant well and silently disables the check for every `A + A` reaction. Stacking keeps the two from ever being separated.

### Tests

- A genuinely mismatched atom count yields `None` rather than `False`. Fails without the fix with `AssertionError: False is not None`.
- A `check_freq_job()`-level assertion that the same mismatch does not reach `switch_ts()`. Fails without the fix with `AssertionError: False is not None`.
- An `A + A` reaction whose TS survives the count gate.

The scheduler-level test is deliberately built on a genuine count mismatch rather than on an `A + A` reaction. Once the count fix is in place an `A + A` reaction clears the gate (4 == 4) and exits at a later `None`, so it never reaches the branch being changed and cannot discriminate this fix.
