### PR TITLE
fix(species): coerce and validate ARCSpecies.run_time at the constructor boundary

### DIFF
--- a/arc/species/species.py
+++ b/arc/species/species.py
@@ -6,7 +6,7 @@ If the species is a transition state (TS), its ``ts_guesses`` attribute will hav
 import datetime
 import numpy as np
 import os
-from math import isclose
+from math import isclose, isfinite
 from typing import Any
 
 import arc.molecule.element as elements
@@ -126,7 +126,8 @@ class ARCSpecies(object):
         rxn_index (int, optional): The reaction index which is the respective key to the Scheduler rxn_dict.
         external_symmetry (int, optional): The external symmetry of the species (not including rotor symmetries).
         optical_isomers (int, optional): Whether (=2) or not (=1) the species has chiral center/s.
-        run_time (timedelta, optional): Overall species execution time.
+        run_time (timedelta | int | float, optional): Overall species execution time,
+                                                     an ``int``/``float`` is interpreted as seconds.
         checkfile (str, optional): The local path to the latest checkfile by Gaussian for the species.
         number_of_radicals (int, optional): The number of radicals (inputted by the user, ARC won't attempt to determine
                                             it). Defaults to None. Important, e.g., if a Species is a bi-rad singlet,
@@ -338,7 +339,7 @@ class ARCSpecies(object):
                  number_of_radicals: int | None = None,
                  optical_isomers: int | None = None,
                  preserve_param_in_scan: list | None = None,
-                 run_time: datetime.timedelta | None = None,
+                 run_time: datetime.timedelta | int | float | None = None,
                  rxn_label: str | None = None,
                  rxn_index: int | None = None,
                  smiles: str = '',
@@ -377,7 +378,7 @@ class ARCSpecies(object):
         self.active = active
         self.optical_isomers = optical_isomers
         self.charge = charge
-        self.run_time = run_time
+        self.run_time = process_run_time(run_time)
         self.checkfile = checkfile
         self.transport_data = TransportData()
         self.yml_path = yml_path
@@ -870,7 +871,7 @@ class ARCSpecies(object):
             self.label = species_dict['label']
         except KeyError:
             raise InputError('All species must have a label')
-        self.run_time = datetime.timedelta(seconds=species_dict['run_time']) if 'run_time' in species_dict else None
+        self.run_time = process_run_time(species_dict.get('run_time'))
         self.original_label = species_dict['original_label'] if 'original_label' in species_dict else None
         self.t1 = species_dict['t1'] if 't1' in species_dict else None
         self.e_elect = species_dict['e_elect'] if 'e_elect' in species_dict else None
@@ -2936,6 +2937,34 @@ class TransportData(object):
         """
         return (TransportData, (self.shapeIndex, self.epsilon, self.sigma, self.dipoleMoment,
                                 self.polarizability, self.rotrelaxcollnum, self.comment))
+
+
+def process_run_time(run_time: datetime.timedelta | int | float | None,
+                     ) -> datetime.timedelta | None:
+    """
+    Coerce a ``run_time`` value to a ``datetime.timedelta`` at the point it enters an ARCSpecies.
+
+    Args:
+        run_time (datetime.timedelta | int | float | None): The overall species execution time.
+            ``None`` stays ``None``; a ``timedelta`` is returned unchanged; an ``int``/``float`` is
+            interpreted as a number of seconds (the convention used by ``as_dict``/``from_dict``).
+
+    Raises:
+        SpeciesError: If ``run_time`` is a bool, a non-finite number, or any type other than the ones
+                      above, so a caller mistake fails loudly at construction rather than silently at
+                      serialization.
+
+    Returns:
+        datetime.timedelta | None: The normalized run time.
+    """
+    if run_time is None or isinstance(run_time, datetime.timedelta):
+        return run_time
+    if isinstance(run_time, bool) or not isinstance(run_time, (int, float)):
+        raise SpeciesError(f'run_time must be a datetime.timedelta, an int/float number of seconds, '
+                           f'or None, got {type(run_time).__name__}: {run_time!r}')
+    if not isfinite(run_time):
+        raise SpeciesError(f'run_time must be a finite number of seconds, got {run_time!r}')
+    return datetime.timedelta(seconds=run_time)
 
 
 def determine_occ(xyz, charge):

--- a/arc/species/species_test.py
+++ b/arc/species/species_test.py
@@ -5,6 +5,7 @@
 This module contains unit tests of the arc.species.species module
 """
 
+import datetime
 import os
 import shutil
 import tempfile
