### PR TITLE
Make the RMG family set configurable via settings, resolved in get_all_families

### DIFF
--- a/arc/family/family.py
+++ b/arc/family/family.py
@@ -56,6 +56,8 @@ REACTANTS_PATTERN = re.compile(r'reactants\s*=\s*\[(.*?)\]', re.DOTALL)
 PRODUCTS_PATTERN = re.compile(r'products\s*=\s*\[(.*?)\]', re.DOTALL)
 ACTIONS_PATTERN = re.compile(r'actions\s*=\s*\[(.*?)\]', re.DOTALL)
 
+RADICAL_RECIPE_ACTIONS = ('GAIN_RADICAL', 'LOSE_RADICAL')
+
 
 def get_reaction_family(label: str, consider_arc_families: bool = True) -> 'ReactionFamily':
     """
@@ -517,7 +519,13 @@ def get_reaction_family_products(rxn: ARCReaction,
                                                           RMG-database/input/kinetics/families/recommended.py.
                                                           Can be a name of a defined set, or a list
                                                           of explicit family labels to consider.
-                                                          Note that surface families are excluded if 'all' is used.
+                                                          Note that 'all' skips family sets whose label contains
+                                                          'surface' and surface family directories, but still
+                                                          includes an individual surface family that a set with a
+                                                          non-surface label lists (e.g. the electrochem set's
+                                                          Surface_Proton_Electron_Reduction_* families).
+                                                          ``None`` (the default) means ``settings['rmg_family_set']``,
+                                                          read on every call.
         consider_rmg_families (bool, optional): Whether to consider RMG's families.
         consider_arc_families (bool, optional): Whether to consider ARC's custom families.
         discover_own_reverse_rxns_in_reverse (bool, optional): Whether to discover reactions belonging to a family
@@ -526,10 +534,17 @@ def get_reaction_family_products(rxn: ARCReaction,
                                                                ``True`` will cause the function to discover reactions
                                                                in both directions, ``False`` will cause the function
                                                                to discover reactions only in the forward direction.
+                                                               Reverse-discovered matches that this flag admits are
+                                                               still dropped by prioritize_family_product_dicts()
+                                                               whenever a forward match exists, so the flag only
+                                                               widens the result for a reaction that no family
+                                                               matches in the forward direction.
 
     Returns:
-        list[dict]: The list of product dictionaries with the reaction family label.
-                    Keys are: 'family', 'group_labels', 'products', 'own_reverse', 'discovered_in_reverse', 'actions'.
+        list[dict]: The list of product dictionaries with the reaction family label, ordered and filtered
+                    by prioritize_family_product_dicts(), so that the first entry is the family match to use.
+                    Keys are: 'family', 'group_labels', 'products', 'r_label_map', 'p_label_map',
+                    'own_reverse', 'discovered_in_reverse'.
     """
     family_labels = get_all_families(rmg_family_set=rmg_family_set,
                                      consider_rmg_families=consider_rmg_families,
@@ -587,7 +602,95 @@ def get_reaction_family_products(rxn: ARCReaction,
                     product_dicts.extend(filtered_products)
         except (KeyError, ValueError, InvalidAdjacencyListError) as e:
             logger.debug(f'Skipping family {family_label} due to unsupported group definition: {type(e).__name__}: {e}')
-    return product_dicts
+    return prioritize_family_product_dicts(rxn=rxn,
+                                           product_dicts=product_dicts,
+                                           consider_arc_families=consider_arc_families,
+                                           )
+
+
+def has_radical_recipe_action(actions: list[list]) -> bool:
+    """
+    Determine whether a family recipe changes the number of unpaired electrons of any of its labeled atoms.
+
+    Args:
+        actions (list[list]): The recipe actions of a reaction family.
+
+    Returns:
+        bool: Whether the recipe contains a ``GAIN_RADICAL`` or a ``LOSE_RADICAL`` action.
+    """
+    return any(action[0] in RADICAL_RECIPE_ACTIONS for action in actions)
+
+
+def count_recipe_bond_changes(actions: list[list]) -> tuple[int, int]:
+    """
+    Count the bond changes a family recipe prescribes.
+
+    Args:
+        actions (list[list]): The recipe actions of a reaction family.
+
+    Returns:
+        tuple[int, int]: The number of bonds the recipe forms or breaks,
+                         and the number of bonds the recipe changes the order of.
+    """
+    formed_or_broken = len([action for action in actions if action[0] in ('FORM_BOND', 'BREAK_BOND')])
+    changed = len([action for action in actions if action[0] == 'CHANGE_BOND'])
+    return formed_or_broken, changed
+
+
+def prioritize_family_product_dicts(rxn: ARCReaction,
+                                    product_dicts: list[dict],
+                                    consider_arc_families: bool = True,
+                                    ) -> list[dict]:
+    """
+    Order family product dictionaries so that the first entry is the family match to use,
+    and drop the entries that must not be used.
+
+    An entry discovered in the reverse direction carries an atom label map in the index space of the
+    flipped reaction, so all such entries are dropped whenever at least one entry was discovered in the
+    forward direction. This gate reads only ``discovered_in_reverse`` and is therefore applied even when a
+    family recipe cannot be read. If any of the reactants carries unpaired electrons, only the entries whose
+    family recipe gains or loses a radical are kept, provided that this keeps at least one entry and drops at
+    least one. The remaining entries are then ordered by the number of bonds their family recipe forms or
+    breaks, then by the number of bonds it changes the order of, then by the order in which the families
+    were considered, which is the order of ``get_all_families()``. Entries of the same family keep their
+    relative order. The radical gate and the ordering both need the family recipes, so an unreadable recipe
+    leaves the direction-gated entries in the order they were discovered in.
+
+    Args:
+        rxn (ARCReaction): The ARC reaction object.
+        product_dicts (list[dict]): The family product dictionaries to order.
+        consider_arc_families (bool, optional): Whether ARC's custom families were considered.
+
+    Returns:
+        list[dict]: The ordered product dictionaries.
+    """
+    forward_dicts = [product_dict for product_dict in product_dicts
+                     if not product_dict['discovered_in_reverse']]
+    if len(forward_dicts):
+        product_dicts = forward_dicts
+    if len(product_dicts) < 2:
+        return product_dicts
+    family_order, actions_by_family = dict(), dict()
+    for product_dict in product_dicts:
+        family_label = product_dict['family']
+        if family_label in family_order:
+            continue
+        try:
+            actions_by_family[family_label] = get_reaction_family(
+                label=family_label, consider_arc_families=consider_arc_families).actions
+        except (FileNotFoundError, KeyError, ValueError, InvalidAdjacencyListError) as e:
+            logger.warning(f'Could not read the recipe of the {family_label} family, so the family match of '
+                           f'reaction {rxn.label} is chosen by the discovery order alone: {type(e).__name__}: {e}')
+            return product_dicts
+        family_order[family_label] = len(family_order)
+    if any(spc.multiplicity is not None and spc.multiplicity > 1 for spc in rxn.r_species):
+        radical_dicts = [product_dict for product_dict in product_dicts
+                         if has_radical_recipe_action(actions_by_family[product_dict['family']])]
+        if len(radical_dicts) and len(radical_dicts) < len(product_dicts):
+            product_dicts = radical_dicts
+    return sorted(product_dicts,
+                  key=lambda product_dict: (*count_recipe_bond_changes(actions_by_family[product_dict['family']]),
+                                            family_order[product_dict['family']]))
 
 
 def _product_graph_key(mols: list[Molecule]) -> tuple:
@@ -763,8 +866,15 @@ def check_product_isomorphism(products: list[Molecule],
                               ) -> bool:
     """
     Check whether the products are isomorphic to the given species.
-    Falls back to InChI comparison when graph isomorphism fails
+    Falls back to comparing the standard InChI, the multiplicity, and the electron-agnostic
+    connectivity (elements and explicit hydrogen positions, ignoring bond orders, charges and
+    radical electrons) when graph isomorphism fails
     (e.g., different Lewis structures perceived from XYZ vs SMILES).
+    Tautomers, which share a standard InChI but place their hydrogens on different heavy atoms,
+    are rejected.
+    The connectivity comparison is made first, so an InChI is only ever generated for a
+    candidate/species pair that it admits.
+    Neither the given molecules nor the molecules of the given species are modified.
 
     Args:
         products (list[Molecule]): The products to check.
@@ -802,85 +912,152 @@ def check_product_isomorphism(products: list[Molecule],
     # Fall back to InChI comparison for unmatched products.
     # Different Lewis structures perceived from XYZ vs SMILES (e.g., O=C=C(O)C=O vs O=C[C-](O)C#[O+])
     # may not be graph-isomorphic but share the same InChI.
-    # InChI does not encode radical electrons, so also require matching multiplicity
-    # to avoid false matches between biradicals and closed-shell species
-    # (e.g., [CH2][CH2] vs C=C both give InChI=1S/C2H4/c1-2/h1-2H2).
-    # Gate behind molecular-formula check to avoid expensive InChI generation
-    # for products that can't possibly match.
-    species_fingerprints = {spc.mol.fingerprint for spc in p_species if spc.mol is not None}
-    needs_inchi = False
-    for i in range(len(products)):
-        if not isomorphic[i] and products[i].fingerprint in species_fingerprints:
-            needs_inchi = True
-            break
-    if not needs_inchi:
-        return False
-    # Precompute p_species InChIs once (not per candidate product).
-    try:
-        species_inchi_mult = [(spc.mol.to_inchi(), spc.mol.multiplicity) for spc in p_species]
-    except Exception:
-        return False
-    for i in range(len(products)):
-        if not isomorphic[i]:
-            if products[i].fingerprint not in species_fingerprints:
+    inchi_cache: dict[int, str | None] = dict()
+    for i, product in enumerate(products):
+        if isomorphic[i]:
+            continue
+        for spc in p_species:
+            if not product.is_isomorphic(spc.mol, save_order=True, strict=False):
                 continue
-            try:
-                inchi_a = products[i].to_inchi()
-                mult_a = products[i].multiplicity
-            except Exception:
-                continue
-            if any(inchi_a == inchi_b and mult_a == mult_b
-                   for inchi_b, mult_b in species_inchi_mult):
+            inchi_a = _get_inchi(product, inchi_cache)
+            if inchi_a is None:
+                break
+            if inchi_a == _get_inchi(spc.mol, inchi_cache):
                 isomorphic[i] = True
+                break
     return all(isomorphic)
 
 
-def get_all_families(rmg_family_set: list[str] | str = 'default',
+def _get_inchi(mol: Molecule,
+               cache: dict[int, str | None],
+               ) -> str | None:
+    """
+    Get the standard InChI of a molecule.
+
+    ``mol`` is not modified: the conversion, which reorders the atoms of the molecule it is
+    given, is run on a deep copy.
+    Results, including failures, are memoized in ``cache`` keyed by the identity of ``mol``,
+    so that no molecule is converted more than once per cache. Every molecule passed with a
+    given ``cache`` must be kept alive for as long as that ``cache`` is in use.
+
+    Args:
+        mol (Molecule): The molecule to convert.
+        cache (dict): An identity-keyed InChI cache to read from and populate.
+
+    Returns:
+        str | None: The standard InChI, or ``None`` if no backend could generate one.
+    """
+    key = id(mol)
+    if key not in cache:
+        try:
+            cache[key] = mol.copy(deep=True).to_inchi()
+        except Exception as e:
+            logger.debug(f'Could not generate an InChI for:\n{mol.to_adjacency_list()}\nGot: {e}')
+            cache[key] = None
+    return cache[key]
+
+
+def get_all_families(rmg_family_set: list[str] | str | None = None,
                      consider_rmg_families: bool = True,
                      consider_arc_families: bool = True,
                      ) -> list[str]:
     """
     Get all available RMG and ARC families.
-    If ``rmg_family_set`` is a list of family labels and does not contain family sets, it will be returned as is.
+    If ``rmg_family_set`` is a list of family labels and does not contain family sets, it will be returned as is
+    (an explicitly given list defines its own order).
+
+    ``'all'`` considers every recommended family set whose label does not contain 'surface' together
+    with every family that exists as a directory in the RMG database.
+
+    Otherwise the result is assembled from three tiers, concatenated in this order: the families the
+    requested recommended family set(s) contribute, then the families that exist as an RMG database
+    directory, then ARC's families. Each tier is sorted by label, and duplicates are removed while
+    keeping the first occurrence, so a family a recommended set contributes stays in the recommended
+    tier and is always positioned before a family reachable only as a database directory. Callers
+    that take the first matching family therefore resolve to a recommended family whenever one
+    matches, and resolve to the same family in every process: the order depends neither on
+    ``PYTHONHASHSEED`` nor on dict, set or file system iteration. Both properties are part of the
+    contract: sorting across the tiers, appending the directories first, or de-duplicating the
+    result through a set would break the first, and leaving a tier unsorted would break the second.
 
     Args:
         rmg_family_set (list[str] | str, optional): The RMG family set to use.
+                                                    ``None`` (the default) means ``settings['rmg_family_set']``,
+                                                    read on every call.
         consider_rmg_families (bool, optional): Whether to consider RMG's families.
         consider_arc_families (bool, optional): Whether to consider ARC's custom families.
 
     Returns:
         list[str]: A list of all available families.
     """
-    rmg_family_set = rmg_family_set or 'default'
+    rmg_family_set = rmg_family_set or settings['rmg_family_set']
     family_sets = get_rmg_recommended_family_sets()
     if isinstance(rmg_family_set, list) and all(fam not in family_sets for fam in rmg_family_set):
         return rmg_family_set
-    rmg_families, arc_families = list(), list()
+    recommended_families, directory_families, arc_families = list(), list(), list()
     if consider_rmg_families:
         if not isinstance(rmg_family_set, list) and rmg_family_set not in list(family_sets) + ['all']:
             raise ValueError(f'Invalid RMG family set: {rmg_family_set}')
         if rmg_family_set == 'all':
             for family_set_label, families in family_sets.items():
                 if 'surface' not in family_set_label:
-                    rmg_families.extend(list(families))
+                    recommended_families.extend(families)
+            directory_families = list(get_rmg_family_directories())
         else:
-            rmg_families = list(family_sets[rmg_family_set]) \
-                if isinstance(rmg_family_set, str) and rmg_family_set in family_sets else [rmg_family_set]
+            recommended_families = list(family_sets[rmg_family_set]) \
+                if isinstance(rmg_family_set, str) and rmg_family_set in family_sets else list(rmg_family_set)
     if consider_arc_families:
         for family in os.listdir(ARC_FAMILIES_PATH):
             if family.startswith('.') or family.startswith('_'):
                 continue
             arc_families.append(os.path.splitext(family)[0])
-    return rmg_families + arc_families if rmg_families is not None else arc_families
+    ordered, seen = list(), set()
+    for family in sorted(recommended_families) + sorted(directory_families) + sorted(arc_families):
+        if family not in seen:
+            seen.add(family)
+            ordered.append(family)
+    return ordered
 
 
 @functools.lru_cache(maxsize=1)
-def get_rmg_recommended_family_sets() -> dict[str, str]:
+def get_rmg_family_directories() -> list[str]:
+    """
+    List every reaction family that exists as a directory in the RMG database, whether or not it
+    belongs to a recommended family set. A directory counts as a family only if it holds a
+    ``groups.py`` template. Directories whose name contains 'surface' are skipped; a surface family
+    that a recommended set lists still reaches ``get_all_families`` through that set.
+    An empty list is returned if the RMG database is unavailable.
+
+    Returns:
+        list[str]: The family directory names available in the RMG database, sorted by name.
+    """
+    if RMG_DB_PATH is None:
+        return list()
+    families_dir = get_rmg_db_subpath('kinetics', 'families', must_exist=True)
+    if not os.path.isdir(families_dir):
+        return list()
+    families = list()
+    for name in sorted(os.listdir(families_dir)):
+        if name.startswith('.') or name.startswith('_') or 'surface' in name.lower():
+            continue
+        family_path = os.path.join(families_dir, name)
+        if os.path.isdir(family_path) and os.path.isfile(os.path.join(family_path, 'groups.py')):
+            families.append(name)
+    return families
+
+
+@functools.lru_cache(maxsize=1)
+def get_rmg_recommended_family_sets() -> dict[str, tuple[str, ...]]:
     """
     Get the recommended RMG family sets from RMG-database/input/kinetics/families/recommended.py.
 
+    The family labels of each set are returned as a tuple in the order in which they are written
+    in ``recommended.py``, since the sets are declared there as Python set literals whose iteration
+    order depends on ``PYTHONHASHSEED``. A set whose elements are not all plain string literals
+    is sorted instead, so that the returned order never depends on the hash seed.
+
     Returns:
-        dict[str, str]: The recommended RMG family sets.
+        dict[str, tuple[str, ...]]: The recommended RMG family sets.
     """
     family_sets = dict()
     recommended_path = get_rmg_db_subpath('kinetics', 'families', 'recommended.py', must_exist=True)
@@ -888,13 +1065,20 @@ def get_rmg_recommended_family_sets() -> dict[str, str]:
         raise FileNotFoundError(f'Could not find the recommended RMG families file at {recommended_path}')
     with open(recommended_path, 'r') as f:
         recommended_content = f.read()
-    dict_strings = re.findall(r'(\w+)\s*=\s*\{[^}]*\}', recommended_content, re.DOTALL)
-    for dict_name in dict_strings:
-        pattern = rf'{dict_name}\s*=\s*(\{{[^}}]*\}})'
-        match = re.search(pattern, recommended_content, re.DOTALL)
-        if match:
-            dict_str = match.group(1)
-            family_sets[dict_name] = ast.literal_eval(dict_str)
+    for node in ast.parse(recommended_content).body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, (ast.Set, ast.List, ast.Tuple)):
+            continue
+        elements = [element.value for element in node.value.elts
+                    if isinstance(element, ast.Constant) and isinstance(element.value, str)]
+        if len(elements) != len(node.value.elts):
+            try:
+                elements = sorted(ast.literal_eval(node.value))
+            except ValueError:
+                logger.debug(f'Could not parse a family set from {recommended_path}, skipping it.')
+                continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                family_sets[target.id] = tuple(elements)
     return family_sets
 
 

--- a/arc/family/family_test.py
+++ b/arc/family/family_test.py
@@ -7,12 +7,14 @@ This module contains unit tests of the arc.reaction.family module
 
 import os
 import unittest
+import unittest.mock as mock
 
 from arc.common import is_equal_family_product_dicts
 from arc.family.family import (ReactionFamily,
                                ARC_FAMILIES_PATH,
                                RMG_DB_PATH,
                                get_rmg_db_subpath,
+                               _get_inchi,
                                add_labels_to_molecule,
                                check_product_isomorphism,
                                descent_complex_group,
@@ -20,6 +22,7 @@ from arc.family.family import (ReactionFamily,
                                filter_products_by_reaction,
                                get_reaction_family_products,
                                get_all_families,
+                               get_rmg_family_directories,
                                get_entries,
                                split_entries,
                                get_group_adjlist,
@@ -27,16 +30,22 @@ from arc.family.family import (ReactionFamily,
                                get_isomorphic_subgraph,
                                get_product_num,
                                get_reactant_groups_from_template,
+                               get_reaction_family,
                                get_recipe_actions,
                                get_rmg_recommended_family_sets,
+                               count_recipe_bond_changes,
+                               has_radical_recipe_action,
+                               prioritize_family_product_dicts,
                                is_own_reverse,
                                is_reversible,
                                check_family_name,
                                read_groups_file_lines,
                                )
+from arc.imports import settings
 from arc.molecule import Group, Molecule
 from arc.molecule.resonance import generate_resonance_structures_safely
 from arc.reaction.reaction import ARCReaction
+from arc.settings.settings import rmg_family_set as shipped_rmg_family_set
 from arc.species.species import ARCSpecies
 
 
@@ -717,10 +726,101 @@ H      -0.83821148   -0.26602407    0.00000000"""
         families = get_all_families(rmg_family_set=['H_Abstraction'])
         self.assertEqual(families, ['H_Abstraction'])
 
+    def test_get_all_families_is_deterministically_ordered(self):
+        """Test that the family order within each tier does not depend on set or file system iteration order"""
+        rmg_families = get_all_families(consider_arc_families=False)
+        arc_families = get_all_families(consider_rmg_families=False)
+        self.assertEqual(rmg_families, sorted(rmg_families))
+        self.assertEqual(arc_families, sorted(arc_families))
+        self.assertEqual(get_all_families(), rmg_families + arc_families)
+        recommended = set()
+        for family_set_label, families in get_rmg_recommended_family_sets().items():
+            if 'surface' not in family_set_label:
+                recommended.update(families)
+        all_families = get_all_families(rmg_family_set='all', consider_arc_families=False)
+        self.assertEqual(len(all_families), len(set(all_families)))
+        recommended_tier = [family for family in all_families if family in recommended]
+        directory_tier = [family for family in all_families if family not in recommended]
+        self.assertEqual(recommended_tier, sorted(recommended_tier))
+        self.assertEqual(directory_tier, sorted(directory_tier))
+        self.assertLess(all_families.index('Intra_Diels_alder_monocyclic'), all_families.index('Intra_R_Add_Exocyclic'))
+
     def test_get_all_families_rejects_unknown_set_name(self):
         """An unknown family-set string should raise ValueError, not fall through to KeyError."""
         with self.assertRaises(ValueError):
             get_all_families(rmg_family_set='not_a_real_family_set', consider_arc_families=False)
+
+    def test_rmg_family_set_setting_ships_as_default(self):
+        """ARC ships with the 'default' family set, so an untouched installation considers
+        only RMG's recommended families."""
+        self.assertEqual(shipped_rmg_family_set, 'default')
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual(get_all_families(consider_arc_families=False),
+                             get_all_families(rmg_family_set='default', consider_arc_families=False))
+            self.assertIn('H_Abstraction', get_all_families(consider_arc_families=False))
+
+    def test_bare_calls_honour_the_rmg_family_set_setting(self):
+        """get_all_families() and check_family_name() consider the configured family set when no
+        set is named at the call site, rather than a hard-coded 'default'."""
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            default_families = get_all_families(consider_arc_families=False)
+            self.assertNotIn('Br_Abstraction', default_families)
+            self.assertFalse(check_family_name('Br_Abstraction'))
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            all_families = get_all_families(consider_arc_families=False)
+            self.assertIn('Br_Abstraction', all_families)
+            self.assertTrue(check_family_name('Br_Abstraction'))
+            self.assertEqual(get_all_families(rmg_family_set='default', consider_arc_families=False),
+                             default_families)
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual(get_all_families(consider_arc_families=False), default_families)
+            self.assertFalse(check_family_name('Br_Abstraction'))
+
+    def test_all_includes_database_directory_families(self):
+        """'all' includes families that exist in the RMG database as directories but belong to no
+        recommended family set, e.g. Intra_RH_Add_Exocyclic, without introducing duplicates."""
+        directory_families = get_rmg_family_directories()
+        self.assertIsInstance(directory_families, list)
+        self.assertIn('Intra_RH_Add_Exocyclic', directory_families)
+        self.assertIn('Intra_RH_Add_Endocyclic', directory_families)
+        all_families = get_all_families(rmg_family_set='all', consider_arc_families=False)
+        default_families = get_all_families(rmg_family_set='default', consider_arc_families=False)
+        self.assertTrue(set(default_families).issubset(set(all_families)))
+        for family in directory_families:
+            self.assertIn(family, all_families)
+        self.assertEqual(len(all_families), len(set(all_families)))
+        self.assertNotIn('Intra_RH_Add_Exocyclic', default_families)
+        self.assertIn('Surface_Proton_Electron_Reduction_Alpha', all_families)
+
+    def test_directory_only_families_are_ordered_last(self):
+        """Under 'all', every family reachable only as an RMG database directory is positioned after
+        every family a recommended family set contributes, and the result is not alphabetically
+        sorted. Sorting the result or de-duplicating it through a set would break this."""
+        all_families = get_all_families(rmg_family_set='all', consider_arc_families=False)
+        recommended = set()
+        for family_set_label, families in get_rmg_recommended_family_sets().items():
+            if 'surface' not in family_set_label:
+                recommended.update(families)
+        recommended_positions = [i for i, fam in enumerate(all_families) if fam in recommended]
+        directory_only_positions = [i for i, fam in enumerate(all_families) if fam not in recommended]
+        self.assertTrue(len(recommended_positions))
+        self.assertTrue(len(directory_only_positions))
+        self.assertLess(max(recommended_positions), min(directory_only_positions))
+        self.assertLess(all_families.index('Intra_R_Add_Exocyclic'),
+                        all_families.index('Intra_RH_Add_Endocyclic'))
+        self.assertLess(all_families.index('Intra_R_Add_Exocyclic'),
+                        all_families.index('Intra_RH_Add_Exocyclic'))
+        self.assertNotEqual(all_families, sorted(all_families))
+
+    def test_rmg_family_set_setting_reaches_a_directory_only_family(self):
+        """Setting rmg_family_set to 'all' makes a family that exists only as a database directory
+        reachable through the bare call and through check_family_name()."""
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertNotIn('Intra_RH_Add_Exocyclic', get_all_families(consider_arc_families=False))
+            self.assertFalse(check_family_name('Intra_RH_Add_Exocyclic'))
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            self.assertIn('Intra_RH_Add_Exocyclic', get_all_families(consider_arc_families=False))
+            self.assertTrue(check_family_name('Intra_RH_Add_Exocyclic'))
 
     def test_get_rmg_recommended_family_sets(self):
         """Test getting RMG recommended family sets"""
@@ -728,6 +828,9 @@ H      -0.83821148   -0.26602407    0.00000000"""
         self.assertIn('default', recommended_families)
         self.assertIn('ch_pyrolysis', recommended_families)
         self.assertIn('liquid_peroxide', recommended_families)
+        for family_set in recommended_families.values():
+            self.assertIsInstance(family_set, tuple)
+        self.assertIn('H_Abstraction', recommended_families['default'])
 
     def test_load(self):
         """Test loading a reaction family from the RMG database"""
@@ -1461,6 +1564,108 @@ H       1.24252625    0.91583948   -0.84155142"""
         spc_b = ARCSpecies(label='test', smiles='O=C=C(O)C=O')
         self.assertTrue(check_product_isomorphism([mol_a], [spc_b]))
 
+    def test_check_product_isomorphism_inchi_fallback_accepts_different_lewis_structures(self):
+        """Test that the InChI fallback still matches two Lewis structures of the same molecule.
+        O=C[C-](O)C#[O+] and O=C=C(O)C=O share a standard InChI and place every hydrogen on the
+        same heavy atom. No resonance structure of either is graph-isomorphic to the other, so
+        the fallback is the only path that admits this pair."""
+        mol_a = Molecule(smiles='O=C[C-](O)C#[O+]')
+        spc_b = ARCSpecies(label='test', smiles='O=C=C(O)C=O')
+        self.assertEqual(mol_a.to_inchi(), spc_b.mol.to_inchi())
+        res_a = generate_resonance_structures_safely(mol_a) or [mol_a]
+        res_b = spc_b.mol_list or [spc_b.mol]
+        self.assertFalse(any(mol_b.is_isomorphic(res) for res in res_a for mol_b in res_b))
+        self.assertTrue(check_product_isomorphism([mol_a], [spc_b]))
+
+    def test_check_product_isomorphism_inchi_fallback_rejects_tautomers(self):
+        """Test that the InChI fallback rejects N-H and O-H tautomers.
+        The mobile-H layer of the standard InChI collapses tautomers onto a single string,
+        while they are distinct molecules that place their hydrogens on different heavy atoms."""
+        for smiles_a, smiles_b in [('NNNN=NN', 'NNNNN=N'),
+                                   ('NN=NN', 'NNN=N'),
+                                   ('NC=O', 'N=CO')]:
+            mol_a = Molecule(smiles=smiles_a)
+            spc_b = ARCSpecies(label='test', smiles=smiles_b)
+            self.assertEqual(mol_a.to_inchi(), spc_b.mol.to_inchi())
+            self.assertEqual(mol_a.multiplicity, spc_b.mol.multiplicity)
+            self.assertFalse(check_product_isomorphism([mol_a], [spc_b]),
+                             f'{smiles_a} must not match the tautomer {smiles_b}')
+
+    def test_check_product_isomorphism_inchi_fallback_rejects_tautomers_with_equal_h_counts(self):
+        """Test that the InChI fallback rejects tautomers that carry the same number of hydrogens
+        on every heavy atom.
+        H2N-NH-N=N-NH-NH2 and H2N-NH-NH-N=N-NH2 share a standard InChI and both place two
+        hydrogens on each terminal nitrogen, one on two of the internal nitrogens and none on the
+        remaining two, yet they are different molecules."""
+        mol_a = Molecule(smiles='NNN=NNN')
+        spc_b = ARCSpecies(label='test', smiles='NNNN=NN')
+        self.assertEqual(mol_a.to_inchi(), spc_b.mol.to_inchi())
+        h_counts_a = sorted(sum(1 for nb in atom.edges if nb.is_hydrogen())
+                            for atom in mol_a.atoms if not atom.is_hydrogen())
+        h_counts_b = sorted(sum(1 for nb in atom.edges if nb.is_hydrogen())
+                            for atom in spc_b.mol.atoms if not atom.is_hydrogen())
+        self.assertEqual(h_counts_a, h_counts_b)
+        self.assertFalse(check_product_isomorphism([mol_a], [spc_b]))
+
+    def test_check_product_isomorphism_does_not_generate_inchi_for_rejected_candidates(self):
+        """Test that a candidate the connectivity comparison rejects never reaches InChI generation.
+        [N-]1O[NH+]=C=C1 is a template-generated tautomer of the oxadiazole c1cnon1: the two share a
+        molecular formula and a multiplicity, but one places a hydrogen on a nitrogen where the other
+        places it on a carbon, so the connectivity comparison rejects the pair on its own. The
+        cumulated C=C=N in a five-membered ring is valence-legal yet geometrically impossible, and
+        neither RDKit nor OpenBabel can convert it, so generating its InChI only logs an error and a
+        traceback for a candidate that is rejected either way."""
+        mol_a = Molecule(smiles='[N-]1O[NH+]=C=C1')
+        spc_b = ARCSpecies(label='test', smiles='c1cnon1')
+        self.assertEqual(mol_a.fingerprint, spc_b.mol.fingerprint)
+        self.assertEqual(mol_a.multiplicity, spc_b.mol.multiplicity)
+        with mock.patch('arc.molecule.translator.to_inchi') as mock_to_inchi:
+            self.assertFalse(check_product_isomorphism([mol_a], [spc_b]))
+            self.assertEqual(mock_to_inchi.call_count, 0)
+
+    def test_check_product_isomorphism_inchi_fallback_rejects_charge_isomers(self):
+        """Test that the InChI fallback rejects a cation matched against the corresponding anion.
+        The connectivity comparison ignores Atom.charge and the fingerprint counts elements only, so
+        the two carry the same connectivity and the same multiplicity and differ only in the /q layer
+        of the standard InChI, which the fallback must therefore keep comparing."""
+        for smiles_a, smiles_b in [('[CH3+]', '[CH3-]'),
+                                   ('C=[CH+]', 'C=[CH-]')]:
+            mol_a = Molecule(smiles=smiles_a)
+            spc_b = ARCSpecies(label='test', smiles=smiles_b)
+            self.assertTrue(mol_a.is_isomorphic(spc_b.mol, save_order=True, strict=False))
+            self.assertEqual(mol_a.multiplicity, spc_b.mol.multiplicity)
+            self.assertNotEqual(mol_a.copy(deep=True).to_inchi(), spc_b.mol.copy(deep=True).to_inchi())
+            self.assertFalse(check_product_isomorphism([mol_a], [spc_b]),
+                             f'{smiles_a} must not match {smiles_b}')
+
+    def test_get_inchi_caches_per_molecule(self):
+        """Test that _get_inchi gives each molecule its own cache entry.
+        Two molecules that share a cache entry would be reported as having the same InChI, so a
+        cached InChI must belong to the molecule it was generated from and to no other."""
+        cache = dict()
+        mol_a, mol_b = Molecule(smiles='C'), Molecule(smiles='CC')
+        inchi_a, inchi_b = _get_inchi(mol_a, cache), _get_inchi(mol_b, cache)
+        self.assertEqual(len(cache), 2)
+        self.assertEqual(inchi_a, Molecule(smiles='C').copy(deep=True).to_inchi())
+        self.assertEqual(inchi_b, Molecule(smiles='CC').copy(deep=True).to_inchi())
+        self.assertNotEqual(inchi_a, inchi_b)
+        self.assertEqual(_get_inchi(mol_a, cache), inchi_a)
+        self.assertEqual(_get_inchi(mol_b, cache), inchi_b)
+
+    def test_check_product_isomorphism_does_not_reorder_the_given_molecules(self):
+        """Test that check_product_isomorphism leaves the atom order of both the given products and
+        the molecules of the given species untouched, including on a pair the InChI fallback admits.
+        Molecule.to_inchi reorders the molecule it is given, and the caller of this function goes on
+        to use these molecules to build an atom map and a TS guess."""
+        products = [Molecule(smiles='O=C[C-](O)C#[O+]')]
+        p_species = [ARCSpecies(label='test', smiles='O=C=C(O)C=O')]
+        order_before = ([[atom.element.symbol for atom in mol.atoms] for mol in products],
+                        [[atom.element.symbol for atom in spc.mol.atoms] for spc in p_species])
+        self.assertTrue(check_product_isomorphism(products, p_species))
+        order_after = ([[atom.element.symbol for atom in mol.atoms] for mol in products],
+                       [[atom.element.symbol for atom in spc.mol.atoms] for spc in p_species])
+        self.assertEqual(order_before, order_after)
+
     def test_check_product_isomorphism_length_mismatch(self):
         """Test that check_product_isomorphism returns False for length mismatch."""
         mol = Molecule(smiles='C')
@@ -1604,6 +1809,190 @@ H       1.24252625    0.91583948   -0.84155142"""
         self.assertTrue(check_family_name(None))
         with self.assertRaises(TypeError):
             check_family_name(123)
+
+
+class TestFamilyChoiceGates(unittest.TestCase):
+    """Unit tests for the non-lexical gates that choose between co-matching families"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+        cls.radical_rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH2]C=CC=C')],
+                                      p_species=[ARCSpecies(label='P', smiles='[CH2]C1C=CC1')])
+        cls.closed_shell_rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='C=CC(=C)N')],
+                                           p_species=[ARCSpecies(label='P', smiles='NC1=CCC1')])
+        cls.abstraction_rxn = ARCReaction(r_species=[ARCSpecies(label='C2H5', smiles='C[CH2]'),
+                                                     ARCSpecies(label='C2H3', smiles='[CH]=C')],
+                                          p_species=[ARCSpecies(label='C2H4', smiles='C=C'),
+                                                     ARCSpecies(label='C2H4b', smiles='[CH]C')])
+
+    @staticmethod
+    def make_product_dicts(*entries) -> list[dict]:
+        """Build minimal product dicts, each entry being a (family, discovered_in_reverse) tuple
+        or a (family, discovered_in_reverse, group_labels) tuple."""
+        product_dicts = list()
+        for entry in entries:
+            family, reverse = entry[0], entry[1]
+            product_dicts.append({'family': family,
+                                  'group_labels': entry[2] if len(entry) > 2 else ('a', 'b'),
+                                  'products': list(),
+                                  'r_label_map': dict(),
+                                  'p_label_map': dict(),
+                                  'own_reverse': False,
+                                  'discovered_in_reverse': reverse,
+                                  })
+        return product_dicts
+
+    def test_has_radical_recipe_action(self):
+        """Test identifying the recipes that change an unpaired electron count"""
+        self.assertTrue(has_radical_recipe_action(get_reaction_family(label='Intra_R_Add_Exocyclic').actions))
+        self.assertTrue(has_radical_recipe_action(get_reaction_family(label='H_Abstraction').actions))
+        self.assertFalse(has_radical_recipe_action(get_reaction_family(label='Intra_RH_Add_Endocyclic').actions))
+        self.assertFalse(has_radical_recipe_action(get_reaction_family(label='Intra_2+2_cycloaddition_Cd').actions))
+        self.assertFalse(has_radical_recipe_action(list()))
+
+    def test_count_recipe_bond_changes(self):
+        """Test counting the bond changes a recipe prescribes"""
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='H_Abstraction').actions), (2, 0))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Disproportionation').actions), (2, 1))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Intra_R_Add_Exocyclic').actions), (1, 1))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Intra_RH_Add_Endocyclic').actions), (3, 1))
+        self.assertEqual(count_recipe_bond_changes(list()), (0, 0))
+
+    def test_forward_matches_are_preferred_over_reverse_discovered_matches(self):
+        """A match discovered in reverse carries a label map of the flipped reaction,
+        so it is dropped whenever a forward match exists"""
+        product_dicts = self.make_product_dicts(('R_Addition_MultipleBond', True), ('Retroene', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized], ['Retroene'])
+
+    def test_reverse_discovered_matches_are_kept_when_no_forward_match_exists(self):
+        """Nothing is dropped when every match was discovered in reverse"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', True), ('Intra_R_Add_Exocyclic', True))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['Intra_R_Add_Exocyclic', 'Intra_2+2_cycloaddition_Cd'])
+
+    def test_a_radical_reactant_requires_a_recipe_that_accounts_for_the_radical(self):
+        """A family whose recipe leaves the unpaired electron untouched is dropped
+        when the reactants carry one and a family that accounts for it also matches"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False), ('Intra_R_Add_Exocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized], ['Intra_R_Add_Exocyclic'])
+
+    def test_the_radical_gate_keeps_all_matches_when_no_recipe_accounts_for_the_radical(self):
+        """The radical gate does not empty the candidates when no recipe changes a radical count"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual({product_dict['family'] for product_dict in prioritized},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'})
+
+    def test_the_radical_gate_is_silent_for_closed_shell_reactants(self):
+        """Closed-shell reactants keep every family match, whatever its recipe does to radicals"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False), ('Intra_R_Add_Exocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual({product_dict['family'] for product_dict in prioritized},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_R_Add_Exocyclic'})
+
+    def test_the_fewest_bond_changes_win_the_tie_break(self):
+        """Two families that both account for the radical are ordered by the bond changes
+        their recipes prescribe, before any lexical consideration"""
+        product_dicts = self.make_product_dicts(('Disproportionation', False), ('H_Abstraction', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.abstraction_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['H_Abstraction', 'Disproportionation'])
+
+    def test_matches_of_the_same_family_keep_their_relative_order(self):
+        """Ordering the families does not reorder the label maps within a family"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False, ('c1', 'c2')),
+                                                ('Intra_R_Add_Exocyclic', False, ('r1', 'r2')),
+                                                ('Intra_2+2_cycloaddition_Cd', False, ('c3', 'c4')),
+                                                ('Intra_R_Add_Exocyclic', False, ('r3', 'r4')))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['group_labels'] for product_dict in prioritized],
+                         [('r1', 'r2'), ('r3', 'r4'), ('c1', 'c2'), ('c3', 'c4')])
+
+    def test_a_single_match_is_returned_as_is(self):
+        """A single match is returned unchanged, radical reactants notwithstanding"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', True))
+        self.assertEqual(prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts),
+                         product_dicts)
+        self.assertEqual(prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=list()), list())
+
+    def test_a_radical_cyclization_is_not_labeled_as_a_cycloaddition(self):
+        """The pentadienyl radical cyclization matches both a concerted cycloaddition and a radical
+        addition, and resolves to the radical addition although the cycloaddition sorts first"""
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            concerted = determine_possible_reaction_products_from_family(
+                rxn=self.radical_rxn, family_label='Intra_2+2_cycloaddition_Cd')
+            self.assertTrue(len(concerted))
+            all_families = get_all_families(rmg_family_set='all')
+            self.assertLess(all_families.index('Intra_2+2_cycloaddition_Cd'),
+                            all_families.index('Intra_R_Add_Exocyclic'))
+            product_dicts = get_reaction_family_products(rxn=self.radical_rxn, rmg_family_set='all')
+            self.assertEqual({product_dict['family'] for product_dict in product_dicts}, {'Intra_R_Add_Exocyclic'})
+
+    def test_the_direction_gate_holds_when_a_recipe_cannot_be_read(self):
+        """The direction gate reads only 'discovered_in_reverse', so an unreadable recipe must not
+        resurrect a reverse-discovered match, and only the recipe-based gates degrade"""
+        product_dicts = self.make_product_dicts(('Intra_R_Add_Exocyclic', True),
+                                                ('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        side_effect=FileNotFoundError('groups.py')):
+            prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'])
+
+    def test_an_unreadable_recipe_is_reported_as_a_warning(self):
+        """Losing the radical gate and the bond-change ordering degrades the family choice,
+        so it is reported above the debug level"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_R_Add_Exocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        side_effect=FileNotFoundError('groups.py')):
+            with self.assertLogs('arc', level='WARNING') as captured:
+                prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertIn('Could not read the recipe', '\n'.join(captured.output))
+
+    def test_a_recipe_is_not_read_for_a_reverse_discovered_match(self):
+        """The direction gate runs first, so a match it drops cannot disable the remaining gates"""
+        product_dicts = self.make_product_dicts(('Intra_R_Add_Exocyclic', True),
+                                                ('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        wraps=get_reaction_family) as mocked_get_reaction_family:
+            prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual({call.kwargs['label'] for call in mocked_get_reaction_family.call_args_list},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'})
+
+    def test_the_direction_gate_holds_for_a_caller_that_did_not_ask_for_reverse_discovery(self):
+        """The allyl + propene addition matches R_Addition_MultipleBond in the forward direction and
+        Retroene in the reverse one. Retroene's label map indexes the product, so it is dropped even
+        though 'discover_own_reverse_rxns_in_reverse' never admitted it in the first place"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='allyl', smiles='C=C[CH2]'),
+                                     ARCSpecies(label='propene', smiles='CC=C')],
+                          p_species=[ARCSpecies(label='P', smiles='C=CCC(C)[CH2]')])
+        product_dicts = get_reaction_family_products(rxn=rxn, rmg_family_set='all',
+                                                     discover_own_reverse_rxns_in_reverse=False)
+        self.assertEqual({product_dict['family'] for product_dict in product_dicts},
+                         {'R_Addition_MultipleBond'})
+        self.assertFalse(any(product_dict['discovered_in_reverse'] for product_dict in product_dicts))
+
+    def test_asking_for_reverse_discovery_does_not_defeat_the_direction_gate(self):
+        """'discover_own_reverse_rxns_in_reverse' widens the search, it does not license a label map of
+        the flipped reaction, so a forward match still wins. H_Abstraction is its own reverse, so the
+        flag admits two reverse-discovered matches that the gate then drops"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        product_dicts = get_reaction_family_products(rxn=rxn, rmg_family_set='all',
+                                                     discover_own_reverse_rxns_in_reverse=True)
+        self.assertTrue(len(product_dicts))
+        self.assertEqual({product_dict['family'] for product_dict in product_dicts}, {'H_Abstraction'})
+        self.assertFalse(any(product_dict['discovered_in_reverse'] for product_dict in product_dicts))
 
 
 class TestSplitEntries(unittest.TestCase):

--- a/arc/job/adapters/ts/linear.py
+++ b/arc/job/adapters/ts/linear.py
@@ -1672,7 +1672,10 @@ def interpolate_addition(rxn: ARCReaction,
         cross) is direction-agnostic: bonds that exist in the unimolecular
         species' molecular graph are "split bonds" (stretched), and bonds
         that don't are "cross bonds" (used for insertion-ring detection).
-        This handles ``discovered_in_reverse`` correctly without swapping.
+        Classification therefore needs no direction swap, but the recipe
+        bonds themselves must already be in the reaction's reactant index
+        space: a ``discovered_in_reverse`` entry carries an ``r_label_map``
+        of the flipped reaction, which this function does not translate.
 
     2.  **Fragmentation fallback** — when no ``product_dicts`` are available
         or the template gives unreliable bonds, the function enumerates
@@ -1734,7 +1737,6 @@ def interpolate_addition(rxn: ARCReaction,
                 rmg_family_set='all',
                 consider_rmg_families=True,
                 consider_arc_families=True,
-                discover_own_reverse_rxns_in_reverse=True,
             )
         except Exception as e:
             logger.debug(f'Linear addition (rxn={rxn.label}): wider family-set '

--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -369,7 +369,7 @@ def map_rxn(rxn: ARCReaction,
                                               actual_products=rxn.get_reactants_and_products()[1])
     try:
         make_bond_changes(rxn, r_cuts, r_label_map)
-    except (ValueError, IndexError, ActionError, AtomTypeError) as e:
+    except (KeyError, ValueError, IndexError, ActionError, AtomTypeError) as e:
         logger.warning(e)
     r_cuts, p_cuts = update_xyz(r_cuts), update_xyz(p_cuts)
     pairs = pairing_reactants_and_products_for_mapping(r_cuts, p_cuts)

--- a/arc/mapping/engine.py
+++ b/arc/mapping/engine.py
@@ -1436,6 +1436,10 @@ def make_bond_changes(rxn: ARCReaction, r_cuts: list[ARCSpecies], r_label_dict: 
     """
     Makes bond changes before matching the reactants and products.
 
