### PR TITLE
Support reactions whose participants repeat (A + A), end to end

### DIFF
--- a/arc/checks/nmd.py
+++ b/arc/checks/nmd.py
@@ -34,6 +34,9 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
     Analyze the normal mode displacement by identifying bonds that break and form
     and comparing them to the expected given reaction.
     Note that the TS geometry must be in the standard orientation for the normal mode displacement to be relevant.
+    The forming, breaking and changed bonds of the reaction are indexed into the concatenated reactant atoms,
+    where a species participating more than once (e.g. ``A + A``, for which ``r_species`` holds a single entry)
+    contributes its atoms once per occurrence. The TS geometry must span that same set of atoms.
 
     Args:
         reaction (ARCReaction): The reaction for which the TS is checked.
@@ -46,8 +49,22 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
 
     Returns:
         bool | None: Whether the TS normal mode displacement is consistent with the desired reaction.
+                     ``None`` if the analysis could not be performed, either because no frequency job was
+                     given, because the TS geometry does not span the reactant atoms the bond indices refer
+                     to, or because no normal mode displacements could be parsed from the job's output file.
+                     Only ``False`` marks the TS as inconsistent with the reaction.
     """
     if job is None:
+        return None
+    ts_xyz = reaction.ts_species.get_xyz()
+    n_ts = len(ts_xyz['symbols'])
+    reactants, _ = reaction.get_reactants_and_products(return_copies=False)
+    n_expected = sum(spc.number_of_atoms for spc in reactants)
+    if n_ts != n_expected:
+        logger.warning(f'The geometry of TS {reaction.ts_species.label} has {n_ts} atoms, while the reactants of '
+                       f'reaction {reaction.label} have {n_expected} atoms in total. The forming, breaking and '
+                       f'changed bonds of the reaction are indexed into the reactant atoms, so they cannot be '
+                       f'applied to this TS geometry. Skipping the normal mode displacement analysis.')
         return None
     if reaction.atom_map is None:
         # Without an atom map the formed/broken/changed bonds cannot be determined; skip the NMD
@@ -58,11 +75,6 @@ def analyze_ts_normal_mode_displacement(reaction: ARCReaction,
                 not in reaction.ts_species.ts_checks['warnings']:
             reaction.ts_species.ts_checks['warnings'] += 'Atom map is None; skipped the TS normal mode displacement check; '
         return None
-    ts_xyz = reaction.ts_species.get_xyz()
-    n_ts = len(ts_xyz['symbols'])
-    n_expected = sum(spc.number_of_atoms for spc in reaction.r_species)
-    if n_ts != n_expected:
-        return False
     try:
         freqs, normal_mode_disp = parser.parse_normal_mode_displacement(log_file_path=job.local_path_to_output_file)
     except NotImplementedError:
@@ -486,6 +498,37 @@ def get_bond_length_in_reaction(bond: tuple[int, int] | list[int],
     return float(distance)
 
 
+def get_repeated_species_atom_equivalences(reaction: ARCReaction,
+                                           well: int = 0,
+                                           ) -> list[list[int]]:
+    """
+    Build atom-equivalence groups across repeated identical species in a reaction well.
+
+    When a species participates more than once (e.g. OH + OH), ``r_species`` is deduplicated, so the
+    atom map may assign a reactive atom to one copy while the located TS uses the equivalent atom of
+    another copy. For each atom position within such a species, the atoms at that position across all
+    copies are equivalent. Indices follow the expanded (per-occurrence) atom ordering used by the atom
+    map and by ``get_reactants_and_products``.
+
+    Args:
+        reaction (ARCReaction): The reaction.
+        well (int): ``0`` for the reactants well, ``1`` for the products well.
+
+    Returns:
+        list[list[int]]: Equivalence groups (each a list of global atom indices) for repeated species.
+    """
+    species = reaction.r_species if well == 0 else reaction.p_species
+    groups, offset = list(), 0
+    for spc in species:
+        count = reaction.get_species_count(species=spc, well=well)
+        n_atoms = spc.number_of_atoms
+        if count > 1:
+            for pos in range(n_atoms):
+                groups.append([offset + copy_i * n_atoms + pos for copy_i in range(count)])
+        offset += count * n_atoms
+    return groups
+
+
 def find_equivalent_atoms(reaction: ARCReaction,
                           reactant_only: bool = True,
                           ) -> tuple[list[list[int]], list[list[int]]]:
@@ -493,6 +536,8 @@ def find_equivalent_atoms(reaction: ARCReaction,
     Find equivalent atoms in the reactants and products of a reaction.
     This is a tentative function that should be replaced when atom mapping returns a list.
     It is meant to suggest additional atoms that can move instead of the ones selected by the atom map.
+    Reactant equivalences cover both atoms made equivalent within a molecule and atoms at the same
+    position across the copies of a species that participates more than once.
 
     Args:
         reaction (ARCReaction): The reaction for which equivalent atoms are searched.
@@ -510,6 +555,7 @@ def find_equivalent_atoms(reaction: ARCReaction,
                                                                 inc=sum([len(r.mol.atoms) for r in reactants[:i]]),
                                                                 atom_map=None,
                                                                 ))
+    r_eq_atoms.extend(get_repeated_species_atom_equivalences(reaction, well=0))
     if not reactant_only:
         for i, product in enumerate(products):
             p_eq_atoms.extend(identify_equivalent_atoms_in_molecule(molecule=product.mol,

--- a/arc/checks/nmd_test.py
+++ b/arc/checks/nmd_test.py
@@ -8,6 +8,7 @@ This module contains unit tests for the arc.checks.nmd module
 import unittest
 import os
 import shutil
+from unittest.mock import patch
 
 import numpy as np
 
@@ -56,19 +57,19 @@ class TestNMD(unittest.TestCase):
                          H      -0.34927558    0.98159583   -0.32768232
                          H      -0.02233792   -0.04887375    1.09087665
                          H       1.02216551   -0.15844188   -0.35067554"""
-        oh_xyz = """O       0.48890387    0.00000000    0.00000000
-                    H      -0.48890387    0.00000000    0.00000000"""
-        ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
-                     H       1.06690511   -0.17519582    0.05416493
-                     H      -0.68531716   -0.83753536   -0.02808565
-                     H      -0.38158795    1.01273118   -0.02607927"""
-        h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
-                     H      -0.76330345   -0.19953755    0.00000000
-                     H       0.76363177   -0.19827735    0.00000000"""
+        cls.oh_xyz = """O       0.48890387    0.00000000    0.00000000
+                        H      -0.48890387    0.00000000    0.00000000"""
+        cls.ch3_xyz = """C       0.00000000    0.00000001   -0.00000000
+                         H       1.06690511   -0.17519582    0.05416493
+                         H      -0.68531716   -0.83753536   -0.02808565
+                         H      -0.38158795    1.01273118   -0.02607927"""
+        cls.h2o_xyz = """O      -0.00032832    0.39781490    0.00000000
+                         H      -0.76330345   -0.19953755    0.00000000
+                         H       0.76363177   -0.19827735    0.00000000"""
         cls.rxn_1 = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=cls.ch4_xyz),
