### PR TITLE
Make cycle order, and therefore symmetry numbers, independent of PYTHONHASHSEED

### DIFF
--- a/arc/molecule/graph.pxd
+++ b/arc/molecule/graph.pxd
@@ -54,6 +54,8 @@ cdef class Graph(object):
 
     cpdef list get_all_edges(self)
 
+    cpdef list order_vertex_set(self, set vertex_set)
+
     cpdef dict get_edges(self, Vertex vertex)
 
     cpdef Edge get_edge(self, Vertex vertex1, Vertex vertex2)

--- a/arc/molecule/graph.pyx
+++ b/arc/molecule/graph.pyx
@@ -231,6 +231,22 @@ cdef class Graph(object):
 
         return list(edge_set)
 
+    cpdef list order_vertex_set(self, set vertex_set):
+        """
+        Returns the vertices of `vertex_set` as a list, ordered by their position
+        in the graph's vertex list. The order does not depend on the hash values
+        of the vertices, so it is identical in every process.
+        """
+        cdef list ordered
+        cdef Vertex vertex
+
+        ordered = []
+        for vertex in self.vertices:
+            if vertex in vertex_set:
+                ordered.append(vertex)
+
+        return ordered
+
     cpdef dict get_edges(self, Vertex vertex):
         """
         Return a dictionary of the edges involving the specified `vertex`.
@@ -615,9 +631,12 @@ cdef class Graph(object):
     cpdef list get_polycycles(self):
         """
         Return a list of cycles that are polycyclic.
-        In other words, merge the cycles which are fused or spirocyclic into 
-        a single polycyclic cycle, and return only those cycles. 
+        In other words, merge the cycles which are fused or spirocyclic into
+        a single polycyclic cycle, and return only those cycles.
         Cycles which are not polycyclic are not returned.
+
+        The vertices of each returned cycle are ordered by their position in the
+        graph's vertex list, so the order is identical in every process.
         """
         cdef list polycyclic_vertices, continuous_cycles, sssr
         cdef set polycyclic_cycle
@@ -652,7 +671,7 @@ cdef class Graph(object):
                         polycyclic_cycle.update(cycle)
 
             # convert each set to a list
-            continuous_cycles = [list(cycle) for cycle in continuous_cycles]
+            continuous_cycles = [self.order_vertex_set(cycle) for cycle in continuous_cycles]
             return continuous_cycles
 
     cpdef list get_monocycles(self):
@@ -690,7 +709,10 @@ cdef class Graph(object):
         """
         Get all disjoint monocyclic and polycyclic cycle clusters in the molecule.
         Takes the RC and recursively merges all cycles which share vertices.
-        
+
+        The vertices of each returned cycle are ordered by their position in the
+        graph's vertex list, so the order is identical in every process.
+
         Returns: monocyclic_cycles, polycyclic_cycles
         """
         cdef list rc, cycle_list, cycle_sets, monocyclic_cycles, polycyclic_cycles
@@ -708,8 +730,8 @@ cdef class Graph(object):
         monocyclic_cycles, polycyclic_cycles = self._merge_cycles(cycle_sets)
 
         # Convert cycles back to lists
-        monocyclic_cycles = [list(cycle_set) for cycle_set in monocyclic_cycles]
-        polycyclic_cycles = [list(cycle_set) for cycle_set in polycyclic_cycles]
+        monocyclic_cycles = [self.order_vertex_set(cycle_set) for cycle_set in monocyclic_cycles]
+        polycyclic_cycles = [self.order_vertex_set(cycle_set) for cycle_set in polycyclic_cycles]
 
         return monocyclic_cycles, polycyclic_cycles
 
@@ -779,7 +801,10 @@ cdef class Graph(object):
     cpdef list get_all_cycles_of_size(self, int size):
         """
         Return a list of the all non-duplicate rings with length 'size'. The
-        algorithm implements was adapted from a description by Fan, Panaye,
+        vertices of each ring are ordered by their position in the graph's vertex
+        list, so the order is identical in every process.
+
+        The algorithm implements was adapted from a description by Fan, Panaye,
         Doucet, and Barbu (doi: 10.1021/ci00015a002)
 
         B. T. Fan, A. Panaye, J. P. Doucet, and A. Barbu. "Ring Perception: A
@@ -884,7 +909,7 @@ cdef class Graph(object):
                 cycle_set_list.append(set1)
 
         #transform back to list of lists:
-        cycle_set_list = [list(set1) for set1 in cycle_set_list]
+        cycle_set_list = [self.order_vertex_set(set1) for set1 in cycle_set_list]
 
         return cycle_set_list
 

--- a/arc/molecule/graph_test.py
+++ b/arc/molecule/graph_test.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import os
+import subprocess
+import sys
 import unittest
 
 from arc.molecule.graph import Edge, Graph, Vertex
