### PR TITLE
Make the molecular graph's edge and cycle order independent of the hash seed

### DIFF
--- a/arc/molecule/graph.pxd
+++ b/arc/molecule/graph.pxd
@@ -54,6 +54,8 @@ cdef class Graph(object):
 
     cpdef list get_all_edges(self)
 
+    cpdef list order_vertex_set(self, set vertex_set)
+
     cpdef dict get_edges(self, Vertex vertex)
 
     cpdef Edge get_edge(self, Vertex vertex1, Vertex vertex2)

--- a/arc/molecule/graph.pyx
+++ b/arc/molecule/graph.pyx
@@ -218,18 +218,53 @@ cdef class Graph(object):
 
     cpdef list get_all_edges(self):
         """
-        Returns a list of all edges in the graph.
+        Returns a list of all edges in the graph, each edge appearing once,
+        ordered by the graph's vertex order and, within a vertex, by the order
+        in which its edges were added. The order does not depend on the hash
+        values of the edges, so it is identical in every process.
         """
-        cdef set edge_set
+        cdef list edges
+        cdef set seen
         cdef Vertex vertex
         cdef Edge edge
 
-        edge_set = set()
+        edges = []
+        seen = set()
         for vertex in self.vertices:
             for edge in vertex.edges.values():
-                edge_set.add(edge)
+                if id(edge) not in seen:
+                    seen.add(id(edge))
+                    edges.append(edge)
 
-        return list(edge_set)
+        return edges
+
+    cpdef list order_vertex_set(self, set vertex_set):
+        """
+        Returns the vertices of `vertex_set` as a list, ordered by their position
+        in the graph's vertex list. The order does not depend on the hash values
+        of the vertices, so it is identical in every process.
+
+        Every vertex of `vertex_set` must be a vertex of this graph; a vertex that
+        is not raises a ValueError.
+        """
+        cdef list ordered
+        cdef set identities, found
+        cdef Vertex vertex
+
+        identities = {id(vertex) for vertex in vertex_set}
+
+        ordered = []
+        found = set()
+        for vertex in self.vertices:
+            if id(vertex) in identities and id(vertex) not in found:
+                found.add(id(vertex))
+                ordered.append(vertex)
+
+        if len(found) < len(identities):
+            raise ValueError(f'Attempted to order {len(identities)} vertices of which '
+                             f'{len(identities) - len(found)} are not in the graph.')
+
+        return ordered
 
     cpdef dict get_edges(self, Vertex vertex):
         """
@@ -615,9 +650,12 @@ cdef class Graph(object):
     cpdef list get_polycycles(self):
         """
         Return a list of cycles that are polycyclic.
-        In other words, merge the cycles which are fused or spirocyclic into 
-        a single polycyclic cycle, and return only those cycles. 
+        In other words, merge the cycles which are fused or spirocyclic into
+        a single polycyclic cycle, and return only those cycles.
         Cycles which are not polycyclic are not returned.
+
+        The vertices of each returned cycle are ordered by their position in the
+        graph's vertex list, so the order is identical in every process.
         """
         cdef list polycyclic_vertices, continuous_cycles, sssr
         cdef set polycyclic_cycle
@@ -652,7 +690,7 @@ cdef class Graph(object):
                         polycyclic_cycle.update(cycle)
 
             # convert each set to a list
-            continuous_cycles = [list(cycle) for cycle in continuous_cycles]
+            continuous_cycles = [self.order_vertex_set(cycle) for cycle in continuous_cycles]
             return continuous_cycles
 
     cpdef list get_monocycles(self):
@@ -690,7 +728,10 @@ cdef class Graph(object):
         """
         Get all disjoint monocyclic and polycyclic cycle clusters in the molecule.
         Takes the RC and recursively merges all cycles which share vertices.
