### PR TITLE
Make Lewis-structure perception independent of PYTHONHASHSEED

### DIFF
--- a/arc/molecule/graph.pyx
+++ b/arc/molecule/graph.pyx
@@ -218,18 +218,25 @@ cdef class Graph(object):
 
     cpdef list get_all_edges(self):
         """
-        Returns a list of all edges in the graph.
+        Returns a list of all edges in the graph, each edge appearing once,
+        ordered by the graph's vertex order and, within a vertex, by the order
+        in which its edges were added. The order does not depend on the hash
+        values of the edges, so it is identical in every process.
         """
-        cdef set edge_set
+        cdef list edges
+        cdef set seen
         cdef Vertex vertex
         cdef Edge edge
 
-        edge_set = set()
+        edges = []
+        seen = set()
         for vertex in self.vertices:
             for edge in vertex.edges.values():
-                edge_set.add(edge)
+                if id(edge) not in seen:
+                    seen.add(id(edge))
+                    edges.append(edge)
 
-        return list(edge_set)
+        return edges
 
     cpdef dict get_edges(self, Vertex vertex):
         """

--- a/arc/molecule/graph_test.py
+++ b/arc/molecule/graph_test.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import os
+import subprocess
+import sys
 import unittest
 
+import arc
 from arc.molecule.graph import Edge, Graph, Vertex
 
 
@@ -107,6 +111,37 @@ class TestGraph(unittest.TestCase):
         edges = self.graph.get_all_edges()
         self.assertIsInstance(edges, list)
         self.assertEqual(len(edges), 5)
+
+    def test_get_all_edges_orders_the_edges_by_vertex(self):
+        """
+        Test that Graph.get_all_edges() returns the edges in vertex order, each edge once.
+        """
+        expected = []
+        for vertex in self.graph.vertices:
+            for edge in vertex.edges.values():
+                if not any(edge is seen for seen in expected):
+                    expected.append(edge)
+        self.assertEqual(self.graph.get_all_edges(), expected)
+
+    def test_get_all_edges_order_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that Graph.get_all_edges() returns the same order in processes with different hash seeds.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'mol = Molecule(smiles="c1ccccc1Cc1ccccc1")\n'
+                  'atoms = mol.atoms\n'
+                  'print([(atoms.index(edge.vertex1), atoms.index(edge.vertex2)) '
+                  'for edge in mol.get_all_edges()])\n')
+        orders = list()
+        for seed in ('1', '35'):
+            arc_root = os.path.dirname(os.path.dirname(os.path.abspath(arc.__file__)))
+            environment = dict(os.environ, PYTHONHASHSEED=seed, PYTHONPATH=arc_root)
+            result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True,
+                                    env=environment, timeout=300)
+            self.assertEqual(result.returncode, 0, f'Subprocess failed: {result.stderr}')
+            orders.append(result.stdout.strip())
+        self.assertTrue(orders[0])
+        self.assertEqual(orders[0], orders[1])
 
     def test_has_vertex(self):
         """


### PR DESCRIPTION
ARC perceives a different Lewis structure depending on the process's `PYTHONHASHSEED`. Same molecule, same code, same commit — the answer depends on which process it runs in.

```
seed=1    bonds = B:36  S:116          embeds fine
seed=35   bonds = B:24  D:6  S:122     Explicit valence for atom # 5 C greater than permitted
```

That is `COC1=C(CN[C@H]2C3CCN(CC3)[C@H]2C(C2=CC=CC=C2)C2=CC=CC=C2)C=C(C=C1)C(C)C` built from the same xyz both times. Roughly **2% of seeds** give the wrong structure.

## The chain

`arc/molecule/graph.pyx::get_all_edges` de-duplicated through a set and returned `list(edge_set)`:

```python
edge_set = set()
for vertex in self.vertices:
    for edge in vertex.edges.values():
        edge_set.add(edge)
return list(edge_set)
```

