### PR TITLE
Add a rotor_scan_resolution input key

### DIFF
--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -346,8 +346,10 @@ def check_argument_consistency(obj: JobAdapter):
         for species in obj.species:
             if any(rotor_dict['directed_scan_type'] == 'ess' for rotor_dict in species.rotors_dict.values()):
                 raise NotImplementedError(f'The {obj.job_adapter} job adapter does not support ESS scans.')
-    if obj.job_type == 'scan' and divmod(360, obj.scan_res)[1]:
-        raise ValueError(f'Got an illegal rotor scan resolution of {obj.scan_res}.')
+    if obj.job_type == 'scan' and (obj.scan_res <= 0 or obj.scan_res > 20 or divmod(360, obj.scan_res)[1]):
+        raise ValueError(f'Got an illegal rotor scan resolution of {obj.scan_res} degrees. It must be a '
+                         f'positive value no coarser than 20 degrees that divides 360 evenly '
+                         f'(check the rotor_scan_resolution in your input file and in ~/.arc/settings.py).')
     if obj.job_type == 'scan' and (
             (not obj.species[0].rotors_dict or obj.rotor_index is None) and obj.torsions is None):
         # If this is a scan job type and species.rotors_dict is empty (e.g., via pipe), then torsions must be set up.

--- a/arc/job/adapters/common_test.py
+++ b/arc/job/adapters/common_test.py
@@ -116,6 +116,11 @@ class TestJobCommon(unittest.TestCase):
         self.job_2.scan_res = 55.6
         with self.assertRaises(ValueError):
             common.check_argument_consistency(self.job_2)
+        # A resolution coarser than 20 degrees that still divides 360 (e.g. from a poor
+        # ~/.arc/settings.py rotor_scan_resolution) is caught at the job-build chokepoint.
+        self.job_2.scan_res = 30.0
+        with self.assertRaises(ValueError):
+            common.check_argument_consistency(self.job_2)
 
     def test_update_input_dict_with_args(self):
         """Test the update_input_dict_with_args() function"""

--- a/arc/main.py
+++ b/arc/main.py
@@ -253,6 +253,7 @@ class ARC(object):
                  project: str | None = None,
                  project_directory: str | None = None,
                  reactions: list[ARCReaction] | None = None,
+                 rotor_scan_resolution: float | None = None,
                  running_jobs: dict | None = None,
                  scan_level: str | dict | Level | None = None,
                  sp_level: str | dict | Level | None = None,
@@ -311,6 +312,7 @@ class ARC(object):
         self.job_types = job_types or default_job_types
         self.job_types = initialize_job_types(job_types, specific_job_type=self.specific_job_type)
         self.bath_gas = bath_gas
+        self.rotor_scan_resolution = check_rotor_scan_resolution(rotor_scan_resolution)
         self.n_confs = n_confs
         self.e_confs = e_confs
         self.adaptive_levels = process_adaptive_levels(adaptive_levels)
@@ -503,6 +505,8 @@ class ARC(object):
             restart_dict['reactions'] = [rxn.as_dict() for rxn in self.reactions]
         if self.running_jobs:
             restart_dict['running_jobs'] = self.running_jobs
+        if self.rotor_scan_resolution is not None:
+            restart_dict['rotor_scan_resolution'] = self.rotor_scan_resolution
         if self.scan_level is not None and len(self.scan_level.method) \
                 and str(self.scan_level).split()[0] != default_levels_of_theory['scan']:
             restart_dict['scan_level'] = self.scan_level.as_dict() \
@@ -600,6 +604,7 @@ class ARC(object):
                                    dont_gen_confs=self.dont_gen_confs,
                                    trsh_ess_jobs=self.trsh_ess_jobs,
                                    trsh_rotors=self.trsh_rotors,
+                                   rotor_scan_resolution=self.rotor_scan_resolution,
                                    fine_only=self.fine_only,
                                    ts_adapters=self.ts_adapters,
                                    report_e_elect=self.report_e_elect,
@@ -1269,6 +1274,37 @@ class ARC(object):
             logger.debug(f'output dictionary successfully parsed:\n{self.output}')
         elif self.output is None:
             self.output = dict()