+    A charge-separating bond change is only applied if it leaves a valid electron count, i.e., if the
+    donor atom has a lone pair to give and the accepting atom has the two radical electrons that the
+    new bond consumes. Otherwise, that cut is left unchanged.
+
     Args:
         rxn (ARCReaction): An ARCReaction object
         r_cuts (list[ARCSpecies]): The cut products
@@ -1457,12 +1461,22 @@ def make_bond_changes(rxn: ARCReaction, r_cuts: list[ARCSpecies], r_label_dict: 
                     if atom1.radical_electrons == 0 and atom2.radical_electrons == 0: # Both atoms do not have any radicals, but their bond is changing. There probably is resonance, so this will not affect the isomorphism check.
                         return
                     elif atom1.radical_electrons == 0 and atom2.radical_electrons != 0:
+                        if atom1.lone_pairs < 1 or atom2.radical_electrons < 2:
+                            logger.debug(f'Not applying a charge-separating {action} of the {rxn.family} family '
+                                         f'to atoms {indices} of reaction {rxn.label}: '
+                                         f'it would result in a negative electron count.')
+                            continue
                         atom1.lone_pairs -= 1
                         atom2.lone_pairs += 1
                         atom1.charge += 1
                         atom2.charge -= 1
                         atom2.radical_electrons -= 2
                     elif atom2.radical_electrons == 0 and atom1.radical_electrons != 0:
+                        if atom2.lone_pairs < 1 or atom1.radical_electrons < 2:
+                            logger.debug(f'Not applying a charge-separating {action} of the {rxn.family} family '
+                                         f'to atoms {indices} of reaction {rxn.label}: '
+                                         f'it would result in a negative electron count.')
+                            continue
                         atom2.lone_pairs -= 1
                         atom1.lone_pairs += 1
                         atom2.charge += 1

--- a/arc/mapping/engine_test.py
+++ b/arc/mapping/engine_test.py
@@ -2007,6 +2007,24 @@ class TestMappingEngine(unittest.TestCase):
                                  r_label_dict={'*1': 0, '*2': 1, '*3': 2, '*4': 6})
         self.assertTrue(r_cuts[1].mol.is_isomorphic(rxn.p_species[1].mol))
 
