### PR TITLE
fix(statmech): declare reaction species in the Arkane kinetics input regardless of compute_thermo

### DIFF
--- a/arc/statmech/arkane.py
+++ b/arc/statmech/arkane.py
@@ -343,9 +343,18 @@ class ArkaneAdapter(StatmechAdapter, ABC):
             skip_rotors (bool, optional): Whether to skip internal rotor consideration. Default: ``False``.
             e0_only (bool, optional): Whether to only run statmech (w/o thermo) to compute E0. Default: ``False``.
         """
+        reaction_species_labels = set()
+        for rxn in self.reactions or list():
+            reactants, products = rxn.get_reactants_and_products(return_copies=False)
+            rxn.reactants = [spc.label for spc in reactants]
+            rxn.products = [spc.label for spc in products]
+            reaction_species_labels.update(rxn.reactants + rxn.products)
         species_list = list()
         for spc in self.species:
-            if e0_only or spc.compute_thermo:
+            # A species named by a reaction must be declared even when its thermo is not being
+            # computed: Arkane's reaction() references species by label from the declared-species
+            # dict, so an undeclared reactant/product raises KeyError and no rate is produced.
+            if e0_only or spc.compute_thermo or spc.label in reaction_species_labels:
                 smiles = spc.mol.copy(deep=True).to_smiles() if not spc.is_ts else ''
                 adjlist = ''
                 if smiles:
@@ -387,11 +396,6 @@ class ArkaneAdapter(StatmechAdapter, ABC):
 
         freq_scale_factor = f'\nfrequencyScaleFactor = {self.freq_scale_factor}' \
             if self.freq_scale_factor is not None else ''
-        if self.reactions is not None:
-            for rxn in self.reactions:
-                reactants, products = rxn.get_reactants_and_products()
-                rxn.reactants = [spc.label for spc in reactants]
-                rxn.products = [spc.label for spc in products]
         calc_type = 'kinetics' if self.reactions else 'thermo'
         return Template(main_input_template).render(
             title=f'Arkane {calc_type} calculation',

--- a/arc/statmech/arkane_test.py
+++ b/arc/statmech/arkane_test.py
@@ -471,6 +471,25 @@ class TestArkaneAdapter(unittest.TestCase):
         self.assertNotIn("SMILES('[CH2]')", content)     # must NOT use the lossy SMILES
         self.assertIn("structure=SMILES('O')", content)  # normal species unchanged
 
+    def test_kinetics_input_declares_reaction_species_without_compute_thermo(self):
+        """A reactant/product carrying ``compute_thermo=False`` must still be declared as a
+        ``species(...)`` line in a rendered kinetics input. Otherwise the ``reaction(...)`` block
+        references a species Arkane never declared, and Arkane raises ``KeyError`` on the label
+        (``arkane/input.py`` builds ``reactants`` from the declared-species dict). A species that no
+        reaction names must still be excluded by ``compute_thermo=False``."""
+        rxn = ARCReaction(r_species=[ARCSpecies(label='R', smiles='C[NH]', compute_thermo=False)],
+                          p_species=[ARCSpecies(label='P', smiles='[CH2]N', compute_thermo=False)])
+        rxn.ts_species = ARCSpecies(label='TS', is_ts=True)
+        spc_x = ARCSpecies(label='X', smiles='O', compute_thermo=False)
+        adapter = ArkaneAdapter(output_directory=self.tmpdir, calcs_directory=self.tmpdir,
+                                output_dict=dict(), sp_level=Level('gfn2'),
+                                species=rxn.r_species + rxn.p_species + [rxn.ts_species, spc_x],
+                                reactions=[rxn])
+        content = adapter.render_arkane_input_template(statmech_dir=self.tmpdir)
+        self.assertIn("species('R',", content)
+        self.assertIn("species('P',", content)
+        self.assertNotIn("species('X',", content)
+
     @classmethod
     def tearDownClass(cls):
         """


### PR DESCRIPTION
## What this fixes

An Arkane **kinetics** input generated by ARC can reference species it never declares, so Arkane dies before computing anything:

```
File "arkane/input.py", line 297, in reaction
    reactants = sorted([species_dict[spec] for spec in reactants])
KeyError: '[O]C=O[1]'
```

This was found on a run where everything else went right: two species and a transition state all optimised and frequency-checked on a cluster, and then **no rate coefficient at all**.

## Cause

`ArkaneAdapter.render_arkane_input_template` builds `species_list` under `if e0_only or spc.compute_thermo:`. A caller that sets `compute_thermo=False` — as an orchestrator does when it wants kinetics but does not want a full thermodynamics job queued — gets:

- the **E0** render (`e0_only=True`) → gate passes → all species declared;
- the **kinetics** render (`e0_only=False`) → gate fails → *none* declared, while `reaction(...)` still names them by label.

`generate_species_files` writes the per-species statmech files either way, so ARC writes `statmech/kinetics/species/<label>.py` to disk and then writes a main input that references that species without declaring it. `compute_thermo` should govern whether a thermo job runs — not whether a species may be declared in an input that names it.

The existing `test_generate_arkane_input` never caught this because `ARCSpecies.compute_thermo` defaults to `not is_ts`, i.e. `True` for ordinary species; the defect only surfaces when a caller sets it to `False` explicitly.

## The change

Collect the labels named by any reaction in the render's reaction list, and let a species through the gate if it is one of them:

```python
if e0_only or spc.compute_thermo or spc.label in reaction_species_labels:
```

Deliberately narrow rather than dropping the gate: dropping it would push species into thermo inputs that exclude them on purpose. For a thermo render `self.reactions` is `None`, so the new set is empty and the gate is unchanged — thermo inputs are unaffected.

## Testing

- New unit test: a reactant with `compute_thermo=False` now renders as a `species('R', ...)` line in a kinetics input.
- Mutation: restoring the old gate turns it red, with the rendered text showing `reaction(reactants=['R'], products=['P'])` above zero `species(` lines.
- `arc/statmech/`: 50 passed.
- **End to end on real converged output.** Taking the failing run's own kinetics input and adding only the two `species(...)` declarations this fix emits, Arkane exits 0 and writes the rate coefficient it previously could not produce:
  ```
  kinetics(label = '[O]C=O(1) <=> O=[C]O(8)',
      kinetics = Arrhenius(A=(36.3562,'s^-1'), n=3.33173, Ea=(61.8336,'kJ/mol'),
                           T0=(1,'K'), Tmin=(300,'K'), Tmax=(3000,'K')))
  ```
  No new quantum chemistry — the converged logs were already on disk. (Those numbers come from an RMG-Py checkout that is behind `main` in `arkane/`, so treat them as a plumbing result, not a physical one.)

Note for anyone running these tests: `arc/statmech/` needs `-n0`. Under the default xdist config `test_generate_arkane_input` flakes, because sibling workers share the on-disk `arc/testing/arkane_input_tests_delete` directory. Pre-existing and unrelated to this change.

---

## Separately: an unrelated bug found on the same run

`arc/job/ssh.py:42-43` unpacked `self.connect()`, which returns `None`. Not fixed here, and no longer needs to be: @calvinp0 pointed out it is already fixed in #1001 (`self._sftp, self._ssh = self.connect()` → `self.connect()`, with a regression test). Tracked there.