### PR TITLE
Delete ESS checkfiles on the server too, not just locally

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -510,8 +510,9 @@ def globalize_path(string: str,
 
 def delete_check_files(project_directory: str):
     """
-    Delete ESS checkfiles. They usually take up lots of space and are not needed after ARC terminates.
+    Delete local ESS checkfiles. They usually take up lots of space and are not needed after ARC terminates.
     Pass ``True`` to the ``keep_checks`` flag in ARC to avoid deleting check files.
+    The remote counterpart of this function is ``arc.job.ssh.delete_check_files_on_servers()``.
 
     Args:
         project_directory (str): The path to the ARC project folder.

--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -362,8 +362,8 @@ class JobAdapter(ABC):
             species_name_remote = species_name_remote.replace('(', '_').replace(')', '_')
             path = servers[self.server].get('path', '').lower()
             path = os.path.join(path, servers[self.server]['un']) if path else ''
-            self.remote_path = os.path.join(path, 'runs', 'ARC_Projects', self.project,
-                                            species_name_remote, self.job_name)
+            self.remote_project_path = os.path.join(path, 'runs', 'ARC_Projects', self.project)
+            self.remote_path = os.path.join(self.remote_project_path, species_name_remote, self.job_name)
 
         self.set_additional_file_paths()
 

--- a/arc/job/adapter_test.py
+++ b/arc/job/adapter_test.py
@@ -256,6 +256,9 @@ class TestJobAdapter(unittest.TestCase):
                                                              self.job_1.species_label, self.job_1.job_name))
         self.assertEqual(self.job_1.remote_path, os.path.join('runs', 'ARC_Projects', self.job_1.project,
                                                               self.job_1.species_label, self.job_1.job_name))
+        # The project's remote path is the one the check file cleanup is scoped to, it must contain the job:
+        self.assertEqual(self.job_1.remote_project_path, os.path.join('runs', 'ARC_Projects', self.job_1.project))
+        self.assertTrue(self.job_1.remote_path.startswith(self.job_1.remote_project_path))
 
     def test_format_max_job_time(self):
         """Test that the maximum job time can be formatted properly, including days, minutes, and seconds"""

--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -197,6 +197,7 @@ def _initialize_adapter(obj: JobAdapter,
     obj.number_of_processes = 0
     obj.reactions = [reactions] if reactions is not None and not isinstance(reactions, list) else reactions
     obj.remote_path = None
+    obj.remote_project_path = None
     obj.restarted = bool(job_num)  # If job_num was given, this is a restarted job, don't save as initiated jobs.
     obj.rotor_index = rotor_index
     obj.run_time = None

--- a/arc/job/ssh.py
+++ b/arc/job/ssh.py
@@ -9,6 +9,7 @@ Todo:
 import datetime
 import logging
 import os
+import shlex
 import time
 from typing import Any
 from collections.abc import Callable
@@ -59,16 +60,24 @@ class SSHClient(object):
 
     Args:
         server (str): The server name as specified in ARCs's settings file under ``servers`` as a key.
+        connection_attempts (int, optional): The number of times to try connecting to the server,
+                                             waiting a minute between attempts. The default keeps trying
+                                             for 24 hours, which is appropriate while jobs are running.
+                                             Pass a low number where blocking is worse than giving up.
 
     Attributes:
         server (str): The server name as specified in ARCs's settings file under ``servers`` as a key.
         address (str): The server's address.
         un (str): The username to use on the server.
         key (str): A path to a file containing the RSA SSH private key to the server.
+        connection_attempts (int): The number of times to try connecting to the server.
         _ssh (paramiko.SSHClient): A high-level representation of a session with an SSH server.
         _sftp (paramiko.sftp_client.SFTPClient): SFTP client used to perform remote file operations.
     """
-    def __init__(self, server: str = '') -> None:
+    def __init__(self,
+                 server: str = '',
+                 connection_attempts: int = 1440,  # Continue trying for 24 hrs (24 hr * 60 min/hr).
+                 ) -> None:
         if server == '':
             raise ValueError('A server name must be specified')
         if server not in servers.keys():
@@ -77,6 +86,7 @@ class SSHClient(object):
         self.address = servers[server]['address']
         self.un = servers[server]['un']
         self.key = servers[server]['key']
+        self.connection_attempts = connection_attempts
         self._sftp = None
         self._ssh = None
         logging.getLogger("paramiko").setLevel(logging.WARNING)
@@ -341,9 +351,8 @@ class SSHClient(object):
             ServerError: Cannot connect to the server with maximum times to try
         """
         times_tried = 0
-        max_times_to_try = 1440  # continue trying for 24 hrs (24 hr * 60 min/hr)...
         interval = 60  # wait 60 sec between trials
-        while times_tried < max_times_to_try:
+        while times_tried < self.connection_attempts:
             times_tried += 1
             try:
                 self._sftp, self._ssh = self._connect()
@@ -357,7 +366,8 @@ class SSHClient(object):
             else:
                 logger.debug(f'Successfully connected to {self.server} at the {times_tried} trial.')
                 return
-            time.sleep(interval)
+            if times_tried < self.connection_attempts:
+                time.sleep(interval)
         raise ServerError(f'Could not connect to server {self.server} even after {times_tried} trials.')
 
     def _connect(self) -> tuple[paramiko.sftp_client.SFTPClient, paramiko.SSHClient]:
@@ -489,6 +499,27 @@ class SSHClient(object):
         command = f'chmod{recursive} {mode} {file_name}'
         self._send_command_to_server(command, remote_path)
 
+    def delete_remote_check_files(self, remote_path: str) -> None:
+        """
+        Delete ESS checkfiles under a remote directory (recursively).
+        They usually take up lots of space and are not needed after ARC terminates.
+        Pass ``True`` to the ``keep_checks`` flag in ARC to avoid deleting check files.
+        The local counterpart of this method is ``arc.common.delete_check_files()``.
+
+        Args:
+            remote_path (str): The remote directory path under which checkfiles will be deleted.
+        """
+        if not remote_path:
+            return
+        quoted_path = shlex.quote(remote_path)
+        # Both the existence test and the deletion are done in a single quoted command:
+        # a separate existence check would have to quote the path just as carefully,
+        # and a directory that isn't there is a no-op rather than an error worth reporting.
+        command = f'[ -d {quoted_path} ] && find {quoted_path} -type f -name "*.chk" -delete'
+        _, stderr = self._send_command_to_server(command)
+        if stderr:
+            logger.warning(f'Could not delete all check files under {remote_path} on {self.server}.\nGot: {stderr}')
+
     def _check_file_exists(self,
                            remote_file_path: str,
                            ) -> bool:
@@ -535,6 +566,28 @@ class SSHClient(object):
         if stderr:
             raise ServerError(
                 f'Cannot create dir for the given path ({remote_path}).\nGot: {stderr}')
+
+
+def delete_check_files_on_servers(remote_project_paths: dict) -> None:
+    """
+    Delete ESS checkfiles from an ARC project's directory on all servers it ran jobs on.
+    The local counterpart of this function is ``arc.common.delete_check_files()``.
+    Errors are only logged and never raised: this runs once ARC is done with the science,
+    an unreachable server at that point is an inconvenience, not a reason to lose a run.
+    Only a single connection attempt is made per server for the same reason.
+
+    Args:
+        remote_project_paths (dict): Keys are server names, values are the respective remote paths
+                                     of the project's directory on that server.
+    """
+    for server, remote_project_path in remote_project_paths.items():
+        if not server or server.lower() == 'local' or not remote_project_path:
+            continue
+        try:
+            with SSHClient(server, connection_attempts=1) as ssh:
+                ssh.delete_remote_check_files(remote_path=remote_project_path)
+        except Exception as e:
+            logger.warning(f'Could not delete the check files under {remote_project_path} on {server}.\nGot: {e}')
 
 
 def check_job_status_in_stdout(job_id: int,

--- a/arc/job/ssh_test.py
+++ b/arc/job/ssh_test.py
@@ -5,9 +5,17 @@
 This module contains unit tests of the arc.job.ssh module
 """
 
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
 import unittest
+from unittest import mock
 
 import arc.job.ssh as ssh
+from arc.exceptions import ServerError
+from arc.job.ssh import SSHClient, delete_check_files_on_servers
 
 
 class TestSSH(unittest.TestCase):
@@ -41,6 +49,156 @@ class TestSSH(unittest.TestCase):
         self.assertEqual(status1, 'running')
         status1 = ssh.check_job_status_in_stdout(job_id=4000, stdout=stdout_2, server='local')
         self.assertEqual(status1, 'done')
+
+
+class TestSSHClientConnect(unittest.TestCase):
+    """
+    Contains unit tests for connecting to a server.
+    """
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        Count the connection trials instead of attempting to reach a server.
+        """
+        self.trials, self.intervals = list(), list()
+        for patch in [mock.patch.object(SSHClient, '_connect', lambda ssh_client: self.fail_to_connect()),
+                      mock.patch.object(ssh.time, 'sleep', lambda interval: self.intervals.append(interval))]:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def fail_to_connect(self):
+        """
+        Record a connection trial and fail it, as an unreachable server would.
+
+        Raises:
+            ServerError: Always.
+        """
+        self.trials.append(len(self.trials) + 1)
+        raise ServerError('Could not connect.')
+
+    def test_connect_gives_up_after_a_single_requested_trial(self):
+        """Test that a single connection trial is not followed by an interval, so teardown cannot block"""
+        ssh_client = SSHClient('server2', connection_attempts=1)
+        with self.assertRaises(ServerError):
+            ssh_client.connect()
+        self.assertEqual(len(self.trials), 1)
+        self.assertEqual(self.intervals, list())
+
+    def test_connect_does_not_wait_after_its_last_trial(self):
+        """Test that connecting waits between trials, but not after the last one"""
+        ssh_client = SSHClient('server2', connection_attempts=3)
+        with self.assertRaises(ServerError):
+            ssh_client.connect()
+        self.assertEqual(len(self.trials), 3)
+        self.assertEqual(len(self.intervals), 2)
+
+    def test_connect_defaults_to_the_long_haul(self):
+        """Test that the default number of connection trials, used while jobs are running, is unchanged"""
+        self.assertEqual(SSHClient('server2').connection_attempts, 1440)
+
+
+class TestDeleteCheckFilesOnServers(unittest.TestCase):
+    """
+    Contains unit tests for deleting ESS checkfiles on the servers a project ran on.
+    """
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        Set up a fake remote server: a temporary directory in which the commands ARC would have sent
+        to a server are actually executed, so that the real cleanup code path is exercised.
+        """
+        self.remote_root = tempfile.mkdtemp()
+        self.commands = list()
+        self.server = 'server2'
+        self.project_path = os.path.join('runs', 'ARC_Projects', 'a_project')
+        self.other_project_path = os.path.join('runs', 'ARC_Projects', 'an_unrelated_project')
+        for patch in [mock.patch.object(SSHClient, 'connect', lambda ssh_client: None),
+                      mock.patch.object(SSHClient, '_send_command_to_server',
+                                        lambda ssh_client, command, remote_path='':
+                                        self.execute_on_fake_server(command, remote_path))]:
+            patch.start()
+            self.addCleanup(patch.stop)
+        self.check_file = self.write_remote_file(self.project_path, 'spc1', 'opt_a1', 'check.chk')
+        self.output_file = self.write_remote_file(self.project_path, 'spc1', 'opt_a1', 'input.log')
+        self.other_check_file = self.write_remote_file(self.other_project_path, 'spc2', 'opt_a1', 'check.chk')
+
+    def execute_on_fake_server(self, command: str, remote_path: str = '') -> tuple:
+        """
+        Execute a command in the fake remote server directory instead of sending it to a server.
+
+        Args:
+            command (str): The command to execute.
+            remote_path (str, optional): The directory path at which the command will be executed.
+
+        Returns: tuple[list, list]
+            The lines of the standard output and of the standard error streams.
+        """
+        self.commands.append(command)
+        result = subprocess.run(command, shell=True, capture_output=True, text=True,
+                                cwd=os.path.join(self.remote_root, remote_path))
+        return result.stdout.splitlines(True), result.stderr.splitlines(True)
+
+    def write_remote_file(self, *args) -> str:
+        """
+        Write a file in the fake remote server directory.
+
+        Args:
+            args: The path of the file relative to the fake remote server directory.
+
+        Returns: str
+            The path of the written file.
+        """
+        path = os.path.join(self.remote_root, *args)
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        with open(path, 'w') as f:
+            f.write('dummy file content')
+        return path
+
+    def test_only_check_files_of_the_given_project_are_deleted(self):
+        """Test that check files are deleted, and that nothing else on the server is"""
+        delete_check_files_on_servers({self.server: self.project_path})
+        self.assertFalse(os.path.isfile(self.check_file))
+        self.assertTrue(os.path.isfile(self.output_file))
+        self.assertTrue(os.path.isfile(self.other_check_file))
+
+    def test_a_local_server_is_skipped(self):
+        """Test that a server named 'local' is skipped, its check files are deleted by the local cleanup"""
+        delete_check_files_on_servers({'local': self.project_path})
+        self.assertTrue(os.path.isfile(self.check_file))
+
+    def test_a_missing_remote_directory_is_a_no_op(self):
+        """Test that a project directory which does not exist on the server is silently skipped"""
+        delete_check_files_on_servers({self.server: os.path.join('runs', 'ARC_Projects', 'no_such_project')})
+        self.assertTrue(os.path.isfile(self.check_file))
+        self.assertTrue(os.path.isfile(self.other_check_file))
+
+    def test_a_path_with_shell_characters_is_not_interpreted(self):
+        """Test that the remote path is quoted, so that its content cannot become part of the command"""
+        wild_path = os.path.join('runs', 'ARC_Projects', 'a project $(touch injected.txt)')
+        wild_check_file = self.write_remote_file(wild_path, 'spc1', 'opt_a1', 'check.chk')
+        delete_check_files_on_servers({self.server: wild_path})
+        self.assertEqual(len(self.commands), 1)
+        self.assertEqual([token for token in shlex.split(self.commands[0]) if token == wild_path], [wild_path] * 2)
+        self.assertFalse(os.path.isfile(wild_check_file))
+        self.assertFalse(os.path.isfile(os.path.join(self.remote_root, 'injected.txt')))
+
+    def test_an_unreachable_server_is_only_logged(self):
+        """Test that a server which cannot be reached does not raise, ARC is done with the science by now"""
+        def raise_server_error(ssh_client):
+            raise ServerError(f'Could not connect to server {ssh_client.server}.')
+
+        with mock.patch.object(SSHClient, 'connect', raise_server_error):
+            delete_check_files_on_servers({self.server: self.project_path})  # Must not raise.
+        self.assertTrue(os.path.isfile(self.check_file))
+
+    def tearDown(self):
+        """
+        A method that is run after each unit test in this class.
+        """
+        shutil.rmtree(self.remote_root, ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/arc/main.py
+++ b/arc/main.py
@@ -31,7 +31,7 @@ from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
 from arc.level import Level, assign_frequency_scale_factor
 from arc.job.factory import _registered_job_adapters
-from arc.job.ssh import SSHClient
+from arc.job.ssh import SSHClient, delete_check_files_on_servers
 from arc.output import write_output_yml
 from arc.processor import process_arc_project, resolve_neb_level
 from arc.reaction import ARCReaction
@@ -610,8 +610,7 @@ class ARC(object):
         self.output = self.scheduler.output
         save_yaml_file(path=os.path.join(self.project_directory, 'output', 'status.yml'), content=self.output)
 
-        if not self.keep_checks:
-            delete_check_files(self.project_directory)
+        self.clean_check_files(remote_project_paths=self.scheduler.remote_project_paths)
         self.delete_leftovers()
 
         self.save_project_info_file()
@@ -932,6 +931,20 @@ class ARC(object):
 
         logger.info(f'Using harmonic frequencies scaling factor: {self.freq_scale_factor} '
                     f'(source: {factor_source}).')
+
+    def clean_check_files(self, remote_project_paths: dict | None = None) -> None:
+        """
+        Delete ESS checkfiles, both locally and on the servers this project ran jobs on.
+        Pass ``True`` to the ``keep_checks`` flag in ARC to avoid deleting check files.
+
+        Args:
+            remote_project_paths (dict, optional): Keys are server names, values are the respective remote
+                                                   paths of the project's directory on that server.
+        """
+        if self.keep_checks:
+            return
+        delete_check_files(self.project_directory)
+        delete_check_files_on_servers(remote_project_paths or dict())
 
     def delete_leftovers(self):
         """

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -5,13 +5,19 @@
 This module contains unit tests for the arc.main module
 """
 
+import logging
 import os
 import shutil
+import subprocess
+import tempfile
 import unittest
+from unittest import mock
 
-from arc.common import ARC_PATH
+from arc.common import ARC_PATH, get_logger
 from arc.exceptions import InputError
 from arc.imports import settings
+from arc.job.adapters.gaussian import GaussianAdapter
+from arc.job.ssh import SSHClient
 from arc.level import Level
 from arc.main import ARC, process_adaptive_levels
 from arc.species.species import ARCSpecies
@@ -525,6 +531,158 @@ class TestARC(unittest.TestCase):
             project_directory = os.path.join(ARC_PATH, 'Projects', project)
             if os.path.isdir(project_directory):
                 shutil.rmtree(project_directory, ignore_errors=True)
+
+
+class TestCheckFileCleanup(unittest.TestCase):
+    """
+    Contains unit tests for deleting ESS checkfiles when ARC terminates, both locally and on the servers.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.maxDiff = None
+        cls.project = 'arc_check_file_cleanup_test'
+        cls.other_project = 'an_unrelated_arc_project'
+        cls.server = 'server2'
+        cls.server_settings = {'cluster_soft': 'Slurm',
+                               'address': 'server2.host.edu',
+                               'un': 'test_user',
+                               'key': 'path_to_rsa_key',
+                               }
+
+    def setUp(self):
+        """
+        A method that is run before each unit test in this class.
+        Set up a fake remote server: a temporary directory in which the commands ARC would have sent
+        to a server are actually executed, so that the real cleanup code path is exercised.
+        """
+        self.remote_root = tempfile.mkdtemp()
+        self.project_directory = os.path.join(tempfile.mkdtemp(), self.project)
+        # Pin the server definition so that neither a user settings file nor a missing 'server2'
+        # entry can change the remote path this test builds and cleans.
+        for patch in [mock.patch.dict('arc.job.adapter.servers', {self.server: self.server_settings}),
+                      mock.patch.dict('arc.job.ssh.servers', {self.server: self.server_settings}),
+                      mock.patch.object(SSHClient, 'connect', lambda ssh_client: None),
+                      mock.patch.object(SSHClient, '_send_command_to_server',
+                                        lambda ssh_client, command, remote_path='':
+                                        self.send_command_to_fake_server(command, remote_path))]:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def send_command_to_fake_server(self, command: str, remote_path: str = '') -> tuple:
+        """
+        Execute a command in the fake remote server directory instead of sending it to a server.
+
+        Args:
+            command (str): The command to execute.
+            remote_path (str, optional): The directory path at which the command will be executed.
+
+        Returns: tuple[list, list]
+            The lines of the standard output and of the standard error streams.
+        """
+        result = subprocess.run(command, shell=True, capture_output=True, text=True,
+                                cwd=os.path.join(self.remote_root, remote_path))
+        return result.stdout.splitlines(True), result.stderr.splitlines(True)
+
+    def get_remote_project_path(self, project: str) -> str:
+        """
+        Get the remote path of a project's directory, as spawning a job on the server determines it.
+
+        Args:
+            project (str): The ARC project name.
+
+        Returns: str
+            The remote path of the project's directory.
+        """
+        job = GaussianAdapter(execution_type='queue',
+                              job_type='opt',
+                              level=Level(method='b3lyp', basis='6-31g'),
+                              project=project,
+                              project_directory=self.project_directory,
+                              species=[ARCSpecies(label='spc1', smiles='C')],
+                              server=self.server,
+                              testing=True,
+                              )
+        return job.remote_project_path
+
+    def set_up_arc_and_check_files(self, keep_checks: bool) -> ARC:
+        """
+        Create an ARC object running Gaussian on the fake remote server, along with the check files
+        it would have left behind locally and remotely.
+
+        Args:
+            keep_checks (bool): Whether to keep ESS checkfiles when ARC terminates.
+
+        Returns: ARC
+            The ARC object.
+        """
+        arc0 = ARC(project=self.project,
+                   project_directory=self.project_directory,
+                   species=[ARCSpecies(label='spc1', smiles='CC', compute_thermo=False)],
+                   level_of_theory='ccsd(t)-f12/cc-pvdz-f12//b3lyp/6-311+g(3df,2p)',
+                   ess_settings={'gaussian': ['local', self.server]},
+                   keep_checks=keep_checks,
+                   )
+        self.remote_project_paths = {self.server: self.get_remote_project_path(self.project)}
+        self.local_check_path = os.path.join(arc0.project_directory, 'calcs', 'Species', 'spc1',
+                                             'opt_a1', 'check.chk')
+        self.remote_check_path = os.path.join(self.remote_root, self.remote_project_paths[self.server],
+                                              'spc1', 'opt_a1', 'check.chk')
+        self.remote_output_path = os.path.join(self.remote_root, self.remote_project_paths[self.server],
+                                               'spc1', 'opt_a1', 'input.log')
+        self.other_project_check_path = os.path.join(self.remote_root,
+                                                     self.get_remote_project_path(self.other_project),
+                                                     'spc2', 'opt_a1', 'check.chk')
+        for path in [self.local_check_path, self.remote_check_path,
+                     self.remote_output_path, self.other_project_check_path]:
+            if not os.path.isdir(os.path.dirname(path)):
+                os.makedirs(os.path.dirname(path))
+            with open(path, 'w') as f:
+                f.write('dummy file content')
+        return arc0
+
+    def test_check_files_are_deleted_locally_and_remotely(self):
+        """Test that check files are deleted on the server as well as locally when keep_checks is False"""
+        arc0 = self.set_up_arc_and_check_files(keep_checks=False)
+        arc0.clean_check_files(remote_project_paths=self.remote_project_paths)
+        self.assertFalse(os.path.isfile(self.local_check_path))
+        self.assertFalse(os.path.isfile(self.remote_check_path))
+        # Only check files, and only under this project's own remote directory, are deleted:
+        self.assertTrue(os.path.isfile(self.remote_output_path))
+        self.assertTrue(os.path.isfile(self.other_project_check_path))
+
+    def test_check_files_are_kept_locally_and_remotely(self):
+        """Test that check files are kept on the server as well as locally when keep_checks is True"""
+        arc0 = self.set_up_arc_and_check_files(keep_checks=True)
+        arc0.clean_check_files(remote_project_paths=self.remote_project_paths)
+        self.assertTrue(os.path.isfile(self.local_check_path))
+        self.assertTrue(os.path.isfile(self.remote_check_path))
+        self.assertTrue(os.path.isfile(self.remote_output_path))
+        self.assertTrue(os.path.isfile(self.other_project_check_path))
+
+    def test_check_files_are_deleted_locally_when_no_server_was_used(self):
+        """Test that a project which only ran locally still has its local check files deleted"""
+        arc0 = self.set_up_arc_and_check_files(keep_checks=False)
+        arc0.clean_check_files()
+        self.assertFalse(os.path.isfile(self.local_check_path))
+        self.assertTrue(os.path.isfile(self.remote_check_path))
+
+    def tearDown(self):
+        """
+        A method that is run after each unit test in this class.
+        Detach ARC's log file handler before removing the directory it writes into,
+        so that a later test logging through it does not hit a deleted file.
+        """
+        arc_logger = get_logger()
+        for handler in arc_logger.handlers[:]:
+            if isinstance(handler, logging.FileHandler):
+                handler.close()
+                arc_logger.removeHandler(handler)
+        shutil.rmtree(self.remote_root, ignore_errors=True)
+        shutil.rmtree(os.path.dirname(self.project_directory), ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -206,6 +206,8 @@ class Scheduler(object):
     Attributes:
         project (str): The project's name. Used for naming the working directory.
         servers (list): A list of servers used for the present project.
+        remote_project_paths (dict): Keys are servers used for the present project, values are the respective
+                                     remote paths of the project's directory on that server.
         species_list (list): Contains input :ref:`ARCSpecies <species>` objects (both species and TSs).
         species_dict (dict): Keys are labels, values are :ref:`ARCSpecies <species>` objects.
         rxn_list (list): Contains input :ref:`ARCReaction <reaction>` objects.
@@ -349,6 +351,7 @@ class Scheduler(object):
         self.report_time = time.time()  # init time for reporting status every 1 hr
         self._last_status_payload: dict | None = None
         self.servers = list()
+        self.remote_project_paths = dict()
         self.composite_method = composite_method
         self.conformer_opt_level = conformer_opt_level
         self.conformer_sp_level = conformer_sp_level
@@ -1105,8 +1108,11 @@ class Scheduler(object):
             if 'tsg' not in self.job_dict[label]:
                 self.job_dict[label]['tsg'] = dict()
             self.job_dict[label]['tsg'][tsg] = job  # save job object
-        if job.server is not None and job.server not in self.servers:
-            self.servers.append(job.server)
+        if job.server is not None:
+            if job.server not in self.servers:
+                self.servers.append(job.server)
+            if job.remote_project_path and not self.remote_project_paths.get(job.server):
+                self.remote_project_paths[job.server] = job.remote_project_path
         self.check_max_simultaneous_jobs_limit(job.server)
         job.execute()
         self.save_restart_dict()

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -521,7 +521,9 @@ you need strict no-resubmission behavior:
    trsh_rotors: false
 
 Use ``keep_checks: true`` when Gaussian checkfiles or other retained files are
-needed for manual diagnosis.
+needed for manual diagnosis. Otherwise ARC deletes checkfiles when it terminates,
+both under the local project directory and under the project's directory on each
+server it ran jobs on.
 
 At times a user might know in advance that a particular additional keyword is
 required for the calculation. In such cases, pass the relevant keyword in the

--- a/docs/source/input_reference.rst
+++ b/docs/source/input_reference.rst
@@ -71,7 +71,7 @@ Job selection and resources:
 * ``specific_job_type`` - run one job family; takes precedence over ``job_types``.
 * ``job_memory`` - memory per job in GB.
 * ``max_job_time`` - wall-time limit in hours.
-* ``keep_checks`` - keep ESS checkfiles.
+* ``keep_checks`` - keep ESS checkfiles, both locally and on the servers.
 * ``trsh_ess_jobs`` - troubleshoot failed ESS jobs. Default: ``true``.
 * ``trsh_rotors`` - troubleshoot failed rotor scans. Default: ``true``.
 * ``skip_nmd`` - skip normal-mode-displacement checks.


### PR DESCRIPTION
ARC uploads a Gaussian checkpoint as a wavefunction guess for each job and downloads it again afterwards. When a run terminates it deletes those files — but only on the local machine:

- `delete_check_files(project_directory)` walks `<project_directory>/calcs`;
- `main.py` calls it unconditionally at the end of a run, since `keep_checks` defaults to `False`;
- no code path anywhere deletes anything on the remote server.

So the documented policy — *"they usually take up lots of space and are not needed after ARC terminates"* — is half-implemented, and every checkpoint ARC has ever uploaded is still sitting in the remote project directory.

**Measured impact.** On a quota-managed cluster, **82.3% of a fully characterised species' 61.4 MiB footprint is exactly this class of file** — the next largest class is 5.6× smaller — and 6.35 GiB had silently accumulated against a 300 GB quota. Nothing downstream reads the remote copy: thermochemistry is parsed from the primary output log, and the *local* copy is the one reused as a guess.

**What this does.** Adds `SSHClient.delete_check_files` and a `delete_remote_check_files` helper, and routes the existing teardown through a new `ARC.clean_check_files`. Design constraints kept deliberately tight:

- `keep_checks=True` keeps them everywhere, local and remote — the flag's meaning is unchanged;
- deletion is scoped to `*.chk` **under the run's own remote project directory**, using the same path construction `job/adapter.py` already uses, and no-ops if that directory does not exist;
- errors are logged and never raised. This runs after the science is done; an unreachable server at teardown is an inconvenience, not a reason to lose a run;
- servers named `local` are skipped; nothing about uploads, the wavefunction-guess mechanism, or `keep_checks`'s default changes.

**Tests** cover all three: deleted with `keep_checks=False` (asserting only `.chk`, and only under this project's directory), kept with `keep_checks=True`, and a run completing normally when the server call raises. Verified as a regression test rather than a tautology — removing just the remote call while leaving the helper in place makes `test_check_files_are_deleted_locally_and_remotely` fail.