+    def test_make_bond_changes_keeps_electron_counts_non_negative(self):
+        """Test that a charge-separating bond change is skipped rather than yielding a negative electron count"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label="N4", smiles="NNNN")],
+                          p_species=[ARCSpecies(label="NH3", smiles="N"),
+                                     ARCSpecies(label="NH2NHN_p", smiles="[N-]=[NH+]N")])
+        rxn.family = '1,2_NH3_elimination'
+        r_cut = ARCSpecies(label='CH2O_rad', smiles='[CH2]O')
+        engine.label_species_atoms([r_cut])
+        c_index = [i for i, atom in enumerate(r_cut.mol.atoms) if atom.element.symbol == 'C'][0]
+        o_index = [i for i, atom in enumerate(r_cut.mol.atoms) if atom.element.symbol == 'O'][0]
+        self.assertEqual(r_cut.mol.atoms[c_index].radical_electrons, 1)
+        self.assertEqual(r_cut.mol.atoms[o_index].radical_electrons, 0)
+        engine.make_bond_changes(rxn=rxn, r_cuts=[r_cut], r_label_dict={'*2': o_index, '*3': c_index})
+        for atom in r_cut.mol.atoms:
+            self.assertGreaterEqual(atom.radical_electrons, 0)
+            self.assertGreaterEqual(atom.lone_pairs, 0)
+        self.assertTrue(r_cut.mol.is_isomorphic(ARCSpecies(label='ref', smiles='[CH2]O').mol))
+
     def test_update_xyz(self):
         """tests the update_xyz() function"""
         for smiles in ['BrC(F)Cl', 'OCl', 'BrOCl']:

--- a/arc/reaction/reaction.py
+++ b/arc/reaction/reaction.py
@@ -111,17 +111,17 @@ class ARCReaction(object):
         self.long_kinetic_description = ''
         self._family = None
         self._family_determined = False
+        self._family_own_reverse = None
+        self._product_dicts = None
         if family is not None:
             if check_family_name(family):
                 self.family = family
             else:
                 raise ValueError(f"Invalid family name: {family}")
-        self._family_own_reverse = False
         self.ts_label = ts_label
         self.dh_rxn298 = None
         self.ts_xyz_guess = ts_xyz_guess or xyz or list()
         self.preserve_param_in_scan = preserve_param_in_scan
-        self._product_dicts = None
         self._atom_map = None
         self._charge = charge
         self._multiplicity = multiplicity
@@ -171,9 +171,9 @@ class ARCReaction(object):
 
     @property
     def product_dicts(self):
-        """The RMG reaction family product dictionaries"""
+        """The RMG reaction family product dictionaries, all belonging to this reaction's family"""
         if self._product_dicts is None:
