### PR TITLE
Fix installer breakage under mamba 2.x: shell hook not loaded, and a PATH-destroying deactivate hook

### DIFF
--- a/devtools/install_arc.sh
+++ b/devtools/install_arc.sh
@@ -147,8 +147,8 @@ cat >"$DEACTIVATE_DIR/arc_env.sh" <<'EOF'
 strip_path () {
     local needle="$1"; shift
     local joined=":$*:"
-    joined="\${joined//:$needle:/:}"
-    joined="\${joined#:}"; joined="\${joined%:}"
+    joined="${joined//:$needle:/:}"
+    joined="${joined#:}"; joined="${joined%:}"
     printf '%s' "$joined"
 }
 export PATH="$(strip_path "$ARC_ROOT" "$PATH")"

--- a/devtools/install_goflow.sh
+++ b/devtools/install_goflow.sh
@@ -208,6 +208,10 @@ if [[ $COMMAND_PKG == micromamba ]]; then
 else
     BASE=$(conda info --base)
     source "$BASE/etc/profile.d/conda.sh"
+    if [[ $COMMAND_PKG == mamba ]]; then
+        # mamba >= 2 refuses 'mamba activate' unless its own hook is loaded
+        eval "$(mamba shell hook --shell bash)"
+    fi
 fi
 
 # ── clone or update goflow_lean ───────────────────────────────────────────

--- a/devtools/install_rits.sh
+++ b/devtools/install_rits.sh
@@ -175,6 +175,10 @@ if [[ $COMMAND_PKG == micromamba ]]; then
 else
     BASE=$(conda info --base)
     source "$BASE/etc/profile.d/conda.sh"
+    if [[ $COMMAND_PKG == mamba ]]; then
+        # mamba >= 2 refuses 'mamba activate' unless its own hook is loaded
+        eval "$(mamba shell hook --shell bash)"
+    fi
 fi
 
 # ── clone or update RitS ──────────────────────────────────────────────────

--- a/devtools/install_xtb.sh
+++ b/devtools/install_xtb.sh
@@ -20,6 +20,10 @@ if [ "$COMMAND_PKG" = "micromamba" ]; then
 elif [ "$COMMAND_PKG" = "mamba" ] || [ "$COMMAND_PKG" = "conda" ]; then
     BASE=$(conda info --base)
     source "$BASE/etc/profile.d/conda.sh"
+    if [ "$COMMAND_PKG" = "mamba" ]; then
+        # mamba >= 2 refuses 'mamba activate' unless its own hook is loaded
+        eval "$(mamba shell hook --shell bash)"
+    fi
 fi
 
 


### PR DESCRIPTION
This fixes two independent bugs that make `make install` / `make install-all` fail on a machine whose conda frontend is mamba >= 2.

## 1. Generated deactivate hook destroys `PATH` (`install_arc.sh`)

The `deactivate.d/arc_env.sh` hook is written through a quoted heredoc (`<<'EOF'`), but the heredoc body backslash-escapes its parameter expansions (`\${joined...}`). Since a quoted heredoc performs no expansion, the backslashes land literally in the generated file, so when the hook runs on `conda deactivate` the expansions never evaluate and `PATH` is assigned the **literal string** `${joined%:}`. Every subsequent command in the calling shell then fails with `command not found` (this is how we hit `bash: command not found` at the tail of T3's installer).

Fix: drop the backslashes — a quoted heredoc needs no escaping. Users who already have a broken `envs/arc_env/etc/conda/deactivate.d/arc_env.sh` on disk should re-run `install_arc.sh` (or apply the same two-line fix to the generated file) to repair it.

## 2. `mamba activate` fails with "Shell not initialized" (`install_goflow.sh`, `install_xtb.sh`, `install_rits.sh`)

mamba >= 2 refuses `mamba activate` unless its own shell hook has been eval'd in the current shell:

```
critical libmamba Shell not initialized
'mamba' is running as a subprocess and can't modify the parent shell.
```

Sourcing `conda.sh` only defines the `conda` function. `install_arc.sh`, `install_gcn.sh`, `compile.sh`, and `install_kinbot.sh` already eval the hook, but these three installers did not, so they die when run from a non-interactive shell such as `make install-all` (reproduced with mamba 2.5.0 — `install_goflow.sh` created `goflow_env` and then failed to activate it).

Fix: eval `mamba shell hook --shell bash` in the mamba branch of each, matching the pattern the other installers already use. Verified that `mamba activate goflow_env` now succeeds in a bare non-interactive shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)