### PR TITLE
Gate the reaction family choice on reaction direction and the radical before the label tie-break

### DIFF
--- a/arc/family/family.py
+++ b/arc/family/family.py
@@ -56,6 +56,8 @@ REACTANTS_PATTERN = re.compile(r'reactants\s*=\s*\[(.*?)\]', re.DOTALL)
 PRODUCTS_PATTERN = re.compile(r'products\s*=\s*\[(.*?)\]', re.DOTALL)
 ACTIONS_PATTERN = re.compile(r'actions\s*=\s*\[(.*?)\]', re.DOTALL)
 
+RADICAL_RECIPE_ACTIONS = ('GAIN_RADICAL', 'LOSE_RADICAL')
+
 
 def get_reaction_family(label: str, consider_arc_families: bool = True) -> 'ReactionFamily':
     """
@@ -532,10 +534,17 @@ def get_reaction_family_products(rxn: ARCReaction,
                                                                ``True`` will cause the function to discover reactions
                                                                in both directions, ``False`` will cause the function
                                                                to discover reactions only in the forward direction.
+                                                               Reverse-discovered matches that this flag admits are
+                                                               still dropped by prioritize_family_product_dicts()
+                                                               whenever a forward match exists, so the flag only
+                                                               widens the result for a reaction that no family
+                                                               matches in the forward direction.
 
     Returns:
-        list[dict]: The list of product dictionaries with the reaction family label.
-                    Keys are: 'family', 'group_labels', 'products', 'own_reverse', 'discovered_in_reverse', 'actions'.
+        list[dict]: The list of product dictionaries with the reaction family label, ordered and filtered
+                    by prioritize_family_product_dicts(), so that the first entry is the family match to use.
+                    Keys are: 'family', 'group_labels', 'products', 'r_label_map', 'p_label_map',
+                    'own_reverse', 'discovered_in_reverse'.
     """
     family_labels = get_all_families(rmg_family_set=rmg_family_set,
                                      consider_rmg_families=consider_rmg_families,
@@ -593,7 +602,95 @@ def get_reaction_family_products(rxn: ARCReaction,
                     product_dicts.extend(filtered_products)
         except (KeyError, ValueError, InvalidAdjacencyListError) as e:
             logger.debug(f'Skipping family {family_label} due to unsupported group definition: {type(e).__name__}: {e}')
-    return product_dicts
+    return prioritize_family_product_dicts(rxn=rxn,
+                                           product_dicts=product_dicts,
+                                           consider_arc_families=consider_arc_families,
+                                           )
+
+
+def has_radical_recipe_action(actions: list[list]) -> bool:
+    """
+    Determine whether a family recipe changes the number of unpaired electrons of any of its labeled atoms.
+
+    Args:
+        actions (list[list]): The recipe actions of a reaction family.
+
+    Returns:
+        bool: Whether the recipe contains a ``GAIN_RADICAL`` or a ``LOSE_RADICAL`` action.
+    """
+    return any(action[0] in RADICAL_RECIPE_ACTIONS for action in actions)
+
+
+def count_recipe_bond_changes(actions: list[list]) -> tuple[int, int]:
+    """
+    Count the bond changes a family recipe prescribes.
+
+    Args:
+        actions (list[list]): The recipe actions of a reaction family.
+
+    Returns:
+        tuple[int, int]: The number of bonds the recipe forms or breaks,
+                         and the number of bonds the recipe changes the order of.
+    """
+    formed_or_broken = len([action for action in actions if action[0] in ('FORM_BOND', 'BREAK_BOND')])
+    changed = len([action for action in actions if action[0] == 'CHANGE_BOND'])
+    return formed_or_broken, changed
+
+
+def prioritize_family_product_dicts(rxn: ARCReaction,
+                                    product_dicts: list[dict],
+                                    consider_arc_families: bool = True,
+                                    ) -> list[dict]:
+    """
+    Order family product dictionaries so that the first entry is the family match to use,
+    and drop the entries that must not be used.
+
+    An entry discovered in the reverse direction carries an atom label map in the index space of the
+    flipped reaction, so all such entries are dropped whenever at least one entry was discovered in the
+    forward direction. This gate reads only ``discovered_in_reverse`` and is therefore applied even when a
+    family recipe cannot be read. If any of the reactants carries unpaired electrons, only the entries whose
+    family recipe gains or loses a radical are kept, provided that this keeps at least one entry and drops at
+    least one. The remaining entries are then ordered by the number of bonds their family recipe forms or
+    breaks, then by the number of bonds it changes the order of, then by the order in which the families
+    were considered, which is the order of ``get_all_families()``. Entries of the same family keep their
+    relative order. The radical gate and the ordering both need the family recipes, so an unreadable recipe
+    leaves the direction-gated entries in the order they were discovered in.
+
+    Args:
+        rxn (ARCReaction): The ARC reaction object.
+        product_dicts (list[dict]): The family product dictionaries to order.
+        consider_arc_families (bool, optional): Whether ARC's custom families were considered.
+
+    Returns:
+        list[dict]: The ordered product dictionaries.
+    """
+    forward_dicts = [product_dict for product_dict in product_dicts
+                     if not product_dict['discovered_in_reverse']]
+    if len(forward_dicts):
+        product_dicts = forward_dicts
+    if len(product_dicts) < 2:
+        return product_dicts
+    family_order, actions_by_family = dict(), dict()
+    for product_dict in product_dicts:
+        family_label = product_dict['family']
+        if family_label in family_order:
+            continue
+        try:
+            actions_by_family[family_label] = get_reaction_family(
+                label=family_label, consider_arc_families=consider_arc_families).actions
+        except (FileNotFoundError, KeyError, ValueError, InvalidAdjacencyListError) as e:
+            logger.warning(f'Could not read the recipe of the {family_label} family, so the family match of '
+                           f'reaction {rxn.label} is chosen by the discovery order alone: {type(e).__name__}: {e}')
+            return product_dicts
+        family_order[family_label] = len(family_order)
+    if any(spc.multiplicity is not None and spc.multiplicity > 1 for spc in rxn.r_species):
+        radical_dicts = [product_dict for product_dict in product_dicts
+                         if has_radical_recipe_action(actions_by_family[product_dict['family']])]
+        if len(radical_dicts) and len(radical_dicts) < len(product_dicts):
+            product_dicts = radical_dicts
+    return sorted(product_dicts,
+                  key=lambda product_dict: (*count_recipe_bond_changes(actions_by_family[product_dict['family']]),
+                                            family_order[product_dict['family']]))
 
 
 def _product_graph_key(mols: list[Molecule]) -> tuple:

--- a/arc/family/family_test.py
+++ b/arc/family/family_test.py
@@ -29,8 +29,12 @@ from arc.family.family import (ReactionFamily,
                                get_isomorphic_subgraph,
                                get_product_num,
                                get_reactant_groups_from_template,
+                               get_reaction_family,
                                get_recipe_actions,
                                get_rmg_recommended_family_sets,
+                               count_recipe_bond_changes,
+                               has_radical_recipe_action,
+                               prioritize_family_product_dicts,
                                is_own_reverse,
                                is_reversible,
                                check_family_name,
@@ -1702,6 +1706,190 @@ H       1.24252625    0.91583948   -0.84155142"""
         self.assertTrue(check_family_name(None))
         with self.assertRaises(TypeError):
             check_family_name(123)
+
+
+class TestFamilyChoiceGates(unittest.TestCase):
+    """Unit tests for the non-lexical gates that choose between co-matching families"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+        cls.radical_rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH2]C=CC=C')],
+                                      p_species=[ARCSpecies(label='P', smiles='[CH2]C1C=CC1')])
+        cls.closed_shell_rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='C=CC(=C)N')],
+                                           p_species=[ARCSpecies(label='P', smiles='NC1=CCC1')])
+        cls.abstraction_rxn = ARCReaction(r_species=[ARCSpecies(label='C2H5', smiles='C[CH2]'),
+                                                     ARCSpecies(label='C2H3', smiles='[CH]=C')],
+                                          p_species=[ARCSpecies(label='C2H4', smiles='C=C'),
+                                                     ARCSpecies(label='C2H4b', smiles='[CH]C')])
+
+    @staticmethod
+    def make_product_dicts(*entries) -> list[dict]:
+        """Build minimal product dicts, each entry being a (family, discovered_in_reverse) tuple
+        or a (family, discovered_in_reverse, group_labels) tuple."""
+        product_dicts = list()
+        for entry in entries:
+            family, reverse = entry[0], entry[1]
+            product_dicts.append({'family': family,
+                                  'group_labels': entry[2] if len(entry) > 2 else ('a', 'b'),
+                                  'products': list(),
+                                  'r_label_map': dict(),
+                                  'p_label_map': dict(),
+                                  'own_reverse': False,
+                                  'discovered_in_reverse': reverse,
+                                  })
+        return product_dicts
+
+    def test_has_radical_recipe_action(self):
+        """Test identifying the recipes that change an unpaired electron count"""
+        self.assertTrue(has_radical_recipe_action(get_reaction_family(label='Intra_R_Add_Exocyclic').actions))
+        self.assertTrue(has_radical_recipe_action(get_reaction_family(label='H_Abstraction').actions))
+        self.assertFalse(has_radical_recipe_action(get_reaction_family(label='Intra_RH_Add_Endocyclic').actions))
+        self.assertFalse(has_radical_recipe_action(get_reaction_family(label='Intra_2+2_cycloaddition_Cd').actions))
+        self.assertFalse(has_radical_recipe_action(list()))
+
+    def test_count_recipe_bond_changes(self):
+        """Test counting the bond changes a recipe prescribes"""
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='H_Abstraction').actions), (2, 0))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Disproportionation').actions), (2, 1))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Intra_R_Add_Exocyclic').actions), (1, 1))
+        self.assertEqual(count_recipe_bond_changes(get_reaction_family(label='Intra_RH_Add_Endocyclic').actions), (3, 1))
+        self.assertEqual(count_recipe_bond_changes(list()), (0, 0))
+
+    def test_forward_matches_are_preferred_over_reverse_discovered_matches(self):
+        """A match discovered in reverse carries a label map of the flipped reaction,
+        so it is dropped whenever a forward match exists"""
+        product_dicts = self.make_product_dicts(('R_Addition_MultipleBond', True), ('Retroene', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized], ['Retroene'])
+
+    def test_reverse_discovered_matches_are_kept_when_no_forward_match_exists(self):
+        """Nothing is dropped when every match was discovered in reverse"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', True), ('Intra_R_Add_Exocyclic', True))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['Intra_R_Add_Exocyclic', 'Intra_2+2_cycloaddition_Cd'])
+
+    def test_a_radical_reactant_requires_a_recipe_that_accounts_for_the_radical(self):
+        """A family whose recipe leaves the unpaired electron untouched is dropped
+        when the reactants carry one and a family that accounts for it also matches"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False), ('Intra_R_Add_Exocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized], ['Intra_R_Add_Exocyclic'])
+
+    def test_the_radical_gate_keeps_all_matches_when_no_recipe_accounts_for_the_radical(self):
+        """The radical gate does not empty the candidates when no recipe changes a radical count"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual({product_dict['family'] for product_dict in prioritized},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'})
+
+    def test_the_radical_gate_is_silent_for_closed_shell_reactants(self):
+        """Closed-shell reactants keep every family match, whatever its recipe does to radicals"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False), ('Intra_R_Add_Exocyclic', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual({product_dict['family'] for product_dict in prioritized},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_R_Add_Exocyclic'})
+
+    def test_the_fewest_bond_changes_win_the_tie_break(self):
+        """Two families that both account for the radical are ordered by the bond changes
+        their recipes prescribe, before any lexical consideration"""
+        product_dicts = self.make_product_dicts(('Disproportionation', False), ('H_Abstraction', False))
+        prioritized = prioritize_family_product_dicts(rxn=self.abstraction_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['H_Abstraction', 'Disproportionation'])
+
+    def test_matches_of_the_same_family_keep_their_relative_order(self):
+        """Ordering the families does not reorder the label maps within a family"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False, ('c1', 'c2')),
+                                                ('Intra_R_Add_Exocyclic', False, ('r1', 'r2')),
+                                                ('Intra_2+2_cycloaddition_Cd', False, ('c3', 'c4')),
+                                                ('Intra_R_Add_Exocyclic', False, ('r3', 'r4')))
+        prioritized = prioritize_family_product_dicts(rxn=self.closed_shell_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['group_labels'] for product_dict in prioritized],
+                         [('r1', 'r2'), ('r3', 'r4'), ('c1', 'c2'), ('c3', 'c4')])
+
+    def test_a_single_match_is_returned_as_is(self):
+        """A single match is returned unchanged, radical reactants notwithstanding"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', True))
+        self.assertEqual(prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts),
+                         product_dicts)
+        self.assertEqual(prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=list()), list())
+
+    def test_a_radical_cyclization_is_not_labeled_as_a_cycloaddition(self):
+        """The pentadienyl radical cyclization matches both a concerted cycloaddition and a radical
+        addition, and resolves to the radical addition although the cycloaddition sorts first"""
+        with mock.patch.dict(settings, {'rmg_family_set': 'all'}):
+            concerted = determine_possible_reaction_products_from_family(
+                rxn=self.radical_rxn, family_label='Intra_2+2_cycloaddition_Cd')
+            self.assertTrue(len(concerted))
+            all_families = get_all_families(rmg_family_set='all')
+            self.assertLess(all_families.index('Intra_2+2_cycloaddition_Cd'),
+                            all_families.index('Intra_R_Add_Exocyclic'))
+            product_dicts = get_reaction_family_products(rxn=self.radical_rxn, rmg_family_set='all')
+            self.assertEqual({product_dict['family'] for product_dict in product_dicts}, {'Intra_R_Add_Exocyclic'})
+
+    def test_the_direction_gate_holds_when_a_recipe_cannot_be_read(self):
+        """The direction gate reads only 'discovered_in_reverse', so an unreadable recipe must not
+        resurrect a reverse-discovered match, and only the recipe-based gates degrade"""
+        product_dicts = self.make_product_dicts(('Intra_R_Add_Exocyclic', True),
+                                                ('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        side_effect=FileNotFoundError('groups.py')):
+            prioritized = prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual([product_dict['family'] for product_dict in prioritized],
+                         ['Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'])
+
+    def test_an_unreadable_recipe_is_reported_as_a_warning(self):
+        """Losing the radical gate and the bond-change ordering degrades the family choice,
+        so it is reported above the debug level"""
+        product_dicts = self.make_product_dicts(('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_R_Add_Exocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        side_effect=FileNotFoundError('groups.py')):
+            with self.assertLogs('arc', level='WARNING') as captured:
+                prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertIn('Could not read the recipe', '\n'.join(captured.output))
+
+    def test_a_recipe_is_not_read_for_a_reverse_discovered_match(self):
+        """The direction gate runs first, so a match it drops cannot disable the remaining gates"""
+        product_dicts = self.make_product_dicts(('Intra_R_Add_Exocyclic', True),
+                                                ('Intra_2+2_cycloaddition_Cd', False),
+                                                ('Intra_RH_Add_Endocyclic', False))
+        with mock.patch('arc.family.family.get_reaction_family',
+                        wraps=get_reaction_family) as mocked_get_reaction_family:
+            prioritize_family_product_dicts(rxn=self.radical_rxn, product_dicts=product_dicts)
+        self.assertEqual({call.kwargs['label'] for call in mocked_get_reaction_family.call_args_list},
+                         {'Intra_2+2_cycloaddition_Cd', 'Intra_RH_Add_Endocyclic'})
+
+    def test_the_direction_gate_holds_for_a_caller_that_did_not_ask_for_reverse_discovery(self):
+        """The allyl + propene addition matches R_Addition_MultipleBond in the forward direction and
+        Retroene in the reverse one. Retroene's label map indexes the product, so it is dropped even
+        though 'discover_own_reverse_rxns_in_reverse' never admitted it in the first place"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='allyl', smiles='C=C[CH2]'),
+                                     ARCSpecies(label='propene', smiles='CC=C')],
+                          p_species=[ARCSpecies(label='P', smiles='C=CCC(C)[CH2]')])
+        product_dicts = get_reaction_family_products(rxn=rxn, rmg_family_set='all',
+                                                     discover_own_reverse_rxns_in_reverse=False)
+        self.assertEqual({product_dict['family'] for product_dict in product_dicts},
+                         {'R_Addition_MultipleBond'})
+        self.assertFalse(any(product_dict['discovered_in_reverse'] for product_dict in product_dicts))
+
+    def test_asking_for_reverse_discovery_does_not_defeat_the_direction_gate(self):
+        """'discover_own_reverse_rxns_in_reverse' widens the search, it does not license a label map of
+        the flipped reaction, so a forward match still wins. H_Abstraction is its own reverse, so the
+        flag admits two reverse-discovered matches that the gate then drops"""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]'),
+                                     ARCSpecies(label='H2O', smiles='O')])
+        product_dicts = get_reaction_family_products(rxn=rxn, rmg_family_set='all',
+                                                     discover_own_reverse_rxns_in_reverse=True)
+        self.assertTrue(len(product_dicts))
+        self.assertEqual({product_dict['family'] for product_dict in product_dicts}, {'H_Abstraction'})
+        self.assertFalse(any(product_dict['discovered_in_reverse'] for product_dict in product_dicts))
 
 
 class TestSplitEntries(unittest.TestCase):

--- a/arc/job/adapters/ts/linear.py
+++ b/arc/job/adapters/ts/linear.py
@@ -1672,7 +1672,10 @@ def interpolate_addition(rxn: ARCReaction,
         cross) is direction-agnostic: bonds that exist in the unimolecular
         species' molecular graph are "split bonds" (stretched), and bonds
         that don't are "cross bonds" (used for insertion-ring detection).
-        This handles ``discovered_in_reverse`` correctly without swapping.
+        Classification therefore needs no direction swap, but the recipe
+        bonds themselves must already be in the reaction's reactant index
+        space: a ``discovered_in_reverse`` entry carries an ``r_label_map``
+        of the flipped reaction, which this function does not translate.
 
     2.  **Fragmentation fallback** — when no ``product_dicts`` are available
         or the template gives unreliable bonds, the function enumerates
@@ -1734,7 +1737,6 @@ def interpolate_addition(rxn: ARCReaction,
                 rmg_family_set='all',
                 consider_rmg_families=True,
                 consider_arc_families=True,
-                discover_own_reverse_rxns_in_reverse=True,
             )
         except Exception as e:
             logger.debug(f'Linear addition (rxn={rxn.label}): wider family-set '

--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -557,7 +557,7 @@ class TestARCReaction(unittest.TestCase):
         """Test that the product dicts of a reaction that matches several families are restricted to one family"""
         rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='[CH]1C=Cc2ccccc21')],
                           p_species=[ARCSpecies(label='P', smiles='[CH]1C=CC2C3=C1C=CC32')])
-        self.assertEqual(rxn.family, 'Intra_Diels_alder_monocyclic')
+        self.assertEqual(rxn.family, 'Intra_R_Add_Endocyclic')
         self.assertTrue(len(rxn.product_dicts))
         self.assertEqual({product_dict['family'] for product_dict in rxn.product_dicts}, {rxn.family})
 


### PR DESCRIPTION
Stacked on #979, which is stacked on #978. Read those first — #978 makes the wider family set reachable, #979 makes the resulting order deterministic, and this PR decides *which* of several matching families wins.

## The problem

- More than one reaction family can match the same reaction. When that happens, `product_dicts[0]` wins.
- #979 made that order deterministic — but deterministic is not correct. The winner is currently decided by the **family label's sort order**, which has nothing to do with chemistry.
- That order is not neutral. RMG's naming puts concerted/pericyclic families early in the alphabet and radical-addition families late, so a radical reaction that also matches a concerted template loses to it by default.
- The choice is not cosmetic: the family drives the recipe used for reactive-bond identification, and it selects which TS-guess adapters run at all.

## What this PR does

New `prioritize_family_product_dicts`, applied inside `get_reaction_family_products` **before** the existing label-sort tie-break:

1. **Direction gate** — if any match was found in the forward direction, drop the ones found in reverse. A reverse match's atom-label map is built against the flipped reaction, so its indices address the *products*; pairing it with a forward recipe yields bonds that do not exist in the reactant.
2. **Radical gate** — if the reactants carry unpaired electrons, prefer families whose recipe actually gains or loses a radical. A family with no radical bookkeeping is a closed-shell template that matched only because the radical sat out the graph transformation. Applied only if it leaves at least one candidate.
3. **Tie-break** — fewest bonds formed/broken, then fewest bonds changed, then the existing deterministic order from #979.

Both gates only ever choose among families that **already matched**, so they cannot invent a mechanism — only pick between valid ones.

### Why this order

- The direction gate is first because it is a **validity** filter, not a preference: a reverse-discovered entry's label map is in the wrong index space whatever its chemistry, so it must not be weighed against a chemical criterion.
- The radical gate is second because it discriminates among entries that are all *valid* — it is a chemical preference, and it is applied only when it neither empties nor fails to narrow the candidate set.
- The recipe bond-change counts are last before the label sort because they are the weakest signal: they prefer the simpler elementary step when nothing stronger separates two families. Both counts were needed — `formed/broken` alone leaves `H_Abstraction` (2, 0) tied with families that differ only in `changed`.
- Bracketing: each of the three steps was removed in turn and a distinct test fails; and the agreement figure below falls if any is dropped. Nothing here is a tunable threshold — there is no magic number to pick, only the sequence.

## Contract change worth flagging

- `get_reaction_family_products` previously returned **every** match; it now returns a **filtered and ordered** list, and the docstring says so. Measured on `C=C[CH]CCC + CC=CCCC >> C=CC(CCC)C(C)[CH]CCC` under `'all'`: 4 product dicts before (1 forward `R_Addition_MultipleBond` + 3 reverse `Retroene`), 1 after.
- This applies **regardless of `discover_own_reverse_rxns_in_reverse`**. `linear.py` is the one caller that passes that flag as `True` and it has dedicated handling for `discovered_in_reverse`; after this PR it no longer receives reverse-discovered entries whenever a forward match co-exists. That is intended — those entries are the ones whose label maps produce non-existent bonds — but it is a real change to a caller that opted in, and reviewers of `linear.py` should know.
- `R_Addition_MultipleBond` / `Retroene` is the single largest ambiguous combination in the benchmark pool (118 of the 281 ambiguous reactions), so the direction gate, not the radical gate, is the highest-volume change here.

## Why we think it is right

The benchmark data records which family each reaction was originally generated from, which gives an independent check over the 281 ambiguous reactions:

| | agrees with the recorded family |
|---|---|
| before | 122 / 281 |
| after | **227 / 281** |

- Of the 130 reactions whose family changes, **110 move toward the recorded family, 5 away.**
- That figure **understates** the improvement: 13 of the 15 changes that match no recorded family are the hex-5-enyl radical-clock class, where the recorded family is the wrong mechanism — `Intra_RH_Add_Endocyclic` reproduces the product connectivity by shifting a hydrogen with the radical as a spectator, which is not the reaction anyone means.

### The 5 that move away are `Ketoenol` → `intra_H_migration`, and they are correct

This is the one result a reviewer should not have to re-derive, so the reasoning is here in full:

- **`Ketoenol/groups.py` contains no `u1` atom anywhere in its group tree.** It is a closed-shell tautomerisation template, trained on closed-shell reactants, and it needs a separate `Ketone_To_Enol` family for the reverse direction. All 5 of these reactants are delocalised doublets with the spin density **on the H-acceptor carbon**. A template with no radical atom matching a radical reaction is precisely the failure mode the radical gate exists to catch.
- **4 of the 5 produce byte-identical formed and broken bonds either way** — the two families differ only in `changed`, so the TS is the same and only the label moves.
- **The 5th is symmetry-degenerate.** For 2-hydroxyallyl radical (`[CH2]C(=C)O`), C0 and C2 are equivalent allyl termini, so H→C0 and H→C2 are the same 1,3-shift under a mirror. There the gate measurably wins: `Ketoenol`'s atom map scrambles the four CH₂ hydrogens across both termini, giving formed 5 / broken 5, which no single imaginary mode can satisfy, against a clean 1 / 1 for `intra_H_migration`.
- **The recorded labels are internally inconsistent** for this pair: of the 8 `Ketoenol`/`intra_H_migration` ambiguities the record labels 5 as `Ketoenol` and 3 as `intra_H_migration`, while 6 of the 8 give identical bonds. The record tracks which Lewis structure RMG enumerated first, not a chemical distinction.
- `intra_H_migration` additionally gains AutoTST, which is not registered for `Ketoenol`.

Chemistry review: **passed, ship as written.** Two non-blocking follow-ups it raised, neither introduced by this PR: `get_number_of_atoms_in_reaction_zone` drops 4→3 under `intra_H_migration`, and `intra_H_migration`'s empty `changed` list will interact with the NMD family-recipe work when the two meet.

## Behaviour worth knowing

- `Disproportionation → H_Abstraction` moves 4 reactions from **no TS adapters at all** to heuristics/autotst/crest.
- `Intra_2+2_cycloaddition_Cd → Intra_R_Add_*` gains kinbot.
- Genuinely ambiguous pairs are left alone — `Intra_R_Add_Endo/Exocyclic`, `Intra_RH_Add_Endo/Exocyclic`, `Cl_/H_Abstraction`, `H_Abstraction`/`Substitution_O` all tie on recipe counts and still fall through to the deterministic order, as intended.
- **Known limitation**, deliberate: the radical gate tests `multiplicity > 1`, so a singlet biradical does not trigger it.

## The direction gate runs before the recipes, and it outranks the reverse-discovery opt-in

Two things that an earlier revision of this PR got wrong, both fixed here.

**The gates were silently abandoned by one unreadable `groups.py`.** `prioritize_family_product_dicts` read every candidate family's recipe first and, on `FileNotFoundError`/`KeyError`/`ValueError`/`InvalidAdjacencyListError`, returned the list untouched at `logger.debug`. A correctness precondition that one unparsable file disables at debug level is not one. The salient asymmetry is that **the direction gate needs no recipe at all** — only `discovered_in_reverse`. So it now runs *first*, and an unreadable recipe costs only the radical gate and the bond-change ordering, which genuinely do need the recipes; that degradation is logged at `warning`. Running the gate first also means the recipes of the matches it drops are never read.

**`linear.py` was asking for reverse-discovered matches it cannot use.** `arc/job/adapters/ts/linear.py:1738` passed `discover_own_reverse_rxns_in_reverse=True` into its wider family-set rescue. That flag is now inert — and not only in the obvious case. It admits *only* `own_reverse` reverse matches, and "own reverse" means the same template matches the forward direction too, so a forward match always co-exists and the gate always fires. Measured on the base: H_Abstraction CH4 + OH goes 4 → 6 dicts with the flag, `intra_H_migration` on `[CH2]CCC` goes 4 → 10; with the gate, both stay at 4 either way.

The gate is nevertheless right and the call site was wrong, because a reverse-discovered `r_label_map` indexes the **flipped** reaction:

```
CH4 + OH >> CH3 + H2O, reactant symbols [C,H,H,H,H,O,H], product symbols [C,H,H,H,O,H,H]
  path 3 [forward]  BREAK=[(0, 4)]  -> in reactant graph: True   in product graph: False
  path 4 [REVERSE]  BREAK=[(4, 5)]  -> in reactant graph: False  in product graph: True
  path 5 [REVERSE]  BREAK=[(4, 6)]  -> in reactant graph: False  in product graph: True
```

Every reverse-discovered `BREAK_BOND` pair is absent from the reactant graph and present in the product graph — those are the H₂O O–H bonds. Every consumer reads that map as reactant indices: `get_expected_changing_bonds()` at six sites in `linear.py`, and `map_rxn`, which calls `find_all_breaking_bonds(r_direction=True)` and then cuts the **reactants** with the result. `arc/mapping/` contains no reference to `discovered_in_reverse` anywhere.

`linear.py`'s three `discovered_in_reverse` sites do not close that gap:

- `:246` — a `_PathContext` dataclass field. Plumbing.
- `:1676` — a docstring claiming the split/cross classification is direction-agnostic. That claim is about a *different axis*: given indices already in the unimolecular species' space, graph membership tells you which bonds to stretch without knowing the direction. It says nothing about index space, and the `in uni_bond_set` test it describes is exactly what makes wrong-space indices *quiet* — they usually fail it and the path is dropped with no message. Corrected here rather than deleted.
- `:3035` — `_strategy_ring_scission` uses the flag as a strategy **trigger** (`discovered_in_reverse and bb and not fb`), then consumes `ctx.bb[0]` as a reactant-space bond without translating it.

So the flag requested matches the adapter has no way to interpret, and the call now omits it. This matches `feature_nmd_family_recipe`, which returns `None` for reverse-discovered matches rather than emit wrong-index-space bonds, on the grounds that translating a reverse label map needs the very atom-mapping machinery the recipe path exists to bypass.

`_strategy_ring_scission` is unaffected: the gate drops reverse matches only when a forward match exists, and a reverse-only reaction — which is the ring-scission case — keeps all of them.

## Checks

*Rebased onto #979's head `9c3ca6aa`, which itself now sits on `origin/main` at `44a6b112`; the whole stack is 0 commits behind `main`. This PR's own contribution is byte-identical across that rebase — the added and removed lines of `git diff <base> <head>` are identical before and after; no hunk header, no content line, and no commit message character changed. The rebase auto-merged `arc/job/adapters/ts/linear.py`, where `main`'s TS-guess identity change (`869a1e2e`) and this PR's removal of the `discover_own_reverse_rxns_in_reverse` kwarg both survive.*

- #978's ordering guarantee still holds: its three mutations (reversed tiers / sorted across tiers / set dedup) each still fail its ordering test and #979's determinism test.
- #979's determinism still holds: `get_all_families()` is sha256-identical across `PYTHONHASHSEED` 0, 1, 2, 3, 7, 13.
- 16 tests in `TestFamilyChoiceGates`, each mutation-proved — removing either gate or the count tie-break fails a distinct test. `test_a_radical_cyclization_is_not_labeled_as_a_cycloaddition` exercises the real path end to end on pentadienyl cyclisation, where `Intra_2+2_cycloaddition_Cd` sorts ahead of `Intra_R_Add_Exocyclic` and the gate still resolves to the radical addition.
- Of the 5 added here, 3 fail on the previous revision: the direction gate surviving an unreadable recipe, the `warning` level, and not reading a dropped match's recipe. The other two pin the decision end to end — allyl + propene keeps only the forward `R_Addition_MultipleBond` over three reverse `Retroene` matches *without* the caller opting in, and CH4 + OH still drops both reverse matches *with* the caller opting in.
- `linear_test.py` and `arc/mapping/`: 215 passed.
- Full-suite parity against `origin/main` (`44a6b112`), re-run on the current head `4aed863b`: **5 failed / 2761 passed / 36 skipped** on the branch vs **5 failed / 2730 passed / 36 skipped** on `main` — the same 5 on both, all `arc/job/adapters/torch_ani_test.py`, an environment issue. **0 added, 0 removed.** (The branch passes 31 more tests because the stack adds that many.) Under `-n 6` the branch additionally trips `scheduler_test.py::test_initialize_output_dict`; that test is order-dependent and **fails identically on `origin/main` when run in isolation**, so it is a pre-existing xdist worker-distribution artefact, not a regression — `main` at `-n 8` trips a different pair (`conformers_test`, `ts_test`) for the same reason. (`test_arc_families_path` passes here; it fails only when the worktree path lacks the string `ARC`.)

### Reuse before writing

Searched for an existing home for the direction check before touching it: `discovered_in_reverse` across the repo (only `arc/common.py`'s dict comparison, `linear.py`'s four sites, and `family.py` itself), and `arc/mapping/` for any existing reverse-aware label-map translation — there is none, which is the finding that decided this. No new helper was added; the fix is a reordering, a log level, and a removed keyword argument.