-        
+
+        The vertices of each returned cycle are ordered by their position in the
+        graph's vertex list, so the order is identical in every process.
+
         Returns: monocyclic_cycles, polycyclic_cycles
         """
         cdef list rc, cycle_list, cycle_sets, monocyclic_cycles, polycyclic_cycles
@@ -708,8 +749,8 @@ cdef class Graph(object):
         monocyclic_cycles, polycyclic_cycles = self._merge_cycles(cycle_sets)
 
         # Convert cycles back to lists
-        monocyclic_cycles = [list(cycle_set) for cycle_set in monocyclic_cycles]
-        polycyclic_cycles = [list(cycle_set) for cycle_set in polycyclic_cycles]
+        monocyclic_cycles = [self.order_vertex_set(cycle_set) for cycle_set in monocyclic_cycles]
+        polycyclic_cycles = [self.order_vertex_set(cycle_set) for cycle_set in polycyclic_cycles]
 
         return monocyclic_cycles, polycyclic_cycles
 
@@ -779,7 +820,10 @@ cdef class Graph(object):
     cpdef list get_all_cycles_of_size(self, int size):
         """
         Return a list of the all non-duplicate rings with length 'size'. The
-        algorithm implements was adapted from a description by Fan, Panaye,
+        vertices of each ring are ordered by their position in the graph's vertex
+        list, so the order is identical in every process.
+
+        The algorithm implements was adapted from a description by Fan, Panaye,
         Doucet, and Barbu (doi: 10.1021/ci00015a002)
 
         B. T. Fan, A. Panaye, J. P. Doucet, and A. Barbu. "Ring Perception: A
@@ -884,7 +928,7 @@ cdef class Graph(object):
                 cycle_set_list.append(set1)
 
         #transform back to list of lists:
-        cycle_set_list = [list(set1) for set1 in cycle_set_list]
+        cycle_set_list = [self.order_vertex_set(set1) for set1 in cycle_set_list]
 
         return cycle_set_list
 

--- a/arc/molecule/graph_test.py
+++ b/arc/molecule/graph_test.py
@@ -1,9 +1,36 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import os
+import subprocess
+import sys
 import unittest
 
 from arc.molecule.graph import Edge, Graph, Vertex
+
+
+REPOSITORY_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def outputs_at_hash_seeds(script, seeds):
+    """
+    Run `script` in a subprocess once per hash seed in `seeds`, and return the stripped standard
+    output of each run. The subprocesses are given the repository as their working directory and at
+    the front of PYTHONPATH, so they import the tree under test rather than an installed ARC while
+    keeping whatever else the environment already put on the path.
+
+    Raises a RuntimeError if any of the subprocesses exits with a non-zero return code.
+    """
+    python_path = os.pathsep.join(path for path in (REPOSITORY_DIRECTORY, os.environ.get('PYTHONPATH', '')) if path)
+    outputs = list()
+    for seed in seeds:
+        environment = dict(os.environ, PYTHONHASHSEED=seed, PYTHONPATH=python_path)
+        result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True,
+                                env=environment, cwd=REPOSITORY_DIRECTORY, timeout=600)
+        if result.returncode:
+            raise RuntimeError(f'The subprocess run with PYTHONHASHSEED={seed} failed:\n{result.stderr}')
+        outputs.append(result.stdout.strip())
+    return outputs
 
 
 class TestGraph(unittest.TestCase):
@@ -107,6 +134,86 @@ class TestGraph(unittest.TestCase):
         edges = self.graph.get_all_edges()
         self.assertIsInstance(edges, list)
         self.assertEqual(len(edges), 5)
