### PR TITLE
Apply the capped memory overhead to a job that requests exactly the cap

### DIFF
--- a/arc/job/adapter.py
+++ b/arc/job/adapter.py
@@ -591,9 +591,9 @@ class JobAdapter(ABC):
         self.cpu_cores = self.cpu_cores or job_cpu_cores
         max_mem = servers[self.server].get('memory', None) if self.server is not None else 32.0  # Max memory per node in GB.
         job_max_server_node_memory_allocation = default_job_settings.get('job_max_server_node_memory_allocation', 0.95)
-        if max_mem is not None and self.job_memory_gb > max_mem * job_max_server_node_memory_allocation:
+        if max_mem is not None and self.job_memory_gb >= max_mem * job_max_server_node_memory_allocation:
             logger.warning(f'The memory for job {self.job_name} using {self.job_adapter} ({self.job_memory_gb} GB) '
-                           f'exceeds {100 * job_max_server_node_memory_allocation}% of the the maximum node memory on '
+                           f'reaches {100 * job_max_server_node_memory_allocation}% of the the maximum node memory on '
                            f'{self.server}. Setting it to {job_max_server_node_memory_allocation * max_mem:.2f} GB.')
             self.job_memory_gb = job_max_server_node_memory_allocation * max_mem
             total_submit_script_memory_mib = math.ceil(self.job_memory_gb * MEMORY_GB_TO_MIB * CAPPED_JOB_MEMORY_OVERHEAD)

--- a/arc/job/adapter_test.py
+++ b/arc/job/adapter_test.py
@@ -22,7 +22,8 @@ from arc.job.adapters.gaussian import GaussianAdapter
 from arc.level import Level
 from arc.species import ARCSpecies
 
-servers, submit_filenames = settings['servers'], settings['submit_filenames']
+default_job_settings, servers, submit_filenames = \
+    settings['default_job_settings'], settings['servers'], settings['submit_filenames']
 
 
 class TestEnumerationClasses(unittest.TestCase):
@@ -248,6 +249,23 @@ class TestJobAdapter(unittest.TestCase):
         self.job_4.set_cpu_and_mem()
         expected_memory = math.ceil(14 * 1024 * 1.1)
         self.assertEqual(self.job_4.submit_script_memory, expected_memory)
+        self.job_4.server = 'local'
+
+        capped_memory_gb = servers['server2']['memory'] \
+            * default_job_settings['job_max_server_node_memory_allocation']
+        original_job_memory_gb = self.job_4.job_memory_gb
+        self.addCleanup(setattr, self.job_4, 'job_memory_gb', original_job_memory_gb)
+        self.addCleanup(setattr, self.job_4, 'server', 'local')
+        self.job_4.server = 'server2'
+        self.job_4.cpu_cores = None
+        self.job_4.job_memory_gb = capped_memory_gb
+        self.job_4.set_cpu_and_mem()
+        self.assertEqual(self.job_4.job_memory_gb, capped_memory_gb)
+        self.assertEqual(self.job_4.submit_script_memory_mib, math.ceil(capped_memory_gb * 1024 * 1.05))
+        self.assertLess(self.job_4.submit_script_memory_mib, servers['server2']['memory'] * 1024)
+        self.assertIn('max_total_job_memory', self.job_4.job_status[1]['keywords'])
+        self.job_4.job_status[1]['keywords'].remove('max_total_job_memory')
+        self.job_4.job_memory_gb = original_job_memory_gb
         self.job_4.server = 'local'
 
     def test_set_file_paths(self):


### PR DESCRIPTION
A job requesting **exactly** the node memory cap was not given the capped-overhead treatment.

```python
- if max_mem is not None and self.job_memory_gb >  max_mem * job_max_server_node_memory_allocation:
+ if max_mem is not None and self.job_memory_gb >= max_mem * job_max_server_node_memory_allocation:
```

The guard read "strictly greater than the cap", so a request landing precisely on the boundary fell through and was submitted without the overhead adjustment. The log wording moves from `exceeds` to `reaches` to match.

## Provenance

Split out of #960, which is being closed. That PR's other commit reclassified Gaussian `galloc` failures as `MemoryOverallocation` and halved the memory reservation — superseded by `main`'s `5b5b11b9`, which classifies the same failure as `GaussianMemoryAllocation` and steps the `%mem` *fraction* down while holding the reservation, and whose message explicitly rebuts halving as *"equally wrong, and strictly worse"*. Its `arc/testing/trsh/gaussian/galloc.out` fixture is already byte-identical on `main`.

This commit is independent of that: it touches `arc/job/adapter.py` and `arc/job/adapter_test.py`, the superseded one touched `arc/job/trsh.py`. It cherry-picks onto `main` cleanly.

## Verification

`16 passed` in `arc/job/adapter_test.py`, including the boundary case added here. One commit, two files — no file touched by more than one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
