### PR TITLE
Add a G4 harmonic frequency scale factor entry (0.994)

### DIFF
--- a/arc/level_test.py
+++ b/arc/level_test.py
@@ -247,11 +247,11 @@ class TestLevel(unittest.TestCase):
         """Test the assign_frequency_scale_factor() method with a string level argument."""
         self.assertEqual(assign_frequency_scale_factor('hf/sto3g, software: gaussian'), 0.817)
         self.assertEqual(assign_frequency_scale_factor('cbs-qb3'), 1.004)
-        self.assertIsNone(assign_frequency_scale_factor('g4, software: gaussian'))
+        self.assertIsNone(assign_frequency_scale_factor('g4mp2, software: gaussian'))
         self.assertIsNone(assign_frequency_scale_factor('no/such, software: nonesuch, solvent: water'))
         # Only assign_frequency_scale_factor() tolerates these strings, Level() itself still raises.
         for repr_ in ['hf/sto3g, software: gaussian',
-                      'g4, software: gaussian',
+                      'g4mp2, software: gaussian',
                       'no/such, software: nonesuch, solvent: water']:
             with self.assertRaises(ValueError):
                 Level(repr=repr_)

--- a/data/freq_scale_factors.yml
+++ b/data/freq_scale_factors.yml
@@ -178,6 +178,10 @@ freq_scale_factors:
     factor: 1.004
     source: 5
     note: 'Same as cbs-qb3, added for consistency with Arkane'
+  'g4, software: gaussian':
+    factor: 0.994
+    source: 4
+    note: '0.980 * 1.014, the 0.980 value is the ZPE scale factor of G4, fitted with Truhlar''s method over the 15-species standard set'
   'ccsd/cc-pvdz, software: molpro':
     factor: 0.947
     source: 2


### PR DESCRIPTION
Prepared by the campaign manager (ticket I-001, dispatch D-002).

### What this adds

One entry in `data/freq_scale_factors.yml`:

```yaml
  'g4, software: gaussian':
    factor: 0.994
    source: 4
    note: '0.980 * 1.014, the 0.980 value is the ZPE scale factor of G4, fitted with Truhlar''s method over the 15-species standard set'
```

Nothing else in the file is touched, and no behaviour changes — this is data.

### Why

G4 had no entry, so `assign_frequency_scale_factor()` returned `None` for
`str(Level(repr='g4')) == 'g4, software: gaussian'`. ARC then falls through to fitting the factor
on the fly, spawning quantum-chemistry jobs on every project that uses G4; Arkane, downstream,
assumes unity.

### Where the number comes from

`arc.utils.scale.determine_scaling_factors(['g4'], ess_settings={'gaussian': ['zeus']})` was run
over its fixed 15-species standard set (C2H2, CH2O, CH4, CO, CO2, Cl2, F2, H2, H2O, HCN, HF, N2,
N2O, NH3, OH). All 15 G4 composite jobs converged with Gaussian 16.

λ_ZPE = 0.98046, and `0.980 × 1.014 → 0.994`.

Two notes on the fit:

* The harmonic `Zero-point correction=` line was used, **not** the composite summary's `E(ZPE)`.
  The latter already carries G4's built-in ZPE scale factor (0.9854, visible as the ratio between
  the two lines in every one of the 15 logs), and fitting against it would divide out the very
  quantity being measured.
* The driver itself does not reach the fit for a *composite* level: `scale.py:98` sets
  `job_types['freq'] = False`, so no frequency job runs, yet `scale.py:107-112` reads
  `output/Species/<label>/geometry/freq.out`, which only a frequency job writes. It therefore
  raises `FileNotFoundError` *after* all 15 jobs have run. That defect is not addressed here — it
  is a separate ticket. The ZPEs were recovered offline from the raw
  `calcs/Species/<label>/composite_a<N>/input.log` files the scheduler had already downloaded, and
  the fit was reproduced from them.

### Verifier that was run

* `assign_frequency_scale_factor(Level(repr='g4'))` → `0.994`, where it previously returned `None`.
  Same for the string form `'g4, software: gaussian'`.
* The offline recovery's per-species ZPEs and final λ_ZPE were cross-checked against ARC's own
  `arc.parser.parser.parse_zpe_correction` and `arc.utils.scale.calculate_truhlar_scaling_factors`
  to within 1e-9 relative — they agreed on all 15 species and on λ_ZPE.
* `pytest arc/level_test.py` → 15 passed.

### Sanity

0.994 sits between the published neighbouring methods (0.961, 0.967) and the CBS-QB3 arm's
`0.99 × 1.014 = 1.004`, nearer the latter. That is the expected neighbourhood for a composite
method whose own built-in ZPE factor is 0.9854.

### Companion change

A matching one-entry addition to RMG-database's `freq_dict`
(`input/quantum_corrections/data.py`, keyed `"LevelOfTheory(method='g4')"`, same value 0.994) is
committed locally and will be opened separately by the project owner. Without it Arkane still
computes `zpe_scale_factor = 1.0 / 1.014` for G4.
