### PR TITLE
Seed a bridging hydrogen's TS distances from measured data

### DIFF
--- a/arc/job/adapters/ts/linear_test.py
+++ b/arc/job/adapters/ts/linear_test.py
@@ -75,6 +75,7 @@ from arc.mapping.driver import map_rxn
 from arc.molecule import Molecule
 from arc.reaction import ARCReaction
 from arc.species.converter import compare_zmats, order_mol_by_atom_map, order_xyz_by_atom_map, str_to_xyz, xyz_to_str, zmat_from_xyz
+from arc.species.vectors import calculate_angle
 from arc.species.species import ARCSpecies, colliding_atoms
 
 
@@ -1226,14 +1227,14 @@ H      -0.58902376   -0.50657502    2.07187062"""
         self.assertGreaterEqual(len(ts_xyzs), 1)
         # Check 3-membered ring distances in the TS guess.
         # Product ordering: P[4]=CO carbon (*1, ins), P[1]=quaternary C (*2, sub),
-        # P[15]=migrating H (*3, mig). Targets: C-C ~ sbl+0.42 = 1.96, C-H ~ 1.51.
+        # P[15]=migrating H (*3, mig). Targets: C-C ~ sbl+PAULING_DELTA = 1.96, C-H ~ 1.34.
         ts_coords = np.array(ts_xyzs[0]['coords'])
         d_cc = float(np.linalg.norm(ts_coords[4] - ts_coords[1]))   # *1-*2 C-C forming
         d_ch1 = float(np.linalg.norm(ts_coords[4] - ts_coords[15]))  # *1-*3 C-H forming
         d_ch2 = float(np.linalg.norm(ts_coords[1] - ts_coords[15]))  # *2-*3 C-H breaking
         self.assertAlmostEqual(d_cc, 1.96, delta=0.05)
-        self.assertAlmostEqual(d_ch1, 1.51, delta=0.05)
-        self.assertAlmostEqual(d_ch2, 1.51, delta=0.05)
+        self.assertAlmostEqual(d_ch1, 1.34, delta=0.05)
+        self.assertAlmostEqual(d_ch2, 1.34, delta=0.05)
         # Verify the TS guess also works through the main interpolate() dispatcher.
         ts_xyzs_dispatch = interpolate(rxn, weight=0.5)
         self.assertIsNotNone(ts_xyzs_dispatch)
@@ -1253,7 +1254,7 @@ H       2.19094503    0.35635213   -0.37050110
 H       0.73390517   -1.58346878   -1.32345883
 H       0.40195890   -2.11601880    0.33323885
 H      -0.93707925   -1.76281070   -0.75913154
-H       0.11567616   -0.67766058    1.34266988"""
+H      -0.01773334   -0.52002285    1.22575722"""
         self.assertTrue(almost_equal_coords(ts_xyzs_dispatch[0], str_to_xyz(expected_ts)))
 
     def test_interpolate_1_2_insertion_carbene(self):
@@ -1295,19 +1296,19 @@ H      -0.58767904   -1.85093188    0.22577726"""
         rxn = ARCReaction(r_species=[r_1, r_2], p_species=[p])
         self.assertTrue(any(pd['family'] == '1,2_Insertion_carbene' for pd in rxn.product_dicts))
         ts_xyzs = interpolate_addition(rxn, weight=0.5)
-        expected_ts = """ C                  1.97753426   -0.34691463   -0.12195850
- C                  0.96032171    0.45485914   -0.46215363
- C                 -0.43629664    0.27157147   -0.09968556
- C                 -1.35584640    1.15966116   -0.51269091
- C                 -1.01062785   -1.43028901    1.10007048
- H                  2.98719352   -0.11575642   -0.44772907
- H                  1.84910220   -1.24076974    0.47792776
- H                  1.19368072    1.33006788   -1.06832846
- H                 -2.40510842    1.04750710   -0.25687679
- H                 -1.09525737    2.02366247   -1.11636739
- H                 -0.50299705   -1.41014794    2.07047336
- H                 -2.08819756   -1.44598384    1.29850705
- H                 -0.26777988   -1.39577664   -0.43976256"""
+        expected_ts = """C       1.97753426   -0.34691463   -0.12195850
+ C       0.96032171    0.45485914   -0.46215363
+ C      -0.43629664    0.27157147   -0.09968556
+ C      -1.35584640    1.15966116   -0.51269091
+ C      -1.01062785   -1.43028901    1.10007048
+ H       2.98719352   -0.11575642   -0.44772907
+ H       1.84910220   -1.24076974    0.47792776
+ H       1.19368072    1.33006788   -1.06832846
+ H      -2.40510842    1.04750710   -0.25687679
+ H      -1.09525737    2.02366247   -1.11636739
+ H      -0.50299705   -1.41014794    2.07047336
+ H      -2.08819756   -1.44598384    1.29850705
+ H      -0.26777988   -1.39577664   -0.43976256"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
         for ts in ts_xyzs:
             coords = np.array(ts['coords'], dtype=float)
@@ -1351,7 +1352,7 @@ H       0.93760911   -0.05885406   -0.10079043"""
         ts_xyzs = interpolate_addition(rxn, weight=0.5)
         self.assertIsNotNone(ts_xyzs)
         self.assertGreaterEqual(len(ts_xyzs), 1)
-        # Targets: N-N breaking ~ 1.87 Å, migrating N-H bonds ~ 1.46 Å each.
+        # Targets: N-N breaking ~ 1.87 Å, migrating N-H bonds ~ 1.29 Å each.
         # Checks are element-based to be agnostic to symmetric atom-map choices.
         ts_coords = np.array(ts_xyzs[0]['coords'])
         ts_syms = ts_xyzs[0]['symbols']
@@ -1361,8 +1362,8 @@ H       0.93760911   -0.05885406   -0.10079043"""
         nh_dists = [float(np.linalg.norm(ts_coords[i] - ts_coords[j])) for i in n_idx for j in h_idx]
         self.assertTrue(any(abs(d - 1.87) <= 0.05 for d in nn_dists),
                         msg=f'No N-N distance near 1.87; found: {sorted(nn_dists)}')
-        self.assertGreaterEqual(sum(1 for d in nh_dists if abs(d - 1.46) <= 0.05), 2,
-                                msg=f'Expected ≥2 N-H distances near 1.46; found: {sorted(nh_dists)}')
+        self.assertGreaterEqual(sum(1 for d in nh_dists if abs(d - 1.29) <= 0.05), 2,
+                                msg=f'Expected ≥2 N-H distances near 1.29; found: {sorted(nh_dists)}')
         # Verify the dispatcher routes correctly.
         ts_xyzs_dispatch = interpolate(rxn, weight=0.5)
         self.assertIsNotNone(ts_xyzs_dispatch)
@@ -1372,7 +1373,7 @@ N      -0.00831159    0.62912211   -0.22607923
 N      -0.04578555    2.00661712    1.03804228
 H      -1.36396603   -0.52480010    0.69598616
 H      -1.33497366   -0.72150540   -0.90528855
-H       0.20944918    2.06247116   -0.39838925
+H       0.15989085    1.90643919   -0.22983258
 H       0.00589419    1.63067767    1.98481623
 H      -0.94141747    2.49625864    0.98628387"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts_1)) for ts in ts_xyzs))
@@ -2442,7 +2443,7 @@ C       1.98480797   -0.63419881    1.11326670
 C       2.89460169   -0.97770151    2.03563992
 C       4.29204937   -1.25631974    1.79961635
 C       4.92103178   -1.21988996    0.61918910
-H       2.12504139   -0.23109108   -1.76747526
+H       2.20865236   -0.27471550   -1.60325852
 H       0.97240698   -0.46160558    1.47844588
 H       2.59583552   -1.06787309    3.08000952
 H       4.91203689   -1.52458145    2.65504088
@@ -3089,26 +3090,26 @@ H       1.69266033   -2.46579510   -0.55597779"""
         p = ARCSpecies(label='P', smiles='C=C1CCC2=C1C=CC=C2', xyz=p_xyz)
         rxn = ARCReaction(r_species=[r], p_species=[p])
         ts_xyzs = interpolate_isomerization(rxn)
-        expected_ts = """C      -0.58774421   -0.86950721    2.63194231
-C      -0.58774421   -0.86950721    1.29403214
-C      -0.58952820   -2.08017911    0.49379930
-C      -0.45729633   -1.74899326   -0.96181761
-C      -0.12535369   -0.28971609   -0.97015576
-C       0.65939956    0.36132863   -1.84283691
-C       1.11449884    1.69981068   -1.52783610
-C       0.97158794    2.21611489   -0.29562157
-C       0.27050202    1.49082421    0.74624400
-C      -0.57692212    0.31372713    0.34526007
-H      -0.58774421    0.05552675    3.19964356
-H      -0.58785136   -1.79508467    3.19726799
-H      -0.66085240   -3.08094831    0.89043651
-H      -1.40566432   -1.93678516   -1.47484489
-H       0.33134177   -2.35084298   -1.42324989
-H       1.04547189   -0.11798246   -2.73605523
-H       1.64252956    2.24915027   -2.30122663
-H       1.37243859    3.19513137   -0.05266282
-H       0.14206110    1.96105425    1.71281136
-H      -1.77466057   -0.87821251   -0.07728816"""
+        expected_ts = """C      -0.58774422   -0.86950720    2.63194234
+C      -0.58774422   -0.86950720    1.29403216
+C      -0.58952820   -2.08017915    0.49379940
+C      -0.45729633   -1.74899326   -0.96181750
+C      -0.12535370   -0.28971609   -0.97015567
+C       0.65939956    0.36132853   -1.84283689
+C       1.11449881    1.69981057   -1.52783603
+C       0.97158797    2.21611488   -0.29562189
+C       0.27050205    1.49082443    0.74624385
+C      -0.57692215    0.31372715    0.34526011
+H      -0.58774422    0.05552677    3.19964358
+H      -0.58785138   -1.79508464    3.19726806
+H      -0.66085241   -3.08094829    0.89043676
+H      -1.40566434   -1.93678518   -1.47484474
+H       0.33134179   -2.35084300   -1.42324972
+H       1.04547190   -0.11798256   -2.73605520
+H       1.64252953    2.24915004   -2.30122665
+H       1.37243865    3.19513137   -0.05266329
+H       0.14206121    1.96105474    1.71281109
+H      -1.47957749   -0.89065621    0.22371156"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_intra_rh_add_endocyclic(self):
@@ -3211,8 +3212,8 @@ C       1.02784361   -1.57835621    1.17626773
 C       2.36484309   -2.03834764    1.74819711
 C       3.50408935   -1.61952543    0.87973604
 O       4.36546469   -0.72181688    1.21157095
-H       1.56422743   -0.09701856   -0.79062545
-H       2.09115810    0.99539655    0.50054197
+H       1.68417194   -0.44580003   -0.71317147
+H       1.89123885    1.06362994    0.19064516
 H       3.53132429    0.21665884    0.80480632
 H       1.02736061    0.55104643    1.50934439
 H       0.23918280    0.06065247    0.01999661
@@ -3720,7 +3721,7 @@ H      -0.75612115    0.91309122   -0.33892602
 H      -2.15639522   -1.27161736   -1.23186705
 H      -3.00922579    0.01645873   -0.34766873
 H      -1.97255720    0.42567634   -1.73551809
-H       1.60421902    1.70916992    1.40821236"""
+H       1.48729600    1.49629175    1.22632102"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_korcek_step2(self):
@@ -3791,7 +3792,7 @@ H       3.54727149   -0.08890978   -0.67544945
 H       2.62277112    0.06434082    1.34585278
 H      -0.09844973   -0.43616204    1.68554384
 H       0.18774256   -1.65691471    0.41684740