-            self._product_dicts = self.get_product_dicts()
+            self._product_dicts = self.restrict_product_dicts_to_family(self.get_product_dicts())
         return self._product_dicts
 
     @product_dicts.setter
@@ -218,23 +218,31 @@ class ARCReaction(object):
     def family(self):
         """The RMG reaction family"""
         if not self._family_determined:
-            self._family, self._family_own_reverse = self.determine_family()
+            self._family = self.determine_family()[0]
             self._family_determined = True
         return self._family
 
     @family.setter
     def family(self, value):
-        """Allow setting family"""
-        self._family = value
-        self._family_determined = True
+        """
+        Allow setting family. Product dictionaries that were already generated are restricted to the
+        new family, and are discarded so that they are regenerated on demand if none of them belong
+        to it.
+        """
         if value is not None and not isinstance(value, str):
             raise InputError(f'Reaction family must be a string, got {value} which is a {type(value)}.')
+        self._family = value
+        self._family_determined = True
+        self._family_own_reverse = None
+        if self._product_dicts is not None and value is not None:
+            self._product_dicts = [product_dict for product_dict in self._product_dicts
+                                   if product_dict['family'] == value] or None
 
     @property
     def family_own_reverse(self):
         """The RMG reaction family's own reverse property"""
         if self._family_own_reverse is None:
-            self._family, self._family_own_reverse = self.determine_family()
+            self._family_own_reverse = self.get_family_own_reverse()
         return self._family_own_reverse
 
     @family_own_reverse.setter
@@ -316,7 +324,8 @@ class ARCReaction(object):
         self.products = reaction_dict.get('products') or list()
         if 'family' in reaction_dict and reaction_dict['family'] is not None:
             self.family = reaction_dict['family']
-        self.family_own_reverse = reaction_dict['family_own_reverse'] if 'family_own_reverse' in reaction_dict else False
+        if 'family_own_reverse' in reaction_dict:
+            self.family_own_reverse = reaction_dict['family_own_reverse']
         self.set_label_reactants_products(species_list)
         if not (len(self.reactants) * len(self.products)):
             raise InputError(f'Cannot determine reactants and/or products labels for reaction {self.label}')
@@ -526,7 +535,7 @@ class ARCReaction(object):
         return multiplicity
 
     def get_product_dicts(self,
-                          rmg_family_set: str = 'default',
+                          rmg_family_set: list[str] | str | None = None,
                           consider_rmg_families: bool = True,
                           consider_arc_families: bool = True,
                           discover_own_reverse_rxns_in_reverse: bool = False,
@@ -547,6 +556,14 @@ class ARCReaction(object):
               'discovered_in_reverse': bool: Whether the reaction was discovered in reverse},
              ]
 
