### PR TITLE
assign_frequency_scale_factor: return None for an unparseable level string instead of raising

### DIFF
--- a/arc/level.py
+++ b/arc/level.py
@@ -464,7 +464,7 @@ class Level(object):
                     self.compatible_ess.append(ess)
 
 
-def assign_frequency_scale_factor(level: str | Level) -> int | None:
+def assign_frequency_scale_factor(level: str | Level) -> float | None:
     """
     Assign a frequency scaling factor to a level of theory.
 
@@ -472,14 +472,18 @@ def assign_frequency_scale_factor(level: str | Level) -> int | None:
         level (str | Level): The level of theory.
 
     Returns:
-        int | None: The frequency scaling factor.
+        float | None: The frequency scaling factor.
     """
     freq_scale_factors = read_yaml_file(os.path.join(ARC_PATH, 'data', 'freq_scale_factors.yml'))['freq_scale_factors']
     if isinstance(level, str):
         entry = freq_scale_factors.get(level)
         if entry is not None:
             return entry['factor'] if isinstance(entry, dict) else entry
-        level = Level(repr=level)
+        try:
+            level = Level(repr=level)
+        except ValueError:
+            # A string ARC cannot parse as a level has no scale factor on file.
+            return None
     level_str = str(level)
     entry = freq_scale_factors.get(level_str)
     if entry is not None:

--- a/arc/level_test.py
+++ b/arc/level_test.py
@@ -243,6 +243,19 @@ class TestLevel(unittest.TestCase):
         self.assertEqual(assign_frequency_scale_factor(Level(method='CBS-QB3')), 1.004)
         self.assertEqual(assign_frequency_scale_factor(Level(method='PM6')), 1.093)
 
+    def test_assign_frequency_scale_factor_from_str(self):
+        """Test the assign_frequency_scale_factor() method with a string level argument."""
+        self.assertEqual(assign_frequency_scale_factor('hf/sto3g, software: gaussian'), 0.817)
+        self.assertEqual(assign_frequency_scale_factor('cbs-qb3'), 1.004)
+        self.assertIsNone(assign_frequency_scale_factor('g4, software: gaussian'))
+        self.assertIsNone(assign_frequency_scale_factor('no/such, software: nonesuch, solvent: water'))
+        # Only assign_frequency_scale_factor() tolerates these strings, Level() itself still raises.
+        for repr_ in ['hf/sto3g, software: gaussian',
+                      'g4, software: gaussian',
+                      'no/such, software: nonesuch, solvent: water']:
+            with self.assertRaises(ValueError):
+                Level(repr=repr_)
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
### The defect

`assign_frequency_scale_factor(level: str | Level) -> int | None` cannot return `None` when given a
string. On a table miss the string branch falls through to `Level(repr=level)`, and `Level.build()`
rejects any string containing a space:

```python
if isinstance(level, str):
    entry = freq_scale_factors.get(level)
    if entry is not None:
        return entry['factor'] if isinstance(entry, dict) else entry
    level = Level(repr=level)   # raises ValueError for any string with a space
```

Every key in `data/freq_scale_factors.yml` has the form `'method/basis, software: gaussian'`, so a
string key that misses the table takes exactly the shape `build()` refuses. For a string argument
the function therefore returns a number or raises — never `None`, which is what its annotation, its
docstring and both of its callers expect.

This is not only tidiness. `ARC.check_freq_scaling_factor()` (`arc/main.py`) does:

```python
self.freq_scale_factor = assign_frequency_scale_factor(level=freq_level)
if self.freq_scale_factor is None:
    ...  # determine it via Truhlar's method, or fall back to 1.0
```

A raise where `None` was expected turns "ARC computes the factor you are missing" into a crash.
`arc/main.py:643` (output-YAML bookkeeping) has the same exposure.

### The fix

Guard the fallback; a string ARC cannot parse as a level certainly has no scale factor on file.

```diff
-        level = Level(repr=level)
+        try:
+            level = Level(repr=level)
+        except ValueError:
+            # A string ARC cannot parse as a level has no scale factor on file.
+            return None
```

No change to `Level`, to `build()`'s parsing, to the auto-determination policy, or to
`data/freq_scale_factors.yml`.

### Test evidence

New `TestLevel::test_assign_frequency_scale_factor_from_str` covers the string hit path
(`'hf/sto3g, software: gaussian'` → 0.817), the parse-then-hit path (`'cbs-qb3'` → 1.004), and two
misses that contain spaces.

Before the fix (`arc/level.py` at parent `e325e571`, test present):

```
E   ValueError: g4, software: gaussian has empty spaces. Please use a dictionary format ...
arc/level.py:228: ValueError
FAILED arc/level_test.py::TestLevel::test_assign_frequency_scale_factor_from_str
1 failed, 15 passed in 1.84s
```

After the fix:

```
16 passed in 0.95s
```

`arc/main_test.py` and `arc/utils/scale_test.py` (the caller side) also pass: `15 passed`.

### Callers

`grep` over the repo finds three uses: `arc/main.py:643`, `arc/main.py:915`, and the existing
`arc/level_test.py` tests, which exercise only `Level` objects on the hit path. Nothing wraps the
call in `try`/`except` and nothing depends on the `ValueError`.