-H       0.32780493   -0.78747574   -0.84507611
+H       0.24678821   -0.69217359   -0.68602000
 H      -2.30557569    0.51236113    1.05290855
 H      -2.48665452   -0.83141064   -0.10098054
 H      -2.65275729    0.85777810   -0.63272727"""
@@ -4396,26 +4397,26 @@ H       1.80251143    1.03132880   -1.10238169"""
             break
         self.assertTrue(found_ring, msg='No TS guess has 6-membered ring retroene characteristics: O3-C4 stretched '
                                         '(breaking), O2-C4 contracted (ring), H13 migrating from C5 toward O3')
-        expected_ts = """C                  3.35667786   -0.45750645    0.53734155
- C                  2.24637997    0.53978750    0.40948895
- O                  1.25975689    0.57306185    1.13089404
- O                  1.90798055    1.60139464   -0.37185519
- C                 -0.25465664    2.12528094    0.76768134
- C                 -0.03131089    3.04259438   -0.26607527
- C                 -1.40160640    3.23262677    0.38080580
- C                  0.80777963    4.31367617   -0.11759400
- H                  3.43291583   -1.04518301   -0.37749397
- H                  4.29490197    0.05808884    0.74227330
- H                  3.14278867   -1.13176712    1.36663279
- H                 -0.88551430    1.24137878    0.67368347
- H                 -0.03778772    2.29994313    1.82151292
- H                  0.87654037    2.16543158   -1.09462311
- H                 -1.31181604    3.41929928    1.45094180
- H                 -1.92716397    4.07668244   -0.06580283
- H                 -2.02058432    2.34596864    0.24367923
- H                  1.76588869    4.21544196   -0.62796354
- H                  0.29073745    5.16969147   -0.55118965
- H                  1.00524898    4.53585118    0.93109285"""
+        expected_ts = """C       3.35667786   -0.45750645    0.53734155
+ C       2.24637997    0.53978750    0.40948895
+ O       1.25975689    0.57306185    1.13089404
+ O       1.90798055    1.60139464   -0.37185519
+ C      -0.25465664    2.12528094    0.76768134
+ C      -0.03131089    3.04259438   -0.26607527
+ C      -1.40160640    3.23262677    0.38080580
+ C       0.80777963    4.31367617   -0.11759400
+ H       3.43291583   -1.04518301   -0.37749397
+ H       4.29490197    0.05808884    0.74227330
+ H       3.14278867   -1.13176712    1.36663279
+ H      -0.88551430    1.24137878    0.67368347
+ H      -0.03778772    2.29994313    1.82151292
+ H       0.87654037    2.16543158   -1.09462311
+ H      -1.31181604    3.41929928    1.45094180
+ H      -1.92716397    4.07668244   -0.06580283
+ H      -2.02058432    2.34596864    0.24367923
+ H       1.76588869    4.21544196   -0.62796354
+ H       0.29073745    5.16969147   -0.55118965
+ H       1.00524898    4.53585118    0.93109285"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_singlet_carbene_intra_disproportionation(self):
@@ -4456,16 +4457,16 @@ H       0.06681877   -2.19837465    0.09887848"""
         for ts_xyz in ts_xyzs:
             coords = np.array(ts_xyz['coords'], dtype=float)
             d_h10_h11 = float(np.linalg.norm(coords[10] - coords[11]))
-            # Check if one H is at Pauling distance from both C4 and C5.
+            # Check if one H is at the bridging-H distance from both C4 and C5.
             for hi in [10, 11]:
                 d_c4 = float(np.linalg.norm(coords[4] - coords[hi]))
                 d_c5 = float(np.linalg.norm(coords[5] - coords[hi]))
-                if abs(d_c4 - 1.51) < 0.15 and abs(d_c5 - 1.51) < 0.15:
+                if abs(d_c4 - 1.34) < 0.15 and abs(d_c5 - 1.34) < 0.15:
                     found_good = True
                     break
             if found_good:
                 break
-        self.assertTrue(found_good, msg='No TS guess has a Pauling-triangulated H between carbene and donor')
+        self.assertTrue(found_good, msg='No TS guess has a bridge-triangulated H between carbene and donor')
         # The two H's should be well separated (opposite faces).
         self.assertGreater(d_h10_h11, 2.0, msg=f'H10-H11 distance {d_h10_h11:.3f} Å indicates same-side placement')
         expected_ts = """C      -1.75380171    0.48873088   -0.19068706
@@ -4479,7 +4480,7 @@ H      -2.54598297   -0.24449127   -0.30238247
 H       0.56818218    2.09730281    0.12230795
 H       2.80053789    0.73996491    0.34529891
 H      -0.15810977   -1.84238058   -0.97429551
-H       0.49026533   -0.61960200    1.22593576"""
+H       0.53006247   -0.70383622    1.04891837"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_family_none_unimolecular(self):
@@ -4601,15 +4602,15 @@ O       1.37316735   -0.34819332    0.00000000"""
         self.assertTrue(d_cc_break > d_cc_form, 'C-C breaking > C-C forming')
         expected_ts = """C      -1.37170024    0.17370802    0.12747389
 C      -0.17943385   -0.58558878   -0.10310381
-C       0.07444792   -2.33816244    1.48699984
-O       0.97730152   -3.15342961    1.55831677
-O      -0.94011004   -2.36056172    2.37408508
+C       0.07431608   -2.33725228    1.48617406
+O       0.97765269   -3.15193431    1.55805879
+O      -0.94086828   -2.36041047    2.37252288
 H      -1.13665983    1.22554833    0.32156567
 H      -2.02965631    0.12528004   -0.74559965
-H      -1.68321413   -0.67381831    1.26740259
+H      -1.68361962   -0.67383190    1.26652005
 H      -0.21702502   -1.02774537   -1.10407189
 H       0.69165336    0.07422934   -0.03456899
-H      -1.39287106   -1.33285689    1.69980176"""
+H      -1.39333322   -1.33299036    1.69877452"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_halocarbene_recombination(self):
@@ -4706,14 +4707,14 @@ H      -1.18833722   -0.86211206   -0.54632476"""
             assert_h_migration_quality(self, ts_xyz)
         assert_unique_guesses(self, ts_xyzs)
         self.assertGreaterEqual(len(ts_xyzs), 1)
-        expected_ts = """C      -0.41865872    1.21447395   -0.16611224
-H      -0.67018571    1.94949404    0.56967272
-H      -0.67018574    1.32368640   -1.20037860
-C      -0.41865872   -0.23745201    0.34722104
-H      -0.41865872   -0.23745201    1.41722109
-H      -1.29230999   -0.74185488   -0.00944557
-O       0.74893138   -0.91156055   -0.12944556
-H       0.88979859    0.45040550   -0.69723648"""
+        expected_ts = """C      -0.41865873    1.21447391   -0.16611227
+H      -0.67018574    1.94949392    0.56967275
+H      -0.67018575    1.32368629   -1.20037864
+C      -0.41865873   -0.23745204    0.34722107
+H      -0.41865873   -0.23745204    1.41722112
+H      -1.29231003   -0.74185484   -0.00944556
+O       0.74893141   -0.91156049   -0.12944555
+H       0.76705416    0.38587864   -0.59925752"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_intra_h_migration_ccoo(self):  # TODO: some could converge, H's incorrect
@@ -4777,37 +4778,18 @@ H       0.88979859    0.45040550   -0.69723648"""
                         f'd(H,O[2])={d_backbone_O:.3f} vs d(H,O[3])={d_acceptor:.3f}\n'
                         f'{xyz_to_str(ts_xyz)}')
         assert_unique_guesses(self, ts_xyzs)
-        found_good_migrating = False
-        for ts_xyz in ts_xyzs:
-            coords = np.array(ts_xyz['coords'], dtype=float)
-            d_h4_c0 = float(np.linalg.norm(coords[4] - coords[0]))
-            d_h4_o3 = float(np.linalg.norm(coords[4] - coords[3]))
-            if abs(d_h4_c0 - 1.47) < 0.15 and abs(d_h4_o3 - 1.37) < 0.15:
-                found_good_migrating = True
-                break
-        self.assertTrue(found_good_migrating, msg='No TS guess has migrating H4 at Pauling distances from both C0 and O3')
-        # CH₂ on C1: H7-C1-H8 angle should be proper sp³ (~109°).
-        coords_best = np.array(ts_xyzs[0]['coords'], dtype=float)
-        v1 = coords_best[7] - coords_best[1]
-        v2 = coords_best[8] - coords_best[1]
-        cos_a = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
-        h_c_h_angle = float(np.degrees(np.arccos(np.clip(cos_a, -1, 1))))
-        self.assertAlmostEqual(h_c_h_angle, 109.5, delta=10.0, msg=f'H7-C1-H8 angle {h_c_h_angle:.1f}° is not sp³')
-        # H5-C0-H6 angle on the donor should be proper sp³.
-        v1 = coords_best[5] - coords_best[0]
-        v2 = coords_best[6] - coords_best[0]
-        cos_a = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
-        h_c_h_donor = float(np.degrees(np.arccos(np.clip(cos_a, -1, 1))))
-        self.assertAlmostEqual(h_c_h_donor, 109.5, delta=10.0, msg=f'H5-C0-H6 angle {h_c_h_donor:.1f}° is not sp³')
-        # Both donor H's (H5, H6) should point AWAY from acceptor O3
-        # (angle > 90° from C0→O3).
-        co = coords_best[3] - coords_best[0]
-        co_d = float(np.linalg.norm(co))
-        for hi in [5, 6]:
-            ch = coords_best[hi] - coords_best[0]
-            cos_a = float(np.dot(ch, co) / (np.linalg.norm(ch) * co_d))
-            angle_from_o3 = float(np.degrees(np.arccos(np.clip(cos_a, -1, 1))))
-            self.assertGreater(angle_from_o3, 90.0, msg=f'H{hi} at {angle_from_o3:.1f}° from C0→O3 (should be >90° — pointing away from acceptor)')
+        # The best-ranked guess must carry the whole reactive-core geometry: migrating
+        # H4 at bridging distances from C0 and O3, sp3 CH2 groups on C0 and C1, and both
+        # donor H atoms pointing away from the acceptor.
+        best = ts_xyzs[0]
+        coords = np.array(best['coords'], dtype=float)
+        self.assertAlmostEqual(float(np.linalg.norm(coords[4] - coords[0])), 1.34, delta=0.15)
+        self.assertAlmostEqual(float(np.linalg.norm(coords[4] - coords[3])), 1.21, delta=0.15)
+        self.assertAlmostEqual(calculate_angle(coords=best, atoms=[7, 1, 8]), 109.5, delta=10.0)
+        self.assertAlmostEqual(calculate_angle(coords=best, atoms=[5, 0, 6]), 109.5, delta=10.0)
+        for hi in (5, 6):
+            self.assertGreater(calculate_angle(coords=best, atoms=[hi, 0, 3]), 90.0,
+                               msg=f'H{hi} does not point away from the acceptor')
 
     def test_interpolate_intra_h_migration_cccoo(self):
         """Test the interpolate_isomerization() function for intra H migration: CCCOO (6-membered ring): CCCO[O] <=> [CH2]CCOO"""