-                                           ARCSpecies(label='OH', smiles='[OH]', xyz=oh_xyz)],
-                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=ch3_xyz),
-                                           ARCSpecies(label='H2O', smiles='O', xyz=h2o_xyz)])
+                                           ARCSpecies(label='OH', smiles='[OH]', xyz=cls.oh_xyz)],
+                                p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=cls.ch3_xyz),
+                                           ARCSpecies(label='H2O', smiles='O', xyz=cls.h2o_xyz)])
         cls.ts_1_xyz = check_xyz_dict("""C                    -1.212192   -0.010161    0.000000
                                          H                     0.010122    0.150115    0.000001
                                          H                    -1.460491   -0.555461   -0.907884
@@ -224,6 +225,53 @@ class TestNMD(unittest.TestCase):
                                          H       -2.906412   -0.425097    0.055493
                                          H       -1.951439    0.465285   -1.158262""")
         cls.rxn_3.ts_species = ARCSpecies(label='TS3', is_ts=True, xyz=cls.ts_3_xyz)
+
+        cls.ts_oh_oh_xyz = check_xyz_dict("""O      -1.10000000    0.00000000    0.00000000
+                                             H      -0.15000000    0.00000000    0.00000000
+                                             O       1.20000000    0.00000000    0.00000000
+                                             H       1.55000000    0.85000000    0.00000000""")
+
+    def test_get_repeated_species_atom_equivalences(self):
+        """Repeated identical reactants (e.g. OH + OH) must yield cross-copy atom-equivalence groups
+        (the two O's, the two H's) so NMD can try the alternative mapping when the atom map picks one
+        copy's atom but the TS uses the other's. Non-repeated reactions must yield none."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]'),
+                                     ARCSpecies(label='OH', smiles='[OH]')],
+                          p_species=[ARCSpecies(label='H2O', smiles='O'),
+                                     ARCSpecies(label='O', smiles='[O]', multiplicity=3)],
+                          reactants=['OH', 'OH'], products=['H2O', 'O'])
+        groups = nmd.get_repeated_species_atom_equivalences(rxn, well=0)
+        self.assertEqual(sorted(sorted(g) for g in groups), [[0, 2], [1, 3]])
+        self.assertEqual(nmd.get_repeated_species_atom_equivalences(self.rxn_1, well=0), [])
+
+    def test_analyze_ts_normal_mode_displacement_repeated_reactant(self):
+        """Test that a TS of an A + A reaction is not reported as inconsistent with the reaction."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)],
+                          p_species=[ARCSpecies(label='H2O', smiles='O', xyz=self.h2o_xyz),
+                                     ARCSpecies(label='O', smiles='[O]', multiplicity=3,
+                                                xyz='O 0.00000000 0.00000000 0.00000000')])
+        rxn.ts_species = ARCSpecies(label='TS_OH_OH', is_ts=True, xyz=self.ts_oh_oh_xyz)
+        self.assertEqual(len(rxn.r_species), 1)
+        reactants, _ = rxn.get_reactants_and_products(return_copies=False)
+        self.assertEqual(sum(spc.number_of_atoms for spc in reactants), 4)
+        self.assertEqual(len(rxn.ts_species.get_xyz()['symbols']), 4)
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'CHO_neg_freq.out')
+        with patch.object(nmd.parser, 'parse_normal_mode_displacement', side_effect=NotImplementedError):
+            valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertIsNone(valid)
+
+    def test_analyze_ts_normal_mode_displacement_atom_count_mismatch(self):
+        """Test that a TS spanning a different set of atoms than the reactants is not reported as consistent."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=self.ch4_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=self.oh_xyz)],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=self.ch3_xyz),
+                                     ARCSpecies(label='H2O', smiles='O', xyz=self.h2o_xyz)])
+        rxn.ts_species = ARCSpecies(label='TS_short', is_ts=True, xyz=self.ch4_xyz)
+        self.generic_job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'TS_CH4_OH.log')
+        valid = nmd.analyze_ts_normal_mode_displacement(reaction=rxn, job=self.generic_job, amplitude=0.25)
+        self.assertIsNot(valid, True)
+        self.assertIsNone(valid)
 
     def test_analyze_ts_normal_mode_displacement_simple_rxns(self):
         """Test the analyze_ts_normal_mode_displacement() function with simple reactions."""

--- a/arc/job/adapters/ts/autotst_ts.py
+++ b/arc/job/adapters/ts/autotst_ts.py
@@ -211,6 +211,8 @@ class AutoTSTAdapter(JobAdapter):
     def execute_incore(self):
         """
         Execute a job incore.
+        The reverse-direction reaction label repeats each species by the number of times it
+        participates in its well, so a well with a repeated species stays atom-balanced.
         """
         if not AUTOTST_PYTHON or not os.path.isfile(AUTOTST_PYTHON):
             raise FileNotFoundError('AutoTST python executable was not found. '
@@ -230,10 +232,14 @@ class AutoTSTAdapter(JobAdapter):
                                                 multiplicity=rxn.multiplicity,
                                                 )
                 reaction_label_fwd = get_autotst_reaction_string(rxn)
+                rev_reactant_labels = [lbl for lbl in rxn.products
+                                       for _ in range(rxn.get_species_count(label=lbl, well=1))]
+                rev_product_labels = [lbl for lbl in rxn.reactants
+                                      for _ in range(rxn.get_species_count(label=lbl, well=0))]
                 reaction_label_rev = get_autotst_reaction_string(ARCReaction(r_species=rxn.p_species,
                                                                              p_species=rxn.r_species,
-                                                                             reactants=rxn.products,
-                                                                             products=rxn.reactants))
+                                                                             reactants=rev_reactant_labels,
+                                                                             products=rev_product_labels))
 
                 i = 0
                 for reaction_label, direction in zip([reaction_label_fwd, reaction_label_rev], ['F', 'R']):

--- a/arc/plotter.py
+++ b/arc/plotter.py
@@ -32,8 +32,9 @@ from arc.common import (NUMBER_BY_SYMBOL,
                         sort_two_lists_by_the_first,
                         )
 from arc.checks.common import TS_IRC_FAILED_MARKER, get_ts_validation_comment
-from arc.exceptions import InputError
+from arc.exceptions import InputError, InvalidAdjacencyListError
 from arc.level import Level
+from arc.molecule.molecule import Molecule
 from arc.parser.parser import parse_trajectory
 from arc.species.converter import (check_xyz_dict,
                                    get_xyz_radius,
@@ -766,6 +767,40 @@ def save_irc_traj_animation(irc_f_path, irc_r_path, out_path):
             f.write(' Normal termination of Gaussian 16\n')
 
 
+def _get_thermo_lib_duplicate(adjlist: str,
+                              written: list,
+                              ) -> str | None:
+    """
+    Return the label of an already written thermo library entry that RMG would reject
+    ``adjlist`` as a duplicate of, or ``None`` if there is none.
+
+    Applies the same test as ``rmgpy.data.thermo.ThermoLibrary.load_entry``: an isomorphic
+    molecule with an equal multiplicity. An adjacency list that cannot be parsed is reported
+    as not a duplicate, leaving the entry to be written as it was before this check existed.
+
+    Args:
+        adjlist (str): The adjacency list of the candidate entry.
+        written (list): Entries are (label, adjacency list) tuples already written.
+
+    Returns:
+        str | None: The label of the matching entry, or ``None``.
+    """
+    try:
+        mol = Molecule().from_adjacency_list(adjlist)
+    except (ValueError, InvalidAdjacencyListError):
+        logger.warning(f'Could not parse an adjacency list while checking the thermo library for '
+                       f'duplicates:\n{adjlist}')
+        return None
+    for label, written_adjlist in written:
+        try:
+            written_mol = Molecule().from_adjacency_list(written_adjlist)
+        except (ValueError, InvalidAdjacencyListError):
+            continue
+        if mol.multiplicity == written_mol.multiplicity and mol.is_isomorphic(written_mol):
+            return label
+    return None
+
+
 def save_thermo_lib(species_list: list,
                     path: str,
                     name: str,
@@ -773,6 +808,14 @@ def save_thermo_lib(species_list: list,
                     ) -> None:
     """
     Save an RMG thermo library of all species.