So the returned order was the set's iteration order. `Atom` and `Bond` take **content-derived** hashes — `hash(('Atom', self.symbol))`, `hash(('Bond', order, sym1, sym2))` — while `__eq__` is identity. Every carbon therefore collides into one bucket, and the resulting order is governed by Python's per-process randomized string hash.

`arc/species/perceive.py::generate_lewis_structure` consumes that order directly:

```python
bond_pairs = [(base_mol.atoms.index(e.vertex1), base_mol.atoms.index(e.vertex2))
              for e in base_mol.get_all_edges()]
```

and runs an A\* that expands equal-cost states in `bond_pairs` order. The molecule above has **two degenerate minimum-cost Lewis structures**, so the tie is broken by the hash seed.

Seed 35 places the double bond on the methoxy C–O rather than inside the anisole ring, leaving ring carbon #5 with three single bonds and a lone pair — a carbene. `to_rdkit_mol`'s carbene handling then sets two radical electrons on it, giving explicit valence 5, and RDKit refuses to sanitize.

## Why this matters beyond the crash

Perception decides **bond orders**. Bond orders feed `bond_corrections`, which feed Arkane's BAC, which feed energies and rates. A calculation is therefore not guaranteed to be reproducible across processes — including between a run and its own restart.

No downstream numerical impact has been measured. That is stated as an open question, not a claim.

## The fix

Return edges in the graph's vertex order, de-duplicating on edge **identity** rather than on hash-and-equality:

```python
edges = []
seen = set()
for vertex in self.vertices:
    for edge in vertex.edges.values():
        if id(edge) not in seen:
            seen.add(id(edge))
            edges.append(edge)
return edges
```

Same edges, same complexity, order identical in every process.

This is deliberately at the producer. `get_all_edges` also feeds `py_rdl` SSSR ring perception (`graph.pyx:962`, `:995`), so fixing the order where it is manufactured fixes every consumer at once, rather than sorting at each call site.

## How it was found

A CI run of an unrelated PR failed on one xdist worker with `IndexError: list index out of range` from `conformers_test.py::test_embed_rdkit`. It looked like flakiness, then like cross-test contamination — both wrong. Replaying that worker's exact 90-test prefix node-by-node passes. Fourteen full-suite runs and ~8,300 per-test canary checks came back clean because they varied test *order*; the variable was the *seed*.

Each xdist worker is a separate process with its own hash seed, which is why parallel CI surfaced it and serial runs never did.

## Checks

- **600 `PYTHONHASHSEED` values** against the affected molecule: **588/600** pass before, **600/600** after, all reporting one identical bond census. Known-bad seeds were 35, 79, 87, 91, 166.
- `bond_pairs` order for seeds 1 and 35: different before, identical after.
- `arc/molecule/graph_test.py`: 41 → 43 passed. The new test asserts the vertex-order contract and spawns two subprocesses at different `PYTHONHASHSEED` values, asserting identical edge order — it fails against the unfixed code.
- `arc/species/conformers_test.py` serial: 48 passed, unchanged.
- The failing worker's exact prefix, replayed: 118 passed.
- Full suite `-n 6 --dist worksteal`: 2745 → 2747 passed, same 5 pre-existing `torch_ani` failures either side.

## Deliberately not addressed

- **The wrong structure passes `is_mol_valid`.** A neutral carbene carbon with three single bonds and a lone pair should not survive `get_octet_deviation`. This change makes the affected molecule always take the good branch, but the validity gate remains permissive, and another molecule's degenerate optimum could land on a carbene *deterministically*. That wants its own change.
- **`Atom.__hash__` / `Bond.__hash__` are content-derived while `__eq__` is identity.** Legal, but it makes every atom or bond set degenerate to a single bucket per element — an O(n²) hazard as well as an ordering one. Changing it would trade a seed-dependent order for an address-dependent one, so it fixes nothing on its own. `get_all_edges` is where that order escaped into a chemical decision.