@@ -4848,18 +4830,18 @@ H       0.88979859    0.45040550   -0.69723648"""
         for i in range(len(ts_xyzs)):
             for j in range(i + 1, len(ts_xyzs)):
                 self.assertFalse(almost_equal_coords(ts_xyzs[i], ts_xyzs[j]), msg=f'Dedup failed: guesses {i} and {j} are near-identical.')
-        expected_ts = """C       0.47409326    0.59770509    1.10290571
-C       0.47409326   -0.85422084    0.58957212
-O       0.47409326   -0.85422084   -0.84042783
-O      -0.54534795   -0.14040038   -1.28042795
-H       1.38779179    1.07650792    0.81864710
-H       0.38755877    0.59894437    2.16940001
-H      -0.43960528   -1.33302357    0.87383085
-H       1.30125719   -1.38298436    1.01514096
-C      -0.80643171    1.30979943    0.62879906
-H      -0.53394636    2.36241421    0.55228849
-H      -1.42091238    0.67945072   -0.59805628
-H      -1.77954418    0.97859120    0.99136386"""
+        expected_ts = """C       0.47409327    0.59770515    1.10290557
+C       0.47409327   -0.85422085    0.58957221
+O       0.47409327   -0.85422085   -0.84042774
+O      -0.54534797   -0.14040037   -1.28042776
+H       1.38779180    1.07650793    0.81864686
+H       0.38755881    0.59894458    2.16939988
+H      -0.43960522   -1.33302365    0.87383099
+H       1.30125722   -1.38298428    1.01514111
+C      -0.80643172    1.30979939    0.62879881
+H      -0.51375909    2.34878352    0.47729064
+H      -1.05555129    0.61616805   -0.48833818
+H      -1.77316547    1.02523063    1.04418595"""
         self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
 
     def test_interpolate_intra_no2_ono_conversion(self):

--- a/arc/job/adapters/ts/linear_utils/addition.py
+++ b/arc/job/adapters/ts/linear_utils/addition.py
@@ -15,13 +15,15 @@ from arc.job.adapters.ts.linear_utils.geom_utils import (
     atom_index_map,
     bfs_path,
     canonical_bond,
+    bond_path_length,
     mol_to_adjacency,
     two_sphere_intersection,
     xyz_with_coords,
 )
 from arc.job.adapters.ts.linear_utils.isomerization import ring_closure_xyz
 from arc.job.adapters.ts.linear_utils.path_spec import ReactionPathSpec, insertion_ring_extra_stretch, validate_addition_guess
-from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA, has_detached_hydrogen, has_too_many_fragments
+from arc.job.adapters.ts.linear_utils.postprocess import (PAULING_DELTA, h_bridge_target_distances,
+                                                          has_detached_hydrogen, has_too_many_fragments)
 from arc.species.species import ARCSpecies, colliding_atoms
 
 if TYPE_CHECKING:
@@ -1141,6 +1143,7 @@ def migrate_verified_atoms(ts_xyz: dict,
     coords = np.array(ts_xyz['coords'], dtype=float)
     ts_coords = coords.copy()
     atom_to_idx = atom_index_map(uni_mol)
+    uni_adj = mol_to_adjacency(uni_mol)
     core_heavy = [idx for idx in core if symbols[idx] != 'H']
 
     # Acceptor may live in any product fragment, not only ``core`` (e.g.
@@ -1179,8 +1182,14 @@ def migrate_verified_atoms(ts_xyz: dict,
             dists = np.linalg.norm(core_coords - ts_coords[h_idx], axis=1)
             acceptor = core_heavy[int(dists.argmin())]
 
-        d_DH = get_single_bond_length(symbols[donor], symbols[h_idx]) + PAULING_DELTA
-        d_AH = get_single_bond_length(symbols[acceptor], symbols[h_idx]) + PAULING_DELTA
+        if symbols[h_idx] == 'H':
+            d_DH, d_AH = h_bridge_target_distances(
+                symbols[donor], symbols[acceptor],
+                float(np.linalg.norm(ts_coords[acceptor] - ts_coords[donor])),
+                bond_path_length(uni_adj, donor, acceptor))
+        else:
+            d_DH = get_single_bond_length(symbols[donor], symbols[h_idx]) + PAULING_DELTA
+            d_AH = get_single_bond_length(symbols[acceptor], symbols[h_idx]) + PAULING_DELTA
 
         ideal = two_sphere_intersection(
             ts_coords[donor], d_DH, ts_coords[acceptor], d_AH, ts_coords[h_idx])
@@ -1341,8 +1350,10 @@ def migrate_h_between_fragments(ts_xyz: dict,
             # same axis point.
             d_pos = ts_coords[donor_heavy]
             h_pos = ts_coords[h_idx]
-            d_DH = get_single_bond_length(symbols[donor_heavy], 'H') + PAULING_DELTA
-            d_AH = get_single_bond_length(symbols[nearest_heavy], 'H') + PAULING_DELTA
+            d_DH, d_AH = h_bridge_target_distances(
+                symbols[donor_heavy], symbols[nearest_heavy],
+                float(np.linalg.norm(ts_coords[nearest_heavy] - d_pos)),
+                bond_path_length(adj, donor_heavy, nearest_heavy))
             cand_plus = two_sphere_intersection(
                 d_pos, d_DH, ts_coords[nearest_heavy], d_AH, h_pos)
             cand_minus = two_sphere_intersection(

--- a/arc/job/adapters/ts/linear_utils/addition_test.py
+++ b/arc/job/adapters/ts/linear_utils/addition_test.py
@@ -10,9 +10,11 @@ import unittest
 
 import numpy as np
 
+from arc.common import get_single_bond_length
 from arc.molecule.molecule import Molecule
 from arc.species import ARCSpecies
 
+from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
 from arc.job.adapters.ts.linear_utils.addition import (
     _reposition_leaving_groups,
     insertion_ring_extra_stretch,
@@ -735,6 +737,74 @@ class TestMigrateVerifiedAtoms(unittest.TestCase):
             # The migrating H should have moved
             displacement = np.linalg.norm(new_pos - orig_pos)
             self.assertGreater(displacement, 0.01)
+
+    def test_migrating_h_seeded_at_bridge_distances(self):
+        """
+        A migrating H is placed at the bridging-H targets from its donor C and acceptor O.
+
+        The donor C and the acceptor O are three bonds apart, so the transfer is not
+        ring-strained, and they are 2.45 A apart, which the C-H target of 1.3383 A
+        and the O-H target of 1.2084 A span, so both are honoured exactly.
+        """
+        mol = Molecule().from_smiles('CCCO')
+        symbols = tuple(a.symbol for a in mol.atoms)
+        o_idx = next(i for i, a in enumerate(mol.atoms) if a.symbol == 'O')
+        atom_to_idx = {a: i for i, a in enumerate(mol.atoms)}
+        o_nbr_c = next(atom_to_idx[nbr] for nbr in mol.atoms[o_idx].bonds if nbr.symbol == 'C')
+        mid_c = next(atom_to_idx[nbr] for nbr in mol.atoms[o_nbr_c].bonds
+                     if nbr.symbol == 'C' and atom_to_idx[nbr] != o_nbr_c)
+        c_idx = next(atom_to_idx[nbr] for nbr in mol.atoms[mid_c].bonds
+                     if nbr.symbol == 'C' and atom_to_idx[nbr] != o_nbr_c)
+        h_on_c = next(atom_to_idx[nbr] for nbr in mol.atoms[c_idx].bonds if nbr.symbol == 'H')
+        coords = np.zeros((len(symbols), 3))
+        coords[c_idx] = (0.0, 0.0, 0.0)
+        coords[o_idx] = (2.45, 0.0, 0.0)
+        coords[h_on_c] = (1.05, 0.35, 0.0)
+        for k in range(len(symbols)):
+            if k not in (c_idx, o_idx, h_on_c):
+                coords[k] = (10.0 + k, 10.0, 10.0)
+        xyz = {'symbols': symbols,
+               'isotopes': tuple(MASS_NUMBER.get(sym, 12) for sym in symbols),
+               'coords': tuple(tuple(row) for row in coords)}
+        result = migrate_verified_atoms(
+            xyz, mol, migrating_atoms={h_on_c}, core={o_idx},
+            large_prod_atoms={c_idx}, cross_bonds=[(h_on_c, o_idx)])
+        out = np.asarray(result['coords'], dtype=float)
+        self.assertAlmostEqual(float(np.linalg.norm(out[h_on_c] - out[c_idx])), 1.338350, places=4)
+        self.assertAlmostEqual(float(np.linalg.norm(out[h_on_c] - out[o_idx])), 1.208350, places=4)
+
+    def test_heavy_migrating_atom_keeps_the_general_elongation(self):
+        """
+        A migrating atom that is not hydrogen is targeted from its own element, not from H.
+
+        ``migrating_atoms`` is not filtered to hydrogen, so a heavy fragment atom can
+        reach this code. A migrating O between two carbons must be seeded at
+        sbl(C, O) + PAULING_DELTA = 1.85 A, not at the bridging-H distance.
+        """
+        mol = Molecule().from_smiles('CCO')
+        symbols = tuple(a.symbol for a in mol.atoms)
+        c_idx = [i for i, a in enumerate(mol.atoms) if a.symbol == 'C']
+        o_idx = next(i for i, a in enumerate(mol.atoms) if a.symbol == 'O')
+        atom_to_idx = {a: i for i, a in enumerate(mol.atoms)}
+        donor = next(atom_to_idx[nbr] for nbr in mol.atoms[o_idx].bonds if nbr.symbol == 'C')
+        acceptor = next(i for i in c_idx if i != donor)
+        coords = np.zeros((len(symbols), 3))
+        coords[donor] = (0.0, 0.0, 0.0)
+        coords[acceptor] = (3.20, 0.0, 0.0)
+        coords[o_idx] = (1.40, 0.60, 0.0)
+        for k in range(len(symbols)):
+            if k not in (donor, acceptor, o_idx):
+                coords[k] = (10.0 + k, 10.0, 10.0)
+        xyz = {'symbols': symbols,
+               'isotopes': tuple(MASS_NUMBER.get(sym, 12) for sym in symbols),
+               'coords': tuple(tuple(row) for row in coords)}
+        result = migrate_verified_atoms(
+            xyz, mol, migrating_atoms={o_idx}, core={acceptor},
+            large_prod_atoms={donor}, cross_bonds=[(o_idx, acceptor)])
+        out = np.asarray(result['coords'], dtype=float)
+        expected = get_single_bond_length('C', 'O') + PAULING_DELTA
+        self.assertAlmostEqual(float(np.linalg.norm(out[o_idx] - out[donor])), expected, places=4)
+        self.assertAlmostEqual(float(np.linalg.norm(out[o_idx] - out[acceptor])), expected, places=4)
 
     def test_migrate_preserves_non_migrating_atoms(self):
         """Non-migrating atoms stay at their original positions."""

--- a/arc/job/adapters/ts/linear_utils/families.py
+++ b/arc/job/adapters/ts/linear_utils/families.py
@@ -36,13 +36,14 @@ from arc.job.adapters.ts.linear_utils.geom_utils import (
     bond_order_map,
     canonical_bond,
     dihedral_deg,
+    bond_path_length,
     mol_to_adjacency,
     rotate_atoms,
     two_sphere_intersection,
     xyz_with_coords,
 )
 from arc.job.adapters.ts.linear_utils.isomerization import ring_closure_xyz
-from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
+from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA, h_bridge_target_distances
 from arc.species.species import colliding_atoms
 
 if TYPE_CHECKING:
@@ -755,7 +756,7 @@ def build_singlet_carbene_intra_disproportionation_ts(r_xyz: dict,
     In this reaction, a singlet carbene C (divalent, lone pair) on a
     ring accepts an H from an adjacent CH₂ center. The TS has the
     migrating H between the donor C and the carbene C at
-    Pauling-triangulated distances.
+    bridging-hydrogen distances.
 
     Motif identification (from molecular graph):
 
@@ -809,8 +810,9 @@ def build_singlet_carbene_intra_disproportionation_ts(r_xyz: dict,
     if not donor_h_list:
         return None
 
-    sbl_ch = get_single_bond_length('C', 'H') or 1.09
-    d_target = sbl_ch + PAULING_DELTA  # ~1.51 Å
+    d_target, _ = h_bridge_target_distances(
+        'C', 'C', float(np.linalg.norm(coords[carbene_c] - coords[donor_c])),
+        bond_path_length(mol_to_adjacency(r_mol), donor_c, carbene_c))
 
     donor_pos = coords[donor_c]
     carbene_pos = coords[carbene_c]
@@ -946,16 +948,17 @@ def build_korcek_step1_ts(r_xyz: dict,
     if colliding_atoms(rc_xyz):
         return None
 
-    # Step 5: Place the peroxide H equidistant (~1.39 Å) between o_term and o_dbl
+    # Step 5: Place the peroxide H between o_term and o_dbl
     # via two-sphere intersection (it is transferring from o_term to o_dbl).
     coords = np.array(rc_xyz['coords'], dtype=float)
-    sbl_oh = get_single_bond_length('O', 'H') or 0.97
-    d_h_target = sbl_oh + PAULING_DELTA  # ~1.39 Å
     o_term_pos = coords[o_term]
     o_dbl_pos = coords[best_o_dbl]
     h_pos = coords[h_peroxide]
+    d_h_donor, d_h_acceptor = h_bridge_target_distances(
+        'O', 'O', float(np.linalg.norm(o_dbl_pos - o_term_pos)),
+        bond_path_length(adj, o_term, best_o_dbl))
 
-    new_h_pos = two_sphere_intersection(o_term_pos, d_h_target, o_dbl_pos, d_h_target, h_pos)
+    new_h_pos = two_sphere_intersection(o_term_pos, d_h_donor, o_dbl_pos, d_h_acceptor, h_pos)
     if new_h_pos is not None:
         coords[h_peroxide] = new_h_pos
 
@@ -1326,10 +1329,9 @@ def build_retroene_ts(r_xyz: dict,
         coords = np.array(rc_xyz['coords'], dtype=float)
 
     # Step 3: Place migrating H between C5 and O3.
-    sbl_ch = get_single_bond_length('C', 'H') or 1.09
-    sbl_oh = get_single_bond_length('O', 'H') or 0.97
-    d_ch = sbl_ch + PAULING_DELTA  # ~1.51 Å
-    d_oh = sbl_oh + PAULING_DELTA  # ~1.39 Å
+    d_ch, d_oh = h_bridge_target_distances(
+        'C', 'O', float(np.linalg.norm(coords[ester_o] - coords[donor])),
+        bond_path_length(mol_to_adjacency(r_mol), donor, ester_o))
     new_h_pos = two_sphere_intersection(
         coords[donor], d_ch, coords[ester_o], d_oh, coords[mig_h])
     if new_h_pos is None:

--- a/arc/job/adapters/ts/linear_utils/families_test.py
+++ b/arc/job/adapters/ts/linear_utils/families_test.py
@@ -397,14 +397,14 @@ H      -0.36583394   -1.89034834    0.81324667""")
                         continue
                     d_ci = float(np.linalg.norm(coords[ci] - coords[hi]))
                     d_di = float(np.linalg.norm(coords[di] - coords[hi]))
