### PR TITLE
Docker: pin Julia to 1.10.11, unbreaking the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,15 @@ ENV MAMBA_USER=mambauser
 # which then dies with NoChannelsConfiguredError (non-fatally) and silently drops that pin.
 RUN printf 'channels:\n  - conda-forge\n' > /home/mambauser/.condarc
 
-# Set JuliaUp PATH and install Julia 1.10 as req. by RMG (mirrors RMG-Py's own Dockerfile)
+# Set JuliaUp PATH and install Julia as req. by RMG (mirrors RMG-Py's own Dockerfile).
+# Pinned to a patch version, not the 1.10 channel: `from juliacall import Main` segfaults under
+# Julia 1.10.12 (released 17 Aug 2026), and the channel floats to the newest patch, so every build
+# from 20 Aug on died in install_rms.sh. RMG-Py pinned the same version for the same reason in
+# 62eb728c0 ("Pin Julia and openbabel to unbreak CI").
 ENV PATH="/home/mambauser/.juliaup/bin:$PATH"
-RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10 && \
-    juliaup add 1.10 && \
-    juliaup default 1.10 && \
+RUN wget -qO- https://install.julialang.org | sh -s -- --yes --default-channel 1.10.11 && \
+    juliaup add 1.10.11 && \
+    juliaup default 1.10.11 && \
     juliaup list && \
     rm -rf /home/mambauser/.juliaup/downloads /home/mambauser/.juliaup/tmp
 
@@ -153,7 +157,7 @@ ENV PYTHON_JULIAPKG_EXE=/home/mambauser/.juliaup/bin/julia
 # any --entrypoint override) lands on root with HOME=/root rather than going through
 # entrywrapper.sh's `runuser -u mambauser`. juliaup then finds no config, falls back to the
 # `release` channel, and downloads a newer Julia over the network - silently bypassing the pinned
-# 1.10 and every pkgimage baked above, or hard-failing when the host is offline. Pinning the depot
+# 1.10.11 and every pkgimage baked above, or hard-failing when the host is offline. Pinning the depot
 # explicitly makes resolution HOME-independent. Note this is JULIAUP_DEPOT_PATH, not
 # JULIA_DEPOT_PATH; juliaup does not read the latter for channel lookup.
 ENV JULIAUP_DEPOT_PATH=/home/mambauser/.julia


### PR DESCRIPTION
## The failure

Every push to `main` since 20 Aug has failed the *Docker Image Build and Push* workflow ([latest run](https://github.com/ReactionMechanismGenerator/ARC/actions/runs/33111621501/job/98655611199)), always in the same layer:

```
#17 1864.3 install_rms.sh: line 140:  77 Segmentation fault  (core dumped) python <<EOF
#17 ERROR: process "... micromamba run -n rmg_env bash -c \"cd .../RMG-Py && source install_rms.sh\"" did not complete successfully: exit code: 1
```

That heredoc is install_rms.sh's `from juliacall import Main` check, and `python << EOF || return 1` turns its failure into a failed build. Same segfault in the 20 Aug (job 96581372697) and 24 Aug (job 97406886973) runs, so it is one cause for the whole red streak, not a flake.

## Root cause

The builder stage asked juliaup for the floating `1.10` channel. That channel resolved to 1.10.11 through 16 Aug and to **1.10.12 from 17 Aug**, and juliacall segfaults on import under 1.10.12. RMG-Py walked into this first and pinned the same patch version in its CI workflow and Dockerfile in [62eb728c0](https://github.com/ReactionMechanismGenerator/RMG-Py/commit/62eb728c0) ("Pin Julia and openbabel to unbreak CI"); ARC's Dockerfile installs Julia itself and did not follow.

## The fix

Ask juliaup for `1.10.11` instead of `1.10`, in all three places of the install step. One hunk, plus one final-stage comment line that names the pinned version.

## Why pyjuliacall is left alone

RMG-Py pinned `pyjuliacall==0.9.28` alongside the Julia pin. ARC does not need to follow: the identical Dockerfile with only the Julia pin applied built green on 27 Aug on branch `fix_remote_job_lifecycle` ([job 98677031469](https://github.com/ReactionMechanismGenerator/ARC/actions/runs/33117859982), reaching "✅ ReactionMechanismSimulator is succesfully installed!") with pyjuliacall 0.9.34, which is what `pyjuliacall<0.9.35` resolves to today. Keeping the change to one variable also keeps the bisect honest.

That green run is on a feature branch that also carries unrelated SSH work; this PR isolates the pin so `main` can go green without waiting on it.

## Known, not fixed here

install_rms.sh's `conda install -y 'conda-forge::pyjuliacall==0.9.28'` fails inside the image — in the green run too, so it is not what breaks the build:

```
PackagesNotFoundInChannelsError: The following packages are not available from current channels:
  - blas*.*
```

conda cannot re-solve the `blas=*=openblas` spec that RMG-Py's `environment.yml` records into the micromamba-created env. It is silently non-fatal (install_rms.sh does not check the status), but it burned ~30 of the 44 minutes of the failing run and means the upstream pyjuliacall pin never takes effect in this image. Upstream territory; worth its own issue.

## Verification

CI on this PR is the verifier: the "Build Docker Image (No Push)" job has to get past `install_rms.sh` to "✅ ReactionMechanismSimulator is succesfully installed!".