+        Args:
+            rmg_family_set (list[str] | str, optional): The RMG family set to use.
+                                                        ``None`` (the default) means ``settings['rmg_family_set']``,
+                                                        read on every call.
+            consider_rmg_families (bool, optional): Whether to consider RMG's families in addition to ARC's.
+            consider_arc_families (bool, optional): Whether to consider ARC's families in addition to RMG's.
+            discover_own_reverse_rxns_in_reverse (bool, optional): Whether to discover own reverse reactions in reverse.
+
         Returns:
             list[dict]: A list of dictionaries with the RMG reaction family products.
         """
@@ -558,17 +575,78 @@ class ARCReaction(object):
                                                      )
         return product_dicts
 
+    def restrict_product_dicts_to_family(self,
+                                         product_dicts: list[dict],
+                                         ) -> list[dict]:
+        """
+        Restrict family product dictionaries to the entries of a single reaction family.
+
+        The retained family is this reaction's family if one was set, otherwise the family of the
+        first entry. Entries of any other family are dropped, so that a family recipe is only ever
+        combined with an atom label map generated by that same family.
+
+        Args:
+            product_dicts (list[dict]): The family product dictionaries to restrict.
+
+        Raises:
+            ReactionError: If this reaction's family was set and none of the entries belong to it.
+
+        Returns:
+            list[dict]: The product dictionaries belonging to a single family.
+        """
+        if not len(product_dicts):
+            return product_dicts
+        families = list()
+        for product_dict in product_dicts:
+            if product_dict['family'] not in families:
+                families.append(product_dict['family'])
+        family = self._family if self._family is not None else families[0]
+        restricted = [product_dict for product_dict in product_dicts if product_dict['family'] == family]
+        if not len(restricted):
+            raise ReactionError(f'Reaction {self.label} was assigned the {family} family, but it does not match '
+                                f'this family. The families it does match are: {families}.')
+        if len(families) > 1:
+            if self._family is None:
+                logger.warning(f'Reaction {self.label} matches several reaction families: {families}. '
+                               f'Using {family}. Set the "family" attribute of this reaction '
+                               f'to choose a different one.')
+            else:
+                logger.info(f'Reaction {self.label} was assigned the {family} family, '
+                            f'it also matches {[f for f in families if f != family]}.')
+        return restricted
+
+    def get_family_own_reverse(self) -> bool:
+        """
+        Get whether this reaction's family template also represents its own reverse.
+
+        Returns:
+            bool: Whether the family's template also represents its own reverse.
+        """
+        family = self.family
+        if family is None:
+            return False
+        try:
+            return ReactionFamily(label=family).own_reverse
+        except FileNotFoundError:
+            logger.error(f'Could not find the groups file of the {family} family of reaction {self.label}, '
+                         f'assuming that this family is not its own reverse.')
+            return False
+
     def determine_family(self,
-                         rmg_family_set: str = 'default',
+                         rmg_family_set: list[str] | str | None = None,
                          consider_rmg_families: bool = True,
                          consider_arc_families: bool = True,
                          discover_own_reverse_rxns_in_reverse: bool = False,
                          ):
         """
         Determine the RMG reaction family.
+        When all arguments are left at their defaults, the cached ``product_dicts`` property is used
+        instead of generating a new product dicts list.
 
         Args:
-            rmg_family_set (str, optional): The RMG family set to use.
+            rmg_family_set (list[str] | str, optional): The RMG family set to use.
+                                                        ``None`` (the default) means ``settings['rmg_family_set']``,
+                                                        read on every call.
             consider_rmg_families (bool, optional): Whether to consider RMG's families in addition to ARC's.
             consider_arc_families (bool, optional): Whether to consider ARC's families in addition to RMG's.
             discover_own_reverse_rxns_in_reverse (bool, optional): Whether to discover own reverse reactions in reverse.
@@ -577,8 +655,7 @@ class ARCReaction(object):
             tuple[str | None, bool | None]: The reaction family label,
                 and whether the family's template also represents its own reverse.
         """
-        if rmg_family_set == 'default' and consider_rmg_families and consider_arc_families and not discover_own_reverse_rxns_in_reverse:
-            # these are the default values, don't bother generating a new product_dicts list, use the property
+        if rmg_family_set is None and consider_rmg_families and consider_arc_families and not discover_own_reverse_rxns_in_reverse:
             product_dicts = self.product_dicts
         else:
             product_dicts = get_reaction_family_products(rxn=self,

--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -10,9 +10,12 @@ import os
 import shutil
 import time
 import unittest
+import unittest.mock as mock
 
 from arc.common import ARC_PATH, ARC_TESTING_PATH, almost_equal_lists, read_yaml_file
 from arc.exceptions import ReactionError
+from arc.family.family import get_all_families, get_rmg_recommended_family_sets
+from arc.imports import settings
 from arc.main import ARC
 from arc.reaction.reaction import ARCReaction, remove_dup_species
 from arc.scheduler import Scheduler
@@ -468,6 +471,153 @@ class TestARCReaction(unittest.TestCase):
                                       ARCSpecies(label='NH2NO', smiles='NN=O', yml_path=os.path.join(base_path, 'NH2NO.yml'))])
         self.assertEqual(rxn2.family, 'H_Abstraction')
         self.assertEqual(self.rxn12.family, 'H_Abstraction')
+
+    def test_bare_calls_honour_the_rmg_family_set_setting(self):
+        """determine_family() and get_product_dicts() consider the configured family set when no
+        set is named at the call site, rather than a hard-coded 'default'."""
+        def build_rxn():
+            return ARCReaction(r_species=[ARCSpecies(label='H', smiles='[H]'),
+                                          ARCSpecies(label='CH3Br', smiles='CBr')],
+                               p_species=[ARCSpecies(label='HBr', smiles='Br'),
+                                          ARCSpecies(label='CH3', smiles='[CH3]')])
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual(build_rxn().determine_family(), (None, None))
+            self.assertEqual(build_rxn().get_product_dicts(), list())
+            self.assertEqual(self.rxn1.determine_family()[0], 'H_Abstraction')
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            self.assertEqual(build_rxn().determine_family(), ('Br_Abstraction', True))
+            product_dicts = build_rxn().get_product_dicts()
+            self.assertTrue(len(product_dicts))
+            self.assertTrue(all(product_dict['family'] == 'Br_Abstraction' for product_dict in product_dicts))
+            self.assertEqual(build_rxn().determine_family(rmg_family_set='default'), (None, None))
+            self.assertEqual(build_rxn().get_product_dicts(rmg_family_set='default'), list())
+
+    def test_determine_family_reaches_a_directory_only_family(self):
+        """2-methyl-1-butene <=> 1,1-dimethylcyclopropane belongs to Intra_RH_Add_Exocyclic, which
+        exists only as an RMG database directory. It is discoverable under rmg_family_set 'all'
+        and remains undiscoverable under 'default'."""
+        def build_rxn():
+            return ARCReaction(r_species=[ARCSpecies(label='2-methyl-1-butene', smiles='C=C(C)CC')],
+                               p_species=[ARCSpecies(label='1,1-dimethylcyclopropane', smiles='CC1(C)CC1')])
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual(build_rxn().determine_family(), (None, None))
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            self.assertEqual(build_rxn().determine_family()[0], 'Intra_RH_Add_Exocyclic')
+            self.assertEqual(build_rxn().determine_family(rmg_family_set='default'), (None, None))
+
+    def test_widening_keeps_the_recommended_family_when_both_match(self):
+        """OH + HO2 <=> H2O2 + O matches the recommended H_Abstraction and the directory-only
+        Substitution_O, each on its own. Under 'all' both are discovered, the recommended one comes
+        first, and the family resolves to H_Abstraction, as it does under 'default'."""
+        def build_rxn():
+            return ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                          ARCSpecies(label='HO2', smiles='[O]O')],
+                               p_species=[ARCSpecies(label='H2O2', smiles='OO'),
+                                          ARCSpecies(label='O', smiles='[O]')])
+        for family in ['H_Abstraction', 'Substitution_O']:
+            self.assertEqual(len(build_rxn().get_product_dicts(rmg_family_set=[family],
+                                                               consider_arc_families=False)), 1)
+        all_families = get_all_families(rmg_family_set='all', consider_arc_families=False)
+        recommended = set()
+        for family_set_label, families in get_rmg_recommended_family_sets().items():
+            if 'surface' not in family_set_label:
+                recommended.update(families)
+        self.assertIn('H_Abstraction', recommended)
+        self.assertNotIn('Substitution_O', recommended)
+        self.assertLess(max(i for i, fam in enumerate(all_families) if fam in recommended),
+                        all_families.index('Substitution_O'))
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual([pd['family'] for pd in build_rxn().get_product_dicts()], ['H_Abstraction'])
+            self.assertEqual(build_rxn().determine_family(), ('H_Abstraction', True))
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            self.assertEqual([pd['family'] for pd in build_rxn().get_product_dicts()],
+                             ['H_Abstraction', 'Substitution_O'])
+            self.assertEqual(build_rxn().determine_family(), ('H_Abstraction', True))
+
+    def test_wider_family_set_scan_used_by_the_linear_ts_adapter(self):
+        """The Linear TS adapter retries with rmg_family_set='all' whenever the configured set
+        yields no product dicts, so what 'all' means reaches an installation that never changes the
+        setting. 1,4-cyclohexadiene <=> benzene + H2 has no family under the shipped default and
+        resolves to H2_Loss, an RMG database directory family, under that retry."""
+        def build_rxn():
+            return ARCReaction(r_species=[ARCSpecies(label='1,4-cyclohexadiene', smiles='C1=CCC=CC1')],
+                               p_species=[ARCSpecies(label='benzene', smiles='c1ccccc1'),
+                                          ARCSpecies(label='H2', smiles='[H][H]')])
+        with mock.patch.dict(settings, {'rmg_family_set': 'default'}):
+            self.assertEqual(build_rxn().product_dicts, list())
+            self.assertIsNone(build_rxn().family)
+            wider_product_dicts = build_rxn().get_product_dicts(rmg_family_set='all',
+                                                                consider_rmg_families=True,
+                                                                consider_arc_families=True,
+                                                                discover_own_reverse_rxns_in_reverse=True)
+            self.assertTrue(len(wider_product_dicts))
+            self.assertEqual({pd['family'] for pd in wider_product_dicts}, {'H2_Loss'})
+
+    def test_product_dicts_all_belong_to_the_reaction_family(self):
+        """Test that the product dicts of a reaction that matches several families are restricted to one family"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH]1C=Cc2ccccc21')],
+                          p_species=[ARCSpecies(label='P', smiles='[CH]1C=CC2C3=C1C=CC32')])
+        self.assertEqual(rxn.family, 'Intra_R_Add_Endocyclic')
+        self.assertTrue(len(rxn.product_dicts))
+        self.assertEqual({product_dict['family'] for product_dict in rxn.product_dicts}, {rxn.family})
+
+    def test_pinned_family_restricts_the_product_dicts(self):
+        """Test that pinning a family restricts the product dicts to that family's atom label maps.
+        The reactant atoms are C0 C1 C2 C3 O4 S5, and the breaking bond is one of its bonds."""
+        r_species = [ARCSpecies(label='R', smiles='[CH2]C(C=C)OS')]
+        p_species = [ARCSpecies(label='P', smiles='[O]C(C=C)CS')]
+        rxn = ARCReaction(r_species=r_species, p_species=p_species)
+        self.assertEqual({product_dict['family'] for product_dict in rxn.product_dicts}, {'intra_OH_migration'})
+        pinned = ARCReaction(r_species=r_species, p_species=p_species, family='intra_substitutionS_isomerization')
+        self.assertEqual(pinned.family, 'intra_substitutionS_isomerization')
+        self.assertEqual({product_dict['family'] for product_dict in pinned.product_dicts},
+                         {'intra_substitutionS_isomerization'})
+        breaking_bonds, forming_bonds = rxn.get_expected_changing_bonds(
+            r_label_dict=rxn.product_dicts[0]['r_label_map'])
+        self.assertEqual(breaking_bonds, [(4, 5)])
+        self.assertEqual(forming_bonds, [(0, 5)])
+
+    def test_setting_a_family_restricts_already_generated_product_dicts(self):
+        """Test that assigning a family restricts product dicts that were already set to that family,
+        and discards them only if none of them belong to it"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                     ARCSpecies(label='HO2', smiles='[O]O')],
+                          p_species=[ARCSpecies(label='H2O2', smiles='OO'),
+                                     ARCSpecies(label='O', smiles='[O]')])
+        rxn.product_dicts = rxn.get_product_dicts(rmg_family_set='all')
+        self.assertEqual({product_dict['family'] for product_dict in rxn.product_dicts},
+                         {'H_Abstraction', 'Substitution_O'})
+        rxn.family = 'Substitution_O'
+        self.assertEqual({product_dict['family'] for product_dict in rxn.product_dicts}, {'Substitution_O'})
+        rxn.family = 'intra_H_migration'
+        with self.assertRaises(ReactionError):
+            _ = rxn.product_dicts
+
+    def test_pinning_a_family_that_does_not_match_raises(self):
+        """Test that pinning a family which the reaction does not match raises an error"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH2]C(C=C)OS')],
+                          p_species=[ARCSpecies(label='P', smiles='[O]C(C=C)CS')],
+                          family='intra_H_migration')
+        with self.assertRaises(ReactionError):
+            _ = rxn.product_dicts
+
+    def test_family_own_reverse_is_derived_from_a_pinned_family(self):
+        """Test that pinning a family also determines whether that family is its own reverse"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='C2H6', smiles='CC'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='C2H5', smiles='C[CH2]'),
+                                     ARCSpecies(label='H2O', smiles='O')],
+                          family='H_Abstraction')
+        self.assertTrue(rxn.family_own_reverse)
+        rxn_2 = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH2]C(C=C)OS')],
+                            p_species=[ARCSpecies(label='P', smiles='[O]C(C=C)CS')],
+                            family='intra_OH_migration')
+        self.assertFalse(rxn_2.family_own_reverse)
+        rxn_3 = ARCReaction(reaction_dict={'label': 'C2H6 + OH <=> C2H5 + H2O',
+                                           'r_species': [spc.as_dict() for spc in rxn.r_species],
+                                           'p_species': [spc.as_dict() for spc in rxn.p_species],
+                                           'family': 'H_Abstraction'})
+        self.assertTrue(rxn_3.family_own_reverse)
 
     def test_charge_property(self):
         """Test determining charge"""

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -410,6 +410,14 @@ kinbot_uma_settings = {
 # ARC families folder path
 ARC_FAMILIES_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'data', 'families')
 
+# The RMG reaction family set ARC uses to determine and validate reaction families whenever a
+# family set is not given explicitly. 'default' considers only RMG's recommended families, as is
+# appropriate for mechanism generation. Any other family set defined in
+# RMG-database/input/kinetics/families/recommended.py may be used (e.g. 'halogens'), as may 'all',
+# which unions the sets whose label does not contain 'surface' with the families that exist as RMG
+# database directories.
+rmg_family_set = 'default'
+
 # Default environment names for sister repos
 TS_GCN_PYTHON, TANI_PYTHON, UMA_PYTHON, AUTOTST_PYTHON, KINBOT_PYTHON, GOFLOW_PYTHON, GOFLOW_REPO_PATH, \
     GOFLOW_CKPT_PATH, GOFLOW_FEAT_DICT_PATH, RITS_PYTHON, RITS_REPO_PATH, RITS_CKPT_PATH, \

--- a/arc/species/converter_test.py
+++ b/arc/species/converter_test.py
@@ -1025,7 +1025,9 @@ H                 -4.01978712   -0.12970163    0.82103635"""
                                     (-2.4426534384901547e-09, 0.9528575945413793, -1.015818661524137),
                                     (7.032081834243086e-08, -0.9528574729632926, 1.015818803737915))}
 
