### PR TITLE
fix(common): tolerate string angles in get_angle_in_180_range (unbreak cont_opt rotor scans)

### DIFF
--- a/arc/common.py
+++ b/arc/common.py
@@ -1615,20 +1615,22 @@ def is_xyz_linear(xyz: dict | None) -> bool | None:
     return True
 
 
-def get_angle_in_180_range(angle: float,
+def get_angle_in_180_range(angle: int | float | str,
                            round_to: int | None = 2,
                            ) -> float:
     """
     Get the corresponding angle in the -180 to +180 degree range, [-180, 180)
 
     Args:
-        angle (float): An angle in degrees.
+        angle (int | float | str): An angle in degrees. Accepts a string too, since the Scheduler
+                                   stores rotor dihedrals as ':.2f' strings for YAML restart serialization.
         round_to (int, optional): The number of decimal figures to round the result to.
                                   ``None`` to not round. Default: 2.
 
     Returns:
         float: The corresponding angle in the -180 to +180 degree range.
     """
+    angle = float(angle)
     wrapped = (angle + HALF_CIRCLE) % FULL_CIRCLE - HALF_CIRCLE
     return round(wrapped, round_to) if round_to is not None else wrapped
 

--- a/arc/common_test.py
+++ b/arc/common_test.py
@@ -1211,6 +1211,12 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(common.get_angle_in_180_range(362), 2)
         self.assertEqual(common.get_angle_in_180_range(1000), -80)
         self.assertEqual(common.get_angle_in_180_range(-1000), 80)
+        # Angles round-tripped through the restart YAML are stored as strings (e.g. the Scheduler's
+        # rotors_dict[i]['original_dihedrals'], saved as ':.2f' strings), so the function must
+        # accept a string angle too.
+        self.assertEqual(common.get_angle_in_180_range('60.00'), 60)
+        self.assertEqual(common.get_angle_in_180_range('181'), -179)
+        self.assertAlmostEqual(common.get_angle_in_180_range('-5.364589', round_to=None), -5.364589)
         self.assertEqual(common.get_angle_in_180_range(247.62), -112.38)
         self.assertEqual(common.get_angle_in_180_range(0), 0)
         self.assertEqual(common.get_angle_in_180_range(180), -180)


### PR DESCRIPTION
## Problem

Every continuous-directed (`cont_opt`) rotor scan crashes deterministically:

```
File ".../arc/scheduler.py", in spawn_directed_scan_jobs
    original_dihedrals.append(get_angle_in_180_range(dihedral))
File ".../arc/common.py", in get_angle_in_180_range
    wrapped = (angle + HALF_CIRCLE) % FULL_CIRCLE - HALF_CIRCLE
TypeError: can only concatenate str (not "float") to str
```

`Scheduler.spawn_directed_scan_jobs` stores `rotors_dict[i]['original_dihedrals']` as `':.2f'`
**strings** (deliberately, for YAML restart serialization — see the `# stores as str for YAML`
comment), then reads them straight back into `get_angle_in_180_range()`, which does arithmetic on
the value. `str + float` raises `TypeError`.

This has been latent since 2020 because `ess` (single-job) scans are the default; `cont_opt`
directed scans are rarely exercised. A UMA / queued-ASE hindered-rotor scan forces `cont_opt` and
hits it on the first rotor, every time.

## Fix

Coerce the input to `float` inside `get_angle_in_180_range` (a no-op for the numeric callers) and
widen the type hint. The string serialization of `original_dihedrals` is left untouched, so
restart-file compatibility is preserved; only the read now tolerates the serialized form.

## Test

Extends the existing `test_get_angle_in_180_range` with string-input regression cases
(`'60.00'`, `'181'`, `'-5.364589'`). Fails with the `TypeError` before the change, passes after.