+
+    def test_get_all_edges_orders_the_edges_by_vertex(self):
+        """
+        Test that Graph.get_all_edges() returns the edges in vertex order, each edge once.
+        """
+        expected = []
+        for vertex in self.graph.vertices:
+            for edge in vertex.edges.values():
+                if not any(edge is seen for seen in expected):
+                    expected.append(edge)
+        self.assertEqual(self.graph.get_all_edges(), expected)
+
+    def test_get_all_edges_order_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that Graph.get_all_edges() returns the same order in processes with different hash seeds.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'mol = Molecule(smiles="c1ccccc1Cc1ccccc1")\n'
+                  'atoms = mol.atoms\n'
+                  'print([(atoms.index(edge.vertex1), atoms.index(edge.vertex2)) '
+                  'for edge in mol.get_all_edges()])\n')
+        outputs = outputs_at_hash_seeds(script, ('1', '35'))
+        self.assertTrue(outputs[0])
+        self.assertEqual(len(set(outputs)), 1, f'The edge order differs between hash seeds: {outputs}')
+
+    def test_order_vertex_set(self):
+        """
+        Test that Graph.order_vertex_set() returns the vertices in the graph's vertex order.
+        """
+        vertices = self.graph.vertices
+        self.assertEqual(self.graph.order_vertex_set({vertices[4], vertices[1], vertices[3]}),
+                         [vertices[1], vertices[3], vertices[4]])
+        self.assertEqual(self.graph.order_vertex_set(set()), [])
+        self.assertEqual(self.graph.order_vertex_set(set(vertices)), vertices)
+
+    def test_order_vertex_set_rejects_a_vertex_that_is_not_in_the_graph(self):
+        """
+        Test that Graph.order_vertex_set() raises a ValueError instead of dropping a foreign vertex.
+        """
+        vertices = self.graph.vertices
+        with self.assertRaises(ValueError):
+            self.graph.order_vertex_set({Vertex()})
+        with self.assertRaises(ValueError):
+            self.graph.order_vertex_set({vertices[0], vertices[2], Vertex()})
+        copied = self.graph.copy(deep=True)
+        with self.assertRaises(ValueError):
+            self.graph.order_vertex_set(set(copied.vertices))
+
+    def test_order_vertex_set_counts_a_repeated_vertex_once(self):
+        """
+        Test that Graph.order_vertex_set() returns a vertex once and still rejects a foreign vertex
+        when the graph's vertex list holds the same vertex twice.
+        """
+        vertices = self.graph.vertices
+        repeated = Graph(vertices=[vertices[0], vertices[0], vertices[1]])
+        self.assertEqual(repeated.order_vertex_set({vertices[0], vertices[1]}),
+                         [vertices[0], vertices[1]])
+        with self.assertRaises(ValueError):
+            repeated.order_vertex_set({vertices[0], Vertex()})
+
+    def test_cycle_order_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that the cycles a graph returns are ordered identically in processes with different hash seeds.
+
+        The comparison covers the order of the vertices within one cycle and the order of the cycles
+        within the returned list.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'for smiles in ("C1CC2CCC1C2", "c1ccccc1Cc1ccccc1", "C1CC2CCC3CCC1C23"):\n'
+                  '    mol = Molecule(smiles=smiles)\n'
+                  '    atoms = mol.atoms\n'
+                  '    index = lambda cycle: [atoms.index(atom) for atom in cycle]\n'
+                  '    monocyclic, polycyclic = mol.get_disparate_cycles()\n'
+                  '    print(smiles, [index(cycle) for cycle in monocyclic + polycyclic])\n'
+                  '    print(smiles, [index(cycle) for cycle in mol.get_polycycles()])\n'
+                  '    print(smiles, [index(cycle) for cycle in mol.get_all_cycles_of_size(5)])\n'
+                  '    print(smiles, [index(cycle) for cycle in mol.get_smallest_set_of_smallest_rings()])\n')
+        outputs = outputs_at_hash_seeds(script, ('1', '5', '87'))
+        self.assertTrue(outputs[0])
+        self.assertEqual(len(set(outputs)), 1, f'The cycle order differs between hash seeds: {outputs}')
 
     def test_has_vertex(self):
         """

--- a/arc/molecule/symmetry_test.py
+++ b/arc/molecule/symmetry_test.py
@@ -3,11 +3,26 @@
 
 import unittest
 
+from arc.molecule.graph_test import outputs_at_hash_seeds
 from arc.molecule.molecule import Molecule
 from arc.molecule.resonance import generate_optimal_aromatic_resonance_structures
 from arc.molecule.symmetry import (calculate_atom_symmetry_number, calculate_axis_symmetry_number,
     calculate_bond_symmetry_number, calculate_cyclic_symmetry_number, _indistinguishable)
 from arc.species.species import ARCSpecies
+
+
+HASH_SEED_SPECIES = ('C1CC2CCC1C2',
+                     'C1CC2CCC1CC2',
+                     'C1CC2CCC3CCC1C23',
+                     'C1CC2CCC1O2',
+                     'C1=CC2C=CC1C2',
+                     'c1cc2ccc3cccc4ccc(c1)c2c34',
+                     'c1ccc2c(c1)-c1cccc3cccc2c13',
+                     'c1cc2cccc3c4cccc5cccc(c(c1)c23)c54',
+                     'c1cc2ccc3ccc4ccc5ccc6ccc1c1c2c3c4c5c61',
+                     '[CH2]c1ccc2ccccc2c1')
+
+HASH_SEEDS = ('1', '3', '5', '13')
 
 
 class TestMoleculeSymmetry(unittest.TestCase):
@@ -675,6 +690,39 @@ multiplicity 3
         self.assertTrue(_indistinguishable(mol.atoms[1], mol.atoms[3]))
         # O is different from H
         self.assertFalse(_indistinguishable(mol.atoms[6], mol.atoms[7]))
+
+    def test_symmetry_number_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that calculate_symmetry_number() returns the same value in processes with different hash seeds.
+
+        The bridged polycyclics and fused aromatics of HASH_SEED_SPECIES reach
+        calculate_cyclic_symmetry_number() through get_disparate_cycles(). Only agreement between the
+        processes is asserted, not the value they agree on.
+        """
+        script = ('from arc.molecule.molecule import Molecule\n'
+                  'from arc.molecule.symmetry import calculate_symmetry_number\n'
+                  f'print([calculate_symmetry_number(Molecule(smiles=smiles)) for smiles in {HASH_SEED_SPECIES}])\n')
+        symmetry_numbers = outputs_at_hash_seeds(script, HASH_SEEDS)
+        self.assertTrue(symmetry_numbers[0])
+        self.assertEqual(len(set(symmetry_numbers)), 1,
+                         f'The symmetry numbers differ between hash seeds: {symmetry_numbers}')
+
+    def test_species_symmetry_number_does_not_depend_on_the_hash_seed(self):
+        """
+        Test that ARCSpecies.get_symmetry_number() returns the same value in processes with different hash seeds.
+
+        This is the entry point production uses. It reaches the symmetry code through
+        get_resonance_hybrid() rather than through the molecule it was given, so the resonance layer
+        lies between the caller and the cycles. Only agreement between the processes is asserted, not
+        the value they agree on.
+        """
+        script = ('from arc.species.species import ARCSpecies\n'
+                  'print([ARCSpecies(label=f"species{index}", smiles=smiles).get_symmetry_number() '
+                  f'for index, smiles in enumerate({HASH_SEED_SPECIES})])\n')
+        symmetry_numbers = outputs_at_hash_seeds(script, HASH_SEEDS)
+        self.assertTrue(symmetry_numbers[0])
+        self.assertEqual(len(set(symmetry_numbers)), 1,
+                         f'The symmetry numbers differ between hash seeds: {symmetry_numbers}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Make the molecular graph's edge and cycle order independent of the hash seed

Combines #989 and #991. They cannot land separately, and this was measured in both directions: on a build of #991 alone, `get_smallest_set_of_smallest_rings` still gave 14–19 distinct orders per molecule over 20 seeds, biphenylmethane's `get_disparate_cycles` 2 and a steroid skeleton's `get_polycycles` 3, because #991 orders the vertices *within* a cycle while the *list* of cycles still follows the hash-ordered edge list that only #989 fixes. On a build with #989's fix alone, 3 of the 7 new tests still fail and σ stays seed-dependent for norbornane, pyrene, fluoranthene and the triquinacene skeleton. Combined: 1 distinct result for every probe over 200 seeds.

**The defect.** `get_all_edges()` de-duplicated through a `set` of `Edge` and returned `list(edge_set)`; the three cycle methods returned `list(cycle_set)`. `Atom` and `Bond` hash on symbol and bond order but compare by identity, and those hashes derive from string hashes, which Python randomises per process. Every atom of one element therefore lands in a single bucket and the iteration order follows the seed.

**Why this matters most: bond orders feed bond additivity corrections.** `generate_lewis_structure()` explores equal-cost A* states in bond-list order. For `COC1=C(CN[C@H]2C3CCN(CC3)[C@H]2C(C2=CC=CC=C2)C2=CC=CC=C2)C=C(C=C1)C(C)C` (C31H38N2O, three aromatic rings) the same xyz was perceived differently in 2 of 60 seeds, and the two perceptions do not merely differ cosmetically:

```
neutral (correct):  {'C-C': 13, 'C-H': 37, 'C-N': 5, 'C-O': 2, 'C:C': 18, 'H-N': 1}
charge-separated :  {'C-C': 17, 'C-H': 37, 'C-N': 5, 'C-O': 1, 'C:C': 12, 'C=C': 2, 'C=O': 1, 'H-N': 1}
```

Six aromatic bonds become four C–C plus two C=C, and a C–O becomes a C=O. `arc/species/species.py` computes `bond_corrections` from exactly this perceived molecule, and those feed Arkane's Petersson/Melius BACs. So a species built from xyz could receive a materially different energy correction depending on which process perceived it — including between a run and its own restart. The alternative structure is a **methyl oxocarbenium (O⁺) paired with a ring carbanion** (three σ bonds, one lone pair, formal −1) — the standard anisole lone-pair-donation resonance set, whose members sit at the ortho and para positions. It is a real but minor contributor; the neutral aromatic form is the ground-state description, and it is the one now pinned. In the worst case RDKit then refused the charge-separated structure outright with `Explicit valence for atom # 5 C greater than permitted`, which is how this was first noticed.

The same ordering also reached ring perception (`py_rdl` SSSR and relevant cycles), atom mapping, and TS-guess construction — all of which become reproducible here. For a kinetics code that is worth more than the symmetry-number story below.

**Symmetry numbers.** `calculate_cyclic_symmetry_number()` calls `get_largest_ring(ring[0])`, seeding from whichever atom the set listed first. Bicyclo[2.2.1]heptane returned 4 for 163 of seeds 0–200 and 2 for the other 38. σ enters entropy as −R ln σ, so a factor of two is 1.377 cal/mol/K in S.

**The fix.** Return edges in the graph's vertex order de-duplicated on edge identity, and route every cycle through a new `Graph.order_vertex_set()`. It matches on vertex identity — `Atom.__hash__` is content-derived while `__eq__` is identity, so `in` was O(V) per lookup — and raises rather than dropping a vertex that is not in the graph, because a silently short cycle feeds `size = len(ring)` and yields a wrong σ with no signal. `get_all_edges` also loses a quadratic term: 0.300 → 0.036 ms at 302 atoms and 24.257 → 0.356 ms at 3002, i.e. quadratic to linear. (The cycle methods pay a small cost instead — `order_vertex_set` is O(V) per cycle where `list(set)` was O(k) — measured at 9% of `get_disparate_cycles` on a 72-atom polyacene.)

### This deliberately does not fix σ, and the tests assert only that processes agree

ARC's polycyclic branch replaces a fused cluster with one largest circuit and applies planar-monocycle logic. Grading the values this PR freezes — 5 of the 10 pinned species are wrong:

| species | pinned | true σ_ext | |
|---|---|---|---|
| triquinacene skeleton | 3 | 3 | correct |
| pyrene | 4 | 4 | correct |
| fluoranthene | 2 | 2 | correct |
| perylene | 4 | 4 | correct only by coincidence — it flips to 1 under reordering |
| norbornane | 4 | **2** | wrong |
| 7-oxanorbornane | 4 | **2** | wrong |
| norbornadiene | 4 | **2** | wrong |
| bicyclo[2.2.2]octane | 4 | **6** | wrong |
| adamantane | 8 | **12** | wrong |
| cubane | 16 | **24** | wrong |

Across a wider sweep, 12 of 18 polycyclics tested return a wrong value. For bicyclo[2.2.2]octane, adamantane and cubane the returned value **does not even divide** the true σ_ext — a subgroup order would. The function is not selecting the wrong subgroup; it is not computing a group order at all.

There are two distinct failure modes. For small bridged bicyclics the result is an **over**count of at most 2, because a mirror plane is counted as a rotation — verified directly on norbornane, where the ring "flip" automorphism has determinant −1. For larger cages and peri-fused PAHs the result is an **under**count from the polycycle-to-single-circuit reduction, with no improper operation involved at all.

**"Wrong for cages" understates it.** Peri-fused **planar** PAHs take the same branch — pyrene reduces to a 14-circuit over 16 carbons, perylene 18 over 20, and **coronene returns 2 against a true 12**, its chosen "ring" being a 22-membered circuit over 24 carbons that detours through the inner ring and omits two rim carbons. It is not a chemical ring. Had the 18-carbon rim been used, the correct 12 would follow. PAHs are core combustion species — pyrene dimerisation is the canonical soot-inception step — so this is not an exotic corner.

Because several pinned values are known-wrong, **no test asserts a σ value**; every new determinism test asserts only that separate processes produce identical output. Nothing here obstructs a later correctness fix.

### Honest limitations

- **This removes hash-seed dependence, not order dependence.** Two SMILES for the same species (identical InChIKey) still disagree — norbornane `C1CC2CCC1C2` → 4.0 but `C1C2CCC1CC2` → 2.0. On the motivating molecule, 30 random xyz atom orderings still yield the wrong perception for exactly 1 ordering, at every seed, where `main` produced it for 8.1% of (ordering, seed) pairs. The defect is pinned, not eliminated.
- **This is not a no-op relative to `main` for tie cases.** `py_rdl`'s node indexing follows the edge order, so where the SSSR is not unique the selected ring set — and hence σ — is now frozen to one choice. Any σ cached from a previous ARC run can disagree with the new value by a factor of two. In every case measured the pinned value equals `main`'s modal value, so this affects the minority branch only.

### Also found, not fixed here

`ARCSpecies.get_symmetry_number()` and `calculate_symmetry_number()` diverge for benzylic radicals: benzyl `[CH2]c1ccccc1` gives 4.0 direct vs 2.0 through the production path, and 2-naphthylmethyl 2.0 vs 1.0. The resonance hybrid's fractional exocyclic bond order (1.75 and 1.25 respectively) matches none of `calculate_atom_symmetry_number`'s single/double/triple/benzene branches, so the CH₂ factor of 2 is silently dropped. That method's docstring also promises "the highest symmetry number amongst its resonance isomers and the resonance hybrid" while the code only ever uses the hybrid.

### Blast radius

`ARCSpecies.get_symmetry_number()` has no production consumer: `spc.external_symmetry`, which is what reaches `output.yml`, is set by parsing Arkane's own geometry-based `NonlinearRotor(symmetry=N)` block, and ARC passes Arkane no external symmetry at all. So freezing wrong polycyclic σ values changes no number ARC reports today. The reproducibility that does matter is the bond-order and ring-perception path described above.

### Reuse check

Searched for an existing vertex-ordering or set-ordering helper before adding `order_vertex_set` — `git grep "def order_"`, `def sort_`, `sorted(.*vertices`, and a search by behaviour for "put a set of atoms back into the molecule's atom order". `sort_vertices` sorts by connectivity and mutates; `sort_cyclic_vertices` orders a cycle by adjacency; neither maps a vertex set onto graph position. For the tests, no test-utility module exists and `PYTHONHASHSEED` appeared nowhere else, so `outputs_at_hash_seeds` is new; `symmetry_test.py` imports it from `graph_test.py`, matching the existing `species_test.py` → `perceive_test.py` precedent.

### Verification

All 7 new tests fail on `main`; 3 also fail on a build carrying only the `get_all_edges` half, and each of the three `order_vertex_set` call sites is independently covered. The two symmetry-number tests are not redundant: at the seeds they pin, pyrene is invariant through `calculate_symmetry_number` but varies through `ARCSpecies.get_symmetry_number()`, so each catches species the other misses. `arc/molecule/` + `arc/species/` 913 passed under `-n 6 --dist worksteal`; full suite 2752 passed with the 5 pre-existing `torch_ani_test.py` failures unchanged.