+
+
+REPOSITORY_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestGraph(unittest.TestCase):
@@ -107,6 +113,39 @@ class TestGraph(unittest.TestCase):
         edges = self.graph.get_all_edges()
         self.assertIsInstance(edges, list)
         self.assertEqual(len(edges), 5)
+
+    def test_order_vertex_set(self):
+        """
+        Test that Graph.order_vertex_set() returns the vertices in the graph's vertex order.
+        """
+        vertices = self.graph.vertices
+        self.assertEqual(self.graph.order_vertex_set({vertices[4], vertices[1], vertices[3]}),
+                         [vertices[1], vertices[3], vertices[4]])
+        self.assertEqual(self.graph.order_vertex_set(set()), [])
+        self.assertEqual(self.graph.order_vertex_set(set(vertices)), vertices)
+
+    def test_cycle_vertex_order_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that the cycles a graph returns are ordered identically in processes with different hash seeds.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'mol = Molecule(smiles="C1CC2CCC1C2")\n'
+                  'atoms = mol.atoms\n'
+                  'index = lambda cycle: [atoms.index(atom) for atom in cycle]\n'
+                  'monocyclic, polycyclic = mol.get_disparate_cycles()\n'
+                  'print([index(cycle) for cycle in monocyclic + polycyclic])\n'
+                  'print([index(cycle) for cycle in mol.get_polycycles()])\n'
+                  'print([index(cycle) for cycle in mol.get_all_cycles_of_size(5)])\n')
+        orders = list()
+        for seed in ('1', '5', '87'):
+            environment = dict(os.environ, PYTHONHASHSEED=seed, PYTHONPATH=REPOSITORY_DIRECTORY)
+            result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True,
+                                    env=environment, cwd=REPOSITORY_DIRECTORY, timeout=300)
+            self.assertEqual(result.returncode, 0, f'Subprocess failed: {result.stderr}')
+            orders.append(result.stdout.strip())
+        self.assertTrue(orders[0])
+        for order in orders[1:]:
+            self.assertEqual(orders[0], order)
 
     def test_has_vertex(self):
         """

--- a/arc/molecule/symmetry_test.py
+++ b/arc/molecule/symmetry_test.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import os
+import subprocess
+import sys
 import unittest
 
 from arc.molecule.molecule import Molecule
@@ -8,6 +11,9 @@ from arc.molecule.resonance import generate_optimal_aromatic_resonance_structure
 from arc.molecule.symmetry import (calculate_atom_symmetry_number, calculate_axis_symmetry_number,
     calculate_bond_symmetry_number, calculate_cyclic_symmetry_number, _indistinguishable)
 from arc.species.species import ARCSpecies
+
+
+REPOSITORY_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestMoleculeSymmetry(unittest.TestCase):
@@ -675,6 +681,29 @@ multiplicity 3
         self.assertTrue(_indistinguishable(mol.atoms[1], mol.atoms[3]))
         # O is different from H
         self.assertFalse(_indistinguishable(mol.atoms[6], mol.atoms[7]))
+
+    def test_symmetry_number_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that calculate_symmetry_number() returns the same value in processes with different hash seeds.
+
+        The bridged polycyclics listed here reach calculate_cyclic_symmetry_number() through
+        get_disparate_cycles(), whose cycles used to be ordered by the hash values of their atoms.
+        The value asserted is only that every process agrees, not what that value is.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'from arc.molecule.symmetry import calculate_symmetry_number\n'
+                  'print([calculate_symmetry_number(Molecule(smiles=smiles)) '
+                  'for smiles in ("C1CC2CCC1C2", "C1CC2CCC1CC2", "C1CC2CCC3CCC1C23", "C1CC2CCC1O2")])\n')
+        symmetry_numbers = list()
+        for seed in ('1', '5', '87'):
+            environment = dict(os.environ, PYTHONHASHSEED=seed, PYTHONPATH=REPOSITORY_DIRECTORY)
+            result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True,
+                                    env=environment, cwd=REPOSITORY_DIRECTORY, timeout=300)
+            self.assertEqual(result.returncode, 0, f'Subprocess failed: {result.stderr}')
+            symmetry_numbers.append(result.stdout.strip())
+        self.assertTrue(symmetry_numbers[0])
+        for symmetry_number in symmetry_numbers[1:]:
+            self.assertEqual(symmetry_numbers[0], symmetry_number)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`Molecule.calculate_symmetry_number()` returns different values for the same molecule in different processes. Over hash seeds 0–200:

| species | before | after |
|---|---|---|
| norbornane `C1CC2CCC1C2` | 4.0 ×163, **2.0 ×38** | 4.0 ×201 |
| 7-oxanorbornane `C1CC2CCC1O2` | 4.0 ×128, **2.0 ×73** | 4.0 ×201 |
| triquinacane skeleton `C1CC2CCC3CCC1C23` | 3.0 ×166, **2.0 ×35** | 3.0 ×201 |

All 27 species tested — bridged, fused, spiro, cage, aromatic, monocyclic, acyclic — are single-valued after. No species that was already stable changed.

## Cause

`graph.pyx` converted merged cycles from sets back to lists with `[list(cycle_set) for cycle_set in ...]`. `Atom.__hash__` is `hash(('Atom', symbol))` with an identity `__eq__`, so every carbon collides into one bucket and the resulting order is the set's probe order — which follows Python's per-process randomized string hash.

`symmetry.py:373` then calls `get_largest_ring(ring[0])`, seeding a largest-ring search from a hash-order-chosen atom. Instrumented on norbornane:

```
seed=0  order=[3,6,4,5,2,1,0]  ring0=3  largest_ring=6  -> sigma 4.0
seed=5  order=[6,2,0,1,4,3,5]  ring0=6  largest_ring=5  -> sigma 2.0
```

Atom 6 is C7, the one-carbon bridge. The largest cycle through the bridge is a 5-ring; through any other atom it is a 6-ring.

The existing suite already contained a fossil of this: `graph_test.py:874` reads *"Try two different items since one might contain the vertex 8."*

## Fix

A `Graph.order_vertex_set()` helper returning vertices in the graph's own vertex order, applied at all three `list(set)` sites — `get_disparate_cycles`, `get_polycycles`, `get_all_cycles_of_size`. Producer-level, because there is a second consumer: `kekulize.pyx:54` seeds ring-by-ring resolution from `get_all_cycles_of_size(6)`, so hash order could select a different Kekulé structure for an ambiguous polycyclic aromatic.

Cost is negligible — 15 ms for 50 calls on a 36-atom PAH.

This is the same idiom as `get_all_edges` in #989, at a different site. `get_all_edges` itself is untouched here.

## What this PR does NOT fix — please read

**The value it makes deterministic is chemically wrong for cages, and that is not a consequence of this change.** ARC's polycyclic symmetry branch is structurally incorrect regardless of hash seed:

```
            norbornane  ARC=4.0   true=2
  bicyclo[2.2.2]octane  ARC=4.0   true=6      <- same answer, different molecules
            adamantane  ARC=8.0   true=12
                cubane  ARC=16.0  true=24
```

12 of 18 polycyclics tested are wrong. `calculate_cyclic_symmetry_number` reduces a polycyclic cluster to one largest cycle, discards the bonds that make a cage a cage, and applies planar-monocycle logic — in which reversing the atom sequence is a proper in-plane C2. In a rigid 3D cage that reversal is a reflection, which must not enter σ. Errors are erratic in sign (prismane 2× high, adamantane 1.5× low), so they do not cancel across a reaction.

A function returning 4 for both norbornane and bicyclo[2.2.2]octane is not one ordering away from correct.

Note also that the nondeterminism was masking this flatteringly: seeding on the bridge gave norbornane the right answer for the wrong reason, and after this change `ring[0]` is essentially never the bridge.

**The new test asserts only that processes agree — never a value — so it does not enshrine the wrong number.** Correcting cage symmetry is left to a separate change; `Graph.find_isomorphism(self, self)` already enumerates the automorphism group (norbornane 128 = 4 × 2⁵, adamantane 1536 = 24 × 2⁶), so the machinery exists and only the chirality decision is missing — which a 2D graph cannot supply.

This PR is offered because one wrong answer everywhere is strictly better than two different wrong answers depending on which process you happen to run in.

## Blast radius

ARC's thermo does **not** consume this value. `external_symmetry` is parsed back out of Arkane's own geometry-based point-group determination (`arc/statmech/arkane.py:1363`). `get_symmetry_number()` only populates `ARCSpecies.symmetry_number`, which reaches the `output.yml`/TCKDB export and any RMG-side group-additivity use.

Separately: `arc/species/species.py:310` documents that attribute as *"The external symmetry number"*, contradicting the method's own docstring — a doc bug that invites exactly the wrong use of this value. Not changed here.

## Upstream

Both defects exist in RMG-Py: the `list(cycle_set)` conversion at `rmgpy/molecule/molecule.py:2892` and the `get_largest_ring(ring[0])` call at `rmgpy/molecule/symmetry.py:404`.

## Checks

- Seed sweep 0–200 across 27 species, before and after.
- `arc/molecule/`: 582 passed. `arc/species/`: 327 passed + 180 subtests.
- New tests: an `order_vertex_set` unit test, a cross-seed cycle-order test, and a cross-seed symmetry-number test. Both subprocess tests pin `PYTHONPATH` and `cwd`, so the child validates the tree under test rather than whatever `import arc` resolves to.
- Test species were rebuilt from explicit von Baeyer bond lists after three initial SMILES (cuneane, quadricyclane, twistane) parsed cleanly but produced the wrong isomers; formula, degree sequence and SSSR sizes were verified before any number was trusted.

Touches `graph_test.py`, as does #989 — they will conflict on the import block only, a union resolve.
