### PR TITLE
Run the TS E0 check for reactions with a monoatomic participant

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -2952,7 +2952,7 @@ class Scheduler(object):
     def check_rxn_e0_by_spc(self, label: str):
         """
         Check the E0 (electronic energy + ZPE) of reactions related to a specific species.
-        Requires all opt + freq computations to be converged for all species (and TS) participating in each reaction.
+        Requires SP energies for all participants and frequencies for all non-monoatomic participants.
 
         Args:
             label (str): A label representing a species.
@@ -2960,8 +2960,8 @@ class Scheduler(object):
         for rxn in self.rxn_list:
             labels = rxn.reactants + rxn.products + [rxn.ts_label]
             if label in labels and rxn.ts_species.ts_checks['E0'] is None \
-                    and all([species_has_sp_and_freq(output_dict, self.species_dict[spc_label].yml_path)
-                             for spc_label, output_dict in self.output.items() if spc_label in labels]):
+                    and all([species_is_ready_for_e0(self.output[spc_label], self.species_dict[spc_label])
+                             for spc_label in set(labels)]):
                 check_ts(reaction=rxn,
                          checks=['energy'],
                          species_dict=self.species_dict,
@@ -3090,7 +3090,7 @@ class Scheduler(object):
                     self.output[label]['paths']['sp_no_sol'] = sp_path
                 self.output[label]['paths']['sp'] = original_sp_path  # restore the original path
 
-        if species_has_freq(self.output[label], self.species_dict[label].yml_path):
+        if species_is_ready_for_e0(self.output[label], self.species_dict[label]):
             self.check_rxn_e0_by_spc(label)
 
         if self.report_e_elect:
@@ -4516,3 +4516,12 @@ def species_has_sp_and_freq(species_output_dict: dict,
         Whether a species has a valid converged single-point energy and frequencies.
     """
     return species_has_sp(species_output_dict, yml_path) and species_has_freq(species_output_dict, yml_path)
+
+
+def species_is_ready_for_e0(species_output_dict: dict,
+                            species: ARCSpecies,
+                            ) -> bool:
+    """Check whether a species has the SP energy and, when applicable, frequencies needed to compute its E0."""
+    if species.is_monoatomic():
+        return species_has_sp(species_output_dict, species.yml_path)
+    return species_has_sp_and_freq(species_output_dict, species.yml_path)

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -20,7 +20,8 @@ from arc.job.factory import job_factory
 from arc.level import Level
 from arc.plotter import save_conformers_file
 from arc.scheduler import (Scheduler, SchedulerError, species_has_freq, species_has_geo, species_has_sp,
-                           species_has_sp_and_freq, tsg_method_matches_adapter)
+                           species_has_sp_and_freq, species_is_ready_for_e0,
+                           tsg_method_matches_adapter)
 from arc.imports import settings
 from arc.reaction import ARCReaction
 from arc.species.converter import str_to_xyz