+
+    A species is written only if it has thermo data and ``include_in_thermo_lib`` is ``True``.
+    A species whose adjacency list and multiplicity match an already written entry is skipped
+    with a warning, because ``rmgpy.data.thermo.ThermoLibrary.load_entry`` raises
+    ``DatabaseError`` on such a pair and the whole library would then fail to load. This applies
+    to a reaction whose two reactants are the same species, which reaches this function as two
+    separately labeled entries. Skipping affects the library file only; every species keeps its
+    own computed thermo everywhere else it is reported.
 
     Args:
         species_list (list): Entries are ARCSpecies objects to be saved in the library.
@@ -788,15 +831,23 @@ shortDesc = ""
 longDesc = \"\"\"\n{lib_long_desc}\n\"\"\"\n
 """
     species_dict = dict()
+    written = list()
     if not len(species_list) or not any(spc.thermo for spc in species_list):
         logger.warning('No species to save in the thermo library.')
         return
 
     for i, spc in enumerate(species_list):
         if spc.thermo.data and spc.include_in_thermo_lib:
-            if spc.label not in species_dict:
-                adjlist = spc.adjlist or spc.mol_list[0].copy(deep=True).to_adjacency_list()
-                species_dict[spc.label] = adjlist
+            adjlist = species_dict.get(spc.label) \
+                or spc.adjlist or spc.mol_list[0].copy(deep=True).to_adjacency_list()
+            duplicate_of = _get_thermo_lib_duplicate(adjlist, written)
+            if duplicate_of is not None:
+                logger.warning(f'Species {spc.label} has the same adjacency list and multiplicity as '
+                               f'{duplicate_of}, which is already in the thermo library. Omitting '
+                               f'{spc.label} from the library, RMG cannot load a library containing both.')
+                continue
+            species_dict[spc.label] = adjlist
+            written.append((spc.label, adjlist))
             spc.long_thermo_description += (
                 f'\nExternal symmetry: {spc.external_symmetry}, '
                 f'optical isomers: {spc.optical_isomers}\n'

--- a/arc/plotter_test.py
+++ b/arc/plotter_test.py
@@ -7,12 +7,112 @@ This module contains unit tests for the plotter functions
 
 import os
 import shutil
+import subprocess
+import tempfile
 import unittest
 
 import arc.plotter as plotter
 from arc.common import ARC_PATH, ARC_TESTING_PATH, read_yaml_file, safe_copy_file
 from arc.species.converter import str_to_xyz
 from arc.species.species import ARCSpecies
+
+
+OH_ADJLIST = """1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}"""
+
+OH_NASA = ("NASA(polynomials=[NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, "
+           "-6.45157e-13, 2675.74, 1.48391], Tmin=(10,'K'), Tmax=(974.045,'K')), "
+           "NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, "
+           "1.92114], Tmin=(974.045,'K'), Tmax=(3000,'K'))], Tmin=(10,'K'), Tmax=(3000,'K'))")
+
+
+def _rmg_env_available() -> bool:
+    """Check whether the rmg_env conda environment is available."""
+    try:
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', '-c', 'import rmgpy'],
+                                capture_output=True, timeout=60)
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+RMG_ENV = _rmg_env_available()
+
+
+def _make_oh_species(label: str) -> ARCSpecies:
+    """Return an OH ARCSpecies carrying enough computed thermo to be written to a library."""
+    spc = ARCSpecies(label=label, smiles='[OH]', multiplicity=2)
+    spc.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.97""")
+    spc.external_symmetry, spc.optical_isomers = 1, 1
+    spc.thermo.data = OH_NASA
+    spc.thermo.H298, spc.thermo.S298 = 30.93, 178.17
+    return spc
+
+
+class TestSaveThermoLibDuplicates(unittest.TestCase):
+    """
+    A reaction whose two reactants are the same species reaches save_thermo_lib as two separately
+    labeled entries with identical adjacency lists. RMG refuses to load a library containing both.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='test_thermo_lib_')
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+    def _lib_path(self, name='aa_project'):
+        return os.path.join(self.tmp_dir, 'thermo', f'{name}.py')
+
+    def test_identical_species_written_once(self):
+        """The A+A duplicate is omitted from the library; the distinct species are both kept."""
+        r1, r2 = _make_oh_species('R1'), _make_oh_species('R2')
+        p1 = ARCSpecies(label='P1', smiles='O', multiplicity=1)
+        p1.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.24""")
+        p1.external_symmetry, p1.optical_isomers = 2, 1
+        p1.thermo.data = OH_NASA
+        p1.thermo.H298, p1.thermo.S298 = -240.63, 188.62
+        plotter.save_thermo_lib([r1, r2, p1], path=self.tmp_dir, name='aa_project', lib_long_desc='test')
+        with open(self._lib_path(), 'r') as f:
+            content = f.read()
+        self.assertIn('label = "R1"', content)
+        self.assertNotIn('label = "R2"', content)
+        self.assertIn('label = "P1"', content)
+        self.assertEqual(content.count('entry('), 2)
+
+    def test_distinct_species_all_written(self):
+        """Regression: species that are not duplicates are all written."""
+        a = _make_oh_species('A')
+        b = ARCSpecies(label='B', smiles='O', multiplicity=1)
+        b.final_xyz = str_to_xyz("""O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.24""")
+        b.external_symmetry, b.optical_isomers = 2, 1
+        b.thermo.data = OH_NASA
+        b.thermo.H298, b.thermo.S298 = -240.63, 188.62
+        plotter.save_thermo_lib([a, b], path=self.tmp_dir, name='distinct', lib_long_desc='test')
+        with open(self._lib_path('distinct'), 'r') as f:
+            content = f.read()
+        self.assertEqual(content.count('entry('), 2)
+        self.assertIn('label = "A"', content)
+        self.assertIn('label = "B"', content)
+
+    @unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+    def test_generated_library_loads_in_rmg(self):
+        """The generated library must actually load with RMG, not merely look right."""
+        r1, r2 = _make_oh_species('R1'), _make_oh_species('R2')
+        plotter.save_thermo_lib([r1, r2], path=self.tmp_dir, name='aa_project', lib_long_desc='test')
+        loader = os.path.join(self.tmp_dir, 'load_lib.py')
+        with open(loader, 'w') as f:
+            f.write('import sys\n'
+                    'from rmgpy.data.thermo import ThermoLibrary\n'
+                    'from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit\n'
+                    'local_context = {"ThermoData": ThermoData, "Wilhoit": Wilhoit,\n'
+                    '                 "NASAPolynomial": NASAPolynomial, "NASA": NASA}\n'
+                    'lib = ThermoLibrary()\n'
+                    f'lib.load({self._lib_path()!r}, local_context, {{}})\n'
+                    'sys.stdout.write("LOADED %d\\n" % len(lib.entries))\n')
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', loader],
+                                capture_output=True, text=True, timeout=300)
+        self.assertEqual(result.returncode, 0,
+                         f'RMG could not load the generated thermo library:\n{result.stdout}\n{result.stderr}')
+        self.assertIn('LOADED 1', result.stdout)
 
 
 class TestPlotter(unittest.TestCase):

