### PR TITLE
Add a one-process relaxed rotor scan to the ASE adapter

### DIFF
--- a/arc/job/adapters/ase_adapter.py
+++ b/arc/job/adapters/ase_adapter.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-from arc.common import get_logger, read_yaml_file, save_yaml_file
+from arc.common import get_logger, read_yaml_file, save_yaml_file, torsions_to_scans
 from arc.job.adapter import JobAdapter
 from arc.job.adapters.common import _initialize_adapter
 from arc.job.factory import register_job_adapter
@@ -188,6 +188,28 @@ class ASEAdapter(JobAdapter):
             
         return ARC_PYTHON or 'python'
 
+    def set_scan_torsions(self) -> None:
+        """
+        Resolve the torsion(s) a 'scan' job should sweep, and store them in ``self.torsions``.
+
+        A scan job may be given either an explicit ``torsions`` list (the pipe path) or a species
+        ``rotors_dict`` together with a ``rotor_index`` (the scheduler path, which leaves
+        ``torsions`` None). This resolves whichever was supplied, mirroring the other ESS adapters,
+        so that ``self.torsions`` is always populated for both the input file and the scheduler,
+        which reads ``job.torsions[0]`` when the job returns.
+
+        Raises:
+            ValueError: If neither a rotor nor a torsion was supplied.
+        """
+        if self.torsions is not None and len(self.torsions):
+            return
+        if self.rotor_index is not None and self.species[0].rotors_dict:
+            scans = self.species[0].rotors_dict[self.rotor_index]['scan']
+            scans = [scans] if not isinstance(scans[0], list) else scans
+            self.torsions = torsions_to_scans(scans, direction=-1)
+            return
+        raise ValueError(f'Could not determine scan parameters for scan job {self.job_name}')
+
     def write_input_file(self) -> None:
         """
         Write the input file for ase_script.py.
@@ -202,6 +224,15 @@ class ASEAdapter(JobAdapter):
             'irc_direction': self.irc_direction,
             'settings': self.determine_settings(),
         }
+        if self.job_type == 'scan':
+            # A 'scan' job sweeps a whole rotor in one process: pass the torsion(s) and the
+            # scan resolution so ase_script.py can run the relaxed torsional scan itself.
+            # The scheduler dispatches a rotor with rotors_dict + rotor_index and leaves torsions
+            # None, so resolve the scan the same way Gaussian/QChem/TeraChem/Psi4 do and back-fill
+            # self.torsions, which the scheduler later reads directly (as job.torsions[0]).
+            self.set_scan_torsions()
+            input_dict['torsions'] = self.torsions
+            input_dict['scan_res'] = self.scan_res
         save_yaml_file(os.path.join(self.local_path, 'input.yml'), input_dict)
 
     def warn_if_unreliable_uma_sp(self) -> bool:
@@ -301,6 +332,8 @@ class ASEAdapter(JobAdapter):
             self.normal_modes = results.get('modes')
             self.reduced_masses = results.get('reduced_masses')
             self.force_constants = results.get('force_constants')
+            for warning in results.get('warnings') or list():
+                logger.warning(f"ASE job warning: {warning}")
             if 'error' in results:
                 logger.error(f"ASE job error: {results['error']}")
 

--- a/arc/job/adapters/ase_test.py
+++ b/arc/job/adapters/ase_test.py
@@ -12,10 +12,32 @@ import unittest
 from unittest.mock import patch
 import numpy as np
 
+from ase import Atoms
+from ase.calculators.emt import EMT
+
 from arc.common import ARC_TESTING_PATH, read_yaml_file, save_yaml_file
 from arc.job.adapters.ase_adapter import ASEAdapter
+from arc.parser.parser import parse_1d_scan_coords, parse_1d_scan_energies
 from arc.species.species import ARCSpecies
-from arc.job.adapters.scripts.ase_script import to_kJmol, numpy_vibrational_analysis, is_linear
+from arc.job.adapters.scripts.ase_script import (is_linear,
+                                                 merge_scan_branches,
+                                                 numpy_vibrational_analysis,
+                                                 relaxed_torsion_scan,
+                                                 rotor_top,
+                                                 run_torsion_scan,
+                                                 scan_convergence_warning,
+                                                 to_kJmol)
+
+ETHANE_XYZ = {'symbols': ('C', 'C', 'H', 'H', 'H', 'H', 'H', 'H'),
+              'isotopes': (12, 12, 1, 1, 1, 1, 1, 1),
+              'coords': ((0.0, 0.0, 0.761395),
+                         (0.0, 0.0, -0.761395),
+                         (0.0, 1.017111, 1.157241),
+                         (0.880844, -0.508556, 1.157241),
+                         (-0.880844, -0.508556, 1.157241),
+                         (0.880844, 0.508556, -1.157241),
+                         (-0.880844, 0.508556, -1.157241),
+                         (0.0, -1.017111, -1.157241))}
 
 
 class TestASEAdapter(unittest.TestCase):
@@ -30,8 +52,7 @@ class TestASEAdapter(unittest.TestCase):
         """
         cls.maxDiff = None
         cls.project_directory = os.path.join(ARC_TESTING_PATH, 'test_ASEAdapter')
