### PR TITLE
Seed the flipped reaction with a family so the reverse-discovery retry can map it

### DIFF
--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -61,7 +61,7 @@ def map_reaction(rxn: ARCReaction,
         except ValueError:
             return None
     if flip:
-        raw_map = try_mapping(rxn.flip_reaction())
+        raw_map = try_mapping(prepare_flipped_reaction(rxn))
         if raw_map is None:
             return None
         return check_atom_map_and_return(flip_map(raw_map))
@@ -78,6 +78,42 @@ def map_reaction(rxn: ARCReaction,
     if raw_map is None:
         return map_reaction(rxn, backend=backend, flip=True)
     return check_atom_map_and_return(raw_map)
+
+
+def prepare_flipped_reaction(rxn: ARCReaction) -> ARCReaction:
+    """
+    Build the flipped reaction and give it a usable, forward-discovered family template.
+
+    ``ARCReaction.flip_reaction`` resets the family, so the flipped copy re-derives its product dictionaries
+    lazily with the *default* family set. When the original reaction was matched only by a broader set - the
+    usual situation for a template discovered in reverse - that rederivation comes back empty and the flip
+    retry has nothing to map with. Widen the search in that case, and prefer a template that describes the
+    flipped reaction forward.
+
+    Args:
+        rxn (ARCReaction): The reaction to flip.
+
+    Returns:
+        ARCReaction: The flipped reaction, seeded with a family and product dictionaries where possible.
+    """
+    flipped = rxn.flip_reaction()
+    try:
+        product_dicts = flipped.product_dicts or list()
+    except (ValueError, KeyError, AttributeError):
+        product_dicts = list()
+    if not any(not pd.get('discovered_in_reverse') for pd in product_dicts):
+        try:
+            widened = flipped.get_product_dicts(rmg_family_set='all')
+        except (ValueError, KeyError, AttributeError):
+            widened = list()
+        product_dicts = widened or product_dicts
+    forward_dicts = [pd for pd in product_dicts if not pd.get('discovered_in_reverse')]
+    product_dicts = forward_dicts or product_dicts
+    if product_dicts:
+        flipped.product_dicts = product_dicts
+        flipped.family = product_dicts[0]['family']
+        flipped.family_own_reverse = product_dicts[0]['own_reverse']
+    return flipped
 
 
 def check_atom_map_and_return(atom_map: list[int] | None) -> list[int] | None:

--- a/arc/mapping/driver.py
+++ b/arc/mapping/driver.py
@@ -101,17 +101,27 @@ def prepare_flipped_reaction(rxn: ARCReaction) -> ARCReaction:
         product_dicts = flipped.product_dicts or list()
     except (ValueError, KeyError, AttributeError):
         product_dicts = list()
-    if not any(not pd.get('discovered_in_reverse') for pd in product_dicts):
+    if all(pd.get('discovered_in_reverse') for pd in product_dicts):
         try:
             widened = flipped.get_product_dicts(rmg_family_set='all')
         except (ValueError, KeyError, AttributeError):
             widened = list()
+        logger.debug(f'Widened the family search for {flipped.label} to all families, '
+                     f'got {len(widened)} product dictionaries.')
         product_dicts = widened or product_dicts
     forward_dicts = [pd for pd in product_dicts if not pd.get('discovered_in_reverse')]
     product_dicts = forward_dicts or product_dicts
     if product_dicts:
+        # Keep only the chosen family's dictionaries. get_reaction_family_products() concatenates matches
+        # across every family without grouping them, while ``family`` can only name one, so leaving the
+        # whole list in place lets map_rxn's product_dict_index retry pair one family's recipe with
+        # another's label map. Every family labels its atoms *1/*2/*3, so that mispairing resolves against
+        # the wrong atoms and still yields a permutation, which is all check_atom_map_and_return verifies.
+        # TODO: replace with ARCReaction.restrict_product_dicts_to_family() once #978 lands.
+        family = product_dicts[0]['family']
+        product_dicts = [pd for pd in product_dicts if pd['family'] == family]
         flipped.product_dicts = product_dicts
-        flipped.family = product_dicts[0]['family']
+        flipped.family = family
         flipped.family_own_reverse = product_dicts[0]['own_reverse']
     return flipped
 

--- a/arc/mapping/driver_test.py
+++ b/arc/mapping/driver_test.py
@@ -871,9 +871,12 @@ class TestMappingDriver(unittest.TestCase):
                                      ARCSpecies(label='HCl', smiles='Cl')])
         rxn.product_dicts = rxn.get_product_dicts(rmg_family_set='all')
         flipped = prepare_flipped_reaction(rxn)