@@ -893,6 +894,105 @@ H      -0.38158795    1.01273118   -0.02607927""")),
         self.assertTrue(species_has_geo(species_output_dict=species_output_dict, yml_path=yml_path))
         self.assertTrue(species_has_sp(species_output_dict=species_output_dict, yml_path=yml_path))
         self.assertTrue(species_has_sp_and_freq(species_output_dict=species_output_dict, yml_path=yml_path))
+
+    def test_species_is_ready_for_e0(self):
+        """Monoatomic species require an SP energy but legitimately have no frequencies."""
+        output = {'paths': {'sp': 'sp.out', 'freq': '', 'composite': ''}}
+        monoatomic = ARCSpecies(label='O', smiles='[O]')
+        molecular = ARCSpecies(label='OH', smiles='[OH]')
+        self.assertTrue(species_is_ready_for_e0(output, monoatomic))
+        self.assertFalse(species_is_ready_for_e0(output, molecular))
+        output['paths']['sp'] = ''
+        self.assertFalse(species_is_ready_for_e0(output, monoatomic))
+
+    @patch('arc.scheduler.check_ts')
+    def test_monoatomic_participant_reaches_e0_check_and_switches_ts(self, mock_check_ts):
+        """A failed E0 check switches guesses even when one reaction participant is monoatomic."""
+        scheduler = object.__new__(Scheduler)
+        species = {
+            'R': ARCSpecies(label='R', smiles='OO'),
+            'O': ARCSpecies(label='O', smiles='[O]'),
+            'P': ARCSpecies(label='P', smiles='O=O'),
+            'TS0': ARCSpecies(label='TS0', is_ts=True),
+        }
+        species['TS0'].ts_guesses_exhausted = False
+        species['TS0'].chosen_ts = 1
+        rxn = MagicMock()
+        rxn.reactants = ['R', 'O']
+        rxn.products = ['P']
+        rxn.ts_label = 'TS0'
+        rxn.ts_species = species['TS0']
+        rxn.label = 'R + O <=> P'
+        scheduler.rxn_list = [rxn]
+        scheduler.species_dict = species
+        scheduler.output = {
+            label: {'paths': {'sp': 'sp.out', 'freq': '' if label == 'O' else 'freq.out', 'composite': ''},
+                    'convergence': True}
+            for label in species
+        }
+        scheduler.project_directory = '/tmp'
+        scheduler.kinetics_adapter = 'arkane'
+        scheduler.sp_level = Level('gfn2')
+        scheduler.composite_method = None
+        scheduler.freq_scale_factor = 1.0
+        scheduler.switch_ts = MagicMock()
+
+        def fail_e0(**kwargs):
+            kwargs['reaction'].ts_species.ts_checks['E0'] = False
+
+        mock_check_ts.side_effect = fail_e0
+        scheduler.check_rxn_e0_by_spc('O')
+
+        mock_check_ts.assert_called_once()
+        scheduler.switch_ts.assert_called_once_with('TS0')
+
+    @patch('arc.scheduler.check_ts')
+    @patch('arc.scheduler.parser.parse_e_elect', return_value=-75.0)
+    def test_atomic_sp_completion_triggers_e0_check_and_switches_ts(self, mock_parse_e_elect, mock_check_ts):
+        """Completing the last atomic SP triggers the E0 check and switches a failed TS."""
+        scheduler = object.__new__(Scheduler)
+        species = {
+            'R': ARCSpecies(label='R', smiles='OO'),
+            'O': ARCSpecies(label='O', smiles='[O]'),
+            'P': ARCSpecies(label='P', smiles='O=O'),
+            'TS0': ARCSpecies(label='TS0', is_ts=True),
+        }
+        species['TS0'].ts_guesses_exhausted = False
+        species['TS0'].chosen_ts = 1
+        rxn = MagicMock()
+        rxn.reactants = ['R', 'O']
+        rxn.products = ['P']
+        rxn.ts_label = 'TS0'
+        rxn.ts_species = species['TS0']
+        rxn.label = 'R + O <=> P'
+        scheduler.rxn_list = [rxn]
+        scheduler.species_dict = species
+        scheduler.output = {
+            label: {'paths': {'sp': '' if label == 'O' else 'sp.out',
+                              'freq': '' if label == 'O' else 'freq.out',
+                              'composite': ''},
+                    'job_types': {'sp': False},
+                    'info': '',
+                    'convergence': True}
+            for label in species
+        }
+        scheduler.project_directory = '/tmp'
+        scheduler.kinetics_adapter = 'arkane'
+        scheduler.sp_level = Level('gfn2')
+        scheduler.composite_method = None
+        scheduler.freq_scale_factor = 1.0
+        scheduler.report_e_elect = False
+        scheduler.switch_ts = MagicMock()
+
+        def fail_e0(**kwargs):
+            kwargs['reaction'].ts_species.ts_checks['E0'] = False
+
+        mock_check_ts.side_effect = fail_e0
+        scheduler.post_sp_actions('O', 'atomic-sp.out')
+
+        mock_parse_e_elect.assert_called_once_with('atomic-sp.out')
+        mock_check_ts.assert_called_once()
+        scheduler.switch_ts.assert_called_once_with('TS0')
 
     def test_add_label_to_unique_species_labels(self):
         """Test the add_label_to_unique_species_labels() method."""


### PR DESCRIPTION
The E0 sanity check for a transition state was gated on **every** reaction participant having both a converged single-point energy *and* frequencies.

A monoatomic participant — `[O]`, `[H]`, `[Cl]` — never runs a frequency job, because it has no vibrational modes. So that gate could never be satisfied, and **the E0 check silently never ran for any reaction involving an atom.**

## The fix, in two halves

**Readiness.** A new `species_is_ready_for_e0()` requires an SP energy from all participants but frequencies only from the non-monoatomic ones. Both readiness sites route through it.

**The trigger.** `post_sp_actions()` called `check_rxn_e0_by_spc()` only when `species_has_freq()` was true. So when the *last* job to complete was an atom's single-point, the newly-satisfied reaction was never re-evaluated, and the TS kept an unvalidated `ts_checks['E0'] is None` for the rest of the run. It now re-checks on the same readiness predicate.

The participant loop also iterates `set(labels)` and indexes `self.output` directly, rather than filtering `self.output.items()` — so a participant **absent** from `self.output` now fails the gate instead of being skipped as vacuously ready.

## Tests

Three, covering the predicate itself; a monoatomic participant reaching `check_ts` and driving `switch_ts` on a failed E0; and an atomic SP completing last as the event that triggers the check.

None of them touch the class-level `sched1`/`sched3` fixtures — two build `object.__new__(Scheduler)` directly and one calls the module function — so they are unaffected by #1009's `setUpClass` → `setUp` restructuring of `TestScheduler`.

## Verification

Rebased from **146 behind** onto current `main`. One conflict, in `arc/scheduler_test.py`'s `from arc.scheduler import (...)` block: `main` had added `tsg_method_matches_adapter` to the same line this branch extended with `species_is_ready_for_e0`. Resolved as a union across two lines.

Content identity against the old merge-base accounts for every difference — all four changed lines are that one resolution, and there is no unexplained only-in-old line, so no hunk was dropped. `arc/scheduler.py` auto-merged; `check_rxn_e0_by_spc`, `post_sp_actions` and the new helper were each re-read on the new base, and `ARCSpecies.is_monoatomic()` still exists on `main`.

Tests serial: **82 passed** on the pre-rebase head → **99 passed** after (main added tests). Nothing introduced. One commit, two files, each touched once.

## Note

The original commit message is a single subject line with no body, so it records no measurement or failure-mode detail beyond what the diff shows. The description above is derived from the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
