### PR TITLE
Report the two RDKit failures ARC currently swallows

### DIFF
--- a/arc/species/conformers.py
+++ b/arc/species/conformers.py
@@ -1465,7 +1465,8 @@ def embed_rdkit(label, mol, num_confs=None, xyz=None):
         xyz (dict, optional): The 3D coordinates.
 
     Returns:
-        RDMol | None: An RDKIt molecule with embedded conformers.
+        RDMol | None: An RDKIt molecule with embedded conformers,
+                      or ``None`` if no conformers could be embedded.
     """
     if num_confs is None and xyz is None:
         raise ConformerError(f'Either num_confs or xyz must be set when calling embed_rdkit() for {label}')
@@ -1481,6 +1482,10 @@ def embed_rdkit(label, mol, num_confs=None, xyz=None):
             AllChem.EmbedMultipleConfs(rd_mol, numConfs=num_confs, randomSeed=1, enforceChirality=True)
         except Exception as e:
             logger.warning(f'Could not embed conformers using RDKit for {label}, failed with: {e}')
+            return None
+        if not rd_mol.GetNumConformers():
+            logger.warning(f'Could not embed conformers using RDKit for {label}, '
+                           f'RDKit returned no conformers without raising an error.')
             return None
     elif xyz is not None:
         rd_conf = Chem.Conformer(rd_mol.GetNumAtoms())

--- a/arc/species/conformers_test.py
+++ b/arc/species/conformers_test.py
@@ -681,6 +681,17 @@ H       0.68104300    0.74807180    0.61546062""")]
         self.assertIsNone(rd_mol)
         self.assertIn('Bad Conformer Id', '\n'.join(captured.output))
 
+    def test_embed_rdkit_does_not_return_a_conformer_less_molecule(self):
+        """Test that an embedding which yields no conformers returns None rather than an unusable molecule"""
+        spc = ARCSpecies(label='c-C3H2', smiles='C1#CC1')
+        with self.assertLogs('arc', level='WARNING') as captured:
+            rd_mol = conformers.embed_rdkit(label='c-C3H2', mol=spc.mol, num_confs=5)
+            if rd_mol is not None:
+                xyzs = conformers.read_rdkit_embedded_conformers(label='c-C3H2', rd_mol=rd_mol)
+                self.assertIsInstance(xyzs[0], dict)
+        self.assertIsNone(rd_mol)
+        self.assertIn('c-C3H2', '\n'.join(captured.output))
+
     def test_rdkit_force_field_abandons_an_optimization_that_raises(self):
         """Test that a raising optimization is logged and attempted once per conformer"""
         rd_mol = conformers.embed_rdkit(label='CJ', mol=self.cj_spc.mol, num_confs=1)

--- a/arc/species/converter.py
+++ b/arc/species/converter.py
@@ -1614,6 +1614,7 @@ def to_rdkit_mol(mol, remove_h=False, sanitize=True):
 
     Returns:
         RDMol: An RDKit molecule object corresponding to the input RMG Molecule object.
+        If sanitization was requested but failed, an unsanitized molecule is returned and a warning is logged.
     """
     atom_id_map = dict()
 
@@ -1654,9 +1655,10 @@ def to_rdkit_mol(mol, remove_h=False, sanitize=True):
     if sanitize:
         try:
             Chem.SanitizeMol(rd_mol)
-        except AtomValenceException:
-            # [C-]#[O+] raises this
-            pass
+        except AtomValenceException as e:
+            logger.warning(f'Could not sanitize the RDKit molecule of {mol_copy.get_formula()} '
+                           f'(multiplicity {mol_copy.multiplicity}), returning an unsanitized RDKit molecule. '
+                           f'Got {e.__class__.__name__}: {e}')
     if remove_h:
         rd_mol = Chem.RemoveHs(rd_mol, sanitize=sanitize)
     return rd_mol

--- a/arc/species/converter_test.py
+++ b/arc/species/converter_test.py
@@ -3432,6 +3432,17 @@ R1=1.0912"""
         rd_mol_block = Chem.MolToMolBlock(rd_mol).splitlines()
         self._check_atom_connectivity_in_rd_mol_block(spc3.mol, rd_mol_block)
 
+    def test_to_rdkit_mol_reports_a_sanitization_failure(self):
+        """Test that a molecule RDKit refuses to sanitize is reported and still returned"""
+        spc = ARCSpecies(label='CO', smiles='[C-]#[O+]')
+        with self.assertLogs('arc', level='WARNING') as captured:
+            rd_mol = converter.to_rdkit_mol(spc.mol)
+        self.assertIsInstance(rd_mol, rdchem.Mol)
+        log = '\n'.join(captured.output)
+        self.assertIn('AtomValenceException', log)
+        self.assertIn('Explicit valence', log)
+        self.assertIn('unsanitized', log)
+
     def test_xyz_to_ase(self):
         """Test the xyz_to_ase function"""
         atoms_1 = converter.xyz_to_ase(self.xyz1['dict'])


### PR DESCRIPTION
Two RDKit failures that ARC currently absorbs without a trace.

## `converter.to_rdkit_mol` swallowed a valence exception

It caught `AtomValenceException` with a bare `pass` and returned an **unsanitized** molecule — no log line, no signal to the caller that sanitization had failed. Everything downstream treated it as a normal RDKit molecule.

It now logs a warning naming the formula, the multiplicity and the exception, so the failure appears in `arc.log` at the point it happens rather than as a puzzling result later.

## `conformers.embed_rdkit` could return zero conformers without raising

RDKit's embedder can fail *without* an exception — `C1#CC1` is one such case. The function's own signature documents `RDMol | None`, but it returned the conformer-less molecule instead of `None`, so callers proceeded to read conformers that were not there.

It now checks `rd_mol.GetNumConformers()` and returns `None` with a warning naming the species, matching the contract the docstring already stated.

## Why this is standalone

The only PR with any file overlap is #921 (`crest_adapter_clean`), whose `converter.py` change adds a `reorder_xyz_string` helper — a different function in a different layer from `to_rdkit_mol`. Folding these in would have made a 24-file TS-search adapter PR larger and buried an unrelated diagnostics fix.

## Verification

Rebased from 27 behind onto current `main`; the changed-line set is identical in both directions against the old merge-base, so nothing was dropped. `140 passed` across `arc/species/conformers_test.py` and `arc/species/converter_test.py`. Two commits, four files, each file touched by exactly one commit. ~31 added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