-        if not os.path.exists(cls.project_directory):
-            os.makedirs(cls.project_directory)
+        os.makedirs(cls.project_directory, exist_ok=True)  # parallel workers race here
 
         xyz = {'symbols': ('O', 'H', 'H'),
                'isotopes': (16, 1, 1),
@@ -203,6 +224,184 @@ class TestASEAdapter(unittest.TestCase):
         self.assertEqual(len(results['freqs']), 4)
         for i, val in enumerate(freqs[5:]):
             self.assertAlmostEqual(results['freqs'][i], val, delta=1e-3)
+
+    def test_write_input_file_scan(self):
+        """Test that a scan job writes torsions and scan resolution into the input file"""
+        scan_dir = os.path.join(self.project_directory, 'scan_input')
+        os.makedirs(scan_dir, exist_ok=True)
+        job = ASEAdapter(execution_type='incore',
+                         job_type='scan',
+                         project='test_scan',
+                         project_directory=scan_dir,
+                         species=[ARCSpecies(label='ethane', xyz=ETHANE_XYZ)],
+                         torsions=[[2, 0, 1, 5]],
+                         args={'keyword': {'calculator': 'uma', 'model': 'uma-s-1p2'},
+                               'trsh': {'scan_res': 8.0}},
+                         testing=True)
+        job.local_path = scan_dir
+        job.write_input_file()
+        data = read_yaml_file(os.path.join(scan_dir, 'input.yml'))
+        self.assertEqual(data['job_type'], 'scan')
+        self.assertEqual(data['torsions'], [[2, 0, 1, 5]])
+        self.assertEqual(data['scan_res'], 8.0)
+
+    def test_rotor_top(self):
+        """Test resolving the rotating group across a pivot bond"""
+        atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])
+        # The dihedral is [2, 0, 1, 5]; pivots are atoms 0 and 1. The group on the atom-1 side is
+        # that carbon and its three hydrogens (5, 6, 7).
+        self.assertEqual(rotor_top(atoms, 0, 1), [1, 5, 6, 7])
+        self.assertEqual(rotor_top(atoms, 1, 0), [0, 2, 3, 4])
+        # A pivot bond inside a ring is ill-defined for a 1D rotor.
+        cyclopropane = Atoms(symbols=('C', 'C', 'C'),
+                             positions=((0.0, 0.87, 0.0), (0.75, -0.43, 0.0), (-0.75, -0.43, 0.0)))
+        with self.assertRaises(ValueError):
+            rotor_top(cyclopropane, 0, 1)
+        # Pivots that are not bonded cannot define a rotating group.
+        with self.assertRaises(ValueError):
+            rotor_top(atoms, 2, 5)
+        # A stretched pivot bond (the TS case) falls outside the default cutoff, but only the pivot
+        # pair gets the looser allowance, so the top is still resolved and no spurious ring appears.
+        stretched = ETHANE_XYZ['coords'][:1] + ((0.0, 0.0, -1.9),) + ETHANE_XYZ['coords'][2:]
+        ts_like = Atoms(symbols=ETHANE_XYZ['symbols'], positions=stretched)
+        self.assertEqual(rotor_top(ts_like, 0, 1), [1, 5, 6, 7])
+        # Pulled far enough apart, they are no longer a bond at all.
+        with self.assertRaises(ValueError):
+            rotor_top(ts_like, 0, 1, pivot_mult=1.0)
+
+    def test_relaxed_torsion_scan(self):
+        """Test a full 1D relaxed torsional scan on the machinery (EMT keeps it hermetic)"""
+        atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])
+        atoms.calc = EMT()
+        result = relaxed_torsion_scan(atoms, [2, 0, 1, 5], step_deg=8.0, nsteps=45,
+                                      fmax=0.05, steps=100)
+        # 8 deg over 360 deg is 46 points including the duplicated endpoint.
+        self.assertEqual(len(result['energies']), 46)
+        self.assertEqual(len(result['angles']), 46)
+        self.assertEqual(result['angles'][0], 0.0)
+        self.assertEqual(result['angles'][-1], 360.0)
+        # The endpoint duplicates the start (a periodic grid).
+        self.assertEqual(result['energies'][0], result['energies'][-1])
+        self.assertTrue(all(np.isfinite(e) for e in result['energies']))
+        self.assertEqual(result['top'], [1, 5, 6, 7])
+        self.assertIn('fmax_worst', result)
+        self.assertIn('branch_gap_max', result)
+        # A non-positive resolution or a zero-length grid is rejected before any division.
+        with self.assertRaises(ValueError):
+            relaxed_torsion_scan(atoms, [2, 0, 1, 5], step_deg=8.0, nsteps=0)
+        with self.assertRaises(ValueError):
+            relaxed_torsion_scan(atoms, [2, 0, 1, 5], step_deg=0.0, nsteps=45)
+
+    def test_run_torsion_scan_output_is_parseable(self):
+        """Test that run_torsion_scan output is readable by ARC's YAML scan parser, in kJ/mol"""
+        atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])
+        atoms.calc = EMT()
+        input_dict = {'torsions': [[2, 0, 1, 5]], 'scan_res': 8.0}
+        result = run_torsion_scan(atoms, input_dict, settings={'fmax': 0.05, 'steps': 100})
+        self.assertEqual(len(result['energies']), 46)
+        scan_dir = os.path.join(self.project_directory, 'scan_output')
+        os.makedirs(scan_dir, exist_ok=True)
+        out_path = os.path.join(scan_dir, 'output.yml')
+        save_yaml_file(out_path, {'energies': result['energies'], 'angles': result['angles']})
+        energies, angles = parse_1d_scan_energies(log_file_path=out_path)
+        self.assertIsNotNone(energies)
+        self.assertIsNotNone(angles)
+        self.assertEqual(len(energies), 46)
+        self.assertEqual(len(angles), 46)
+        self.assertAlmostEqual(min(energies), 0.0)  # parser zeroes the minimum, in kJ/mol
+        self.assertGreaterEqual(min(energies), 0.0)
+
+    def test_run_torsion_scan_rejects_multiple_torsions(self):
+        """Test that a 1D scan refuses more than one torsion"""
+        atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])
+        atoms.calc = EMT()
+        with self.assertRaises(ValueError):
+            run_torsion_scan(atoms, {'torsions': [[2, 0, 1, 5], [3, 0, 1, 6]], 'scan_res': 8.0}, settings={})
+        with self.assertRaises(ValueError):
+            run_torsion_scan(atoms, {'torsions': None, 'scan_res': 8.0}, settings={})
+        # A non-positive scan resolution is rejected before the 360/scan_res division.
+        with self.assertRaises(ValueError):
+            run_torsion_scan(atoms, {'torsions': [[2, 0, 1, 5]], 'scan_res': 0.0}, settings={})
+        # A resolution that does not close the revolution would corrupt the periodic grid.
+        with self.assertRaises(ValueError):
+            run_torsion_scan(atoms, {'torsions': [[2, 0, 1, 5]], 'scan_res': 7.0}, settings={})
+
+    def test_merge_scan_branches(self):
+        """Test folding the forward and backward walks onto one grid and keeping the lower branch"""
+        nsteps = 4
+        # The forward walk is trapped high from its second point on; the backward walk (which
+        # visits the grid in reverse) is the low branch there. The merge must take each pointwise.
+        e_f = [0.0, 1.0, 9.0, 9.0, 0.0]
+        e_b = [0.0, 5.0, 2.0, 3.0, 0.0]
+        merged, grid_f, grid_b, coords = merge_scan_branches(e_f, e_b, nsteps)
+        # Backward index n lands on grid point (-n) % 4, so e_b maps onto [0.0, 3.0, 2.0, 5.0].
+        self.assertEqual(list(grid_f), [0.0, 1.0, 9.0, 9.0])
+        self.assertEqual(list(grid_b), [0.0, 3.0, 2.0, 5.0])
+        self.assertEqual(list(merged), [0.0, 1.0, 2.0, 5.0])
+        self.assertIsNone(coords)  # no geometries supplied
+        # The endpoint of each walk folds back onto grid point 0 and must not lose a lower value.
+        merged, _, _, _ = merge_scan_branches([5.0, 1.0, 2.0, 3.0, 0.0], [5.0, 6.0, 7.0, 8.0, 9.0], nsteps)
+        self.assertEqual(merged[0], 0.0)
+        # Geometries follow whichever branch won at each grid point.
+        coords_f = [('f', n) for n in range(nsteps + 1)]
+        coords_b = [('b', n) for n in range(nsteps + 1)]
+        merged, _, _, coords = merge_scan_branches(e_f, e_b, nsteps, coords_f, coords_b)
+        self.assertEqual(coords[1], ('f', 1))  # forward won here (1.0 < 3.0)
+        self.assertEqual(coords[2], ('b', 2))  # backward won here (2.0 < 9.0)
+        self.assertEqual(coords[3], ('b', 1))  # backward index 1 folds onto grid point 3
+
+    def test_scan_coords_are_parseable(self):
+        """Test that the relaxed scan geometries round-trip through ARC's YAML coords parser"""
+        atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])
+        atoms.calc = EMT()
+        input_dict = {'torsions': [[2, 0, 1, 5]], 'scan_res': 40.0, 'xyz': ETHANE_XYZ}
+        result = run_torsion_scan(atoms, input_dict, settings={'fmax': 0.05, 'steps': 50})
+        self.assertEqual(len(result['scan_coords']), 10)
+        self.assertEqual(result['scan_coords'][0]['symbols'], ETHANE_XYZ['symbols'])
+        self.assertEqual(result['scan_coords'][0]['isotopes'], ETHANE_XYZ['isotopes'])
+        scan_dir = os.path.join(self.project_directory, 'scan_coords')
+        os.makedirs(scan_dir, exist_ok=True)
+        out_path = os.path.join(scan_dir, 'output.yml')
+        save_yaml_file(out_path, {'energies': result['energies'], 'angles': result['angles'],
+                                  'scan_coords': result['scan_coords']})
+        traj = parse_1d_scan_coords(log_file_path=out_path)
+        self.assertIsNotNone(traj)
+        self.assertEqual(len(traj), 10)
+        self.assertEqual(len(traj[0]['coords']), len(ETHANE_XYZ['symbols']))
+
+    def test_scan_convergence_warning(self):
+        """Test that only an untrustworthy scan is called out"""
+        clean = {'converged': True, 'fmax_worst': 0.004, 'branch_gap_max': 0.001}
+        self.assertIsNone(scan_convergence_warning(clean, fmax=0.005))
+        loose = {'converged': False, 'fmax_worst': 0.9, 'branch_gap_max': 0.001}
+        self.assertIn('0.9', scan_convergence_warning(loose, fmax=0.005))
+        split = {'converged': True, 'fmax_worst': 0.004, 'branch_gap_max': 0.5}
+        self.assertIn('different conformers', scan_convergence_warning(split, fmax=0.005))
+
+    def test_set_scan_torsions_from_rotors_dict(self):
+        """Test that a scheduler-dispatched rotor (rotors_dict + rotor_index, torsions None) resolves"""
+        scan_dir = os.path.join(self.project_directory, 'scan_rotor_index')
+        os.makedirs(scan_dir, exist_ok=True)
+        spc = ARCSpecies(label='ethane', xyz=ETHANE_XYZ)
+        spc.determine_rotors()
+        job = ASEAdapter(execution_type='incore',
+                         job_type='scan',
+                         project='test_scan',
+                         project_directory=scan_dir,
+                         species=[spc],
+                         rotor_index=0,
+                         args={'keyword': {'calculator': 'uma', 'model': 'uma-s-1p2'}},
+                         testing=True)
+        self.assertIsNone(job.torsions)  # the scheduler leaves this unset
+        job.local_path = scan_dir
+        job.write_input_file()
+        # The scan is resolved from rotors_dict and back-filled, since the scheduler later reads
+        # job.torsions[0] directly when the job returns.
+        expected = [[atom - 1 for atom in spc.rotors_dict[0]['scan']]]
+        self.assertEqual(job.torsions, expected)
+        data = read_yaml_file(os.path.join(scan_dir, 'input.yml'))
+        self.assertEqual(data['torsions'], expected)
+        self.assertIsNotNone(data['torsions'][0])
 
     @classmethod
     def tearDownClass(cls):

