### PR TITLE
Stop YAML from coercing a bare SMILES like NO into a boolean

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -353,6 +353,26 @@ def get_git_branch(path: str | None = None) -> str:
         return ''
 
 
+class ARCYAMLLoader(yaml.FullLoader):
+    """A YAML loader that does not coerce YAML 1.1 boolean aliases into booleans.
+
+    PyYAML implements YAML 1.1, in which ``yes``, ``no``, ``on``, and ``off`` (in any case) are
+    booleans just like ``true`` and ``false``. That silently turns a bare SMILES such as ``NO``
+    (hydroxylamine) or an element symbol such as ``No`` (nobelium) into ``False`` before ARC ever
+    sees it. Here only the YAML 1.2 spellings ``true`` and ``false`` resolve as booleans, and
+    every other alias loads as the string the user wrote.
+    """
+
+
+ARCYAMLLoader.yaml_implicit_resolvers = {
+    first_char: [(tag, regexp) for tag, regexp in resolvers if tag != 'tag:yaml.org,2002:bool']
+    for first_char, resolvers in yaml.FullLoader.yaml_implicit_resolvers.items()
+}
+ARCYAMLLoader.add_implicit_resolver('tag:yaml.org,2002:bool',
+                                    re.compile(r'^(?:true|True|TRUE|false|False|FALSE)$'),
+                                    list('tTfF'))
+
+
 def read_yaml_file(path: str,
                    project_directory: str | None = None,
                    ) -> dict | list:
@@ -374,7 +394,7 @@ def read_yaml_file(path: str,
     if not os.path.isfile(path):
         raise InputError(f'Could not find the YAML file {path}')
     with open(path, 'r') as f:
-        content = yaml.load(stream=f, Loader=yaml.FullLoader)
+        content = yaml.load(stream=f, Loader=ARCYAMLLoader)
     return content
 
 
@@ -405,7 +425,7 @@ def from_yaml(yaml_str: str) -> dict | list:
     Returns: dict | list
         The respective Python object.
     """
-    return yaml.load(stream=yaml_str, Loader=yaml.FullLoader)
+    return yaml.load(stream=yaml_str, Loader=ARCYAMLLoader)
 
 
 def to_yaml(py_content: list | dict) -> str:

--- a/arc/common_test.py
+++ b/arc/common_test.py
@@ -86,6 +86,46 @@ class TestCommon(unittest.TestCase):
         with self.assertRaises(InputError):
             common.read_yaml_file('nopath')
 
+    def test_read_yaml_file_does_not_coerce_yaml_1_1_booleans(self):
+        """Test that YAML 1.1 boolean aliases are read as strings, not as booleans.
+
+        A bare SMILES that looks like a YAML 1.1 boolean (e.g., ``NO`` for hydroxylamine)
+        must survive as a string, while genuine ``true``/``false`` values must still load as bools.
+        """
+        content = ('smiles_1: NO\n'
+                   'smiles_2: ON\n'
+                   'word_1: yes\n'
+                   'word_2: Off\n'
+                   'word_3: n\n'
+                   'bool_1: true\n'
+                   'bool_2: False\n'
+                   'bool_3: TRUE\n')
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            loaded = common.read_yaml_file(path)
+        finally:
+            os.remove(path)
+        self.assertEqual(loaded['smiles_1'], 'NO')
+        self.assertEqual(loaded['smiles_2'], 'ON')
+        self.assertEqual(loaded['word_1'], 'yes')
+        self.assertEqual(loaded['word_2'], 'Off')
+        self.assertEqual(loaded['word_3'], 'n')
+        self.assertIs(loaded['bool_1'], True)
+        self.assertIs(loaded['bool_2'], False)
+        self.assertIs(loaded['bool_3'], True)
+        self.assertEqual(common.from_yaml('smiles: NO\nkeep_files: true\n'),
+                         {'smiles': 'NO', 'keep_files': True})
+
+    def test_read_element_dicts_nobelium(self):
+        """Test that nobelium ('No') is not coerced into a boolean by the YAML loader."""
+        self.assertEqual(common.SYMBOL_BY_NUMBER[102], 'No')
+        self.assertEqual(common.NUMBER_BY_SYMBOL['No'], 102)
+        self.assertIn('No', common.MASS_BY_SYMBOL)
+        self.assertTrue(all(isinstance(symbol, str) for symbol in common.NUMBER_BY_SYMBOL.keys()))
+        self.assertTrue(all(isinstance(symbol, str) for symbol in common.MASS_BY_SYMBOL.keys()))
+
     def test_get_git_commit(self):
         """Test the get_git_commit() function"""
         git_commit = common.get_git_commit()

--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import os
 from math import isclose
+from typing import Any
 
 import arc.molecule.element as elements
 from arc.common import (almost_equal_coords,
@@ -390,6 +391,7 @@ class ARCSpecies(object):
         self.label = label
         self.symmetry_number = None
         self.index = None
+        check_smiles(smiles=smiles, label=label)
 
         if species_dict is not None:
             # Reading from a dictionary (it's possible that the dict contains only a 'yml_path' argument, check first)
@@ -933,6 +935,7 @@ class ARCSpecies(object):
         else:
             self.mol = None
         smiles = species_dict['smiles'] if 'smiles' in species_dict else None
+        check_smiles(smiles=smiles, label=self.label)
         inchi = species_dict['inchi'] if 'inchi' in species_dict else None
         adjlist = species_dict['adjlist'] if 'adjlist' in species_dict else None
         if self.mol is None:
@@ -942,11 +945,6 @@ class ARCSpecies(object):
             elif inchi is not None:
                 self.mol = rmg_mol_from_inchi(inchi)
             elif smiles is not None:
-                if isinstance(smiles, list):
-                    raise SpeciesError(f'Got a list value type for SMILES of species {self.label}:\n'
-                                       f'{smiles}, type: {type(smiles)}\n'
-                                       f'Did you mean to enter this as a string? Consider adding quotation marks '
-                                       f'before and after the SMILES value if entering through a YAML file.')
                 self.mol = Molecule(smiles=smiles)
         # Perceive molecule from xyz coordinates. This also populates the .mol attribute of the Species.
         # It overrides self.mol generated from adjlist or smiles so xyz and mol will have the same atom order.
@@ -1116,7 +1114,9 @@ class ARCSpecies(object):
         """
         if self.mol is not None and len(self.mol.atoms):
             return len(self.mol.atoms) == 2
-        xyz = self.get_xyz()
+        if self.mol_list is not None and len(self.mol_list):
+            return len(self.mol_list[0].atoms) == 2
+        xyz = self.get_xyz(generate=False)
         if xyz is not None:
             return len(xyz['symbols']) == 2
         return None
@@ -3186,6 +3186,32 @@ def colliding_atoms(xyz: dict,
             if actual_r < single_bond_r * threshold:
                 return True
     return False
+
+
+def check_smiles(smiles: Any,
+                 label: str | None = None,
+                 ) -> None:
+    """
+    Check that a SMILES descriptor is a string, and raise a descriptive error if it isn't.
+
+    A bare SMILES that spells a YAML 1.1 boolean alias (e.g., ``NO`` for hydroxylamine) used to
+    reach ARC as a bool, which cannot be translated into a molecule and eventually caused an
+    uninformative RecursionError. Fail here instead, naming the species.
+
+    Args:
+        smiles (Any): The SMILES descriptor to check.
+        label (str, optional): The species label, used in the error message.
+
+    Raises:
+        SpeciesError: If ``smiles`` is neither ``None`` nor a string.
+    """
+    if smiles is None or isinstance(smiles, str):
+        return
+    raise SpeciesError(f'The SMILES descriptor of species {label} must be a string, '
+                       f'got {smiles}, type: {type(smiles)}.\n'
+                       f'If entering through a YAML file, consider adding quotation marks before and after the '
+                       f'SMILES value, e.g., "NO". A bare list is read by YAML as a list, and a bare NO, ON, '
+                       f'YES, or OFF is read as a boolean.')
 
 
 def check_label(label: str,

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -613,6 +613,33 @@ H      -1.67091600   -1.35164600   -0.93286400"""
         self.assertEqual(spc7.multiplicity, 2)
         self.assertEqual(spc8.multiplicity, 1)
 
+    def test_non_str_smiles_raises_named_error(self):
+        """Test that a non-string SMILES raises a SpeciesError naming the species, not a RecursionError."""
+        for smiles in [False, True, 5]:
+            with self.assertRaises(SpeciesError) as cm:
+                ARCSpecies(label='hydroxylamine', smiles=smiles, compute_thermo=False)
+            self.assertIn('hydroxylamine', str(cm.exception))
+            self.assertIn('SMILES', str(cm.exception))
+            self.assertIn(str(type(smiles)), str(cm.exception))
+            with self.assertRaises(SpeciesError) as cm:
+                ARCSpecies(species_dict={'label': 'hydroxylamine', 'smiles': smiles, 'compute_thermo': False})
+            self.assertIn('hydroxylamine', str(cm.exception))
+        # A SMILES that is a string but chemically invalid must not recurse either.
+        with self.assertRaises((SpeciesError, ValueError)):
+            ARCSpecies(label='junk', smiles='this is not a SMILES', compute_thermo=False)
+
+    def test_is_diatomic_does_not_generate_conformers(self):
+        """Test that is_diatomic() queries existing coordinates only and never triggers conformer generation."""
+        spc = ARCSpecies(label='NO', smiles='[N]=O', compute_thermo=False)
+        self.assertTrue(spc.is_diatomic())
+        spc_no_structure = ARCSpecies(label='no_structure', smiles='C', compute_thermo=False)
+        spc_no_structure.mol = None
+        spc_no_structure.mol_list = None
+        spc_no_structure.conformers = list()
+        spc_no_structure.final_xyz, spc_no_structure.initial_xyz = None, None
+        spc_no_structure.most_stable_conformer, spc_no_structure.cheap_conformer = None, None
+        self.assertIsNone(spc_no_structure.is_diatomic())
+
     def test_check_multiplicity_parity_neutral(self):
         """Test that an impossible electron-count/multiplicity parity of a neutral species raises SpeciesError."""
         spc_even = ARCSpecies(label='ethylene', smiles='C=C', multiplicity=1, compute_thermo=False)


### PR DESCRIPTION
## Motivation

PyYAML implements YAML 1.1, in which `yes`, `no`, `on`, and `off` (in any case) are booleans just like `true` and `false`. So an ARC input file containing

```yaml
species:
  - label: hydroxylamine
    smiles: NO
```

hands ARC the Python value `False`, never the string `NO`. `Molecule(smiles=False)` does not raise — it silently returns an *empty* molecule. `get_xyz()` then sees `self.mol is not None` and calls `get_cheap_conformer()`, which calls `is_diatomic()`, which found `len(self.mol.atoms) == 0` and fell through to `self.get_xyz()` with the default `generate=True`. Infinite recursion, ending in a bare `RecursionError` that names no species and points at nothing the user wrote.

The same coercion has already corrupted ARC's own data. `data/elements.yml` maps `102: No` — nobelium. On `main` today:

```python
>>> SYMBOL_BY_NUMBER[102]
False
>>> NUMBER_BY_SYMBOL['No']
KeyError: 'No'
```

`MASS_BY_SYMBOL` likewise carries a `False` key instead of `'No'`.

## What this does

1. `ARCYAMLLoader` in `arc/common.py` narrows the implicit boolean resolver to the YAML 1.2 spellings `true`/`false`. Every other alias loads as the string the user wrote. Both YAML entry points (`read_yaml_file` and `from_yaml`) use it, so files and strings behave identically. This fixes the nobelium entry with no edit to `elements.yml`.
2. Belt and suspenders, so bad input fails loudly rather than mysteriously: `check_smiles()` raises a `SpeciesError` naming the species when a SMILES is not a string (it subsumes the previous list-only check in `from_dict`, and now runs on the `__init__` path too), and `is_diatomic()` consults `mol_list` and calls `get_xyz(generate=False)` — mirroring `is_monoatomic()` — so it can never re-enter conformer generation.

Writing is untouched. `save_yaml_file` / `to_yaml` already emit `true`/`false`, so every ARC-written `restart.yml` / `output.yml` round-trips unchanged.

## Testing

`test_read_yaml_file_does_not_coerce_yaml_1_1_booleans` (round-trips `NO`, `ON`, `yes`, `Off` as strings while `true`/`False`/`TRUE` stay bools, via both entry points), `test_read_element_dicts_nobelium`, `test_non_str_smiles_raises_named_error`, `test_is_diatomic_does_not_generate_conformers`. All four were written failing first.

End-to-end, under `sys.setrecursionlimit(300)`:

```
parsed: {'project': 'yaml_bool_repro', 'species': [{'label': 'hydroxylamine', 'smiles': 'NO'}]}
label: hydroxylamine | mol: NO | formula: H3NO | mult: 1
is_diatomic: False
```

Full local suite: 2742 passed, 7 skipped. The single failure, `functional/restart_test.py::TestRestart::test_globalize_paths`, is pre-existing and environmental — it asserts the substring `ARC/arc/testing/...` against an absolute path, so it fails in any worktree directory not named exactly `ARC`. Verified by stashing this diff and re-running it on a clean tree.

## Notes for reviewers

- One behavior change worth naming: an existing input file written as `keep_files: yes` now yields the string `'yes'` rather than `True`. Still truthy at essentially every call site, but not identical. Nothing in this repo relies on `yes`/`no` as booleans — the docs consistently use `true`/`false` — so the exposure is limited to user files in the wild.
- Not addressed here: the standalone job-adapter scripts under `arc/job/adapters/scripts/` load YAML themselves with `FullLoader`. They run detached on remote servers and cannot import `arc.common`, so covering them means duplicating the loader in seven files. Happy to open a follow-up issue.