### PR TITLE
Pin setup-micromamba to v3.1.0 to avoid its flaky release lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           swap-storage: false
 
       - name: Set up micromamba (arc_env)
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@v3.1.0
         with:
           environment-name: arc_env
           environment-file: ARC/environment.yml

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
 
       # ── rmg_env for Arkane/database availability ───────────────
       - name: Set up micromamba (rmg_env)
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@v3.1.0
         with:
           environment-name: rmg_env
           create-args: >-
@@ -33,7 +33,7 @@ jobs:
 
       # ── docs env (wrapper shell) ────────────────────────────────
       - name: Set up micromamba (arc_env)
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@v3.1.0
         with:
           environment-name: arc_env
           environment-file: ARC/environment.yml


### PR DESCRIPTION
## Symptom

CI has been failing repo-wide **before a single test runs**, in the `Set up micromamba` step — tonight on `perf_hotspots` (#927) twice, `fix_nmd_aa_reaction_atom_count`, and `input_schema`:

```
##[error]Could not find a micromamba binary for release 2.9.0-0 on platform linux-64.
##[error]fetch failed
##[error]Unexpected end of JSON input
```

The message is misleading. Release `2.9.0-0` **does** ship `micromamba-linux-64` — uploaded 2026-08-07, `state: uploaded`, 18 MB — and a `HEAD` on that URL answers `302 -> 200`. Nothing upstream is missing. The *lookup* is what fails.

## Cause

`v3.2.0` (#310, "Support prereleases of micromamba", 2026-08-05) replaced the direct download URL with a resolution step in `src/micromamba-version.ts`: list releases over `api.github.com`, then probe the asset with a `HEAD` via `urlExists()`.

`fetchLatestStableMicromambaTag()` wraps its call in `try/catch` and falls back to `/releases/latest/download`. `resolveGithubAssetUrl()` has no such guard:

```ts
const resolveGithubAssetUrl = async (arch, tag) => {
  for (const url of githubAssetUrls(arch, tag)) {
    if (await urlExists(url)) return url
  }
  throw new Error(`Could not find a micromamba binary for release ${tag} on platform ${arch}.`)
}
```

One flaky `HEAD` and the step dies. The `v3` floating tag has pointed at this code since 2026-08-06, which is why it started biting now — and why it is intermittent (`linear_ts_bugfix` passed at 17:59 between two failures).

## Fix

Pin all three `setup-micromamba` steps — one in `ci.yml`, two in `gh-pages.yml` — to **`v3.1.0`**, which predates #310. There `src/util.ts` returns the download URL directly:

```ts
return `https://github.com/mamba-org/micromamba-releases/releases/download/${version}/micromamba-${arch}`
```

No API call, no `HEAD` probe, so the failure mode does not exist. `micromamba-version.ts` isn't even in that tree. Every input we pass (`environment-name`, `environment-file`, `create-args`, `condarc`, `cache-environment`, `cache-environment-key`, `cache-downloads`, `generate-run-shell`) is supported in `v3.1.0`.

## What was ruled out

- **`GITHUB_TOKEN` on the step** — first attempt, on the theory that `githubApiHeaders()` sending unauthenticated requests meant 60/hr per-runner-IP throttling. Pushed it, CI failed **identically**. Not the cause; dropped.
- **Pinning `micromamba-version` instead** — does not help. That path still calls `resolveGithubAssetUrl()`, i.e. the same `HEAD`. It only skips the list call, which was already the one with a fallback.
- **A broken upstream release** — refuted by the asset metadata and a live `302 -> 200`.

## Verification

Both files parse; all three steps pinned, no leftover `env`:

```
.github/workflows/ci.yml       | build-and-test | Set up micromamba (arc_env) -> mamba-org/setup-micromamba@v3.1.0
.github/workflows/gh-pages.yml | deploy         | Set up micromamba (rmg_env) -> mamba-org/setup-micromamba@v3.1.0
.github/workflows/gh-pages.yml | deploy         | Set up micromamba (arc_env) -> mamba-org/setup-micromamba@v3.1.0
steps: 3
```

The real check is this PR's own CI getting past `Set up micromamba` into the test steps.

Worth reporting upstream as a missing fallback in `resolveGithubAssetUrl()`; this pin holds until it's fixed.
