### PR TITLE
Don't crash h_abstraction() on empty product_dicts

### DIFF
--- a/arc/job/adapters/ts/heuristics.py
+++ b/arc/job/adapters/ts/heuristics.py
@@ -871,10 +871,15 @@ def h_abstraction(reaction: ARCReaction,
         dihedral_increment (int, optional): The dihedral increment to use for B-H-A-C and D-B-H-C dihedral scans.
 
     Returns: list[dict]
-        Entries are Cartesian coordinates of TS guesses for all reactions.
+        Entries are Cartesian coordinates of TS guesses for all reactions. Returns an empty list if
+        ``reaction.product_dicts`` is empty (i.e., no matching H_Abstraction family products were identified).
     """
     xyz_guesses = list()
     dihedral_increment = dihedral_increment or DIHEDRAL_INCREMENT
+    if not reaction.product_dicts:
+        logger.warning(f'Could not generate H_Abstraction TS guesses for reaction {reaction}: '
+                        f'no product_dicts were identified for this reaction. Other TS search methods will be attempted.')
+        return xyz_guesses
     reactants_reversed, products_reversed = are_h_abs_wells_reversed(rxn=reaction, product_dict=reaction.product_dicts[0])
     for product_dict in reaction.product_dicts:
         # Identify R1H and R2H in the "R1H + R2 <=> R1 + R2H" or "R2 + R1H <=> R2H + R1" reaction

--- a/arc/job/adapters/ts/heuristics_test.py
+++ b/arc/job/adapters/ts/heuristics_test.py
@@ -30,6 +30,7 @@ from arc.job.adapters.ts.heuristics import (HeuristicsAdapter,
                                             generate_dihedral_variants,
                                             check_dao_angle,
                                             check_ts_bonds,
+                                            h_abstraction,
                                             )
 from arc.reaction import ARCReaction
 from arc.species.converter import str_to_xyz, zmat_to_xyz, zmat_from_xyz
@@ -547,6 +548,17 @@ H      -3.45360689    0.15275707   -0.76116277""")
                                    (-0.5075499920716767, 1.0297354786962867, 1.666119475718375e-08),
                                    (2.063927797423041, -2.798718649055232e-07, -1.7157539600187732e-07))}
         self.assertTrue(almost_equal_coords(rxn4.ts_species.ts_guesses[0].initial_xyz, expected_xyz))
+
+    def test_h_abstraction_with_empty_product_dicts(self):
+        """
+        Test that h_abstraction() does not raise and returns an empty list of TS guesses
+        when reaction.product_dicts is empty (rather than crashing on an unguarded [0] index).
+        """
+        rxn1 = ARCReaction(r_species=[self.h2, self.o], p_species=[self.h, self.oh])
+        self.assertEqual(rxn1.family, 'H_Abstraction')
+        rxn1.product_dicts = []
+        xyz_guesses = h_abstraction(reaction=rxn1)
+        self.assertEqual(xyz_guesses, [])
 
     def test_heuristics_for_h_abstraction_2(self):
         # C3H8 + HO2 <=> C3H7 + H2O2


### PR DESCRIPTION
## The crash

`h_abstraction()` in `arc/job/adapters/ts/heuristics.py` indexes
`reaction.product_dicts[0]` *before* the loop that iterates over the same
list:

```python
xyz_guesses = list()
dihedral_increment = dihedral_increment or DIHEDRAL_INCREMENT
reactants_reversed, products_reversed = are_h_abs_wells_reversed(rxn=reaction, product_dict=reaction.product_dicts[0])
for product_dict in reaction.product_dicts:
    ...
```

When `reaction.product_dicts` is empty (no matching H_Abstraction family
products were identified for the reaction), the `for` loop below would
simply not execute and leave `xyz_guesses` empty — a correct "no guesses"
outcome. But the unguarded `[0]` on the preceding line raises
`IndexError: list index out of range` first, turning "no guesses" into a
fatal crash.

## Real-run evidence

Observed in a multi-hour T3 PDep→QM ARC run. The exception propagated all
the way up through `Scheduler.__init__` and killed the whole run:

```
  File "/home/alon/Code/ARC/arc/scheduler.py", line 557, in __init__
    self.schedule_jobs()
  File "/home/alon/Code/ARC/arc/scheduler.py", line 633, in schedule_jobs
    self.spawn_ts_jobs()  # If all reactants/products are already known (Arkane yml or restart), spawn TS searches.
  File "/home/alon/Code/ARC/arc/scheduler.py", line 1795, in spawn_ts_jobs
    self.run_job(job_type='tsg', ...)
  File "/home/alon/Code/ARC/arc/scheduler.py", line 1072, in run_job
    job.execute()
  File "/home/alon/Code/ARC/arc/job/adapter.py", line 229, in execute
    self.execute_incore()
  File "/home/alon/Code/ARC/arc/job/adapters/ts/heuristics.py", line 266, in execute_incore
    xyzs = h_abstraction(reaction=rxn, dihedral_increment=self.dihedral_increment)
  File "/home/alon/Code/ARC/arc/job/adapters/ts/heuristics.py", line 879, in h_abstraction
    reactants_reversed, products_reversed = are_h_abs_wells_reversed(rxn=reaction, product_dict=reaction.product_dicts[0])
IndexError: list index out of range
```

## Root cause of empty `product_dicts`

`ARCReaction.product_dicts` lazily calls `get_product_dicts()` →
`get_reaction_family_products()`, which returns an empty list whenever no
RMG reaction-family template matches the reaction (e.g. atom-mapping
ambiguity, an unusual/edge-case reaction, or a family that legitimately
doesn't apply). This is an expected, already-handled emptiness elsewhere in
the file: `get_products_and_check_families()` (around line 981) has its own
`if not product_dicts:` branch for the case where a specifically-requested
family produced no products. There's no evidence of a deeper upstream defect
here — a TS-guess heuristic simply has to tolerate "no guesses could be
constructed" as a valid outcome rather than treating it as fatal, since ARC
has other TS search methods to fall back on.

## Fix

Guard the `[0]` access: if `reaction.product_dicts` is empty, log a warning
naming the reaction and return an empty guess list immediately, before ever
touching `[0]`. This matches the existing logging/docstring style in the
file (`logger.warning`, numpydoc-ish `Returns` section).

## Sibling-pattern search

Searched the rest of `heuristics.py` for the same "unguarded `[0]`-index
before a loop over the same list" pattern in the other family heuristic
functions (`hydrolysis`, `get_products_and_check_families`,
`get_reaction_family_products`, etc.). None found — `h_abstraction()` was
the only function with this defect.

## Tests

Added `test_h_abstraction_with_empty_product_dicts` to
`arc/job/adapters/ts/heuristics_test.py`, which builds a real H_Abstraction
`ARCReaction`, forces `product_dicts = []` via the existing setter, calls
`h_abstraction()` directly, and asserts it returns `[]` instead of raising.

Baseline (before fix): `43 passed` (`heuristics_test.py`)
After fix: `44 passed` (`heuristics_test.py`)

## Test plan

- [x] `python -m pytest arc/job/adapters/ts/heuristics_test.py -q` — 44 passed (was 43 before this change; new test added)