-                    if abs(d_ci - 1.51) < 0.15 and abs(d_di - 1.51) < 0.15:
+                    if abs(d_ci - 1.34) < 0.15 and abs(d_di - 1.34) < 0.15:
                         found_good = True
                         break
                 if found_good:
                     break
             if found_good:
                 break
-        self.assertTrue(found_good, msg='No H at Pauling-triangulated ~1.51 Å from a C-C pair in the TS')
+        self.assertTrue(found_good, msg='No H at bridge-triangulated ~1.34 Å from a C-C pair in the TS')
 
     def test_returns_none_for_non_carbene(self):
         """The builder returns None for a molecule without a carbene center."""
@@ -635,6 +635,22 @@ H       3.11088096    4.66875130   -0.79438064""")
                         msg=f'migrating C5-H13 too long: {d_c5h13:.3f}')
         self.assertLess(d_o3h13, 2.5,
                         msg=f'forming O3-H13 too long: {d_o3h13:.3f}')
+
+    def test_migrating_h_seeded_at_the_strained_ring_targets(self):
+        """
+        The migrating H is triangulated at the general targets, not the bridging-H ones.
+
+        Donor C5 and acceptor O3 are two bonds apart through C4, so the transferring
+        H closes a four-membered ring whose D-H-A angle cannot reach the near-linear
+        geometry H_BRIDGE_DELTA is measured on. C5-H13 is therefore 1.09 + 0.42 and
+        O3-H13 is 0.96 + 0.42.
+        """
+        ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                               breaking_bonds=[(3, 4), (5, 13)], forming_bonds=[(3, 13)])
+        self.assertIsNotNone(ts)
+        coords = np.array(ts['coords'], dtype=float)
+        self.assertAlmostEqual(float(np.linalg.norm(coords[5] - coords[13])), 1.51, places=4)
+        self.assertAlmostEqual(float(np.linalg.norm(coords[3] - coords[13])), 1.38, places=4)
 
     def test_returns_none_when_bond_counts_wrong(self):
         """The builder returns None when bb has != 2 entries or fb has != 1."""

--- a/arc/job/adapters/ts/linear_utils/geom_utils.py
+++ b/arc/job/adapters/ts/linear_utils/geom_utils.py
@@ -210,6 +210,28 @@ def bfs_path(adj: list[list[int]], src: int, dst: int) -> list[int] | None:
     return None
 
 
+def bond_path_length(adj: dict[int, set[int]],
+                     start: int,
+                     end: int,
+                     ) -> int | None:
+    """
+    Return the number of bonds on the shortest path between two atoms.
+
+    Delegates to :func:`bfs_path` and reports the length of the path it finds.
+
+    Args:
+        adj: Adjacency dict from :func:`mol_to_adjacency`.
+        start: Atom index to search from.
+        end: Atom index to search for.
+
+    Returns:
+        int | None: The bond count, or ``None`` when the two atoms lie in
+            different fragments.
+    """
+    path = bfs_path(adj, start, end)
+    return None if path is None else len(path) - 1
+
+
 def downstream(adj: list[list[int]], cut_a: int, cut_b: int) -> set[int]:
     """
     Return all atom indices reachable from *cut_b* without crossing *cut_a*.