--- a/arc/processor.py
+++ b/arc/processor.py
@@ -32,6 +32,30 @@ def resolve_neb_level(ts_adapters: list) -> Level | None:
     return None
 
 
+def _thermo_lib_has_isomorph(spc: 'ARCSpecies', species_list: list) -> bool:
+    """
+    Whether ``species_list`` already contains a species with the same molecular identity as ``spc``.
+
+    Arkane keys thermo-library entries by adjacency list + multiplicity and rejects duplicates, so a
+    reaction with identical participants (e.g. OH + OH) must contribute each unique species only once.
+
+    Args:
+        spc (ARCSpecies): The candidate species.
+        species_list (list): Species already collected for the thermo library.
+
+    Returns:
+        bool: ``True`` if an isomorphic, same-multiplicity species is already present.
+    """
+    if spc.mol is None:
+        return False
+    for existing in species_list:
+        if existing.mol is not None \
+                and existing.multiplicity == spc.multiplicity \
+                and existing.mol.is_isomorphic(spc.mol):
+            return True
+    return False
+
+
 def process_arc_project(thermo_adapter: str,
                         kinetics_adapter: str,
                         project: str,
@@ -196,7 +220,7 @@ def process_arc_project(thermo_adapter: str,
                                             )
         statmech_adapter.compute_thermo(e0_only=True)
     for spc in converged_species:
-        if spc.thermo is not None:
+        if spc.thermo is not None and not _thermo_lib_has_isomorph(spc, species_for_thermo_lib):
             species_for_thermo_lib.append(spc)
         plotter.augment_arkane_yml_file_with_mol_repr(spc, output_directory)
     if species_for_thermo_lib:

--- a/arc/reaction/reaction.py
+++ b/arc/reaction/reaction.py
@@ -873,6 +873,8 @@ class ARCReaction(object):
     def get_reactants_xyz(self, return_format='str') -> dict | str:
         """
         Get a combined string/dict representation of the cartesian coordinates of all reactant species.
+        A species participating more than once in the reactant well contributes its atoms once per
+        occurrence.
 
         Args:
             return_format (str): Either ``'dict'`` to return a dict format or ``'str'`` to return a string format.
@@ -885,15 +887,17 @@ class ARCReaction(object):
             Orient the fragments according to the reactive site.
         """
         xyz_dict = dict()
-        if len(self.r_species) == 1:
-            xyz_dict = self.r_species[0].get_xyz()
-        elif len(self.r_species) >= 2:
+        reactants = [spc for spc in self.r_species
+                     for _ in range(self.get_species_count(species=spc, well=0))]
+        if len(reactants) == 1:
+            xyz_dict = reactants[0].get_xyz()
+        elif len(reactants) >= 2:
             xyz_dict = {'symbols': tuple(), 'isotopes': tuple(), 'coords': tuple()}
-            for i, reactant in enumerate(self.r_species):
+            for i, reactant in enumerate(reactants):
                 xyz = translate_to_center_of_mass(reactant.get_xyz())
                 if i:
                     xyz = translate_xyz(xyz_dict=xyz,
-                                        translation=(sum(spc.radius for spc in self.r_species[:i]) * 1.1 * i, 0, 0))
+                                        translation=(sum(spc.radius for spc in reactants[:i]) * 1.1 * i, 0, 0))
                 xyz_dict['symbols'] += xyz['symbols']
                 xyz_dict['isotopes'] += xyz['isotopes']
                 xyz_dict['coords'] += xyz['coords']
@@ -906,6 +910,8 @@ class ARCReaction(object):
         """
         Get a combined string/dict representation of the cartesian coordinates of all product species.
         The resulting coordinates are ordered as the reactants using an atom map.
+        A species participating more than once in the product well contributes its atoms once per
+        occurrence.
 
         Args:
             return_format (str): Either ``'dict'`` to return a dict format or ``'str'`` to return a string format.
@@ -917,15 +923,17 @@ class ARCReaction(object):
         Todo:
             Orient the fragments according to the reactive site.
         """
-        if len(self.p_species) == 1:
-            xyz_dict = self.p_species[0].get_xyz()
+        products = [spc for spc in self.p_species
+                    for _ in range(self.get_species_count(species=spc, well=1))]
+        if len(products) == 1:
+            xyz_dict = products[0].get_xyz()
         else:
             xyz_dict = {'symbols': tuple(), 'isotopes': tuple(), 'coords': tuple()}
-            for i, product in enumerate(self.p_species):
+            for i, product in enumerate(products):
                 xyz = translate_to_center_of_mass(product.get_xyz())
                 if i:
                     xyz = translate_xyz(xyz_dict=xyz,
-                                        translation=(sum(spc.radius for spc in self.p_species[:i]) * 1.1 * i, 0, 0))
+                                        translation=(sum(spc.radius for spc in products[:i]) * 1.1 * i, 0, 0))
                 xyz_dict['symbols'] += xyz['symbols']
                 xyz_dict['isotopes'] += xyz['isotopes']
                 xyz_dict['coords'] += xyz['coords']

--- a/arc/reaction/reaction_test.py
+++ b/arc/reaction/reaction_test.py
@@ -602,6 +602,36 @@ class TestARCReaction(unittest.TestCase):
         rxn2 = ARCReaction(r_species=[h2nn, n2h2], p_species=[n2h3, n2h3])
         self.assertEqual(rxn2.get_species_count(label=n2h3.label, well=1), 2)
 