@@ -37,6 +38,7 @@ from arc.species.species import (ARCSpecies,
                                  colliding_atoms,
                                  determine_rotor_symmetry,
                                  determine_rotor_type,
+                                 process_run_time,
                                  rmg_mol_from_dict_repr,
                                  rmg_mol_to_dict_repr,
                                  split_mol,
@@ -870,6 +872,56 @@ H      -1.67091600   -1.35164600   -0.93286400"""
         restored = ARCSpecies(species_dict=spc_dict)
         self.assertTrue(restored.thermo_at_own_level)
         self.assertEqual(restored.adaptive_lot_n_heavy, 8)
+
+    def test_run_time_coercion(self):
+        """Test that run_time is coerced to a timedelta at construction and round-trips."""
+        # None stays None.
+        spc_none = ARCSpecies(label='x', smiles='C')
+        self.assertIsNone(spc_none.run_time)
+
+        # A plain number is interpreted as seconds and coerced to a timedelta.
+        spc = ARCSpecies(label='x', smiles='C', run_time=12.5)
+        self.assertEqual(spc.run_time, datetime.timedelta(seconds=12.5))
+        restored = ARCSpecies(species_dict=spc.as_dict())
+        self.assertEqual(restored.run_time, datetime.timedelta(seconds=12.5))
+
+        # An int is likewise seconds.
+        self.assertEqual(ARCSpecies(label='x', smiles='C', run_time=90).run_time,
+                         datetime.timedelta(seconds=90))
+
+        # A timedelta is stored unchanged.
+        td = datetime.timedelta(hours=1, seconds=5)
+        self.assertEqual(ARCSpecies(label='x', smiles='C', run_time=td).run_time, td)
+
+        # An unacceptable type raises immediately at construction.
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='x', smiles='C', run_time='12.5')
+        self.assertIn('run_time', str(cm.exception))
+        self.assertIn('str', str(cm.exception))
+
+        # A boolean is a caller mistake, not 1 second.
+        with self.assertRaises(SpeciesError):
+            ARCSpecies(label='x', smiles='C', run_time=True)
+
+        # A non-finite number cannot be a duration.
+        with self.assertRaises(SpeciesError) as cm:
+            ARCSpecies(label='x', smiles='C', run_time=float('inf'))
+        self.assertIn('finite', str(cm.exception))
+
+    def test_process_run_time(self):
+        """Test the process_run_time() coercion helper directly."""
+        self.assertIsNone(process_run_time(None))
+        self.assertEqual(process_run_time(12.5), datetime.timedelta(seconds=12.5))
+        self.assertEqual(process_run_time(90), datetime.timedelta(seconds=90))
+        td = datetime.timedelta(minutes=3)
+        self.assertIs(process_run_time(td), td)
+        with self.assertRaises(SpeciesError):
+            process_run_time('12.5')
+        with self.assertRaises(SpeciesError):
+            process_run_time(True)
+        for non_finite in [float('inf'), float('-inf'), float('nan')]:
+            with self.assertRaises(SpeciesError):
+                process_run_time(non_finite)
 
     def test_from_dict(self):
         """Test Species.from_dict()"""


### PR DESCRIPTION
## What

`ARCSpecies.__init__` stored `run_time` unexamined, even though the annotation and class docstring promise a `datetime.timedelta`. A caller passing seconds as a plain number — `ARCSpecies(label='x', run_time=12.5)` — was accepted silently at construction and only failed much later at serialization, in `as_dict`, with `AttributeError: 'float' object has no attribute 'total_seconds'`. The traceback pointed at `as_dict`, not at where the mistake was made. `from_dict` already coerced on the way in; the constructor was the asymmetry.

## Change

Add a single module-level helper `process_run_time()` in `arc/species/species.py` and route both entry points (constructor at `:380` and `from_dict` at `:873`) through it:

- `None` → stays `None`
- `datetime.timedelta` → stored unchanged
- `int` / `float` → interpreted as **seconds** (the existing `total_seconds()` round-trip convention) and converted to `timedelta`
- anything else → immediate `SpeciesError` naming the parameter, the type received, and the accepted types

**Booleans raise.** `bool` is an `int` subclass, so it is checked first and rejected: a boolean `run_time` is almost certainly a caller mistake, and coercing `True`→1 s would manufacture a plausible-but-wrong duration — the exact fail-late-with-a-wrong-value class this change removes.

The public type of `run_time` is unchanged (`timedelta`); this makes the object honour it. No schema, data-file, migration, or API-signature changes.

## Tests

New `test_run_time_coercion` (round-trip through `as_dict`/`species_dict=`, `timedelta` stored unchanged, `None` stays `None`, `str` and `bool` raise `SpeciesError` at construction with the message asserted) and `test_process_run_time` (helper unit test) in `arc/species/species_test.py`.

- `arc/species/species_test.py` — 95 passed
- `arc/scheduler_test.py` — 52 passed

Mutation-checked: reverting only the constructor wiring makes `test_run_time_coercion` fail on the coercion assertion; restoring it passes.