### PR TITLE
fix: guard against a None species.thermo in parse_arkane_thermo_output

### DIFF
--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -21,6 +21,8 @@ from arc.job.local import execute_command
 from arc.statmech.adapter import StatmechAdapter
 from arc.statmech.factory import register_statmech_adapter
 
+from arc.species.species import ThermoData
+
 if TYPE_CHECKING:
     from arc.level import Level
     from arc.reaction import ARCReaction
@@ -511,6 +513,24 @@ class ArkaneAdapter(StatmechAdapter, ABC):
                 logger.info(header)
                 for lbl in valid_labels:
                     spc = self.species_dict[lbl]
+                    if spc.thermo is None:
+                        # ``ARCSpecies.__init__`` sets ``self.thermo = ThermoData()`` unconditionally,
+                        # so no species ARC builds itself can reach this loop with ``None``. A caller's
+                        # subclass can, though, by re-assigning the attribute after ``super().__init__()``
+                        # -- which is exactly how T3's ``T3Species`` produced the crash this guards
+                        # (fixed at the source in T3 PR #187). Other call sites across the codebase
+                        # (e.g., ``ArkaneAdapter.set_reaction_dh_rxn``, ``processor.process_arc_project``,
+                        # ``output.get_species_output_dict``) already tolerate ``None`` here.
+                        #
+                        # Supply the container rather than crash: the Arkane results being assigned are
+                        # real and already computed, and losing them means discarding converged QM jobs
+                        # at the reporting stage. Warn rather than repair silently, so a caller
+                        # re-introducing this stays visible instead of being absorbed.
+                        logger.warning(f'Species {lbl} reached the Arkane thermo assignment loop with '
+                                       f'.thermo set to None, instead of the ThermoData() instance '
+                                       f'ARCSpecies.__init__() assigns. Supplying an empty ThermoData() '
+                                       f'container so the computed results are not lost.')
+                        spc.thermo = ThermoData()
                     spc.thermo.H298 = content[lbl]['H298']
                     spc.thermo.S298 = content[lbl]['S298']
                     spc.thermo.data = content[lbl]['data']

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -13,7 +13,7 @@ import unittest
 from unittest.mock import patch
 
 from arc.checks.common import TS_IRC_FAILED_MARKER
-from arc.common import ARC_TESTING_PATH
+from arc.common import ARC_TESTING_PATH, save_yaml_file
 from arc.exceptions import InputError
 from arc.level import Level
 from arc.reaction import ARCReaction
@@ -152,6 +152,51 @@ class TestArkaneAdapter(unittest.TestCase):
             self.fail(f'Arkane did not generate {plot_path}.\nstdout.log:\n{stdout_text}\nstderr.log:\n{stderr_text}')
         self.assertTrue(os.path.isfile(plot_path))
         self.assertAlmostEqual(self.ic3h7.e0, 6.75565e+07)
+
+    def test_parse_arkane_thermo_output_recovers_missing_thermo_container(self):
+        """
+        Test that ``parse_arkane_thermo_output`` does not crash when a species reaches the
+        result-assignment loop with ``spc.thermo`` set to ``None`` (rather than the
+        ``ARCSpecies.__init__`` default of a ``ThermoData`` instance), and that a well-formed
+        sibling species (with the default ``ThermoData``) is populated correctly regardless.
+
+        This is a regression test for a real campaign crash: ``arc/statmech/arkane.py`` assumed
+        ``spc.thermo`` is never ``None`` at this point, even though other call sites in the
+        codebase (``ArkaneAdapter.set_reaction_dh_rxn``, ``processor.process_arc_project``,
+        ``output.get_species_output_dict``) already guard against exactly that.
+        """
+        tmpdir = tempfile.mkdtemp(prefix='test_Arkane_thermo_none_')
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        output_dir = os.path.join(tmpdir, 'output')
+        calcs_dir = os.path.join(tmpdir, 'calcs')
+        statmech_dir = os.path.join(calcs_dir, 'statmech', 'thermo')
+        os.makedirs(statmech_dir)
+        with open(os.path.join(statmech_dir, 'output.py'), 'w') as f:
+            f.write('')
+        content = {
+            'none_thermo': {'H298': 1.0, 'S298': 2.0, 'data': 'NASA()'},
+            'ok_thermo': {'H298': 3.0, 'S298': 4.0, 'data': 'NASA()'},
+        }
+        save_yaml_file(path=os.path.join(statmech_dir, 'thermo.yaml'), content=content)
+
+        spc_none = ARCSpecies(label='none_thermo', smiles='O')
+        spc_none.thermo = None
+        spc_ok = ARCSpecies(label='ok_thermo', smiles='C')
+        arkane = ArkaneAdapter(output_directory=output_dir,
+                               calcs_directory=calcs_dir,
+                               output_dict=dict(),
+                               bac_type=None,
+                               species=[spc_none, spc_ok])
+
+        with patch('arc.statmech.arkane.execute_command', return_value=('', '')):
+            arkane.parse_arkane_thermo_output(statmech_dir)
+
+        self.assertIsNotNone(spc_none.thermo)
+        self.assertEqual(spc_none.thermo.H298, 1.0)
+        self.assertEqual(spc_none.thermo.S298, 2.0)
+        self.assertIsNotNone(spc_ok.thermo)
+        self.assertEqual(spc_ok.thermo.H298, 3.0)
+        self.assertEqual(spc_ok.thermo.S298, 4.0)
 
     def test_level_to_str(self):
         """Test the _level_to_str function"""