+    def test_get_reactants_xyz_repeated_species(self):
+        """Test that a reactant appearing twice (e.g. OH + OH) contributes all of its atoms,
+        even though r_species holds a single deduplicated entry for it."""
+        oh = ARCSpecies(label='R1', smiles='[OH]',
+                        xyz={'coords': ((0.0, 0.0, 0.109), (0.0, 0.0, -0.868)),
+                             'isotopes': (16, 1), 'symbols': ('O', 'H')})
+        h2o = ARCSpecies(label='P1', smiles='O')
+        o = ARCSpecies(label='P2', smiles='[O]')
+        rxn = ARCReaction(r_species=[oh, oh], p_species=[h2o, o])
+        self.assertEqual(len(rxn.r_species), 1)
+        self.assertEqual(rxn.get_species_count(species=oh, well=0), 2)
+        reactants_xyz = rxn.get_reactants_xyz(return_format='dict')
+        self.assertEqual(len(reactants_xyz['symbols']), 4)
+        self.assertEqual(sorted(reactants_xyz['symbols']), ['H', 'H', 'O', 'O'])
+
+    def test_reverse_reaction_of_repeated_species(self):
+        """Test that the reverse of a reaction with a repeated species (OH + OH <=> H2O + O) stays
+        atom-balanced when its label lists are expanded by get_species_count, as consumers building
+        the reverse reaction from the deduplicated reactants/products lists do."""
+        oh = ARCSpecies(label='R1', smiles='[OH]', multiplicity=2)
+        h2o = ARCSpecies(label='P1', smiles='O', multiplicity=1)
+        o = ARCSpecies(label='P2', smiles='[O]', multiplicity=3)
+        fwd = ARCReaction(label='R1 + R1 <=> P1 + P2', r_species=[oh, oh], p_species=[h2o, o])
+        rev_reactants = [lbl for lbl in fwd.products for _ in range(fwd.get_species_count(label=lbl, well=1))]
+        rev_products = [lbl for lbl in fwd.reactants for _ in range(fwd.get_species_count(label=lbl, well=0))]
+        self.assertEqual(rev_products, ['R1', 'R1'])
+        rev = ARCReaction(r_species=fwd.p_species, p_species=fwd.r_species,
+                          reactants=rev_reactants, products=rev_products)
+        self.assertEqual(rev.label, 'P1 + P2 <=> R1 + R1')
+
     def test_get_reactants_and_products(self):
         """Test getting reactants and products"""
         self.rxn1.remove_dup_species()

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -289,6 +289,69 @@ H      -1.82570782    0.42754384   -0.56130718"""
         self.assertIsNone(self.sched1.species_dict[label].freqs)
         self.assertFalse(os.path.isfile(freq_path))
 
+    @patch('arc.scheduler.Scheduler.switch_ts')
+    def test_check_freq_job_does_not_switch_ts_when_nmd_cannot_be_run(self, mock_switch_ts):
+        """
+        Test that a TS is not discarded when the normal mode displacement check cannot be performed.
+
+        The forming and breaking bond indices are indices into the concatenated reactant atoms, so a
+        TS geometry spanning a different number of atoms cannot be analyzed at all. Reporting that as
+        a failed check calls switch_ts() and throws away a TS that was never examined, and switching
+        to another guess cannot change the atom count that made the analysis impossible.
+        """
+        oh_xyz = str_to_xyz("""O       0.48890387    0.00000000    0.00000000
+H      -0.48890387    0.00000000    0.00000000""")
+        h2o_xyz = str_to_xyz("""O      -0.00032832    0.39781490    0.00000000
+H      -0.76330345   -0.19953755    0.00000000
+H       0.76363177   -0.19827735    0.00000000""")
+        ch4_xyz = str_to_xyz("""C      -0.00000000    0.00000000    0.00000000
+H      -0.65055201   -0.77428020   -0.41251879
+H      -0.34927558    0.98159583   -0.32768232
+H      -0.02233792   -0.04887375    1.09087665
+H       1.02216551   -0.15844188   -0.35067554""")
+        ts_xyz = ch4_xyz
+        rxn = ARCReaction(r_species=[ARCSpecies(label='CH4', smiles='C', xyz=ch4_xyz),
+                                     ARCSpecies(label='OH', smiles='[OH]', xyz=oh_xyz)],
+                          p_species=[ARCSpecies(label='CH3', smiles='[CH3]', xyz=str_to_xyz(
+                              """C       0.00000000    0.00000001   -0.00000000
+H       1.06690511   -0.17519582    0.05416493
+H      -0.68531716   -0.83753536   -0.02808565
+H      -0.38158795    1.01273118   -0.02607927""")),
+                                     ARCSpecies(label='H2O', smiles='O', xyz=h2o_xyz)])
+        ts_label = 'TS_short'
+        ts_spc = ARCSpecies(label=ts_label, is_ts=True, xyz=ts_xyz, multiplicity=3, charge=0, compute_thermo=False)
+        ts_spc.ts_guesses = [TSGuess(index=0, method='heuristics', success=True, energy=0.0, xyz=ts_xyz,
+                                     execution_time='0:00:01')]
+        ts_spc.ts_guesses[0].opt_xyz = ts_xyz
+        ts_spc.chosen_ts = 0
+        ts_spc.rxn_index = 0
+        rxn.ts_species = ts_spc
+        rxn.ts_label = ts_label
+
+        project_directory = os.path.join(ARC_PATH, 'Projects', 'arc_project_nmd_no_switch_ts')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        sched = Scheduler(project='test_nmd_no_switch', ess_settings=self.ess_settings,
+                          species_list=[ts_spc],
+                          opt_level=Level(repr=default_levels_of_theory['opt']),
+                          freq_level=Level(repr=default_levels_of_theory['freq']),
+                          sp_level=Level(repr=default_levels_of_theory['sp']),
+                          ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
+                          project_directory=project_directory,
+                          testing=True,
+                          job_types=self.job_types1,
+                          )
+        sched.rxn_dict[0] = rxn
+
+        job = job_factory(job_adapter='gaussian', project='test_nmd_no_switch', ess_settings=self.ess_settings,
+                          species=[ts_spc], job_type='freq',
+                          level=Level(repr=default_levels_of_theory['freq']),
+                          project_directory=project_directory, job_num=105)
+        job.local_path_to_output_file = os.path.join(ARC_TESTING_PATH, 'freq', 'CHO_neg_freq.out')
+        job.job_status = ['done', {'status': 'done', 'keywords': list(), 'error': '', 'line': ''}]
+        sched.check_freq_job(label=ts_label, job=job)
+        self.assertIsNone(sched.species_dict[ts_label].ts_checks['NMD'])
+        mock_switch_ts.assert_not_called()
+
     def test_determine_adaptive_level(self):
         """Test the determine_adaptive_level() method"""
         # adaptive_levels get converted to ``Level`` objects in main, but here we skip main and test Scheduler directly

--- a/arc/scripts/save_arkane_thermo.py
+++ b/arc/scripts/save_arkane_thermo.py
@@ -5,7 +5,9 @@
 A standalone script to read an Arknane thermo job and save in the same folder a YAML file with the thermo data.
 """
 
+import ast
 import os
+import sys
 
 from common import save_yaml_file
 
@@ -48,32 +50,95 @@ def _extract_cp(thermo_data):
         return None
 
 
+def _iter_thermo_calls(content):
+    """Return the :class:`ast.Call` node of each ``thermo(...)`` call in ``content``.
+
+    Selects calls to the bare name ``thermo`` only, so the ``thermo=`` keyword nested inside each
+    call is not mistaken for one. If ``content`` is not parseable Python, a message is written to
+    stderr and an empty list is returned.
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError as e:
+        sys.stderr.write(f'Could not parse an Arkane output.py as Python: {e}\n')
+        return []
+    return [node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'thermo']
+
+
+def _load_thermo_entries_from_output_py(output_path, local_context):
+    """Reconstruct a ``{label: NASA}`` mapping directly from an Arkane ``output.py``.
+
+    Used as a fallback when ``RMG_libraries/thermo.py`` is absent because Arkane's
+    ``save_thermo_lib`` crashed *after* writing ``output.py`` (e.g. it rejects the two
+    identical reactants of an A+A reaction such as OH + OH, or a singlet-carbene
+    multiplicity clash). ``output.py`` holds one ``thermo(label=..., thermo=NASA(...))``
+    call per species; each is evaluated with the real rmgpy thermo classes in scope —
+    exactly the context Arkane itself uses to read these files back — so no thermo data
+    is lost to the library-save failure. A block that fails to evaluate is reported on
+    stderr and the remaining blocks are still parsed.
+    """
+    with open(output_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    entries = dict()
+
+    def _capture(label=None, thermo=None, *args, **kwargs):
+        if label is not None:
+            entries[label] = thermo
+
+    eval_context = dict(local_context)
+    eval_context['thermo'] = _capture
+    for node in _iter_thermo_calls(content):
+        try:
+            eval(compile(ast.Expression(body=node), '<arkane_output>', 'eval'), eval_context)
+        except Exception as e:
+            sys.stderr.write(f'Could not parse an Arkane thermo() block from {output_path}: {e}\n')
+    return entries
+
+
 def main():
     """
     Run this script from an Arkane project folder.
     In ARC this is under calcs/statmech/thermo.