--- a/arc/job/adapters/ts/linear_utils/geom_utils_test.py
+++ b/arc/job/adapters/ts/linear_utils/geom_utils_test.py
@@ -15,6 +15,7 @@ from arc.job.adapters.ts.linear_utils.geom_utils import (
     atom_index_map,
     bfs_path,
     bond_order_map,
+    bond_path_length,
     canonical_bond,
     dihedral_deg,
     downstream,
@@ -273,6 +274,49 @@ class TestGeomUtils(unittest.TestCase):
             d = dihedral_deg(*points)
             self.assertGreaterEqual(d, -180.0)
             self.assertLessEqual(d, 180.0)
+
+
+class TestBondPathLength(unittest.TestCase):
+    """Tests for the bond_path_length function."""
+
+    @classmethod
+    def setUpClass(cls):
+        """A method that is run before all unit tests in this class."""
+        cls.maxDiff = None
+        cls.mol = Molecule().from_smiles('CCCO')
+        cls.adj = mol_to_adjacency(cls.mol)
+        a2i = {a: i for i, a in enumerate(cls.mol.atoms)}
+        cls.o = next(i for i, a in enumerate(cls.mol.atoms) if a.symbol == 'O')
+        cls.c1 = next(a2i[n] for n in cls.mol.atoms[cls.o].bonds if n.symbol == 'C')
+        cls.c2 = next(a2i[n] for n in cls.mol.atoms[cls.c1].bonds
+                      if n.symbol == 'C' and a2i[n] != cls.c1)
+        cls.c3 = next(a2i[n] for n in cls.mol.atoms[cls.c2].bonds
+                      if n.symbol == 'C' and a2i[n] != cls.c1)
+
+    def test_counts_bonds_along_the_chain(self):
+        """Propanol: O to each carbon in turn is one, two and three bonds."""
+        self.assertEqual(bond_path_length(self.adj, self.o, self.c1), 1)
+        self.assertEqual(bond_path_length(self.adj, self.o, self.c2), 2)
+        self.assertEqual(bond_path_length(self.adj, self.o, self.c3), 3)
+
+    def test_zero_for_the_same_atom(self):
+        """An atom is zero bonds from itself."""
+        self.assertEqual(bond_path_length(self.adj, self.o, self.o), 0)
+
+    def test_agrees_with_bfs_path(self):
+        """The reported length is the length of the path bfs_path finds, for every atom."""
+        for target in range(len(self.mol.atoms)):
+            path = bfs_path(self.adj, self.o, target)
+            self.assertEqual(bond_path_length(self.adj, self.o, target),
+                             None if path is None else len(path) - 1,
+                             msg=f'disagreed for atom {target}')
+
+    def test_none_across_separate_fragments(self):
+        """Atoms in different fragments are never reachable."""
+        mol = Molecule().from_smiles('C')
+        adj = mol_to_adjacency(mol)
+        adj[99] = set()
+        self.assertIsNone(bond_path_length(adj, 0, 99))
 
 
 class TestMolToAdjacency(unittest.TestCase):

--- a/arc/job/adapters/ts/linear_utils/local_geometry.py
+++ b/arc/job/adapters/ts/linear_utils/local_geometry.py
@@ -65,12 +65,14 @@ import numpy as np
 
 from arc.common import get_logger, get_single_bond_length
 from arc.job.adapters.ts.linear_utils.geom_utils import (
+    bond_path_length,
+    mol_to_adjacency,
     h_neighbors_of,
     heavy_neighbors_of,
     two_sphere_intersection,
     xyz_with_coords,
 )
-from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
+from arc.job.adapters.ts.linear_utils.postprocess import h_bridge_target_distances
 
 if TYPE_CHECKING:
     from arc.molecule import Molecule
@@ -260,6 +262,7 @@ def clean_migrating_h(xyz: dict,
                       donor: int,
                       acceptor: int,
                       h_idx: int,
+                      mol: 'Molecule | None' = None,
                       ) -> dict:
     """
     Re-place a migrating H at the triangulated TS position between ``donor`` and ``acceptor``.
@@ -275,6 +278,9 @@ def clean_migrating_h(xyz: dict,
         donor: Donor heavy-atom index.
         acceptor: Acceptor heavy-atom index.
         h_idx: Migrating H atom index.
+        mol: Reactant molecule, used to measure how many bonds separate the
+            donor from the acceptor. When ``None`` the targets are chosen from
+            the donor-acceptor distance alone.
 
     Returns:
         A new XYZ dict with the migrating H re-placed.
@@ -288,12 +294,10 @@ def clean_migrating_h(xyz: dict,
     if donor >= len(coords) or acceptor >= len(coords):
         return xyz
 
-    sbl_dh = get_single_bond_length(symbols[donor], 'H')
-    sbl_ah = get_single_bond_length(symbols[acceptor], 'H')
-    if sbl_dh is None or sbl_ah is None:
-        return xyz
-    d_DH = float(sbl_dh) + PAULING_DELTA
-    d_AH = float(sbl_ah) + PAULING_DELTA
+    path = None if mol is None else bond_path_length(mol_to_adjacency(mol), donor, acceptor)
+    d_DH, d_AH = h_bridge_target_distances(
+        symbols[donor], symbols[acceptor],
+        float(np.linalg.norm(coords[acceptor] - coords[donor])), path)
 
     ideal = two_sphere_intersection(
         coords[donor], d_DH, coords[acceptor], d_AH, coords[h_idx])
@@ -1076,7 +1080,7 @@ def apply_reactive_center_cleanup(xyz: dict,
         migrating_h_indices.add(h_idx)
         cleanup_centers.add(donor)
         cleanup_centers.add(acceptor)
-        xyz = clean_migrating_h(xyz, donor, acceptor, h_idx)
+        xyz = clean_migrating_h(xyz, donor, acceptor, h_idx, mol=mol)
         # Exempt migrating H so triangulation is not undone.
         xyz = orient_h_away_from_axis(
             xyz, mol, donor, acceptor, exclude_h={h_idx})

--- a/arc/job/adapters/ts/linear_utils/local_geometry_test.py
+++ b/arc/job/adapters/ts/linear_utils/local_geometry_test.py
@@ -25,7 +25,7 @@ from arc.job.adapters.ts.linear_utils.local_geometry import (
     repair_internal_reactive_ch2,
     restore_terminal_h_symmetry,
 )
-from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
+from arc.job.adapters.ts.linear_utils.postprocess import H_BRIDGE_DELTA
 
 
 class TestRegularizeTerminalHGeometry(unittest.TestCase):
@@ -194,8 +194,31 @@ class TestCleanMigratingH(unittest.TestCase):
         h_pos = np.array(out['coords'][2])
         d_dh = float(np.linalg.norm(h_pos - np.array(out['coords'][0])))
         sbl_ch = get_single_bond_length('C', 'H')
-        # The triangulation places H at distance d_DH = sbl + PAULING_DELTA from donor.
-        self.assertAlmostEqual(d_dh, sbl_ch + PAULING_DELTA, places=4)
+        # The triangulation places H at distance d_DH = sbl + H_BRIDGE_DELTA from donor.
+        self.assertAlmostEqual(d_dh, sbl_ch + H_BRIDGE_DELTA, places=4)
+
+
+    def test_h_targets_stretch_to_reach_a_wide_donor_acceptor_gap(self):
+        """
+        A gap the bridge targets cannot span stretches both of them, keeping their ratio.
+
+        C-H 1.3383 plus N-H 1.2884 reaches only 2.6267 A, so a 2.90 A C...N gap scales
+        both up until they span it; neither may exceed its element's general elongation
+        of 1.51 and 1.46 A.
+        """
+        xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+               'coords': ((0.0, 0.0, 0.0), (2.90, 0.0, 0.0), (1.0, 0.5, 0.0))}
+        out = clean_migrating_h(xyz, donor=0, acceptor=1, h_idx=2)
+        coords = np.asarray(out['coords'], dtype=float)
+        d_ch = float(np.linalg.norm(coords[2] - coords[0]))
+        d_nh = float(np.linalg.norm(coords[2] - coords[1]))
+        self.assertGreater(d_ch, get_single_bond_length('C', 'H') + H_BRIDGE_DELTA)
+        self.assertLessEqual(d_ch, get_single_bond_length('C', 'H') + 0.42 + 1e-12)
+        self.assertLessEqual(d_nh, get_single_bond_length('N', 'H') + 0.42 + 1e-12)
+        self.assertGreater(d_ch + d_nh, 2.90)
+        self.assertAlmostEqual(d_ch / d_nh,
+                               (get_single_bond_length('C', 'H') + H_BRIDGE_DELTA)
+                               / (get_single_bond_length('N', 'H') + H_BRIDGE_DELTA), places=6)
 
 
 class TestRestoreTerminalHSymmetry(unittest.TestCase):
@@ -500,15 +523,18 @@ class TestApplyReactiveCenterCleanup(unittest.TestCase):
         """Given a (donor, acceptor, h_idx) record where the H is sitting
         at its donor-side bond length, the orchestrator triangulates it
         to the symmetric Pauling TS position between donor and acceptor."""
-        # Use methylamine (CH3-NH2) — atom 0 is C (donor), atom 1 is N
-        # (acceptor), pick one of C's H atoms as the migrating H.  Then
-        # override the geometry to make the H sit on the C-N axis at
-        # a normal C-H bond length (1.10 Å).
-        sp = ARCSpecies(label='MA', smiles='CN')
+        # Use propylamine, whose terminal C is three bonds from N, so the
+        # transfer is not ring-strained.  Override the geometry to make the
+        # migrating H sit on the C-N axis at a normal C-H bond length.
+        sp = ARCSpecies(label='PA', smiles='CCCN')
         symbols = sp.get_xyz()['symbols']
-        c_idx = next(i for i, s in enumerate(symbols) if s == 'C')
-        n_idx = next(i for i, s in enumerate(symbols) if s == 'N')
         atom_to_idx = {a: i for i, a in enumerate(sp.mol.atoms)}
+        n_idx = next(i for i, s in enumerate(symbols) if s == 'N')
+        n_nbr_c = next(atom_to_idx[nbr] for nbr in sp.mol.atoms[n_idx].bonds.keys() if nbr.element.symbol == 'C')
+        mid_c = next(atom_to_idx[nbr] for nbr in sp.mol.atoms[n_nbr_c].bonds.keys()
+                     if nbr.element.symbol == 'C' and atom_to_idx[nbr] != n_nbr_c)
+        c_idx = next(atom_to_idx[nbr] for nbr in sp.mol.atoms[mid_c].bonds.keys()
+                     if nbr.element.symbol == 'C' and atom_to_idx[nbr] != n_nbr_c)
         h_on_c = next(atom_to_idx[nbr] for nbr in sp.mol.atoms[c_idx].bonds.keys() if nbr.element.symbol == 'H')
         # Build a synthetic geometry that lays C, N, and the chosen H
         # in a straight line: C at origin, N at +x = 3.0, the H at
@@ -531,8 +557,8 @@ class TestApplyReactiveCenterCleanup(unittest.TestCase):
         d_nh = float(np.linalg.norm(coords_out[h_on_c] - coords_out[n_idx]))
         sbl_ch = float(get_single_bond_length('C', 'H'))
         sbl_nh = float(get_single_bond_length('N', 'H'))
-        self.assertAlmostEqual(d_ch, sbl_ch + PAULING_DELTA, places=3)
-        self.assertAlmostEqual(d_nh, sbl_nh + PAULING_DELTA, places=3)
+        self.assertAlmostEqual(d_ch, sbl_ch + H_BRIDGE_DELTA, places=3)
+        self.assertAlmostEqual(d_nh, sbl_nh + H_BRIDGE_DELTA, places=3)
 
     def test_orchestrator_does_not_rotate_already_symmetric_ch3(self):
         """

--- a/arc/job/adapters/ts/linear_utils/migration_inference_test.py
+++ b/arc/job/adapters/ts/linear_utils/migration_inference_test.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from arc.common import get_single_bond_length
 from arc.job.adapters.ts.linear_utils.migration_inference import identify_h_migration_pairs, infer_frag_fallback_h_migration
-from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
+from arc.job.adapters.ts.linear_utils.postprocess import H_BRIDGE_DELTA
 from arc.species import ARCSpecies
 
 
@@ -261,8 +261,8 @@ class TestInferFragFallbackHMigration(unittest.TestCase):
                'isotopes': sp.get_xyz().get('isotopes', tuple(0 for _ in symbols)),
                'coords': tuple(tuple(float(c) for c in row) for row in coords)}
         # Post: the H has moved to the donor–acceptor TS midpoint.
-        d_dh = get_single_bond_length('O', 'H') + PAULING_DELTA
-        d_ah = get_single_bond_length('C', 'H') + PAULING_DELTA
+        d_dh = get_single_bond_length('O', 'H') + H_BRIDGE_DELTA
+        d_ah = get_single_bond_length('C', 'H') + H_BRIDGE_DELTA
         d_da = float(np.linalg.norm(np.array(coords[c_methyl]) - np.array(coords[o_oh])))
         x = (d_da ** 2 + d_dh ** 2 - d_ah ** 2) / (2.0 * d_da)
         y = float(np.sqrt(max(d_dh ** 2 - x ** 2, 0.0)))

