### PR TITLE
Clear the TS energy cache and checkfile when switching to the next TS guess

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2989,6 +2989,10 @@ class Scheduler(object):
         """
         Try the next optimized TS guess in line if a previous TS guess was found to be wrong.
 
+        The energy data cached on the TS species (``e0``, ``e_elect`` and ``freqs``) and the
+        ``checkfile`` are discarded: all four belong to the abandoned guess's geometry and
+        wavefunction, and are repopulated by the jobs run for the new guess.
+
         Args:
             label (str): The TS species label.
         """
@@ -2999,6 +3003,10 @@ class Scheduler(object):
         if os.path.isfile(freq_path):
             os.remove(freq_path)
         self.species_dict[label].populate_ts_checks()  # Restart the TS checks dict.
+        self.species_dict[label].e0 = None
+        self.species_dict[label].e_elect = None
+        self.species_dict[label].freqs = None
+        self.species_dict[label].checkfile = None
         if self.job_types['rotors'] and self.species_dict[label].rotors_dict is not None:
             # Reset rotors so they are re-determined from the new TS geometry.
             # rotors_dict=None is a sentinel meaning "skip rotor scans"; preserve it.

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -1214,6 +1214,79 @@ H      -1.82570782    0.42754384   -0.56130718"""
         # rotors_dict=None must be preserved — do not re-enable rotor scans.
         self.assertIsNone(sched2.species_dict[ts_label2].rotors_dict)
 
+    @patch('arc.scheduler.Scheduler.run_opt_job')
+    def test_switch_ts_clears_stale_ts_energy(self, mock_run_opt):
+        """Test that switch_ts discards the energy data computed for the TS guess being abandoned."""
+        ts_xyz = str_to_xyz("""N       0.91779059    0.51946178    0.00000000
+        H       1.81402049    1.03819414    0.00000000
+        H       0.00000000    0.00000000    0.00000000
+        H       0.91779059    1.22790192    0.72426890""")
+
+        ts_spc = ARCSpecies(label='TS_e0', is_ts=True, xyz=ts_xyz, multiplicity=1, charge=0,
+                            compute_thermo=False)
+        ts_spc.ts_guesses = [
+            TSGuess(index=0, method='heuristics', success=True, energy=100.0, xyz=ts_xyz,
+                    execution_time='0:00:01'),
+            TSGuess(index=1, method='heuristics', success=True, energy=110.0, xyz=ts_xyz,
+                    execution_time='0:00:01'),
+        ]
+        ts_spc.ts_guesses[0].opt_xyz = ts_xyz
+        ts_spc.ts_guesses[0].imaginary_freqs = [-798.8]
+        ts_spc.ts_guesses[1].opt_xyz = ts_xyz
+        ts_spc.ts_guesses[1].imaginary_freqs = [-784.0]
+        ts_spc.chosen_ts = 0
+        ts_spc.chosen_ts_list = [0]
+        ts_spc.ts_guesses_exhausted = False
+        # Energy data computed for guess 0, all of it specific to that geometry.
+        ts_spc.e0 = 121.88
+        ts_spc.e_elect = -148340.0
+        ts_spc.freqs = [-798.8, 1042.3, 1626.7, 1642.1, 3396.4, 3512.9]
+
+        project_directory = os.path.join(ARC_PATH, 'Projects',
+                                         'arc_project_for_testing_delete_after_usage22')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        checkfile_path = os.path.join(project_directory, 'calcs', 'TSs', 'TS_e0', 'opt_a0',
+                                      'check.chk')
+        ts_spc.checkfile = checkfile_path
+        sched = Scheduler(project='test_switch_ts_e0', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+
+        ts_label = 'TS_e0'
+        sched.output[ts_label]['job_types']['opt'] = True
+        sched.output[ts_label]['job_types']['freq'] = True
+        sched.output[ts_label]['job_types']['sp'] = True
+        sched.job_dict[ts_label] = {'opt': {}, 'freq': {}, 'sp': {}}
+        sched.running_jobs[ts_label] = []
+
+        sched.switch_ts(ts_label)
+
+        self.assertEqual(sched.species_dict[ts_label].chosen_ts, 1)
+        self.assertIsNone(sched.species_dict[ts_label].e0)
+        self.assertIsNone(sched.species_dict[ts_label].e_elect)
+        self.assertIsNone(sched.species_dict[ts_label].freqs)
+        self.assertIsNone(sched.species_dict[ts_label].checkfile)
+
+        # The consequence: an E0 computed for the new guess must be adopted, not masked by the
+        # value belonging to guess 0. ``compute_rxn_e0`` returns a copy of the reaction that
+        # ``copy_e0_values`` merges back, and it only fills an E0 that is empty.
+        rxn = ARCReaction(label='NH2 + H <=> NH3',
+                          r_species=[ARCSpecies(label='NH2', smiles='[NH2]'),
+                                     ARCSpecies(label='H', smiles='[H]')],
+                          p_species=[ARCSpecies(label='NH3', smiles='N')])
+        rxn.ts_species = sched.species_dict[ts_label]
+        rxn_copy = rxn.copy()
+        rxn_copy.ts_species.e0 = 245.0
+        rxn.copy_e0_values(rxn_copy)
+        self.assertEqual(rxn.ts_species.e0, 245.0)
+
     def setup_ts_scheduler_for_freq_check(self, project, chosen_ts, chosen_ts_list=None):
         """
         Set up a Scheduler with a single TS species whose TSGuess ``index`` (identity) and