-    It loads the RMG thermo library, extracts H298, S298, NASA polynomial coefficients, and
-    tabulated Cp data, saving the results in a YAML file.
+    It loads the computed thermo (from the RMG thermo library Arkane wrote, or — when
+    that library save failed — straight from ``output.py``), extracts H298, S298, NASA
+    polynomial coefficients, and tabulated Cp data, saving the results in a YAML file.
+    A species whose thermo cannot be evaluated is reported on stderr and skipped, so the
+    remaining species are still written.
     """
-    thermo_lib_path = os.path.join(os.getcwd(), 'RMG_libraries', 'thermo.py')
-    if not os.path.isfile(thermo_lib_path):
-        return
-    result = dict()
+    cwd = os.getcwd()
+    thermo_lib_path = os.path.join(cwd, 'RMG_libraries', 'thermo.py')
+    output_path = os.path.join(cwd, 'output.py')
     local_context = {'ThermoData': ThermoData,
                      'Wilhoit': Wilhoit,
                      'NASAPolynomial': NASAPolynomial,
                      'NASA': NASA}
-    global_context = {}
-    library = ThermoLibrary()
-    library.load(thermo_lib_path, local_context, global_context)
-    for entry in library.entries.values():
-        thermo_data = entry.data
-        H298 = thermo_data.get_enthalpy(RT) / 1000.0
-        S298 = thermo_data.get_entropy(RT)
-        data = str(thermo_data)
-        nasa_low, nasa_high = _extract_nasa(thermo_data)
-        cp_data = _extract_cp(thermo_data)
-        result[entry.label] = {
+    entries = dict()
+    if os.path.isfile(thermo_lib_path):
+        library = ThermoLibrary()
+        library.load(thermo_lib_path, local_context, {})
+        for entry in library.entries.values():
+            entries[entry.label] = entry.data
+    elif os.path.isfile(output_path):
+        entries = _load_thermo_entries_from_output_py(output_path, local_context)
+    else:
+        return
+    result = dict()
+    for label, thermo_data in entries.items():
+        if thermo_data is None:
+            continue
+        try:
+            H298 = thermo_data.get_enthalpy(RT) / 1000.0
+            S298 = thermo_data.get_entropy(RT)
+            data = str(thermo_data)
+            nasa_low, nasa_high = _extract_nasa(thermo_data)
+            cp_data = _extract_cp(thermo_data)
+        except Exception as e:
+            sys.stderr.write(f'Could not evaluate the computed thermo of {label}: {e}\n')
+            continue
+        result[label] = {
             'H298': H298,
             'S298': S298,
             'data': data,
@@ -82,7 +147,7 @@ def main():
             'cp_data': cp_data,
         }
     if result:
-        result_path = os.path.join(os.getcwd(), 'thermo.yaml')
+        result_path = os.path.join(cwd, 'thermo.yaml')
         save_yaml_file(path=result_path, content=result)
 
 

--- a/arc/scripts/save_arkane_thermo_test.py
+++ b/arc/scripts/save_arkane_thermo_test.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+Unit tests for arc/scripts/save_arkane_thermo.py.
+
+The output.py-fallback path reconstructs NASA thermo objects with the real rmgpy thermo
+classes, so these tests require rmgpy (the rmg_env). Run them as a plain script (NOT via
+pytest): rmg_env's Python 3.9 cannot import the ``arc`` package that pytest pulls in for a
+file inside ``arc/scripts/`` (arc.common uses ``X | None`` PEP 604 annotations). As a script,
+only the standalone module + ``common`` are imported:
+
+    conda run -n rmg_env python arc/scripts/save_arkane_thermo_test.py
+
+Under arc_env pytest the file collects and skips cleanly (no rmgpy), so CI is unaffected.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+HAS_RMG = importlib.util.find_spec('rmgpy') is not None
+
+
+OUTPUT_PY_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                              'testing', 'statmech', 'thermo_aa', 'output.py')
+
+with open(OUTPUT_PY_PATH, 'r') as _f:
+    OUTPUT_PY = _f.read()
+
+
+@unittest.skipUnless(HAS_RMG, 'requires rmgpy (rmg_env)')
+class TestOutputPyThermoFallback(unittest.TestCase):
+    """The output.py fallback recovers thermo when RMG_libraries/thermo.py is absent."""
+
+    def test_iter_thermo_calls_finds_each_block(self):
+        """One node per species; the nested thermo= keyword is not mistaken for a call."""
+        import ast
+        import save_arkane_thermo as sat
+        calls = sat._iter_thermo_calls(OUTPUT_PY)
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(all(isinstance(c, ast.Call) for c in calls))
+        self.assertTrue(all(c.func.id == 'thermo' for c in calls))
+
+    def test_iter_thermo_calls_tolerates_parens_in_strings(self):
+        """An unbalanced parenthesis inside a string literal does not drop the block."""
+        import save_arkane_thermo as sat
+        content = ("thermo(\n"
+                   "    label = 'X',\n"
+                   "    thermo = NASA(\n"
+                   "        polynomials = [],\n"
+                   "        comment = 'fitted using ( an unbalanced paren',\n"
+                   "    ),\n"
+                   ")\n")
+        self.assertEqual(len(sat._iter_thermo_calls(content)), 1)
+
+    def test_iter_thermo_calls_reports_unparseable_file(self):
+        """A file that is not valid Python yields no blocks rather than raising."""
+        import save_arkane_thermo as sat
+        self.assertEqual(sat._iter_thermo_calls('thermo(label = ,,,)'), [])
+
+    def test_one_bad_entry_does_not_lose_the_others(self):
+        """A species whose thermo cannot be evaluated is skipped; the rest still reach thermo.yaml."""
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        broken = OUTPUT_PY + """
+thermo(
+    label = 'Broken',
+    thermo = NASA(
+        polynomials = [],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+    ),
+)
+"""
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'output.py'), 'w') as f:
+                f.write(broken)
+            try:
+                os.chdir(d)
+                sat.main()
+                content = read_yaml_file(os.path.join(d, 'thermo.yaml'))
+            finally:
+                os.chdir(cwd)
+        self.assertEqual(set(content), {'R1', 'R2', 'P1'})
+
+    def test_load_thermo_entries_from_output_py(self):
+        import save_arkane_thermo as sat
+        from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit
+        local_context = {'ThermoData': ThermoData, 'Wilhoit': Wilhoit,
+                         'NASAPolynomial': NASAPolynomial, 'NASA': NASA}
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'output.py')
+            with open(path, 'w') as f:
+                f.write(OUTPUT_PY)
+            entries = sat._load_thermo_entries_from_output_py(path, local_context)
+        self.assertEqual(set(entries), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            self.assertIsInstance(entries[label], NASA)
+        self.assertAlmostEqual(entries['R1'].get_enthalpy(298.15), entries['R2'].get_enthalpy(298.15))
+
+    def test_main_writes_thermo_yaml_from_output_py(self):
+        """With output.py present but no RMG_libraries/thermo.py, main() still writes thermo.yaml
+        for every species (including the duplicate R2), carrying the real thermochemistry.
+
+        P1 is H2O and is checked against JANAF reference values rather than against whatever the
+        code emits: dHf(298.15 K) = -241.8 kJ/mol, S(298.15 K) = 188.8 J/(mol*K), and, from the
+        high-temperature polynomial, H(2000 K) - H(298.15 K) = 72.79 kJ/mol and
+        S(2000 K) = 264.77 J/(mol*K). Tolerances are loose so the assertions test the
+        reconstruction rather than the level of theory, and never rely on exact floats.
+
+        R1/R2 are OH, whose S(298.15 K) is deliberately not compared to the accepted
+        183.7 J/(mol*K) because the fixture's electronic partition function omits the 2-Pi
+        spin-orbit structure. What is asserted for them is the A+A invariant: two blocks for the
+        same species must reconstruct to the same thermo.
+        """
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        from rmgpy.thermo import NASA, NASAPolynomial, ThermoData, Wilhoit
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            output_path = os.path.join(d, 'output.py')
+            with open(output_path, 'w') as f:
+                f.write(OUTPUT_PY)
+            try:
+                os.chdir(d)
+                sat.main()
+                yaml_path = os.path.join(d, 'thermo.yaml')
+                self.assertTrue(os.path.isfile(yaml_path), 'thermo.yaml must be written from output.py')
+                content = read_yaml_file(yaml_path)
+            finally:
+                os.chdir(cwd)
+            entries = sat._load_thermo_entries_from_output_py(
+                output_path, {'ThermoData': ThermoData, 'Wilhoit': Wilhoit,
+                              'NASAPolynomial': NASAPolynomial, 'NASA': NASA})
+        self.assertEqual(set(content), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            entry = content[label]
+            self.assertIsNotNone(entry['H298'])
+            self.assertIsNotNone(entry['S298'])
+            self.assertIsNotNone(entry['data'])
+            self.assertIsNotNone(entry['nasa_low'])
+            self.assertIsNotNone(entry['nasa_high'])
+            self.assertEqual(len(entry['nasa_low']['coeffs']), 7)
+        self.assertAlmostEqual(content['R1']['H298'], content['R2']['H298'])
+        self.assertAlmostEqual(content['R1']['S298'], content['R2']['S298'])
+        self.assertEqual(content['R1']['nasa_low'], content['R2']['nasa_low'])
+        self.assertEqual(content['R1']['nasa_high'], content['R2']['nasa_high'])
+        self.assertAlmostEqual(content['P1']['H298'], -241.8, delta=3.0)
+        self.assertAlmostEqual(content['P1']['S298'], 188.8, delta=2.0)
+        self.assertLess(content['P1']['H298'], content['R1']['H298'])
+        self.assertTrue(all(cp['cp_j_mol_k'] > 0 for cp in content['P1']['cp_data']))
+        h_increment = (entries['P1'].get_enthalpy(2000.0) - entries['P1'].get_enthalpy(298.15)) / 1000.0
+        self.assertAlmostEqual(h_increment, 72.79, delta=3.0)
+        self.assertAlmostEqual(entries['P1'].get_entropy(2000.0), 264.77, delta=3.0)
+        self.assertGreater(content['P1']['nasa_high']['tmax_k'], 2000.0)
+
+    def test_library_path_takes_precedence(self):
+        """When RMG_libraries/thermo.py exists, main() uses it (happy path), not output.py."""
+        import save_arkane_thermo as sat
+        from common import read_yaml_file
+        library_py = '''#!/usr/bin/env python
+name = "test"
+shortDesc = ""
+longDesc = """"""
+entry(
+    index = 0,
+    label = "OnlyFromLibrary",
+    molecule = """
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin=(10, 'K'), Tmax=(3000, 'K'),
+    ),
+)
+'''
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, 'RMG_libraries'))
+            with open(os.path.join(d, 'RMG_libraries', 'thermo.py'), 'w') as f:
+                f.write(library_py)
+            with open(os.path.join(d, 'output.py'), 'w') as f:
+                f.write(OUTPUT_PY)
+            try:
+                os.chdir(d)
+                sat.main()
+                content = read_yaml_file(os.path.join(d, 'thermo.yaml'))
+            finally:
+                os.chdir(cwd)
+        self.assertIn('OnlyFromLibrary', content)
+        self.assertNotIn('R1', content)
+
+
+if __name__ == '__main__':
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/arc/scripts_test.py
+++ b/arc/scripts_test.py
@@ -8,6 +8,7 @@ These tests call the scripts as subprocesses in rmg_env (matching production usa
 Tests are skipped if rmg_env is not available.
 """
 
+import math
 import os
 import shutil
 import subprocess
@@ -52,6 +53,20 @@ def _rmg_env_available() -> bool:
 
 
 RMG_ENV = _rmg_env_available()
+
+R_J_MOL_K = 8.314462618
+
+
+def _nasa_enthalpy(coeffs: list, t: float) -> float:
+    """Return H(T) in J/mol from the 7 NASA coefficients of a single temperature range."""
+    a1, a2, a3, a4, a5, a6, _ = coeffs
+    return R_J_MOL_K * t * (a1 + a2 * t / 2 + a3 * t ** 2 / 3 + a4 * t ** 3 / 4 + a5 * t ** 4 / 5 + a6 / t)
+
+
+def _nasa_entropy(coeffs: list, t: float) -> float:
+    """Return S(T) in J/(mol*K) from the 7 NASA coefficients of a single temperature range."""
+    a1, a2, a3, a4, a5, _, a7 = coeffs
+    return R_J_MOL_K * (a1 * math.log(t) + a2 * t + a3 * t ** 2 / 2 + a4 * t ** 3 / 3 + a5 * t ** 4 / 4 + a7)
 
 
 @unittest.skipUnless(RMG_ENV, 'rmg_env not available')
@@ -266,6 +281,60 @@ class TestRmgScriptsOutputFlag(unittest.TestCase):
         self.assertIn('h298', out[0])
         self.assertIn('s298', out[0])
         self.assertIn('comment', out[0])
+
+@unittest.skipUnless(RMG_ENV, 'rmg_env not available')
+class TestSaveArkaneThermoOutputPyFallback(unittest.TestCase):
+    """
+    The motivating scenario end to end: Arkane's save_thermo_lib crashed on the two identical
+    reactants of an A+A reaction, so it left output.py behind but never wrote
+    RMG_libraries/thermo.py. Running the real script must still produce thermo.yaml for every
+    species, including both duplicates.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='test_aa_reload_')
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+        src = os.path.join(ARC_TESTING_PATH, 'statmech', 'thermo_aa', 'output.py')
+        shutil.copy(src, os.path.join(self.tmp_dir, 'output.py'))
+        self.assertFalse(os.path.isdir(os.path.join(self.tmp_dir, 'RMG_libraries')))
+
+    def _run_script(self):
+        script = os.path.join(ARC_PATH, 'arc', 'scripts', 'save_arkane_thermo.py')
+        result = subprocess.run(['conda', 'run', '-n', 'rmg_env', 'python', script],
+                                capture_output=True, text=True, cwd=self.tmp_dir, timeout=300)
+        self.assertEqual(result.returncode, 0, f'Script failed: {result.stderr}')
+        yaml_path = os.path.join(self.tmp_dir, 'thermo.yaml')
+        self.assertTrue(os.path.isfile(yaml_path),
+                        'thermo.yaml must be recovered from output.py when the library is absent')
+        return read_yaml_file(yaml_path)
+
+    def test_both_duplicates_recover_their_own_thermo(self):
+        """R1 and R2 are the same species submitted twice; each recovers thermo from its own block."""
+        data = self._run_script()
+        self.assertEqual(set(data), {'R1', 'R2', 'P1'})
+        for label in ('R1', 'R2', 'P1'):
+            self.assertIsNotNone(data[label]['H298'])
+            self.assertIsNotNone(data[label]['S298'])
+            self.assertIsNotNone(data[label]['nasa_low'])
+            self.assertIsNotNone(data[label]['nasa_high'])
+        self.assertAlmostEqual(data['R1']['H298'], data['R2']['H298'])
+        self.assertAlmostEqual(data['R1']['S298'], data['R2']['S298'])
+
+    def test_recovered_values_match_reference_thermochemistry(self):
+        """P1 is H2O; the recovered values are checked against JANAF, at 298 K and at 2000 K.
+
+        The high-temperature check evaluates the serialized nasa_high coefficients, which is what
+        ARC consumers use up to 3000 K, so a reload that corrupted them cannot pass.
+        """
+        data = self._run_script()
+        self.assertAlmostEqual(data['P1']['H298'], -241.8, delta=3.0)
+        self.assertAlmostEqual(data['P1']['S298'], 188.8, delta=2.0)
+        nasa_high = data['P1']['nasa_high']
+        self.assertGreaterEqual(nasa_high['tmax_k'], 3000.0)
+        h_2000 = _nasa_enthalpy(nasa_high['coeffs'], 2000.0) / 1000.0
+        s_2000 = _nasa_entropy(nasa_high['coeffs'], 2000.0)
+        self.assertAlmostEqual(h_2000 - data['P1']['H298'], 72.79, delta=3.0)
+        self.assertAlmostEqual(s_2000, 264.77, delta=3.0)
 
 
 if __name__ == '__main__':

--- a/arc/testing/statmech/thermo_aa/output.py
+++ b/arc/testing/statmech/thermo_aa/output.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+conformer(
+    label = 'R1',
+    E0 = (22.2577, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(17.0027, 'amu')),
+        LinearRotor(inertia=(0.904473, 'amu*angstrom^2'), symmetry=1),
+        HarmonicOscillator(frequencies=([3675.45], 'cm^-1')),
+    ],
+    spin_multiplicity = 2,
+    optical_isomers = 1,
+)
+
+conformer(
+    label = 'R2',
+    E0 = (22.2577, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(17.0027, 'amu')),
+        LinearRotor(inertia=(0.904473, 'amu*angstrom^2'), symmetry=1),
+        HarmonicOscillator(frequencies=([3675.45], 'cm^-1')),
+    ],
+    spin_multiplicity = 2,
+    optical_isomers = 1,
+)
+
+conformer(
+    label = 'P1',
+    E0 = (-250.574, 'kJ/mol'),
+    modes = [
+        IdealGasTranslation(mass=(18.0106, 'amu')),
+        NonlinearRotor(inertia=([0.611436, 1.17966, 1.7911], 'amu*angstrom^2'), symmetry=2),
+        HarmonicOscillator(frequencies=([1615.43, 3782.01, 3887.1], 'cm^-1')),
+    ],
+    spin_multiplicity = 1,
+    optical_isomers = 1,
+)
+
+thermo(
+    label = 'R1',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (22.2464, 'kJ/mol'), Cp0 = (29.1007, 'J/(mol*K)'), CpInf = (37.4151, 'J/(mol*K)'),
+    ),
+)
+
+thermo(
+    label = 'R2',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.49683, 0.000188285, -1.03135e-06, 1.63951e-09, -6.45157e-13, 2675.74, 1.48391],
+                           Tmin=(10, 'K'), Tmax=(974.045, 'K')),
+            NASAPolynomial(coeffs=[3.44056, -0.000267412, 7.28022e-07, -2.88523e-10, 3.54839e-14, 2719.28, 1.92114],
+                           Tmin=(974.045, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (22.2464, 'kJ/mol'), Cp0 = (29.1007, 'J/(mol*K)'), CpInf = (37.4151, 'J/(mol*K)'),
+    ),
+)
+
+thermo(
+    label = 'P1',
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.00485, -0.000245998, 8.95339e-07, 1.40307e-09, -1.18107e-12, -30136.7, -0.104547],
+                           Tmin=(10, 'K'), Tmax=(772.675, 'K')),
+            NASAPolynomial(coeffs=[3.50315, 0.00113242, 5.85407e-07, -3.70913e-10, 5.33992e-14, -30022.8, 2.42188],
+                           Tmin=(772.675, 'K'), Tmax=(3000, 'K')),
+        ],
+        Tmin = (10, 'K'), Tmax = (3000, 'K'),
+        E0 = (-250.569, 'kJ/mol'), Cp0 = (33.2579, 'J/(mol*K)'), CpInf = (58.2013, 'J/(mol*K)'),
+    ),
+)


### PR DESCRIPTION
A reaction whose two reactants are the same species — `OH + OH <=> H2O + O` — is mishandled at three
layers. One commit per layer.

# 1. A species participating more than once in a well

`ARCReaction` stored each participant once, so a species appearing twice in a well contributed its
atoms once. The occurrence count is now read through `get_species_count(species=spc, well=...)` and the
participants are expanded per occurrence where the geometry needs them, rather than by holding duplicate
objects: the reactant and product well geometries place one copy per occurrence, and the translation
offsets are computed over the expanded list.

# 2. The normal mode displacement check under dedup

`analyze_ts_normal_mode_displacement` mapped bond changes against the deduplicated participant list, so
for an A + A reaction the expected bonds did not line up with the atoms the TS actually holds. The check
is dedup-aware, and a TS it cannot map is reported as uncheckable rather than discarded — an unmappable
TS is not evidence of a bad TS.

# 3. Thermo recovery when Arkane refuses to write its library

For a reaction whose two reactants are the same species, Arkane's `save_thermo_lib` raises
`DatabaseError` on the `R1 == R2` duplicate at the very end of its run — after `output.py` is written but
before `RMG_libraries/thermo.py` is. `save_arkane_thermo.py` guarded on that missing library file and
returned early, so `thermo.yaml` was never written and `parse_arkane_thermo_output` left `spc.thermo`
unset: null thermo in `output.yml` and an empty project thermo library for every species in the run,
despite Arkane having computed full NASA polynomials.

When the library file is absent, each species' thermo is reconstructed from `output.py`, which Arkane has
already written by the time `save_thermo_lib` runs, producing `thermo.yaml` exactly as the library path
would. Blocks are located with `ast.parse` and evaluated with the same rmgpy classes Arkane uses to read
these files back, so a parenthesis inside a string literal cannot drop a species. A species whose thermo
cannot be evaluated is reported on stderr and skipped rather than aborting the remaining ones. The path
where the library file exists is unchanged.

With thermo recovered, both A + A duplicates carry data, and `plotter.save_thermo_lib` emitted two
entries whose adjacency list and multiplicity match — which `rmgpy`'s `ThermoLibrary.load_entry` rejects,
taking the library from empty to unloadable. The same isomorphic-plus-equal-multiplicity test RMG applies
now omits the later entry with a warning. This affects the library file only; every species keeps its own
computed thermo elsewhere.

The species list handed to the thermo library is filtered by the same criterion one layer earlier, in
`processor.py`. The two checks sit at different points — one filters the list, the other filters entries
as they are written — and share a predicate that a later change could collapse into one helper.

# Tests

Per-occurrence well geometry and atom counts; the dedup-aware NMD check including the uncheckable-TS
path; end-to-end thermo recovery through the real script with no library present; both duplicates
recovering their own thermo; JANAF checks on H2O at 298.15 K and 2000 K; parser robustness; and an RMG
load of the generated thermo library.