--- a/arc/job/adapters/scripts/ase_script.py
+++ b/arc/job/adapters/scripts/ase_script.py
@@ -15,6 +15,8 @@ import numpy as np
 
 from ase import Atoms
 from ase.constraints import FixInternals
+from ase.data import covalent_radii
+from ase.neighborlist import build_neighbor_list, natural_cutoffs
 from ase.optimize import BFGS, LBFGS, GPMin
 from ase.optimize.sciopt import SciPyFminBFGS, SciPyFminCG
 from ase.vibrations import Vibrations
@@ -130,6 +132,309 @@ def apply_constraints(atoms: Atoms, constraints_data: list):
         elif len(indices) == 4:
             dihedrals.append([constraint[1], indices])
     atoms.set_constraint(FixInternals(bonds=bonds, angles_deg=angles, dihedrals_deg=dihedrals))
+
+
+def rotor_top(atoms: Atoms, pivot_1: int, pivot_2: int, mult: float = 1.2,
+              pivot_mult: float = 1.8) -> list:
+    """
+    Determine the rotating group (the "top") on the ``pivot_2`` side of the ``pivot_1``-``pivot_2`` bond.
+
+    The two pivots are the central atoms of the scanned torsion; breaking their bond splits the
+    molecule into two fragments, and this returns the atom indices reachable from ``pivot_2``.
+
+    This is the same "top" that ``arc.common.determine_top_group_indices`` computes, but kept as a
+    standalone reimplementation on purpose: this script runs in the calculator's own environment
+    (e.g. ``uma_env``), which has neither ARC nor RMG-Py, so it can import neither that function nor
+    the RMG ``Molecule`` it operates on. Connectivity is instead rebuilt from the geometry via ASE's
+    neighbor list. Keep the two traversals in agreement if either changes.
+
+    Because connectivity here is geometric rather than a real bond graph, a bond stretched well past
+    its equilibrium length - the forming or breaking bond of a TS being the case that matters - can
+    fall outside the default cutoff and look non-bonded. Only the pivot pair is given the looser
+    ``pivot_mult`` allowance; the rest of the graph stays at ``mult``. Loosening the whole graph
+    instead would let the substituents on the two pivots reach each other across the widened gap and
+    fuse into a spurious ring, which the ring check below would then report.
+
+    Args:
+        atoms (Atoms): The molecule.
+        pivot_1 (int): The 0-indexed atom on the fixed side of the rotation axis.
+        pivot_2 (int): The 0-indexed atom on the rotating side of the rotation axis.
+        mult (float, optional): The natural-cutoff multiplier defining the bond graph.
+        pivot_mult (float, optional): The covalent-radii multiplier allowed for the pivot bond
+                                      alone, accommodating a stretched TS bond.
+
+    Raises:
+        ValueError: If the pivots are too far apart to be bonded even under ``pivot_mult``, or if
+                    the pivot bond is part of a ring (a 1D rotor is then ill-defined).
+
+    Returns:
+        list: The sorted 0-indexed atoms of the rotating group.
+    """
+    nl = build_neighbor_list(atoms, natural_cutoffs(atoms, mult=mult),
+                             self_interaction=False, bothways=True)
+    adj = {i: set(nl.get_neighbors(i)[0]) for i in range(len(atoms))}
+    if pivot_2 not in adj[pivot_1]:
+        numbers = atoms.get_atomic_numbers()
+        radii_sum = covalent_radii[numbers[pivot_1]] + covalent_radii[numbers[pivot_2]]
+        distance = float(atoms.get_distance(pivot_1, pivot_2))
+        if distance > pivot_mult * radii_sum:
+            raise ValueError(f'The pivot atoms {pivot_1} and {pivot_2} are {distance:.2f} Angstrom '
+                             f'apart, too far to be bonded; cannot determine the rotating group.')
+    adj[pivot_1].discard(pivot_2)
+    adj[pivot_2].discard(pivot_1)
+    seen, stack = {pivot_2}, [pivot_2]
+    while stack:
+        cur = stack.pop()
+        for nb in adj[cur]:
+            if nb not in seen:
+                seen.add(nb)
+                stack.append(nb)
+    if pivot_1 in seen:
+        raise ValueError(f'The pivot bond {pivot_1}-{pivot_2} is part of a ring; '
+                         f'a 1D rotor scan is ill-defined.')
+    return sorted(int(x) for x in seen)
+
+
+def _scan_walk(atoms: Atoms, torsion: list, step_deg: float, nsteps: int, top: list,
+               fmax: float, steps: int, direction: int, optimizer) -> tuple:
+    """
+    Perform one directional sequential relaxed torsional walk.
+
+    Each grid point starts from the previous point's relaxed geometry (a hysteretic walk), so a
+    coupled coordinate can carry the walk into a different conformer and never return - which is
+    why a full scan runs this in both directions and keeps the lower branch at each point.
+
+    Args:
+        atoms (Atoms): The molecule with a calculator attached (not modified; a copy is walked).
+        torsion (list): The 0-indexed four atoms (i, j, k, l) defining the scanned dihedral.
+        step_deg (float): The dihedral increment in degrees.
+        nsteps (int): The number of increments (the walk visits ``nsteps`` + 1 points).
+        top (list): The 0-indexed rotating group.
+        fmax (float): The force convergence criterion in eV/Angstrom.
+        steps (int): The maximum optimizer steps per point.
+        direction (int): +1 for a 0->360 walk, -1 for a 360->0 walk.
+        optimizer: The ASE optimizer class to relax each point.
+
+    Returns:
+        tuple: (energies in eV, residual max-forces in eV/Angstrom, relaxed Cartesian coordinates),
+        each of length ``nsteps`` + 1.
+    """
+    i, j, k, l = torsion
+    work = atoms.copy()
+    work.calc = atoms.calc
+    energies, residual_forces, coords = list(), list(), list()
+    for n in range(nsteps + 1):
+        if n:
+            work.rotate_dihedral(i, j, k, l, angle=direction * step_deg, indices=top)
+        target = work.get_dihedral(i, j, k, l)
+        work.set_constraint(FixInternals(dihedrals_deg=[[target, [i, j, k, l]]]))
+        opt = optimizer(work, logfile=None)
+        opt.run(fmax=fmax, steps=steps)
+        # Residual force WITH the dihedral constraint still applied is the convergence criterion:
+        # reading opt.converged() after clearing the constraint re-evaluates the free torsional
+        # force, which is nonzero everywhere except the stationary points.
+        residual = float(np.sqrt((work.get_forces() ** 2).sum(axis=1)).max())
+        work.set_constraint()
+        energies.append(float(work.get_potential_energy()))
+        residual_forces.append(residual)
+        coords.append(tuple(map(tuple, work.get_positions().tolist())))
+    return energies, residual_forces, coords
+
+
+def merge_scan_branches(e_f: list, e_b: list, nsteps: int, coords_f: list = None,
+                        coords_b: list = None) -> tuple:
+    """
+    Fold a forward and a backward torsional walk onto a common grid and keep the lower branch.
+
+    The forward walk visits phi = +n * step and the backward walk phi = -n * step, so index ``n``
+    of the backward walk lands on grid point ``(-n) % nsteps``. Both walks also revisit their
+    starting point at index ``nsteps``, which folds back onto grid point 0. At each grid point the
+    lower of the two energies wins, which is what recovers the lowest torsional path when one walk
+    has been carried into a different conformer by a coupled coordinate.
+
+    Args:
+        e_f (list): The forward walk energies, of length ``nsteps`` + 1.
+        e_b (list): The backward walk energies, of length ``nsteps`` + 1.
+        nsteps (int): The number of increments; there are ``nsteps`` unique grid points.
+        coords_f (list, optional): The forward walk Cartesian coordinates, aligned with ``e_f``.
+        coords_b (list, optional): The backward walk Cartesian coordinates, aligned with ``e_b``.
+
+    Returns:
+        tuple: (the merged per-grid-point energies as a numpy array of length ``nsteps``, the
+        forward grid, the backward grid, and the winning coordinates per grid point - the last
+        being None if either coordinate list was not supplied).
+    """
+    grid_f, grid_b = np.full(nsteps, np.inf), np.full(nsteps, np.inf)
+    xyz_f, xyz_b = [None] * nsteps, [None] * nsteps
+    for n in range(nsteps + 1):
+        p = n % nsteps  # forward:  phi = +n*step
+        if e_f[n] < grid_f[p]:
+            grid_f[p] = e_f[n]
+            if coords_f is not None:
+                xyz_f[p] = coords_f[n]
+        q = (-n) % nsteps  # backward: phi = -n*step
+        if e_b[n] < grid_b[q]:
+            grid_b[q] = e_b[n]
+            if coords_b is not None:
+                xyz_b[q] = coords_b[n]
+    merged = np.minimum(grid_f, grid_b)
+    coords = None
+    if coords_f is not None and coords_b is not None:
+        coords = [xyz_f[p] if grid_f[p] <= grid_b[p] else xyz_b[p] for p in range(nsteps)]
+    return merged, grid_f, grid_b, coords
+
+
+def relaxed_torsion_scan(atoms: Atoms, torsion: list, step_deg: float, nsteps: int,
+                         top: list = None, fmax: float = 0.005, steps: int = 500,
+                         optimizer=LBFGS) -> dict:
+    """
+    Perform a full 1D relaxed torsional scan in a single process.
+
+    The torsion is swept 0->360 and 360->0 from the same starting geometry, and the lower energy
+    of the two walks is kept at each grid point. A single directional walk is path-dependent: if a
+    coupled coordinate flips partway round, that walk finishes in a different conformer and its
+    curve is not a torsional potential. Walking both ways and taking the pointwise minimum recovers
+    the lowest torsional path, which is the one the downstream statistical mechanics wants.
+
+    Points that do not fully converge are kept (never dropped), so the periodic grid the downstream
+    Fourier fit reads is always complete; ``fmax_worst`` reports the largest residual force.
+
+    Args:
+        atoms (Atoms): The molecule with a calculator attached.
+        torsion (list): The 0-indexed four atoms (i, j, k, l) defining the scanned dihedral.
+        step_deg (float): The dihedral increment in degrees.
+        nsteps (int): The number of increments; the returned grid has ``nsteps`` + 1 points.
+        top (list, optional): The 0-indexed rotating group; determined from the graph if not given.
+        fmax (float): The force convergence criterion in eV/Angstrom.
+        steps (int): The maximum optimizer steps per point.
+        optimizer: The ASE optimizer class to relax each point.
+
+    Raises:
+        ValueError: If ``nsteps`` is less than 1, ``step_deg`` is not positive, or the two do not
+                    together span a full 360 degree revolution.
+
+    Returns:
+        dict: ``energies`` (absolute, in eV, ``nsteps`` + 1 points with the endpoint duplicating the
+        start), ``angles`` (degrees, 0..360), ``scan_coords`` (the relaxed geometry at each point),
+        ``top``, and convergence diagnostics.
+    """
+    if nsteps < 1:
+        raise ValueError(f'A relaxed torsion scan needs at least one increment, but got nsteps={nsteps}.')
+    if step_deg <= 0:
+        raise ValueError(f'The dihedral increment must be positive, but got step_deg={step_deg}.')
+    # The grid folding below (n % nsteps) and the duplicated endpoint both assume the walk closes on
+    # itself. ARC guarantees this via divmod(360, scan_res) in check_argument_consistency, but this
+    # function is public and runs in a separate environment where that guard does not apply.
+    if abs(nsteps * step_deg - 360.0) > 1e-6:
+        raise ValueError(f'A relaxed torsion scan must span a full revolution, but nsteps={nsteps} '
+                         f'increments of step_deg={step_deg} span {nsteps * step_deg} degrees.')
+    i, j, k, l = torsion
+    if top is None:
+        top = rotor_top(atoms, j, k)
+
+    e_f, r_f, c_f = _scan_walk(atoms, torsion, step_deg, nsteps, top, fmax, steps, +1, optimizer)
+    e_b, r_b, c_b = _scan_walk(atoms, torsion, step_deg, nsteps, top, fmax, steps, -1, optimizer)
+
+    merged, grid_f, grid_b, coords = merge_scan_branches(e_f, e_b, nsteps, c_f, c_b)
+    energies = merged.tolist()
+    energies.append(energies[0])  # duplicate endpoint: 46-point protocol
+    scan_coords = list(coords)
+    scan_coords.append(scan_coords[0])
+    angles = [n * step_deg for n in range(nsteps + 1)]
+    return {
+        'energies': energies,
+        'angles': angles,
+        'scan_coords': scan_coords,
+        'top': top,
+        'branch_gap_max': float(np.abs(grid_f - grid_b).max()),
+        'fmax_worst': float(max(r_f + r_b)),
+        'converged': bool(max(r_f + r_b) <= fmax),
+    }
+
+
+def run_torsion_scan(atoms: Atoms, input_dict: dict, settings: dict) -> dict:
+    """
+    Run a 1D relaxed torsional scan for an ARC ``scan`` job and shape it for ARC's YAML parser.
+
+    Args:
+        atoms (Atoms): The molecule with a calculator attached.
+        input_dict (dict): The job input; ``torsions`` (a list holding one 0-indexed torsion) and
+                           ``scan_res`` (the dihedral increment in degrees) are read here.
+        settings (dict): ASE run settings; optional ``fmax``, ``steps``, ``optimizer`` override the
+                         relaxed-scan defaults (LBFGS, fmax 0.005 eV/Angstrom, 500 steps per point).
+
+    Raises:
+        ValueError: If no torsion is supplied or more than one is (a 1D scan sweeps a single
+                    torsion), or if ``scan_res`` is not positive or does not divide 360 evenly.
+
+    Returns:
+        dict: ``energies`` (Hartree), ``angles`` (degrees) and ``scan_coords`` (an xyz dict per
+        point) for ARC's YAML scan parser, plus the rotating ``top`` and convergence diagnostics.
+    """
+    torsions = input_dict.get('torsions')
+    if not torsions:
+        raise ValueError("A 'scan' job requires a torsion, but none was supplied.")
+    if len(torsions) > 1:
+        raise ValueError(f"A 1D 'scan' job sweeps a single torsion, but got {len(torsions)}: {torsions}.")
+    torsion = list(torsions[0])
+    scan_res = float(input_dict.get('scan_res', 8.0))
+    if scan_res <= 0:
+        raise ValueError(f"The scan resolution must be positive, but got scan_res={scan_res}.")
+    if divmod(360.0, scan_res)[1]:
+        raise ValueError(f"The scan resolution must divide 360 evenly, but got scan_res={scan_res}.")
+    nsteps = int(round(360.0 / scan_res))
+    fmax = float(settings.get('fmax', 0.005))
+    steps = int(settings.get('steps', 500))
+    engine_dict = {'bfgs': BFGS, 'lbfgs': LBFGS, 'gpmin': GPMin,
+                   'scipyfminbfgs': SciPyFminBFGS, 'scipyfmincg': SciPyFminCG}
+    optimizer = engine_dict.get(str(settings.get('optimizer', 'LBFGS')).lower(), LBFGS)
+
+    result = relaxed_torsion_scan(atoms, torsion, scan_res, nsteps, top=None,
+                                  fmax=fmax, steps=steps, optimizer=optimizer)
+    # ARC's YAML scan parser reads absolute energies and subtracts the minimum before converting
+    # Hartree->kJ/mol, so the energies must be in Hartree.
+    result['energies'] = [energy * e / E_h for energy in result['energies']]
+    # Shape the relaxed geometries as ARC xyz dicts so parse_1d_scan_coords can read them back;
+    # trsh.scan_quality_check needs them to emit a 'change conformer' action, and the scheduler
+    # passes them in to check that a TS survived the rotation.
+    xyz = input_dict.get('xyz') or dict()
+    symbols = xyz.get('symbols') or tuple(atoms.get_chemical_symbols())
+    isotopes = xyz.get('isotopes') or tuple([None] * len(symbols))
+    result['scan_coords'] = [{'symbols': symbols, 'isotopes': isotopes, 'coords': coords}
+                             for coords in result['scan_coords']]
+    return result
+
+
+def scan_convergence_warning(result: dict, fmax: float, branch_gap_tolerance: float = 0.05) -> str | None:
+    """
+    Describe what is wrong with a completed torsional scan, if anything.
+
+    Two things make a scan untrustworthy without making it fail: points that never reached the
+    force criterion, and a large disagreement between the forward and backward branches (which
+    means the two walks explored genuinely different conformers rather than one torsional path).
+
+    Args:
+        result (dict): A completed scan result, carrying ``converged``, ``fmax_worst`` and
+                       ``branch_gap_max``.
+        fmax (float): The force convergence criterion that was requested, in eV/Angstrom.
+        branch_gap_tolerance (float): The forward/backward branch disagreement, in eV, above which
+                                      the scan is called out.
+
+    Returns:
+        str | None: A human-readable warning, or None if the scan is clean.
+    """
+    issues = list()
+    if not result.get('converged', True):
+        issues.append(f"the worst point relaxed only to {result.get('fmax_worst'):.4g} eV/Angstrom "
+                      f"against a requested fmax of {fmax:.4g}")
+    branch_gap = result.get('branch_gap_max')
+    if branch_gap is not None and branch_gap > branch_gap_tolerance:
+        issues.append(f"the forward and backward branches disagree by up to {branch_gap:.4g} eV, "
+                      f"so they likely relaxed into different conformers")
+    if not issues:
+        return None
+    return f"The torsional scan completed but {' and '.join(issues)}."
+
 
 def is_linear(atoms: Atoms) -> bool:
     """
@@ -347,6 +652,19 @@ def main():
 
     if job_type == 'sp':
         output['sp'] = to_kJmol(atoms.get_potential_energy())
+
+    if job_type == 'scan':
+        try:
+            output.update(run_torsion_scan(atoms, input_dict, settings))
+            warning = scan_convergence_warning(output, float(settings.get('fmax', 0.005)))
+            if warning is not None:
+                # The scan is kept and reported: a loose point still carries a usable potential,
+                # but a silent 'clean success' would hide a scan where every point hit the step
+                # limit. The adapter logs this without failing the job.
+                output['warnings'] = [warning]
+        except Exception as exc:
+            output['success'] = False
+            output['error'] = f"Torsion scan failed: {exc}"
 
     if job_type in ['opt', 'conf_opt', 'optfreq', 'directed_scan']:
         fmax = float(settings.get('fmax', 0.001))


### PR DESCRIPTION
## What

Implements `job_type='scan'` for `ASEAdapter`: a complete 1D relaxed torsional scan run **in a single process**, sweeping one torsion in fixed increments and relaxing all other degrees of freedom at each point. Previously `ASEAdapter` had no `scan` branch at all — a `scan` job fell through to the geometry-save `else` in `ase_script.py`, so `output.yml` carried no `energies`/`angles` and ARC's YAML scan parser returned `(None, None)` silently (a quiet empty potential, not an error).

## Why one process per rotor, not one job per point

A rotor scan can be decomposed into one constrained optimization per dihedral point (as `directed_scan` does), but for a machine-learned potential (e.g. UMA) each such job re-loads the model checkpoint to do a few seconds of work — for a large corpus that is hundreds of thousands of tiny jobs dominated by fixed startup. An ESS engine like Gaussian sweeps the whole rotor internally via its `scan` keyword; this gives the ASE adapter the same capability, so a full rotor is one in-process task instead of ~46 jobs. The model load is then paid once per worker and amortized across every rotor it handles.

The scan loop lives in `ase_script.py` (which runs in the calculator's own environment); the adapter only writes the input (`torsions`, `scan_res`) and parses the output. `output.yml` carries `energies` (Hartree) and `angles` (degrees), read back through the existing `yaml` parser adapter and `rotors_dict['scan_path']` — no change to the statmech/Arkane side.

## Design choices

- **Bidirectional relaxed walk.** The torsion is swept 0→360 and 360→0 from the same starting geometry, keeping the lower energy at each grid point. A single directional walk is path-dependent: if a coupled coordinate flips partway round, that walk ends in a different conformer and its curve is not a torsional potential. Taking the pointwise minimum of both walks recovers the lowest torsional path.
- **Geometry propagation is hysteretic** — each point starts from the previous relaxed geometry (which is exactly why both directions are walked).
- **Per-point constraint.** After rotating the increment, the point's actual dihedral is measured and pinned with `FixInternals`; convergence is judged on the residual force **with the constraint still applied** (reading `opt.converged()` after clearing it re-exposes the free torsional force and falsely reports non-convergence at relaxed points).
- **Non-converged points are kept, never dropped** — a hole in the periodic grid would corrupt the downstream Fourier fit. `fmax_worst` in the output records the largest residual.
- **Rotating group** is derived by graph traversal (break the pivot bond, flood-fill from the second pivot), raising on a ring pivot.

## Validation

Validated on **ethane** against an already-validated standalone MLIP scan (UMA `uma-s-1p2`), same species / torsion / starting geometry:

| | this PR (incore ASE `scan`) | reference |
|---|---|---|
| barrier | 10.6879 kJ/mol | 10.6880 kJ/mol |
| points × resolution | 46 × 8° | 46 × 8° |
| max abs deviation | — | **0.028 kJ/mol** (mean 0.012) |

The two V(φ) profiles are the same curve; the residual is at the floating-point/optimizer-noise level (the reference ran on GPU, this on CPU).

## Tests

Adds hermetic unit tests using ASE's EMT calculator (no MLIP needed in CI): rotating-group detection incl. the ring-pivot error, a full 46-point relaxed scan (grid, endpoint duplication, finiteness), output round-tripping through ARC's YAML scan parser, and the single-torsion guard.

## Scope

`scan` only; additive and gated on `job_type=='scan'`. `directed_scan` and existing job types are untouched. Wiring `rotor_scan_1d` through the pipe is a follow-up.