### PR DESCRIPTION
`Scheduler.switch_ts()` abandons a TS guess and optimises the next one. It already invalidated the state the new geometry makes meaningless — the chosen guess, running jobs, output paths and `job_types` (via `delete_all_species_jobs()`), the copied `freq.out`, the TS checks dict, the rotors dict. It did not invalidate the energy data cached on the TS species itself, nor the checkfile pointing at the abandoned guess's wavefunction.

## What that cost

Measured on a benchmark run of `O1[C]=CC=N1 + C#CC <=> c1ccno1 + C#C[CH2]` (isoxazol-5-yl + propyne → isoxazole + propargyl), wB97X-D/def2-TZVP, 1187 core-hours over 2.0 days — which produced **no rate coefficient for a reaction ARC had actually solved**:

| TS guess | imag / cm⁻¹ | its own E0 vs reactants | E0 ARC used | correct verdict |
|---|---|---|---|---|
| 0, 12, 24 | −798.8 | −0.29 / −0.35 kJ/mol | 121.88 | reject |
| **18, 30** | −784.0 | **+2.51 kJ/mol** | 121.88 (stale) | **accept** |

Guesses 18 and 30 clear the `> 1 kJ/mol` E0 gate on their own energies. They were rejected on guess 0's.

## Why the value persisted

`compute_rxn_e0()` skips any species that already carries an `e0`; `ARCReaction.copy_e0_values()` only fills an empty one (`self.ts_species.e0 = self.ts_species.e0 or other_rxn.ts_species.e0`); and `e0` is in `as_dict`/`from_dict`, so the stale value survived into `restart.yml`. Three independent "don't overwrite what's cached" idioms, each correct alone, which together made one missed invalidation permanent.

## The four fields

* **`e0`** decides the E0 check, as above.
* **`e_elect`** decides a second gate by the same mechanism — `check_rxn_e_elect()` reads `reaction.ts_species.e_elect` **directly off the species object**, where `delete_all_species_jobs()` cannot reach. This is an independent bug the same fix closes.
* **`freqs`** is the *primary* source of the reported imaginary frequency: `arc/output.py::_get_ts_imag_freq()` takes the most negative entry of `spc.freqs` and only falls back to the chosen guess's `imaginary_freqs`. Without this clear, the run above would have reported **−798.8 cm⁻¹** (guess 0) as the imaginary frequency of the accepted guess 18 (−784.0).
* **`checkfile`** reaches the route builder rather than a check. `run_job()` hands it to every subsequent job, and `GaussianAdapter` resolves it to `guess=read`, seeding the new guess from the discarded geometry's converged orbitals instead of the default a fresh polyatomic species gets. That branch is right when the checkfile is current; the stale pointer is what is wrong.

Caching is correct for reactants and products, whose geometries do not change here.

## Deliberately not cleared

`opt_level` (a level of theory); `external_symmetry` / `optical_isomers` (written onto the scheduler's species only by the final Arkane run, after all switching — safe **only** because `ARCReaction.copy()` round-trips through `as_dict`/`from_dict`, a genuine deep copy, and merges back only `e0`; were `copy()` ever to become shallow this exclusion becomes a bug of the same shape); `t1` (no check reads it); and `active`, which has the identical sticky shape and is left for a deliberate decision, since whether a CASSCF active space is guess-dependent is a chemistry question rather than a caching one.

## Review and verification

Independent adversarial review (**"nothing blocks"**) and quantum-chemistry review (**"SHIP"**), run separately. Both flagged issues that were fixed before this was pushed: the docstring was cut from thirteen lines of rationale to a behavioural statement, and two physically impossible fixture constants were corrected — `e_elect` of −206942.5 kJ/mol (−78.8 Ha, an ethane-sized system) for an NH₃ species → −148340.0 (−56.5 Ha), and `freqs` from three entries to **six** (3N−6 for a four-atom nonlinear species; three is not a possible mode count), exactly one negative.

All four clears are mutation-verified independently: removing each makes the corresponding assertion fail with the stale value. `46 passed` in `arc/scheduler_test.py`. One commit, two files.

## Known limitation, stated deliberately

Clearing the cache makes ARC accept guess 18, which is 2.79 kJ/mol higher in E0 than the true lowest saddle — underestimating *k* by roughly 3× at 300 K and 1.4× at 1000 K. That is a bounded, one-signed error and strictly better than the current outcome of no rate at all, but it is not the whole answer. Ranking surviving TSs by E0, and referencing a submerged barrier to the pre-reactive complex rather than to separated reactants, are tracked separately. This PR deliberately does not loosen the E0 gate, which is what protects Arkane from a below-reactant TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