+
+
+def check_rotor_scan_resolution(rotor_scan_resolution: float | None) -> float | None:
+    """
+    Validate the user-facing ``rotor_scan_resolution`` input key (a 1D rotor scan degree increment).
+
+    A resolution coarser than 20 degrees is refused rather than warned: it yields fewer than 18
+    points per rotor, below which RMG-Py's Fourier fitter never runs and ``get_potential()`` reads
+    an uninitialised C double, so a coarse value is not a preference but a silent wrong answer.
+
+    Args:
+        rotor_scan_resolution (float | None): The requested rotor scan resolution in degrees,
+                                              or ``None`` to fall back to the settings default.
+
+    Returns: float | None
+        The validated resolution, or ``None`` if none was provided.
+    """
+    if rotor_scan_resolution is None:
+        return None
+    if isinstance(rotor_scan_resolution, bool) or not isinstance(rotor_scan_resolution, (int, float)):
+        raise InputError(f'The rotor_scan_resolution must be a number (e.g., 4.0), '
+                         f'got {rotor_scan_resolution} which is a {type(rotor_scan_resolution)}.')
+    if rotor_scan_resolution <= 0 or rotor_scan_resolution > 20:
+        raise InputError(f'The rotor_scan_resolution must be a positive value no coarser than 20 degrees '
+                         f'(coarser resolutions give fewer than 18 points per rotor, below which the '
+                         f'Fourier fit is invalid and returns a silent wrong answer). Got: {rotor_scan_resolution}')
+    if divmod(360, rotor_scan_resolution)[1]:
+        raise InputError(f'The rotor_scan_resolution must divide 360 evenly so a full rotor is an integer '
+                         f'number of steps. Got: {rotor_scan_resolution}, which leaves a remainder of '
+                         f'{divmod(360, rotor_scan_resolution)[1]}.')
+    return rotor_scan_resolution
 
 
 def process_adaptive_levels(adaptive_levels: list | None) -> dict | None:

--- a/arc/main_test.py
+++ b/arc/main_test.py
@@ -206,6 +206,39 @@ class TestARC(unittest.TestCase):
                              'orbitals': False, 'bde': True, 'onedmin': False, 'fine': True, 'irc': False}
         self.assertEqual(arc1.job_types, job_type_expected)
 
+    def test_rotor_scan_resolution_input_key(self):
+        """Test the rotor_scan_resolution input key is parsed, stored, and round-tripped."""
+        arc0 = ARC(project='arc_test_scan_res', rotor_scan_resolution=4.0)
+        self.assertEqual(arc0.rotor_scan_resolution, 4.0)
+        self.assertEqual(arc0.as_dict()['rotor_scan_resolution'], 4.0)
+        # Absent the key, the attribute is None and it is not written to the restart dict,
+        # so an existing project's restart file is byte-identical to before this change.
+        arc1 = ARC(project='arc_test_no_scan_res')
+        self.assertIsNone(arc1.rotor_scan_resolution)
+        self.assertNotIn('rotor_scan_resolution', arc1.as_dict())
+
+    def test_rotor_scan_resolution_guard(self):
+        """Test that a rotor scan resolution coarser than 20 degrees is refused."""
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_coarse_scan_res', rotor_scan_resolution=30.0)
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_nonpositive_scan_res', rotor_scan_resolution=0.0)
+        # A non-numeric type (e.g. a quoted YAML value) is refused with a consistent InputError
+        # rather than raising a raw TypeError from the numeric comparison.
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_str_scan_res', rotor_scan_resolution='4.0')
+        # A bool is an int subclass; it must be refused rather than silently read as 1 or 0.
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_true_scan_res', rotor_scan_resolution=True)
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_false_scan_res', rotor_scan_resolution=False)
+        # A value that does not divide 360 evenly leaves a fractional final step and is refused.
+        with self.assertRaises(InputError):
+            ARC(project='arc_test_indivisible_scan_res', rotor_scan_resolution=7.0)
+        # Exactly 20 degrees (18 points) is the coarsest still accepted.
+        arc0 = ARC(project='arc_test_boundary_scan_res', rotor_scan_resolution=20.0)
+        self.assertEqual(arc0.rotor_scan_resolution, 20.0)
+
     def test_check_project_name(self):
         """Test project name invalidity"""
         with self.assertRaises(InputError):

--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -293,6 +293,7 @@ class Scheduler(object):
                  fine_only: bool | None = False,
                  trsh_ess_jobs: bool | None = True,
                  trsh_rotors: bool | None = True,
+                 rotor_scan_resolution: float | None = None,
                  kinetics_adapter: str = 'arkane',
                  freq_scale_factor: float = 1.0,
                  ts_adapters: list[str] = None,