### PR DESCRIPTION
## Crash

Real T3 campaign run (`~/runs/t3-pes-CH2O2/`) died after all QM jobs converged, during thermo
reporting:

```
AttributeError: 'NoneType' object has no attribute 'H298' and no __dict__ for setting new attributes
  File "arc/statmech/arkane.py", line 509, in parse_arkane_thermo_output
    spc.thermo.H298 = content[lbl]['H298']
```

## Root cause

`ARCSpecies.__init__` always sets `self.thermo = ThermoData()` as a default. Somewhere between
species construction and this loop, a species can end up with `spc.thermo is None` again — I could
not pin the exact assignment site that clears it in the live run, but the codebase itself already
treats this as an expected, guarded-against state in three independent places:

- `ArkaneAdapter.set_reaction_dh_rxn` (arc/statmech/arkane.py)
- `processor.process_arc_project` (arc/processor.py:198)
- `output.get_species_output_dict` (arc/output.py:510)

`parse_arkane_thermo_output`'s result-assignment loop was the one place that assumed `spc.thermo`
can never be `None` and crashed instead of guarding — classifying this as case (a): a species
legitimately reaching this code with no thermo container, not a `valid_labels` filtering bug (I
found no evidence `valid_labels` includes species it should exclude).

## Fix

Restore the `ThermoData()` default (matching the exact construction used in `ARCSpecies.__init__`)
immediately before populating it with the real, successfully-computed Arkane results, instead of
crashing and discarding those results:

```python
if spc.thermo is None:
    spc.thermo = ThermoData()
spc.thermo.H298 = content[lbl]['H298']
...
```

## Sibling kinetics path

Checked `parse_arkane_kinetics_output`/`parse_reaction_kinetics` for the same unguarded-attribute
pattern: none found. `parse_reaction_kinetics` always does one wholesale `reaction.kinetics =
kinetics` dict assignment rather than mutating attributes on an existing kinetics sub-object, so
there's no equivalent `None`-target crash risk there.

## Containment at the process_arc_project/compute_thermo boundary

Deliberately did **not** add a broader try/except there. The crash's root data problem is now fixed
at its source (the offending species gets a real `ThermoData` container populated with its actual
results, not skipped). A blanket guard at the reporting boundary would risk swallowing genuinely
new data-integrity bugs in future runs rather than surfacing them — better handled as its own
decision if a distinct need for it shows up.

## Testing

Added `test_parse_arkane_thermo_output_recovers_missing_thermo_container` to
`arc/statmech/arkane_test.py`, covering a species with `.thermo is None` reaching the loop and a
well-formed sibling species processed normally in the same call.

- Baseline (`git stash`, unmodified branch): `44 passed, 2 failed`. The 2 failures
  (`test_generate_arkane_input`, `test_run_statmech_using_molecular_properties`) are pre-existing,
  caused by a missing `arkane` module in the `rmg_env` conda environment ARC shells out to — unrelated
  to this change.
- Post-fix: `45 passed, 2 failed` (same 2 pre-existing failures, +1 new passing test).
- Verified the new test is a genuine regression test: reverted only `arc/statmech/arkane.py` to
  HEAD and re-ran it in isolation — it failed with the exact same traceback signature as the real
  crash above, then passed again after reapplying the fix.