-        self.assertEqual(xyz6, expected_xyz6)
+        self.assertEqual(xyz6['symbols'], expected_xyz6['symbols'])
+        self.assertEqual(xyz6['isotopes'], expected_xyz6['isotopes'])
+        self.assertTrue(almost_equal_coords(xyz6, expected_xyz6))
 
     def test_remove_dummies(self):
         """Test removing dummy atoms from xyz"""


### PR DESCRIPTION
Base: `main`. This branch absorbs **#979** (deterministic ordering + authoritative pinning) and **#982** (chemical gates on the family choice) — both were flattened into this PR and are now closed. Review this PR alone; nothing else is outstanding.

Three commits, no file touched by more than one of them. Together they make the RMG family set configurable, make family determination reproducible, and make the family that wins a chemical choice rather than an alphabetical one.

## 1. The family set is configurable, and `'all'` reaches the whole database

- `settings['rmg_family_set']` (new, ships as `'default'`) had no equivalent before: `'default'` was the signature default of `get_all_families()` and of every entry point above it, so ARC could not be asked to consider anything else short of naming a set at every call site. That excludes families ARC's own TS adapters declare support for.
- The value is resolved **inside `get_all_families()`** — the single sink every path funnels through, which already owned an in-body fallback — not threaded through signatures. Threading leaves the sink's literal `'default'` in place, so every caller that does not forward the value keeps returning the curated set; `check_family_name()` on `main` was exactly such a bare call site. Measured on a deployed installation whose `~/.arc/settings.py` asked for `'all'`: `get_all_families('all')` → 100 families, bare `get_all_families()` → 55.
- `get_product_dicts()`, `determine_family()`, `get_reaction_family_products()` and `check_family_name()` propagate `None` to mean "not specified". `determine_family()`'s shortcut to the cached `product_dicts` property keys off `rmg_family_set is None` rather than `== 'default'`, so an explicitly requested set is honoured even when it matches the configured one.
- `'all'` previously unioned only the sets named in RMG's `recommended.py`; families such as `Intra_RH_Add_Exocyclic` and `Intra_RH_Add_Endocyclic` appear in none of them despite shipping in the database. `get_all_families()` now also unions the families that exist as RMG database **directories**, via the new `get_rmg_family_directories()`, counting a directory as a family only when it holds a `groups.py`. The union is de-duplicated, which also removes the 24 duplicate labels the recommended sets alone produced (measured locally: `'default'` → 54, `'all'` → 99, of which 11 are directory-only).

**Ordering is a contract, not an accident.** Directory-only families are positioned last, so one wins only where no recommended family matched — i.e. only where the alternative was `family=None`. Every candidate must still reproduce the products the reaction asserts, so such a family cannot introduce a transformation, only propose a mechanism for one already stated. Stated in the `get_all_families()` docstring and pinned by `test_directory_only_families_are_ordered_last` and, end to end, by `test_widening_keeps_the_recommended_family_when_both_match` on `[OH] + [O]O <=> OO + [O]`, where `H_Abstraction` (recommended) and `Substitution_O` (directory-only) each match in isolation.

**This redefines `'all'` for a stock install**, because the Linear TS adapter asks for `'all'` unconditionally whenever the configured set yields no product dicts. Measured on 1,4-cyclohexadiene ⇌ benzene + H₂ at the shipped `'default'`: `origin/main` gets 0 wider-scan product dicts and `family=None`; this branch gets 16 and `H2_Loss`. Pinned by `test_wider_family_set_scan_used_by_the_linear_ts_adapter`.

`get_reaction_family_products()`'s docstring claimed `'all'` excludes surface families outright; two further statements repeated it. `'all'` skips family *sets* whose label contains `'surface'` and surface family *directories*, but a non-surface-labelled set can still list one, as `electrochem` does for `Surface_Proton_Electron_Reduction_*`. The three statements now say what the code does, and a test pins it.

## 2. Determinism and authoritative pinning

| symptom | cause |
|---|---|
| the family ARC picks depends on `PYTHONHASHSEED` | candidates came from the **set literals** in `recommended.py` (`ast.literal_eval`) and from `os.listdir()` — neither iteration order is specified |
| a pinned family could be paired with another family's atom label map | setting `family` recorded the label but left `product_dicts` holding matches from every family that matched |
| `family_own_reverse` was effectively always `False` | `__init__` set it to `False` and the property only recomputed on `None`, so the recompute branch was dead |

Measured: `[CH]1C=Cc2ccccc21 <=> [CH]1C=CC2C3=C1C=CC32` reports `Intra_Diels_alder_monocyclic` at seeds 0/1/13 and `Intra_R_Add_Exocyclic` at 2/5; `[CH2]C(C=C)OS >> [O]C(C=C)CS` flips between `intra_OH_migration` and `intra_substitutionS_isomerization`. With `intra_OH_migration` pinned and `PYTHONHASHSEED=2`, ARC reported `C0-O4` as a breaking bond — there is no `C0-O4` bond in the reactant. About **10%** of the 500-reaction benchmark selection matches more than one family.

- `recommended.py` is read with `ast.parse`, so each family set keeps its labels in written order (`get_rmg_recommended_family_sets()` now returns `dict[str, tuple[str, ...]]`). A set whose elements are not all plain string literals is sorted instead.
- `get_all_families()` sorts by label **within each tier** — recommended, then database directories, then ARC's — and de-duplicates keeping the first occurrence. Sorting within a tier rather than relying on `recommended.py`'s textual layout keeps ARC's answer independent of a cosmetic upstream reordering; sorting *across* tiers would discard the ordering contract above. Both properties hold together: `get_all_families()` is sha256-identical across `PYTHONHASHSEED` 0/1/2/3/7/13, and no directory-only family precedes a recommended one. Mutation-checked — reversing the tiers, sorting across them, or de-duplicating through a `set` each fails an ordering test; leaving a tier unsorted fails the determinism test.
- New `ARCReaction.restrict_product_dicts_to_family()` restricts `product_dicts` to a **single** family — the pinned one, or the family of the first entry when none is pinned — so a recipe is only ever combined with labels its own family generated. A pinned family matching none of the generated dicts raises `ReactionError` rather than silently deriving the TS from a foreign family or from nothing. When nothing is pinned and several match, a warning names them all.
- Assigning `family` **restricts** already-generated dicts instead of discarding them, so the Linear TS adapter's wider-family-set retry (which sets `product_dicts` then `family`) keeps what the retry recovered.
- Assigning a family invalidates `family_own_reverse`, which the new `get_family_own_reverse()` derives on demand from `ReactionFamily(label=family).own_reverse` — using the `ReactionFamily` `reaction.py` already imports at module level, so **no import line changes** and no new `py/unsafe-cyclic-import` alert is raised (those are per imported *name*). `from_dict` no longer forces `False` when the key is absent. Verified: `own_reverse` matches the `ownReverse` declaration read from `groups.py` for every family in `get_all_families()`, 0 mismatches.
- An `rmg_family_set` list mixing set names with family labels reached de-duplication as a nested list, which is unhashable there; it is now flattened.