--- a/arc/job/adapters/ts/linear_utils/path_spec.py
+++ b/arc/job/adapters/ts/linear_utils/path_spec.py
@@ -462,6 +462,11 @@ def get_ts_target_distance(bond: tuple[int, int],
     so the scorer/validator and the builder cannot drift apart on
     calibrated families.
 
+    The migrating-H builders in ``postprocess`` and ``local_geometry`` seed a
+    bridging hydrogen from ``H_BRIDGE_DELTA`` instead. This function has no way
+    to tell a bridging hydrogen from any other X–H bond, so on those bonds its
+    target is wider than what those builders produce.
+
     Args:
         bond: ``(i, j)`` atom-index pair (used to look up symbols).
         role: One of ``'breaking'``, ``'forming'``, ``'changed'``, or
@@ -489,12 +494,7 @@ def get_ts_target_distance(bond: tuple[int, int],
     sym_j = symbols[j]
     sbl = get_single_bond_length(sym_i, sym_j) or 1.5
 
-    if role == 'breaking':
-        # Mirror adjust_reactive_bond_distances: target = sbl + Pauling delta,
-        # plus any family-specific builder calibration.
-        return float(sbl + PAULING_DELTA + insertion_ring_extra_stretch(family))
-
-    if role == 'forming':
+    if role in ('breaking', 'forming'):
         return float(sbl + PAULING_DELTA + insertion_ring_extra_stretch(family))
 
     if role == 'changed':

--- a/arc/job/adapters/ts/linear_utils/path_spec_test.py
+++ b/arc/job/adapters/ts/linear_utils/path_spec_test.py
@@ -303,6 +303,17 @@ class TestGetTsTargetDistance(unittest.TestCase):
         sbl = get_single_bond_length('C', 'C')
         self.assertAlmostEqual(d, sbl + PAULING_DELTA, places=6)
 
+    def test_scorer_uses_the_general_elongation_for_every_bond(self):
+        """
+        Every breaking/forming target is the general elongation, hydrogen-carrying or not.
+
+        The scorer cannot see whether a hydrogen is bridging a donor and an acceptor, and
+        most reactive-core builders seed the general elongation, so it stays uniform here.
+        """
+        self.assertAlmostEqual(get_ts_target_distance((0, 1), 'breaking', ('C', 'C')), 1.96, places=6)
+        self.assertAlmostEqual(get_ts_target_distance((0, 1), 'breaking', ('C', 'H')), 1.51, places=6)
+        self.assertAlmostEqual(get_ts_target_distance((0, 1), 'forming', ('O', 'H')), 1.38, places=6)
+
     def test_changed_interpolates_when_both_distances_given(self):
         symbols = ('C', 'C')
         d = get_ts_target_distance(
@@ -492,7 +503,7 @@ class TestHasRecipeChannelMismatch(unittest.TestCase):
     def test_pauling_triangulated_h_passes(self):
         """A migrating H at the symmetric Pauling TS distance from both partners passes both gates."""
         sbl = get_single_bond_length('C', 'H')
-        d_ts = sbl + 0.42  # ≈ 1.51 Å — symmetric TS bond order n=0.5
+        d_ts = sbl + PAULING_DELTA
         spec = ReactionPathSpec(breaking_bonds=[(0, 1)], forming_bonds=[(0, 1)])
         xyz = self._two_atom_xyz('C', 'H', d_ts)
         mismatch, _ = has_recipe_channel_mismatch(spec, xyz)

--- a/arc/job/adapters/ts/linear_utils/postprocess.py
+++ b/arc/job/adapters/ts/linear_utils/postprocess.py
@@ -22,8 +22,30 @@ This module contains three tiers of functionality:
     ``postprocess_h_migration``, ``postprocess_generic``, or private
     handlers (``_postprocess_group_shift``, ``_postprocess_cc_shift``)
     based on the ``FAMILY_POSTPROCESSORS`` registry.
+
+**Reactive-core distance model**:
+    Every reactive-bond target across ``linear_utils`` is an equilibrium
+    single-bond length from ``arc.common.get_single_bond_length`` plus one of
+    two elongations.
+
+    ``PAULING_DELTA``
+        The general reactive-bond elongation, used for every bond that is not
+        a hydrogen bridging a donor and an acceptor.  Under Pauling's relation
+        ``r(n) = r_e - 0.6 * log10(n)`` it corresponds to a bond order near
+        0.20.
+
+    ``H_BRIDGE_DELTA``
+        The elongation for a hydrogen transferring between a donor and an
+        acceptor, as in ``fix_forming_bond_distances`` and
+        ``local_geometry.clean_migrating_h``.  It is the same relation at the
+        half-formed ``H_BRIDGE_BOND_ORDER``, evaluated with
+        ``H_BRIDGE_BOND_ORDER_COEFFICIENT``.
+
+    Individual builders may add a further family-specific stretch on top of
+    either target.
 """
 
+import math
 from typing import TYPE_CHECKING
 from collections.abc import Callable, Sequence
 
@@ -31,7 +53,9 @@ import numpy as np
 
 from arc.common import get_logger, get_single_bond_length
 from arc.job.adapters.ts.linear_utils.geom_utils import (
+    bond_path_length,
     dihedral_deg,
+    mol_to_adjacency,
     rotate_atoms,
     two_sphere_intersection,
     xyz_with_coords,
@@ -58,18 +82,64 @@ FamilyValidator = Callable[
 FAMILY_POSTPROCESSORS: dict[str, FamilyPostprocessor] = {}
 FAMILY_VALIDATORS: dict[str, FamilyValidator] = {}
 
-_EQ_BOND_TO_H: dict[str, float] = {
-    'C': get_single_bond_length('C', 'H'),
-    'N': get_single_bond_length('N', 'H'),
-    'O': get_single_bond_length('O', 'H'),
-    'S': get_single_bond_length('S', 'H'),
-    'P': get_single_bond_length('P', 'H'),
-    'Si': get_single_bond_length('Si', 'H'),
-}
 _EQ_BOND_TO_H_DEFAULT: float = 1.09
 
-# At a symmetric TS (bond order n = 0.5), Pauling's equation gives d_TS = d0 - 0.6 * ln(n) = d0 + 0.6 * ln(2) ≈ d0 + 0.42 Å.
 PAULING_DELTA: float = 0.42
+
+H_BRIDGE_BOND_ORDER_COEFFICIENT: float = 0.825
+H_BRIDGE_BOND_ORDER: float = 0.5
+H_BRIDGE_DELTA: float = -H_BRIDGE_BOND_ORDER_COEFFICIENT * math.log10(H_BRIDGE_BOND_ORDER)
+H_BRIDGE_STRAINED_DONOR_ACCEPTOR_PATH: int = 2
+H_BRIDGE_MIN_OVERREACH: float = 0.0035
+
+
+def h_bridge_target_distances(donor_symbol: str,
+                              acceptor_symbol: str,
+                              donor_acceptor_distance: float,
+                              donor_acceptor_path: int | None = None,
+                              ) -> tuple[float, float]:
+    """
+    Return the donor-H and acceptor-H target distances for a bridging hydrogen.
+
+    Each target is the element's equilibrium X-H single bond length from
+    ``get_single_bond_length`` plus ``H_BRIDGE_DELTA``, or plus the wider
+    ``PAULING_DELTA`` when ``donor_acceptor_path`` equals
+    ``H_BRIDGE_STRAINED_DONOR_ACCEPTOR_PATH``.
+
+    Both targets are then scaled by a common factor if together they would not
+    span ``donor_acceptor_distance`` plus ``H_BRIDGE_MIN_OVERREACH``, and each
+    is capped at its element's length plus ``PAULING_DELTA``.  Scaling keeps
+    their ratio.  Past the cap the two targets no longer span the separation
+    and the caller places the hydrogen on the donor-acceptor axis.
+
+    An element absent from the single-bond-length table receives
+    ``get_single_bond_length``'s own 1.75 Angstrom fallback as its equilibrium
+    X-H length; no real X-H bond is that long.
+
+    Args:
+        donor_symbol (str): Element symbol of the atom the H starts on.
+        acceptor_symbol (str): Element symbol of the atom the H moves to.
+        donor_acceptor_distance (float): Current donor-acceptor separation, in
+            Angstrom.
+        donor_acceptor_path (int | None): Number of bonds between the donor and
+            the acceptor in the reactant, or ``None`` when they lie in separate
+            fragments or the caller cannot supply it.
+
+    Returns:
+        tuple[float, float]: The donor-H and acceptor-H target distances, in
+            Angstrom.
+    """
+    sbl_dh = float(get_single_bond_length(donor_symbol, 'H'))
+    sbl_ah = float(get_single_bond_length(acceptor_symbol, 'H'))
+    delta = PAULING_DELTA if donor_acceptor_path == H_BRIDGE_STRAINED_DONOR_ACCEPTOR_PATH else H_BRIDGE_DELTA
+    d_dh, d_ah = sbl_dh + delta, sbl_ah + delta
+    gap = float(donor_acceptor_distance)
+    reach = d_dh + d_ah
+    if reach < gap + H_BRIDGE_MIN_OVERREACH:
+        scale = (gap + H_BRIDGE_MIN_OVERREACH) / reach
+        d_dh = min(d_dh * scale, sbl_dh + PAULING_DELTA)
+        d_ah = min(d_ah * scale, sbl_ah + PAULING_DELTA)
+    return d_dh, d_ah
 
 
 def _min_distance_to_heavy_backbone(pos: np.ndarray,
@@ -394,8 +464,8 @@ def has_misdirected_migrating_h(xyz: dict,
 
     For Intra_RH_Add and similar reactions where a hydrogen migrates onto
     an acceptor X, the migrating H must be approaching X in the TS guess.
-    A reasonable TS has ``d(H-X) ≈ sbl(H-X) + 0.42 Å`` (the symmetric Pauling
-    estimate, ~1.4 Å for O-H and ~1.5 Å for C-H).  When the actual H-X
+    A reasonable TS has ``d(H-X) ≈ sbl(H-X) + PAULING_DELTA`` (~1.38 Å for
+    O-H and ~1.51 Å for C-H).  When the actual H-X
     distance in the guess exceeds ``max_factor`` × that target, the H is
     pointing **away** from the acceptor — geometrically invalid for any
     sane TS, regardless of how reasonable the rest of the geometry looks.
@@ -412,8 +482,8 @@ def has_misdirected_migrating_h(xyz: dict,
         forming_bonds (list[tuple[int, int]]): Forming-bond ``(i, j)``
             pairs in the same atom indexing as ``xyz``.
         max_factor (float): Multiplier on the Pauling target above which
-            the H is treated as misdirected.  Default 2.0 → ~2.78 Å for
-            O-H and ~2.98 Å for C-H.
+            the H is treated as misdirected.  Default 2.0 → ~2.76 Å for
+            O-H and ~3.02 Å for C-H.
 
     Returns:
         bool: ``True`` when at least one forming H-X bond exceeds
@@ -746,21 +816,19 @@ def fix_forming_bond_distances(xyz: dict,
 
     For each forming bond that involves hydrogen the function identifies the
     *donor* (heavy atom bonded to H in the reactant) and the *acceptor* (the
-    other atom in the forming bond).  Target distances are computed with the
-    Pauling bond-order equation at n = 0.5:
-
-        d_TS(X–H) = d0(X–H) + 0.42 Å
+    other atom in the forming bond), and takes their target distances from
+    :func:`h_bridge_target_distances`.
 
     The hydrogen is placed at the intersection of the two spheres centerd on
-    the donor and acceptor with the respective target radii.  Among the
-    resulting circle of solutions the point closest to the *current* H
-    position is chosen, preserving the approach direction from the
-    interpolation.  This produces a chemically reasonable (non-collinear)
-    D–H–A transfer geometry.
+    the donor and acceptor with those radii.  Two mirrored solutions are
+    tried and the one with the greater clearance to the rest of the heavy
+    backbone is kept, then pushed away from any heavy atom that is neither
+    reactive nor bonded to the reactive core, and finally discarded if it
+    still lies within 1.2 Angstrom of a heavy atom outside the core.
 
-    When the donor–acceptor distance is too large for the spheres to overlap
-    the function falls back to collinear placement at d_DH from the donor
-    along the D→A vector.
+    When the targets are capped short of the donor-acceptor separation the
+    two spheres do not meet and the hydrogen is placed on the D->A axis at
+    d_DH from the donor.
 
     Args:
         xyz: TS guess XYZ coordinate dictionary.
@@ -771,6 +839,7 @@ def fix_forming_bond_distances(xyz: dict,
         A new XYZ dictionary with migrating H atoms repositioned.
     """
     atom_to_idx = {atom: idx for idx, atom in enumerate(mol.atoms)}
+    adj = mol_to_adjacency(mol)
     symbols = xyz['symbols']
     coords = list(xyz['coords'])
 
@@ -790,14 +859,12 @@ def fix_forming_bond_distances(xyz: dict,
         if donor_idx is None:
             continue
 
-        donor_sym = symbols[donor_idx]
-        acceptor_sym = symbols[acceptor_atom]
-        d_DH = _EQ_BOND_TO_H.get(donor_sym, _EQ_BOND_TO_H_DEFAULT) + PAULING_DELTA
-        d_AH = _EQ_BOND_TO_H.get(acceptor_sym, _EQ_BOND_TO_H_DEFAULT) + PAULING_DELTA
-
         d_pos = np.array(coords[donor_idx], dtype=float)
         a_pos = np.array(coords[acceptor_atom], dtype=float)
         h_pos = np.array(coords[h_atom], dtype=float)
+        d_DH, d_AH = h_bridge_target_distances(
+            symbols[donor_idx], symbols[acceptor_atom], float(np.linalg.norm(a_pos - d_pos)),
+            bond_path_length(adj, donor_idx, acceptor_atom))
 
         # Try both intersection points (h_pos picks one side; mirroring h_pos
         # through the donor picks the opposite side); keep the one with greater
@@ -812,8 +879,11 @@ def fix_forming_bond_distances(xyz: dict,
         clearance_minus = _min_distance_to_heavy_backbone(cand_minus, coords, symbols, exclude)
         new_h_pos = cand_plus if clearance_plus >= clearance_minus else cand_minus
 
+        core_bonded = set(exclude)
+        for core_idx in (donor_idx, acceptor_atom):
+            core_bonded.update(atom_to_idx[nbr] for nbr in mol.atoms[core_idx].bonds.keys())
         for k_idx, sym_k in enumerate(symbols):
-            if k_idx in (h_atom, donor_idx, acceptor_atom) or sym_k == 'H':
+            if k_idx in core_bonded or sym_k == 'H':
                 continue
             b_pos = np.array(coords[k_idx], dtype=float)
             bh_vec = new_h_pos - b_pos
@@ -825,7 +895,7 @@ def fix_forming_bond_distances(xyz: dict,
 
         clash = False
         for k, sym_k in enumerate(symbols):
-            if k == h_atom or k == donor_idx or sym_k == 'H':
+            if k in exclude or sym_k == 'H':
                 continue
             if np.linalg.norm(np.array(coords[k], dtype=float) - new_h_pos) < 1.2:
                 clash = True

--- a/arc/job/adapters/ts/linear_utils/postprocess_test.py
+++ b/arc/job/adapters/ts/linear_utils/postprocess_test.py
@@ -6,13 +6,22 @@ This module contains unit tests of the
 arc.job.adapters.ts.linear_utils.postprocess module
 """
 
+import math
 import unittest
 
 import numpy as np
 
+from arc.common import get_element_mass, get_single_bond_length
+from arc.job.adapters.ts.linear_utils.geom_utils import bond_path_length, mol_to_adjacency
 from arc.molecule.molecule import Molecule
 from arc.job.adapters.ts.linear_utils.postprocess import (
+    H_BRIDGE_BOND_ORDER,
+    H_BRIDGE_BOND_ORDER_COEFFICIENT,
+    H_BRIDGE_DELTA,
+    H_BRIDGE_MIN_OVERREACH,
+    H_BRIDGE_STRAINED_DONOR_ACCEPTOR_PATH,
     PAULING_DELTA,
+    h_bridge_target_distances,
     _get_migrating_group_info,
     _has_detached_heavy_atom,
     _orient_donor_h_away_from_acceptor,
@@ -610,9 +619,206 @@ class TestPostprocessConstants(unittest.TestCase):
         """A method that is run before all unit tests in this class."""
         cls.maxDiff = None
 
-    def test_pauling_delta_value(self):
-        """PAULING_DELTA is approximately 0.6*ln(2) ~ 0.42."""
-        self.assertAlmostEqual(PAULING_DELTA, 0.42, places=2)
+    def test_pauling_delta_is_the_inherited_empirical_value(self):
+        """
+        PAULING_DELTA is 0.42 A and corresponds to a bond order near 0.20, not 0.5.
+
+        Guards the log base: 0.6*log10(0.5) = 0.181 is the half-formed elongation, and
+        0.6*ln(0.5) = 0.416 is the value the module's earlier derivation reached by using
+        the natural log with a log-base-10 coefficient.
+        """
+        self.assertAlmostEqual(PAULING_DELTA, 0.42, places=12)
+        self.assertAlmostEqual(10 ** (-PAULING_DELTA / 0.6), 0.1995, places=4)
+        self.assertNotAlmostEqual(PAULING_DELTA, -0.6 * math.log10(0.5), places=2)
+
+    def test_h_bridge_delta_value(self):
+        """H_BRIDGE_DELTA is the half-formed elongation at the bridging-H coefficient."""
+        self.assertAlmostEqual(H_BRIDGE_DELTA,
+                               -H_BRIDGE_BOND_ORDER_COEFFICIENT * math.log10(H_BRIDGE_BOND_ORDER), places=12)
+        self.assertAlmostEqual(H_BRIDGE_DELTA, 0.248350, places=6)
+        self.assertEqual(H_BRIDGE_BOND_ORDER, 0.5)
+        self.assertLess(H_BRIDGE_DELTA, PAULING_DELTA)
+
+    def test_h_bridge_target_distances_uses_bridge_delta_when_reachable(self):
+        """
+        Both targets are sbl(X-H) + H_BRIDGE_DELTA when they span the donor-acceptor gap.
+
+        C-H is 1.09 + 0.2484 = 1.3383 and N-H is 1.04 + 0.2484 = 1.2884; their sum,
+        2.6267, covers the 2.50 A separation outright, so no fallback is needed.
+        """
+        d_dh, d_ah = h_bridge_target_distances('C', 'N', 2.50)
+        self.assertAlmostEqual(d_dh, 1.338350, places=6)
+        self.assertAlmostEqual(d_ah, 1.288350, places=6)
+        self.assertGreaterEqual(d_dh + d_ah, 2.50)
+
+    def test_h_bridge_target_distances_stretch_smoothly_across_the_gap(self):
+        """
+        Widening the donor-acceptor gap moves both targets continuously.
+
+        Each target grows monotonically with the gap and never jumps: the largest step
+        over a 0.001 A sweep from 2.3 to 3.2 A stays far below the 0.17 A difference
+        between the bridge and the general elongation.
+        """
+        prev_dh = prev_ah = 0.0
+        biggest_step = 0.0
+        gap = 2.30
+        while gap <= 3.20:
+            d_dh, d_ah = h_bridge_target_distances('C', 'O', gap)
+            self.assertGreaterEqual(d_dh, prev_dh - 1e-12, msg=f'donor target went backwards at gap {gap:.3f}')
+            self.assertGreaterEqual(d_ah, prev_ah - 1e-12, msg=f'acceptor target went backwards at gap {gap:.3f}')
+            if prev_dh:
+                biggest_step = max(biggest_step, d_dh - prev_dh, d_ah - prev_ah)
+            prev_dh, prev_ah = d_dh, d_ah
+            gap += 0.001
+        self.assertLess(biggest_step, 0.01, msg=f'largest single step was {biggest_step:.4f} A')
+
+    def test_h_bridge_target_distances_keep_the_h_off_the_axis_while_they_can(self):
+        """
+        Up to the capped reach the two targets span the gap, so the H is placed off-axis.
+
+        Exactly on the axis is a 180 degree D-H-A angle, which ARC's zmat builder treats
+        as linear; the reference transfers sit at 173.95 degrees. Beyond the capped reach
+        the targets stop growing and the caller's axis fallback takes over, which is the
+        right answer for a donor and acceptor too far apart to bridge.
+        """
+        self.assertAlmostEqual(H_BRIDGE_MIN_OVERREACH, 0.0035, places=12)
+        capped_reach = (get_single_bond_length('C', 'H') + get_single_bond_length('O', 'H')
+                        + 2.0 * PAULING_DELTA)
+        for gap in (2.0, 2.45, 2.687, capped_reach - 0.05):
+            d_dh, d_ah = h_bridge_target_distances('C', 'O', gap)
+            self.assertGreater(d_dh + d_ah, gap + 0.003,
+                               msg=f'gap {gap:.3f} leaves the hydrogen on the axis')
+
+    def test_h_bridge_target_distances_are_argument_order_symmetric(self):
+        """Swapping donor and acceptor swaps the two targets and nothing else."""
+        for gap in (2.0, 2.687, 3.2):
+            fwd = h_bridge_target_distances('C', 'O', gap)
+            rev = h_bridge_target_distances('O', 'C', gap)
+            self.assertAlmostEqual(fwd[0], rev[1], places=12, msg=f'gap {gap}')
+            self.assertAlmostEqual(fwd[1], rev[0], places=12, msg=f'gap {gap}')
+
+    def test_h_bridge_target_distances_widen_for_a_four_membered_ring(self):
+        """
+        A donor and acceptor two bonds apart take the general elongation.
+
+        They close a four-membered ring through the transferring hydrogen, whose
+        D-H-A angle the ring holds near 105-120 degrees, while H_BRIDGE_DELTA is
+        measured on transfers near 174 degrees. A three-membered ring (one bond) and
+        every longer path keep the bridge elongation.
+        """
+        self.assertEqual(H_BRIDGE_STRAINED_DONOR_ACCEPTOR_PATH, 2)
+        reachable = 2.20
+        d_dh, d_ah = h_bridge_target_distances('C', 'O', reachable, 2)
+        self.assertAlmostEqual(d_dh, get_single_bond_length('C', 'H') + PAULING_DELTA, places=12)
+        self.assertAlmostEqual(d_ah, get_single_bond_length('O', 'H') + PAULING_DELTA, places=12)
+        for path in (1, 3, 4, None):
+            d_dh, d_ah = h_bridge_target_distances('C', 'O', reachable, path)
+            self.assertAlmostEqual(d_dh, get_single_bond_length('C', 'H') + H_BRIDGE_DELTA, places=12,
+                                   msg=f'donor-acceptor path {path} should take the bridge elongation')
+            self.assertAlmostEqual(d_ah, get_single_bond_length('O', 'H') + H_BRIDGE_DELTA, places=12,
+                                   msg=f'donor-acceptor path {path} should take the bridge elongation')
+
+    def test_h_bridge_target_distances_cap_the_stretch_at_the_general_elongation(self):
+        """
+        A donor-acceptor gap too wide for the targets stops at the general elongation.
+
+        Without the cap the common scaling grows without bound and returns a hydrogen
+        bonded to neither partner: a 3.5 A C...O gap would otherwise ask for 1.83 and
+        1.67 A.
+        """
+        cap_dh = get_single_bond_length('C', 'H') + PAULING_DELTA
+        cap_ah = get_single_bond_length('O', 'H') + PAULING_DELTA
+        for gap in (3.0, 3.5, 4.0, 5.0, 8.0):
+            d_dh, d_ah = h_bridge_target_distances('C', 'O', gap)
+            self.assertLessEqual(d_dh, cap_dh + 1e-12, msg=f'gap {gap} stretched the donor target past the cap')
+            self.assertLessEqual(d_ah, cap_ah + 1e-12, msg=f'gap {gap} stretched the acceptor target past the cap')
+        self.assertAlmostEqual(h_bridge_target_distances('C', 'O', 8.0)[0], cap_dh, places=12)
+
+    def test_strained_gate_reads_the_true_bond_path(self):
+        """
+        Only a two-bond donor-acceptor path is treated as strained, at any chain length.
+
+        bond_path_length reports the real shortest path, so the gate cannot mistake a
+        longer chain for a four-membered ring.
+        """
+        mol = Molecule().from_smiles('CCCCCO')
+        adj = mol_to_adjacency(mol)
+        a2i = {a: i for i, a in enumerate(mol.atoms)}
+        o_idx = next(i for i, a in enumerate(mol.atoms) if a.symbol == 'O')
+        chain, prev, cur = [], None, o_idx
+        for _ in range(5):
+            nxt = next(a2i[n] for n in mol.atoms[cur].bonds if n.symbol == 'C' and a2i[n] != prev)
+            chain.append(nxt)
+            prev, cur = cur, nxt
+        for true_path, atom in enumerate(chain, start=1):
+            measured = bond_path_length(adj, o_idx, atom)
+            self.assertEqual(measured, true_path, msg=f'atom {atom}')
+            d_dh, _ = h_bridge_target_distances('O', 'C', 2.20, measured)
+            expected = get_single_bond_length('O', 'H') + (PAULING_DELTA if true_path == 2 else H_BRIDGE_DELTA)
+            self.assertAlmostEqual(d_dh, expected, places=12, msg=f'true path {true_path}')
+
+    def test_h_bridge_target_distances_unknown_element(self):
+        """
+        An element with no tabulated X-H length takes get_single_bond_length's fallback.
+
+        That fallback is 1.75 A, the generic heavy-heavy value; no real X-H bond is that
+        long, so this pins inherited behaviour rather than a defensible length.
+        """
+        d_dh, d_ah = h_bridge_target_distances('Xx', 'C', 1.0)
+        self.assertAlmostEqual(d_dh, 1.75 + H_BRIDGE_DELTA, places=12)
+        self.assertAlmostEqual(d_ah, get_single_bond_length('C', 'H') + H_BRIDGE_DELTA, places=12)
+
+
+class TestFixFormingBondDistancesReactiveCore(unittest.TestCase):
+    """The clash guard in fix_forming_bond_distances must ignore the reactive core."""
+
+    @classmethod
+    def setUpClass(cls):
+        """A method that is run before all unit tests in this class."""
+        cls.maxDiff = None
+
+    def _linear_transfer_xyz(self, smiles, acceptor_symbol):
+        """Build a donor...acceptor geometry three bonds apart with an H on the donor."""
+        mol = Molecule().from_smiles(smiles)
+        symbols = tuple(a.symbol for a in mol.atoms)
+        a2i = {a: i for i, a in enumerate(mol.atoms)}
+        acceptor = next(i for i, a in enumerate(mol.atoms) if a.symbol == acceptor_symbol)
+        first_c = next(a2i[n] for n in mol.atoms[acceptor].bonds if n.symbol == 'C')
+        mid_c = next(a2i[n] for n in mol.atoms[first_c].bonds
+                     if n.symbol == 'C' and a2i[n] != first_c)
+        donor = next(a2i[n] for n in mol.atoms[mid_c].bonds
+                     if n.symbol == 'C' and a2i[n] != first_c)
+        h_idx = next(a2i[n] for n in mol.atoms[donor].bonds if n.symbol == 'H')
+        coords = np.zeros((len(symbols), 3))
+        coords[donor] = (0.0, 0.0, 0.0)
+        coords[acceptor] = (2.35, 0.0, 0.0)
+        coords[h_idx] = (1.0, 0.5, 0.0)
+        for k in range(len(symbols)):
+            if k not in (donor, acceptor, h_idx):
+                coords[k] = (12.0 + k, 12.0, 12.0)
+        xyz = {'symbols': symbols,
+               'isotopes': tuple(get_element_mass(sym)[1] for sym in symbols),
+               'coords': tuple(tuple(row) for row in coords)}
+        return mol, xyz, donor, acceptor, h_idx
+
+    def test_short_acceptor_h_target_is_not_discarded_as_a_clash(self):
+        """
+        A migrating H is placed even when its acceptor target is below the 1.2 A guard.
+
+        F-H is 0.92 + 0.2484 = 1.1683 A, inside the guard's threshold, so measuring the
+        hydrogen against its own acceptor would reject the placement and leave the H
+        where the interpolation put it. O-H at 1.2083 A clears the threshold by 8 mA,
+        which is not a margin worth relying on either.
+        """
+        for smiles, acceptor_symbol, expected in (('CCCF', 'F', 1.1683),
+                                                  ('CCCO', 'O', 1.2083),
+                                                  ('CCCCl', 'Cl', 1.5183)):
+            mol, xyz, donor, acceptor, h_idx = self._linear_transfer_xyz(smiles, acceptor_symbol)
+            out = fix_forming_bond_distances(xyz, mol, [(acceptor, h_idx)])
+            coords = np.asarray(out['coords'], dtype=float)
+            self.assertAlmostEqual(float(np.linalg.norm(coords[h_idx] - coords[acceptor])),
+                                   expected, places=3,
+                                   msg=f'{smiles}: migrating H was not placed at its acceptor target')
 
 
 class TestAdjustReactiveBondDistances(unittest.TestCase):


### PR DESCRIPTION
Seeds the distances of a migrating hydrogen in a linear-adapter TS guess from measured data, and
corrects the account `PAULING_DELTA` gives of itself.

## What was wrong

`PAULING_DELTA = 0.42` Å was documented as the n = 0.5 elongation, derived as `0.6 × ln(2)`.
Pauling's coefficient belongs to log₁₀, so n = 0.5 gives `0.6 × log10(2)` = 0.181 Å. The value in the
code is larger by exactly ln(10) and corresponds to n ≈ 0.20 — a far more reactant-like core than
the docstring claimed.

## What this does, and does not, change

**`PAULING_DELTA` keeps its value of 0.42 Å.** It is applied to heavy–heavy bonds and to family
calibrations for which there is no reference data, and the six family stretches already in
`families.py` run 0.27–0.77 Å (mean 0.64) — all above 0.42. Lowering it would move six families
0.24 Å toward the product well. What changes is the docstring: the constant is described as
inherited and empirical, corresponding to n ≈ 0.20, rather than as a derivation it never was.

**Where the code names a donor and an acceptor for a migrating hydrogen, it now uses a measured
value.** `H_BRIDGE_DELTA = −0.825 × log10(0.5) = 0.2484 Å`, from 1670 DFT-optimised H-transfer
transition states: the pooled median elongation over 3340 bonds is 0.2494 Å, and BEBO bond-order
conservation independently gives a coefficient of 0.8246, agreeing to 0.5%.

Bridging distances become C–H 1.34, N–H 1.29, O–H 1.21 Å, from 1.51 / 1.46 / 1.38. Every
heavy–heavy distance and every family calibration is unchanged.

Replaying the adapter's own placement against real donor–acceptor separations:

| | D–H–A angle | MAE |
| --- | --- | --- |
| before | 126.3° | 0.164 Å |
| after | 174.15° | 0.0588 Å |

against a measured median of 173.95°.

## Seeding near, but not at, 180 degrees

Both targets are scaled by a common factor to span the donor–acceptor gap, rather than being seeded
collinear. Three reasons: `zmat.py` treats an angle within `TOL_180 = 0.9°` of linear as linear and
builds it through the dummy-atom path, so a collinear seed silently changes construction; an exactly
linear guess can enter a point group the true bent transition state lacks, making it a second-order
saddle; and the bend is doubly degenerate at 180°. Guesses inside the linear window fall from 60.9%
to 0.0% of the reference set and from 20.2% to 1.8% of the adapter's own corpus.

Scaling both targets proportionally also makes the placement independent of donor/acceptor argument
order, which it previously was not. Each target is capped at its element's general elongation.

## Equilibrium bond lengths for the halogens and for hydrogen

The table the bridge builds on used carbon's 1.09 Å for F, Cl, Br, I and for H itself, so a forming
H–H bond was seeded from a C–H length. These now come from `get_single_bond_length`, which is within
0.02 Å of experiment for all five. F–H moves 1.51 → 1.17 Å.

That change exposed a defect it also fixes: the clash guard measured the migrating H against its own
acceptor, so a correctly seeded F at 1.168 Å was rejected outright — worse than the behaviour it
replaces. Oxygen cleared the same guard by 8 mÅ. The guard now excludes the acceptor, with a
regression test.

## Guess count and ordering

`fix_forming_bond_distances` triangulates the migrating H correctly, after which a backbone-pushback
loop moves it away from any heavy atom that is too close. Its exclusion set held the donor, the
acceptor and hydrogens, but not the acceptor's own bonded neighbours — and a bridging H approaching
an acceptor is necessarily near that acceptor's neighbour. With the tighter bridge target the
pushback fired, relocated the H outside the 1.0–2.2 Å motif window, and the guess was discarded.

The pushback now skips heavy atoms bonded to the reactive core, while side selection still counts
them, which is what keeps the hydrogen out of a ring. Guess count and ordering match `main`, and on
`CCO[O] ⇌ [CH2]COO` both migrated guesses improve: D–H–A 167.0° and 149.7°, against `main`'s 122.2°
and 116.5°.

## Reuse

Searched before writing: `get_code_context` for existing bond-length and reactive-core seeding,
`git grep -n PAULING_DELTA` for every use site, and the element data in `arc/common.py`. No new
element table was added — `get_single_bond_length` already tabulates `r_e(X–H)`. No geometry maths
was hand-rolled.

## Tests

791 pass in `arc/job/adapters/ts/`, 0 fail. Validated by mutation rather than coverage: 11 mutants,
each killed by a test — the bridge delta set to 0.42, the general delta to 0.4159, the bridge bond
order to 0.2, the reach margin to 0.0, the strained-ring path threshold moved in both directions,
the donor and acceptor swapped, the heavy-migrating-atom guard removed, and the overreach threshold
moved in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbGeU8wLpafo3YFzTky2ho