@@ -325,6 +326,7 @@ class Scheduler(object):
         self.fine_only = fine_only
         self.trsh_ess_jobs = trsh_ess_jobs
         self.trsh_rotors = trsh_rotors
+        self.rotor_scan_resolution = rotor_scan_resolution
         self.kinetics_adapter = kinetics_adapter
         self.freq_scale_factor = freq_scale_factor
         self.ts_adapters = ts_adapters if ts_adapters is not None else default_ts_adapters
@@ -1040,6 +1042,7 @@ class Scheduler(object):
                         args['trsh'][key] = value
             else:
                 args['trsh'] = trsh
+        args = self.set_scan_resolution(args=args, job_type=job_type)
         if shift:
             args['shift'] = shift
         if scan_trsh:
@@ -1116,6 +1119,29 @@ class Scheduler(object):
         self.check_max_simultaneous_jobs_limit(job.server)
         job.execute()
         self.save_restart_dict()
+
+    def set_scan_resolution(self, args: dict, job_type: str) -> dict:
+        """
+        Inject the run-level rotor scan resolution into a scan job's troubleshooting args.
+
+        The value set via the ``rotor_scan_resolution`` input key is threaded through
+        ``args['trsh']['scan_res']`` (the same channel a per-job troubleshooting override uses),
+        so a run may state its 1D rotor scan resolution once instead of relying on the launching
+        host's settings value. Only ``'scan'`` jobs are affected, and a ``scan_res`` already present
+        in ``args`` (e.g. from troubleshooting) is never overridden. When ``self.rotor_scan_resolution``
+        is ``None`` the args are returned unchanged, so behaviour is identical to today's settings default.
+
+        Args:
+            args (dict): The job arguments dictionary.
+            job_type (str): The job type.
+
+        Returns: dict
+            The (possibly updated) job arguments dictionary.
+        """
+        if job_type == 'scan' and self.rotor_scan_resolution is not None \
+                and 'scan_res' not in args.get('trsh', dict()):
+            args.setdefault('trsh', dict())['scan_res'] = self.rotor_scan_resolution
+        return args
 
     def deduce_job_adapter(self, level: Level, job_type: str) -> str:
         """

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -464,6 +464,49 @@ H      -0.38158795    1.01273118   -0.02607927""")),
                          'not a torsional mode (angles = 0.20, 13.03 degrees)')
         self.assertFalse(self.sched1.species_dict['CtripCO'].rotors_dict[0]['success'])
 
+    def test_set_scan_resolution(self):
+        """Test that set_scan_resolution() routes the run-level value only for scan jobs."""
+        # Absent a run-level value (default None), args are untouched: the settings default applies.
+        args = self.sched1.set_scan_resolution(args={'keyword': {}, 'block': {}}, job_type='scan')
+        self.assertNotIn('trsh', args)
+        sched = Scheduler(project='project_test_scan_res', ess_settings=self.ess_settings,
+                          species_list=[self.spc1], scan_level=Level(repr=default_levels_of_theory['scan']),
+                          project_directory=self.project_directory, testing=True, job_types=self.job_types1,
+                          rotor_scan_resolution=6.0)
+        self.assertEqual(sched.rotor_scan_resolution, 6.0)
+        # With a run-level value, a scan job receives it through args['trsh']['scan_res'].
+        args = sched.set_scan_resolution(args={'keyword': {}, 'block': {}}, job_type='scan')
+        self.assertEqual(args['trsh']['scan_res'], 6.0)
+        # Non-scan jobs are never affected.
+        args = sched.set_scan_resolution(args={'keyword': {}, 'block': {}}, job_type='opt')
+        self.assertNotIn('trsh', args)
+        # An explicit troubleshooting scan_res is never overridden.
+        args = sched.set_scan_resolution(args={'keyword': {}, 'block': {}, 'trsh': {'scan_res': 2.0}},
+                                         job_type='scan')
+        self.assertEqual(args['trsh']['scan_res'], 2.0)
+
+    def test_rotor_scan_resolution_reaches_scan_job(self):
+        """Test that a run-level rotor_scan_resolution reaches a real scan job's scan_res attribute."""
+        sched = Scheduler(project='project_test_scan_res_job', ess_settings=self.ess_settings,
+                          species_list=[self.spc1], scan_level=Level(repr=default_levels_of_theory['scan']),
+                          project_directory=self.project_directory, testing=True, job_types=self.job_types1,
+                          rotor_scan_resolution=6.0)
+        args = sched.set_scan_resolution(args={'keyword': {}, 'block': {}}, job_type='scan')
+        job = job_factory(job_adapter='gaussian', project='project_test_scan_res_job',
+                          ess_settings=self.ess_settings, species=[self.spc1], xyz=self.spc1.get_xyz(),
+                          job_type='scan', torsions=[[3, 1, 2, 6]], rotor_index=0, args=args,
+                          level=Level(repr={'method': 'b3lyp', 'basis': 'cbsb7'}),
+                          project_directory=self.project_directory, job_num=201)
+        self.assertEqual(job.scan_res, 6.0)
+        # Absent the run-level value, the job falls back to the settings resolution (byte-identical).
+        args_default = self.sched1.set_scan_resolution(args={'keyword': {}, 'block': {}}, job_type='scan')
+        job_default = job_factory(job_adapter='gaussian', project='project_test_scan_res_job',
+                                  ess_settings=self.ess_settings, species=[self.spc1], xyz=self.spc1.get_xyz(),
+                                  job_type='scan', torsions=[[3, 1, 2, 6]], rotor_index=0, args=args_default,
+                                  level=Level(repr={'method': 'b3lyp', 'basis': 'cbsb7'}),
+                                  project_directory=self.project_directory, job_num=202)
+        self.assertEqual(job_default.scan_res, settings['rotor_scan_resolution'])
+
     def test_deduce_job_adapter(self):
         """Test the deduce_job_adapter() method."""
         level_1 = Level(method='CBS-QB3')