-        self.assertIsNotNone(flipped.family)
+        self.assertEqual(flipped.family, 'XY_Addition_MultipleBond')
         self.assertTrue(flipped.product_dicts)
         self.assertFalse(flipped.product_dicts[0]['discovered_in_reverse'])
+        # Only the chosen family's dictionaries survive, so a recipe can never be paired with another
+        # family's label map.
+        self.assertEqual({pd['family'] for pd in flipped.product_dicts}, {'XY_Addition_MultipleBond'})
         # The template products of a forward discovery are isomorphic to that reaction's own products.
         template_products = flipped.product_dicts[0]['products']
         self.assertEqual(len(template_products), len(flipped.p_species))

--- a/arc/mapping/driver_test.py
+++ b/arc/mapping/driver_test.py
@@ -860,6 +860,46 @@ class TestMappingDriver(unittest.TestCase):
         self.assertIn(tuple(rxn_4.atom_map[5: 8]), list(permutations([3, 4, 5])))
         self.assertEqual(rxn_4.atom_map[8:], [6, 9])
 
+    def test_prepare_flipped_reaction_seeds_a_forward_template(self):
+        """Test that the flipped reaction is given a family that matches it in the forward direction.
+
+        ``flip_reaction`` resets the family, so the flipped copy would otherwise re-derive its product
+        dictionaries with the default family set, come back empty, and leave the flip retry with nothing.
+        """
+        rxn = ARCReaction(r_species=[ARCSpecies(label='C2H5Cl', smiles='CCCl')],
+                          p_species=[ARCSpecies(label='C2H4', smiles='C=C'),
+                                     ARCSpecies(label='HCl', smiles='Cl')])
+        rxn.product_dicts = rxn.get_product_dicts(rmg_family_set='all')
+        flipped = prepare_flipped_reaction(rxn)
+        self.assertIsNotNone(flipped.family)
+        self.assertTrue(flipped.product_dicts)
+        self.assertFalse(flipped.product_dicts[0]['discovered_in_reverse'])
+        # The template products of a forward discovery are isomorphic to that reaction's own products.
+        template_products = flipped.product_dicts[0]['products']
+        self.assertEqual(len(template_products), len(flipped.p_species))
+        self.assertTrue(any(flipped.p_species[0].is_isomorphic(mol) for mol in template_products))
+
+    def test_map_reaction_with_a_reverse_discovered_template(self):
+        """Test mapping an elimination whose family only matches it in the addition direction.
+
+        ``XY_Addition_MultipleBond`` matches HX elimination only in reverse, so the template's 'products'
+        are isomorphic to the reaction's reactants. Both ``get_template_product_order`` and
+        ``reorder_p_label_map`` compare against the reaction's products, so the forward attempt fails until
+        the reaction is flipped first.
+        """
+        rxn = ARCReaction(r_species=[ARCSpecies(label='C2H5Cl', smiles='CCCl')],
+                          p_species=[ARCSpecies(label='C2H4', smiles='C=C'),
+                                     ARCSpecies(label='HCl', smiles='Cl')])
+        rxn.product_dicts = rxn.get_product_dicts(rmg_family_set='all')
+        rxn.family = rxn.product_dicts[0]['family']
+        rxn.family_own_reverse = rxn.product_dicts[0]['own_reverse']
+        self.assertEqual(rxn.family, 'XY_Addition_MultipleBond')
+        self.assertTrue(rxn.product_dicts[0]['discovered_in_reverse'])
+        atom_map = map_reaction(rxn=rxn, backend='ARC')
+        self.assertIsNotNone(atom_map)
+        self.assertEqual(sorted(atom_map), list(range(len(atom_map))))
+        self.assertTrue(check_atom_map(rxn))
+
     def test_map_flipped_reaction(self):
         """Test the map_flipped_reaction() function."""
         c2h5o3_xyz = {'coords': ((-1.3476727508427788, -0.49923624257482285, -0.3366372557370102),


### PR DESCRIPTION
## Problem

`7885a456` ("Map reactions in the direction their family was discovered in") correctly recognizes a
reaction whose every template was discovered in reverse and routes it to the flip retry:

```python
if rxn.product_dicts and all(product_dict.get('discovered_in_reverse', False)
                             for product_dict in rxn.product_dicts):
    return map_reaction(rxn, backend=backend, flip=True)
```

The detection is right — such a template's `products` are isomorphic to the reaction's *reactants*, and
both `get_template_product_order` and `reorder_p_label_map` compare template products against
`rxn.p_species`, so a forward attempt is doomed.

But the flip retry it hands off to cannot map them:

```python
if flip:
    raw_map = try_mapping(rxn.flip_reaction())
```

`ARCReaction.flip_reaction` deletes `family` from the reaction dict (`reset_keys`), so the flipped copy
re-derives its product dictionaries lazily with the **default** family set. A reaction whose family was
only matched by a broader set — the usual situation for a template discovered in reverse — comes back with
zero product dictionaries and no family, and the retry has nothing to map with. The branch above returns
unconditionally, so the forward attempt is not tried either.

Concretely, for `C2H4F2 <=> CH2CHF + HF`:

```
forward   family=XY_Addition_MultipleBond  discovered_in_reverse=True
          template products ['CC(F)F'] -> isomorphic to the *reactant*, not the products
flipped   product_dicts (default set) = 0   -> family None
```

Measured over the 452 reactions of `testing/errs_no_li.yml`, 43 have a family that is discovered only in
reverse and is not its own reverse. On `main`, 6 of those 43 map.

## Fix

Give the flipped reaction a usable, forward-discovered template before mapping it. New
`prepare_flipped_reaction` widens the family search when the lazy default finds nothing usable, prefers a
template that describes the flipped reaction forward, and seeds `family` / `family_own_reverse` /
`product_dicts` onto the copy.

```diff
     if flip:
-        raw_map = try_mapping(rxn.flip_reaction())
+        raw_map = try_mapping(prepare_flipped_reaction(rxn))
```

The detection block from `7885a456` is unchanged; this only makes the path it delegates to work. Nothing
else in the mapping pipeline is touched, and the forward path is byte-identical.

## Test

Two new tests in `arc/mapping/driver_test.py`:

* `test_prepare_flipped_reaction_seeds_a_forward_template` — the flipped reaction gets a family, its
  template is forward-discovered, and its template products are isomorphic to its own products.
* `test_map_reaction_with_a_reverse_discovered_template` — `C2H5Cl <=> C2H4 + HCl`
  (`XY_Addition_MultipleBond`, discovered in reverse) maps to a valid permutation.

Before (this branch's tests against `main`'s `arc/mapping/driver.py`):

```
E       NameError: name 'prepare_flipped_reaction' is not defined
arc/mapping/driver_test.py:873: NameError
>       self.assertIsNotNone(atom_map)
E       AssertionError: unexpectedly None
arc/mapping/driver_test.py:899: AssertionError
2 failed in 4.40s
```

After:

```
2 passed in 4.89s
```

Full suites: `arc/mapping/` and `arc/reaction/` → `133 passed`.

## Corpus effect

Same script over all 452 reactions of `testing/errs_no_li.yml`, `map_reaction` with
`rmg_family_set='all'`, 45 s per reaction:

| | mapped | of the 43 reverse-discovered |
|---|---|---|
| `main` (c4c2db99) | 294 / 452 | 6 / 43 |
| this branch | 331 / 452 | 43 / 43 |

All 43 reactions whose template is discovered only in reverse now map, and no reaction that mapped before
stops mapping. The families recovered are `XY_Addition_MultipleBond` (32), plus
`halocarbene_recombination` and `R_Addition_MultipleBond` cases — HX eliminations such as
`C2H5Cl <=> C2H4 + HCl` and `C2H3F3 <=> CH2CF2 + HF`, which RMG matches only as additions.