## 3. Which family wins: direction and radical gates

New `prioritize_family_product_dicts()`, applied inside `get_reaction_family_products()` **before** the label-sort tie-break. Deterministic is not correct: the label order systematically favours the concerted families, because RMG names the pericyclic families early in ASCII and the radical-addition families late.

1. **Direction gate** — if any match was found forward, drop the reverse-discovered ones. A reverse match's `r_label_map` addresses the *flipped* reaction.
2. **Radical gate** — if the reactants carry unpaired electrons, keep only matches whose recipe gains or loses a radical, provided that leaves at least one and drops at least one.
3. **Tie-break** — fewest bonds formed/broken, then fewest changed, then the deterministic label order. Both counts are needed: `formed/broken` alone leaves `H_Abstraction` (2, 0) tied with families differing only in `changed`.

Both gates only choose among families that already matched, so they cannot invent a mechanism. The direction gate is first because it is a **validity** filter, not a preference — and because it needs no recipe, only `discovered_in_reverse`. That ordering matters operationally too: a family whose `groups.py` cannot be parsed now costs only the radical gate and the bond-change ordering, instead of silently disabling the direction gate as well, and that degradation is reported at `warning` rather than `debug`. Reading recipes after the gate also skips the recipes of dropped matches.

**Evidence.** The benchmark records which family each reaction was generated from, over 281 ambiguous reactions:

| | agrees with the recorded family |
|---|---|
| before | 122 / 281 |
| after | **227 / 281** |

Of the 130 reactions whose family changes, **110 move toward the recorded family, 5 away**. The 5 are `Ketoenol` → `intra_H_migration` and are correct: `Ketoenol/groups.py` contains no `u1` atom anywhere in its group tree — a closed-shell tautomerisation template — while all 5 reactants are delocalised doublets with spin density on the H-acceptor carbon. 4 of the 5 produce byte-identical formed and broken bonds either way. The 5th, 2-hydroxyallyl radical (`[CH2]C(=C)O`), is symmetry-degenerate and the gate measurably wins: `Ketoenol`'s atom map scrambles the four CH₂ hydrogens across both allyl termini, giving formed 5 / broken 5, which no single imaginary mode can satisfy, against 1 / 1 for `intra_H_migration`. The recorded labels are internally inconsistent for this pair anyway (5 `Ketoenol` / 3 `intra_H_migration` across 8 ambiguities, 6 of which give identical bonds).

**Contract change worth flagging.** `get_reaction_family_products()` previously returned every match; it now returns a filtered and ordered list, and the docstring says so. Measured on `C=C[CH]CCC + CC=CCCC >> C=CC(CCC)C(C)[CH]CCC` under `'all'`: 4 product dicts before (1 forward `R_Addition_MultipleBond` + 3 reverse `Retroene`), 1 after. `R_Addition_MultipleBond`/`Retroene` is the single largest ambiguous combination in the benchmark pool (118 of 281), so the direction gate is the highest-volume change here.

Downstream: `Disproportionation → H_Abstraction` moves 4 reactions from **no TS adapters at all** to heuristics/autotst/crest; `Intra_2+2_cycloaddition_Cd → Intra_R_Add_*` gains kinbot. Genuinely ambiguous pairs are left alone (`Intra_R_Add_Endo/Exocyclic`, `Cl_/H_Abstraction`, `H_Abstraction`/`Substitution_O`). **Known limitation, deliberate:** the radical gate tests `multiplicity > 1`, so a singlet biradical does not trigger it.

Chemistry review on the gates: **passed, ship as written**, with two non-blocking follow-ups neither introduced here — `get_number_of_atoms_in_reaction_zone` drops 4→3 under `intra_H_migration`, and `intra_H_migration`'s empty `changed` list will interact with the NMD family-recipe work when the two meet.

## 4. Two guards the above made reachable

- **`linear.py` stops asking for reverse-discovered matches.** `interpolate_addition()`'s wider family-set rescue passed `discover_own_reverse_rxns_in_reverse=True`, but the adapter branches on `discovered_in_reverse` without ever translating the index space. Measured on CH₄ + OH: every reverse-discovered `BREAK_BOND` pair is absent from the reactant graph and present in the product graph (they are the H₂O O–H bonds), while every consumer — `get_expected_changing_bonds()` here, and `map_rxn()`, which cuts the *reactants* with the map — reads it as reactant indices. `arc/mapping/` contains no reference to `discovered_in_reverse` at all. The kwarg is removed and the misleading docstring at `interpolate_addition()` corrected. `_strategy_ring_scission` is unaffected: the gate drops reverse matches only when a forward match exists, and a reverse-only reaction keeps all of them.
- **`make_bond_changes()` is guarded twice.** `KeyError` is added to `map_rxn()`'s except clause around it (which already caught four other types) — `r_label_dict[action[1]]` raises it when a recipe names a label the map lacks. Restricting product dicts to one family narrows this without closing it, because one family can match with different label sets (`intra_H_migration` on `[CH2]CCC` yields both a four-label and a three-label map). Separately, its charge-separating branch subtracted two radical electrons from an atom that may hold one and a lone pair from an atom that may hold none, yielding `u-1`/`c-1` atoms and, once such an atom reaches RDKit, `OverflowError: can't convert negative value to unsigned int`; that branch now declines the change. **This is a guard, not a reproduced fix** — in all 40 donor/acceptor combinations tried, the following `mol.update()` raised `AtomTypeError` and the molecule was restored from its copy, so the invalid state never survived the function. The guard is a no-op wherever the result is rejected.

## Notes for callers, and scope

- **A bare `get_product_dicts()` or `get_all_families()` is now sensitive to process-global settings state.** That is the fix, but it is a footgun for tests and scripts. Every test added here either patches the setting or passes `rmg_family_set=` explicitly.
- `get_all_families()` at the shipped `'default'` is byte-identical to `main`; `test_rmg_family_set_setting_ships_as_default` asserts the shipped constant. What is *not* unchanged is `'all'`, per §1.
- The two surface filters remain inconsistent (recommended path filters on *set label*, directory path on *directory name*) — pre-existing, not changed here. Also pre-existing and not changed: the `linear.py` wider-scan block restores `_family`/`_product_dicts`/`_atom_map` in a `finally` only after the whole weights loop, while `TSGuess(family=rxn.family, ...)` is written during it.
- No allowlist is applied to the directory union. RMG's curation inverts against TS-search utility (`Intra_RH_Add_Endocyclic`/`Exocyclic` and `Intra_R_Add_ExoTetCyclic` have 0 training reactions; `Substitution_O` has 136 and `SubstitutionS` 148), and a second hand-maintained list would drift from `ts_adapters_by_rmg_family`, which ARC already maintains. A hand-picked list would also have excluded `lone_electron_pair_bond`, a family ARC declares support for and ships a passing test for (`linear_test.py::test_interpolate_lone_electron_pair_bond`).

## Reuse check

Searched for an existing settings-resolution helper by behaviour ("argument-or-fall-back-to-`settings[key]`"), by name across `def resolve*`/`get_setting*`, and for the raw `or settings[...]` idiom at call sites — nothing of the kind exists, so the fallback stays inline in `get_all_families()`, where one already was. Nothing walked the RMG database's `kinetics/families` (`get_all_families` scanned `ARC_FAMILIES_PATH` for ARC's own families only), so `get_rmg_family_directories()` is new and sits beside `get_rmg_recommended_family_sets()`. `get_family_own_reverse()` follows the `ReactionFamily(label=...)` call form already used at two pre-existing sites in `reaction.py` and two in `arc/mapping/engine.py` rather than introducing a fifth; `ReactionFamily.__new__` interns per `(label, consider_arc_families)`, so nothing is re-read from disk. For the direction gate, `arc/mapping/` was searched for any existing reverse-aware label-map translation — there is none, which is the finding that decided it; no new helper was added there.

## Checks

- Full suite at parity with `origin/main`: the same 5 pre-existing `arc/job/adapters/torch_ani_test.py` failures on both, 0 added, 0 removed.
- Verified to fail against `origin/main`: `test_wider_family_set_scan_used_by_the_linear_ts_adapter`, `test_widening_keeps_the_recommended_family_when_both_match`, `test_bare_calls_honour_the_rmg_family_set_setting`, `test_determine_family_reaches_a_directory_only_family`.
- 16 tests in `TestFamilyChoiceGates`, each mutation-proved — removing either gate or the count tie-break fails a distinct test. `test_a_radical_cyclization_is_not_labeled_as_a_cycloaddition` exercises the real path end to end on pentadienyl cyclisation, where `Intra_2+2_cycloaddition_Cd` sorts ahead of `Intra_R_Add_Exocyclic` and the gate still resolves to the radical addition.
- Under `-n 6` the branch additionally trips `scheduler_test.py::test_initialize_output_dict`; that test is order-dependent and fails identically on `origin/main` in isolation — a pre-existing xdist worker-distribution artefact.

Supersedes `fix_family_set` (`916d9943`), which carries the same feature without the sink fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also folds in `fix_product_isomorphism_tautomers`

`check_product_isomorphism`'s InChI fallback compared standard InChI plus multiplicity — and standard InChI carries a mobile-H layer that deliberately collapses tautomers onto one string. So ARC accepted a family-generated product that is a **different molecule** from the one the user specified (`NC=O` accepted as `N=CO`). Observed on benchmark reaction 95, where the bad dict became `product_dicts[0]` and drove a TS guess, an atom map and an NMD check for a reaction that is not in the input.

The fallback now additionally requires `Molecule.is_isomorphic(save_order=True, strict=False)` — ARC's existing electron-agnostic comparison, which ignores bond orders, charges and radicals while keeping explicit hydrogens as graph vertices. Lewis-structure pairs like `O=C=C(O)C=O` / `O=C[C-](O)C#[O+]` still match; tautomers do not.

Because that check is a *necessary* condition it runs first, so InChIs are generated only for pairs it already admits — 30 generations and 2 failures per family resolution drop to 0 and 0 — and the new `_get_inchi` converts a deep copy and memoizes per pair, so one InChI-hostile molecule no longer rejects every candidate. Seven regression tests.

Folded here rather than shipped separately because it touches the same two files as this PR's first commit; apart, whichever landed second would have conflicted.