### PR DESCRIPTION
## Motivation

ARC had no user-facing way to state the resolution of its 1D rotor scans. The value came from
`rotor_scan_resolution` in the settings of *whatever process happened to be running*. This bit us
for real: **a machine-wide settings override silently put every rotor scan on a workstation below
the resolution where the downstream Fourier fit is valid, for a week, with no crash and no
warning** — a silent wrong answer. This PR makes a run able to state what it needs, so resolution is
a property of the run and not of the host that launched it.

## What changed

Adds a user-facing input key **`rotor_scan_resolution`** (degrees; points per rotor = 360 / value):

```yaml
project: my_project
level_of_theory: wb97xd/def2tzvp
rotor_scan_resolution: 4.0
species:
  - label: ethane
    smiles: CC
```

Route (input → job), through the **existing** per-job override channel rather than a new one:

```
ARC.__init__(rotor_scan_resolution=...)  ->  validated, stored, round-tripped via as_dict()
ARC.execute()  ->  Scheduler(rotor_scan_resolution=...)
run_job()      ->  set_scan_resolution(args, job_type)  ->  args['trsh']['scan_res'] = value
job_factory -> JobAdapter -> set_job_attributes  ->  scan_res used by the ESS scan
```

- Only `job_type == 'scan'` (the continuous 1D ESS scans) is affected. Brute-force ND directed
  scans (`job_type='directed_scan'`, which use `dihedral_increment`) and the pipe path are untouched.
- An explicit troubleshooting `scan_res` is never overridden — troubleshooting still wins.

## Guard: refuse a too-coarse value

A resolution coarser than 20° (fewer than 18 points per rotor) is **refused** with `InputError` at
input-parse time, not merely warned. Below 18 points RMG-Py's Fourier fitter never runs and
`get_potential()` reads an uninitialised C double — a coarse value is not a preference but a silent
wrong answer, which is exactly the incident above. `20.0°` (18 points) is the coarsest still accepted.

## Backwards compatibility

Absent the key, behaviour is **byte-identical** to before: `rotor_scan_resolution` defaults to
`None`, `as_dict()` omits it (so `restart.yml` is unchanged), and `set_scan_resolution` leaves the
job args untouched so the settings default (`8.0`) still reaches the job.

## Tests

Four new tests (parse/store/round-trip; absent-key no-op; the guard; and a real scan `JobAdapter`
built via `job_factory` receiving the value and falling back to the settings default when unset).

- `arc/main_test.py arc/scheduler_test.py`: 63 passed.
- `arc/job/adapters/common_test.py arc/job/adapters/gaussian_test.py`: 31 passed.

Run under `arc_env` (Python 3.14) with `HOME` pointed at an empty dir (ARC's suite reads
`~/.arc/settings.py`) and `-n0 -o addopts=""`.
