### PR TITLE
Place the retro-ene migrating H on the recipe acceptor

### DIFF
--- a/arc/job/adapters/ts/linear_test.py
+++ b/arc/job/adapters/ts/linear_test.py
@@ -65,6 +65,7 @@ from arc.job.adapters.ts.linear_utils.math_zmat import (BASE_WEIGHT_GRID,
                                                          )
 from arc.job.adapters.ts.linear_utils.postprocess import (FAMILY_POSTPROCESSORS,
                                                            FAMILY_VALIDATORS,
+                                                           PAULING_DELTA,
                                                            has_inward_migrating_group_h,
                                                            postprocess_generic,
                                                            postprocess_ts_guess,
@@ -76,6 +77,7 @@ from arc.molecule import Molecule
 from arc.reaction import ARCReaction
 from arc.species.converter import compare_zmats, order_mol_by_atom_map, order_xyz_by_atom_map, str_to_xyz, xyz_to_str, zmat_from_xyz
 from arc.species.species import ARCSpecies, colliding_atoms
+from arc.species.vectors import calculate_angle
 
 
 def _angle_deg(p1: np.ndarray, vertex: np.ndarray, p2: np.ndarray) -> float:
@@ -4372,51 +4374,32 @@ H       1.80251143    1.03132880   -1.10238169"""
         p2 = ARCSpecies(label='P2', smiles='CC(=O)O', xyz=p2_xyz)
         rxn = ARCReaction(r_species=[r], p_species=[p1, p2])
         ts_xyzs = interpolate(rxn)
-        found_ring = False
+        d_ch = get_single_bond_length('C', 'H') + PAULING_DELTA
+        d_oh = get_single_bond_length('O', 'H') + PAULING_DELTA
+        ring_guess = None
         for ts_xyz in ts_xyzs:
             coords = np.array(ts_xyz['coords'], dtype=float)
-            d_o3c4 = float(np.linalg.norm(coords[3] - coords[4]))
-            d_o2c4 = float(np.linalg.norm(coords[2] - coords[4]))
-            d_c5h13 = float(np.linalg.norm(coords[5] - coords[13]))
-            d_h13o3 = float(np.linalg.norm(coords[13] - coords[3]))
-            # Check 6-membered ring characteristics:
-            # O3-C4 stretched (breaking)
-            if d_o3c4 < 1.8:
+            if float(np.linalg.norm(coords[3] - coords[4])) < 1.8:
                 continue
-            # O2-C4 contracted (ring contact, both O's participate)
-            if d_o2c4 > 2.5:
+            if abs(float(np.linalg.norm(coords[5] - coords[13])) - d_ch) > 0.1:
                 continue
-            # H13 migrating from C5 (near Pauling TS distance)
-            if d_c5h13 > 1.7:
+            if abs(float(np.linalg.norm(coords[2] - coords[13])) - d_oh) > 0.1:
                 continue
-            # H13 approaching O3
-            if d_h13o3 > 2.5:
-                continue
-            found_ring = True
+            ring_guess = ts_xyz
             break
-        self.assertTrue(found_ring, msg='No TS guess has 6-membered ring retroene characteristics: O3-C4 stretched '
-                                        '(breaking), O2-C4 contracted (ring), H13 migrating from C5 toward O3')
-        expected_ts = """C                  3.35667786   -0.45750645    0.53734155
- C                  2.24637997    0.53978750    0.40948895
- O                  1.25975689    0.57306185    1.13089404
- O                  1.90798055    1.60139464   -0.37185519
- C                 -0.25465664    2.12528094    0.76768134
- C                 -0.03131089    3.04259438   -0.26607527
- C                 -1.40160640    3.23262677    0.38080580
- C                  0.80777963    4.31367617   -0.11759400
- H                  3.43291583   -1.04518301   -0.37749397
- H                  4.29490197    0.05808884    0.74227330
- H                  3.14278867   -1.13176712    1.36663279
- H                 -0.88551430    1.24137878    0.67368347
- H                 -0.03778772    2.29994313    1.82151292
- H                  0.87654037    2.16543158   -1.09462311
- H                 -1.31181604    3.41929928    1.45094180
- H                 -1.92716397    4.07668244   -0.06580283
- H                 -2.02058432    2.34596864    0.24367923
- H                  1.76588869    4.21544196   -0.62796354
- H                  0.29073745    5.16969147   -0.55118965
- H                  1.00524898    4.53585118    0.93109285"""
-        self.assertTrue(any(almost_equal_coords(ts, str_to_xyz(expected_ts)) for ts in ts_xyzs))
+        self.assertIsNotNone(ring_guess,
+                             msg='No TS guess has 6-membered ring retroene characteristics: O3-C4 stretched '
+                                 '(breaking), H13 migrating from C5 toward the carbonyl O2')
+        ring_coords = np.array(ring_guess['coords'], dtype=float)
+        d_o3h13 = float(np.linalg.norm(ring_coords[3] - ring_coords[13]))
+        self.assertGreater(d_o3h13, 2.0,
+                           msg=f'H13 was placed on the ester O3 instead of the carbonyl O2: {d_o3h13:.3f}')
+        d_o2c4 = float(np.linalg.norm(ring_coords[2] - ring_coords[4]))
+        self.assertGreater(d_o2c4, 2.4,
+                           msg=f'a spurious O2-C4 contact was fabricated: {d_o2c4:.3f}')
+        angle = calculate_angle(coords=ring_guess, atoms=[5, 13, 2])
+        self.assertAlmostEqual(angle, 126.0, delta=5.0,
+                               msg=f'C5-H13...O2 bridge angle is {angle:.1f}, expected ~126')
 
     def test_interpolate_singlet_carbene_intra_disproportionation(self):
         """Test the interpolate_isomerization() function for Singlet_Carbene_Intra_Disproportionation: C=C1C=C[C]C1 <=> C=C1C=CC=C1"""

--- a/arc/job/adapters/ts/linear_utils/families.py
+++ b/arc/job/adapters/ts/linear_utils/families.py
@@ -42,6 +42,7 @@ from arc.job.adapters.ts.linear_utils.geom_utils import (
     xyz_with_coords,
 )
 from arc.job.adapters.ts.linear_utils.isomerization import ring_closure_xyz
+from arc.job.adapters.ts.linear_utils.local_geometry import clean_migrating_h
 from arc.job.adapters.ts.linear_utils.postprocess import PAULING_DELTA
 from arc.species.species import colliding_atoms
 
@@ -63,6 +64,10 @@ _BAEYER_VILLIGER_CO_SHORTEN_TARGET: float = 1.28
 _BAEYER_VILLIGER_H_TRANSFER_TARGET: float = 1.40
 
 _OH_MIGRATION_EARLY_TS_CO_DISTANCE: float = 2.08
+
+# Retro-ene bridging-H interior angle (degrees); the six-ring strain minimum
+# for this builder's seed distances.
+_RETROENE_H_BRIDGE_ANGLE: float = 126.0
 
 
 # ---------------------------------------------------------------------------
@@ -1215,20 +1220,36 @@ def build_retroene_ts(r_xyz: dict,
     """
     Build a 6-membered-ring TS for retro-ene fragmentation.
 
-    In a Retroene reaction, an ester fragments through a concerted 6-membered ring TS::
+    The RMG ``Retroene`` recipe labels the ring ``*1`` … ``*6``. Five of its
+    six bonds are already present in the reactant; the ring is closed by the
+    forming ``*1``···``*6`` bond::
 
-         H(mig)
-        /      \\
-      C(donor)  O(ester)
-      |          |
-      C(leaving) C(carbonyl)
-        \\      /
-         O(C=O)
+           *6 (migrating H)
+          /                \\
+        *5 (donor)          *1 (acceptor)
+        |                   |
+        *4 (leaving)        *2
+          \\                /
+                 *3
 
-    The migrating H leaves the donor C and arrives at the ester O,
-    while the C=O oxygen develops a contact with the leaving C.
+    ``*5``-``*6`` and ``*3``-``*4`` break, ``*1``-``*6`` forms, ``*1``-``*2``
+    loses a bond order and ``*2``-``*3`` / ``*4``-``*5`` each gain one. For an
+    ester ``*1`` is the carbonyl O, ``*2`` the carbonyl C and ``*3`` the ester
+    O; for an all-carbon retro-ene ``*1`` is a carbon.
 
-    Returns ``None`` if the motif cannot be identified.
+    The acceptor ``*1`` is read from ``forming_bonds``; the donor ``*5``,
+    the migrating H ``*6``, the leaving atom ``*4`` and its sigma partner
+    ``*3`` are read from ``breaking_bonds``. ``*4`` is first repositioned by
+    two-sphere triangulation so the ``*3``-``*4`` sigma bond stretches while
+    the ``*4``-``*5`` pi bond contracts, the ring is then folded until the
+    donor-acceptor separation matches a relaxed hydrogen bridge, and the
+    migrating H is finally triangulated between donor and acceptor at
+    element-specific Pauling-elongated distances, on the side of the
+    donor-acceptor axis opposite the rest of the ring.
+
+    Returns ``None`` if the motif cannot be identified, if ``*1`` is not two
+    bonds from ``*3``, or if the fold leaves the donor and acceptor too far
+    apart to place the migrating H between them.
     """
     bb = list(breaking_bonds or [])
     fb = list(forming_bonds or [])
@@ -1255,53 +1276,39 @@ def build_retroene_ts(r_xyz: dict,
     if mig_h is None or other_bb_idx is None:
         return None
 
+    acceptor = fb[0][0] if fb[0][1] == mig_h else fb[0][1]
+    if acceptor == mig_h or not 0 <= acceptor < len(symbols) or symbols[acceptor] == 'H':
+        return None
+
     # The other breaking bond is the sigma bond (e.g. O3-C4).
     sigma_bb = bb[other_bb_idx]
 
     leaving_c = None
-    ester_o = None
+    sigma_partner = None
     for candidate in sigma_bb:
         for nbr in r_mol.atoms[candidate].bonds:
             if atom_to_idx[nbr] == donor:
                 leaving_c = candidate
-                ester_o = sigma_bb[0] if sigma_bb[1] == candidate else sigma_bb[1]
+                sigma_partner = sigma_bb[0] if sigma_bb[1] == candidate else sigma_bb[1]
                 break
         if leaving_c is not None:
             break
-    if leaving_c is None or ester_o is None:
+    if leaving_c is None or sigma_partner is None:
         return None
 
-    # carbonyl_c = non-H, non-leaving-C neighbour of ester_o.
-    carbonyl_c = None
-    for nbr in r_mol.atoms[ester_o].bonds:
-        ni = atom_to_idx[nbr]
-        if ni != leaving_c and symbols[ni] != 'H':
-            carbonyl_c = ni
-            break
-    if carbonyl_c is None:
+    adj = mol_to_adjacency(r_mol)
+    ring_bridge = sorted(adj[acceptor] & adj[sigma_partner])
+    if not ring_bridge:
+        logger.debug(f'Retroene builder: acceptor {acceptor} is not two bonds from {sigma_partner}, '
+                     f'so no *1-*2-*3 ring path exists; skipping.')
         return None
-
-    # carbonyl_o = double-bonded O on carbonyl_c (not ester_o).
-    carbonyl_o = None
-    for nbr, bond in r_mol.atoms[carbonyl_c].bonds.items():
-        ni = atom_to_idx[nbr]
-        if symbols[ni] == 'O' and ni != ester_o and bond.order >= 1.5:
-            carbonyl_o = ni
-            break
-    if carbonyl_o is None:
-        return None
-
-    # The acid fragment and the donor stay at reactant positions; only C4 is
-    # repositioned via two-sphere triangulation so d(O3,C4) stretches and
-    # d(C5,C4) contracts simultaneously. Then ring_closure_xyz folds O2
-    # toward C4, and finally H13 is placed between C5 and O3.
 
     # Step 1: Place C4 at the two-sphere intersection of O3 and C5.
     d_break = 2.5   # O3-C4 (breaking sigma)
     d_pi = 1.40     # C5-C4 (forming pi bond)
 
     new_c4 = two_sphere_intersection(
-        coords[ester_o], d_break, coords[donor], d_pi, coords[leaving_c])
+        coords[sigma_partner], d_break, coords[donor], d_pi, coords[leaving_c])
     if new_c4 is None:
         return None
     c4_displacement = new_c4 - coords[leaving_c]
@@ -1315,28 +1322,28 @@ def build_retroene_ts(r_xyz: dict,
     for k in c4_moving:
         coords[k] += c4_displacement
 
-    # Step 2: Fold O2 toward C4's new position.
-    intermediate_xyz = xyz_with_coords(r_xyz, coords)
-    d_co_target = 2.2
+    d_donor_h = get_single_bond_length(symbols[donor], 'H') + PAULING_DELTA
+    d_acceptor_h = get_single_bond_length(symbols[acceptor], 'H') + PAULING_DELTA
+    d_donor_acceptor = float(np.sqrt(
+        d_donor_h ** 2 + d_acceptor_h ** 2
+        - 2.0 * d_donor_h * d_acceptor_h * np.cos(np.radians(_RETROENE_H_BRIDGE_ANGLE))))
+
     rc_xyz = ring_closure_xyz(
-        intermediate_xyz, r_mol,
-        forming_bond=(carbonyl_o, leaving_c),
-        target_distance=d_co_target)
+        xyz_with_coords(r_xyz, coords), r_mol,
+        forming_bond=(acceptor, donor),
+        target_distance=d_donor_acceptor)
     if rc_xyz is not None:
         coords = np.array(rc_xyz['coords'], dtype=float)
 
-    # Step 3: Place migrating H between C5 and O3.
-    sbl_ch = get_single_bond_length('C', 'H') or 1.09
-    sbl_oh = get_single_bond_length('O', 'H') or 0.97
-    d_ch = sbl_ch + PAULING_DELTA  # ~1.51 Å
-    d_oh = sbl_oh + PAULING_DELTA  # ~1.39 Å
-    new_h_pos = two_sphere_intersection(
-        coords[donor], d_ch, coords[ester_o], d_oh, coords[mig_h])
-    if new_h_pos is None:
+    gap = float(np.linalg.norm(coords[acceptor] - coords[donor]))
+    if not abs(d_donor_h - d_acceptor_h) <= gap <= d_donor_h + d_acceptor_h:
+        logger.debug(f'Retroene builder: the ring did not close -- donor {donor} and acceptor {acceptor} '
+                     f'are {gap:.3f} A apart, outside the triangulable window; skipping.')
         return None
-    coords[mig_h] = new_h_pos
 
-    ts_xyz = xyz_with_coords(r_xyz, coords)
+    ring_interior = coords[[ring_bridge[0], sigma_partner, leaving_c]].mean(axis=0)
+    ts_xyz = clean_migrating_h(xyz_with_coords(r_xyz, coords), donor, acceptor, mig_h,
+                               ref_pos=coords[donor] + coords[acceptor] - ring_interior)
     if colliding_atoms(ts_xyz):
         return None
     return ts_xyz

--- a/arc/job/adapters/ts/linear_utils/families_test.py
+++ b/arc/job/adapters/ts/linear_utils/families_test.py
@@ -6,6 +6,7 @@ Unit tests for arc.job.adapters.ts.linear_utils.families
 """
 
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -28,6 +29,7 @@ from arc.job.adapters.ts.linear_utils.families import (
 )
 from arc.job.adapters.ts.linear_utils.geom_utils import bfs_fragment
 from arc.species.species import colliding_atoms
+from arc.species.vectors import calculate_angle
 
 
 class TestGeometryHelpers(unittest.TestCase):
@@ -608,41 +610,147 @@ H       4.03739144    3.33548500   -1.50498669
 H       3.50375149    4.67779028   -2.52219673
 H       3.11088096    4.66875130   -0.79438064""")
         cls.r = ARCSpecies(label='R', smiles='CC(=O)OCC(C)C', xyz=cls.r_xyz)
+        cls.bb = [(3, 4), (5, 13)]
+        cls.fb = [(2, 13)]
+        cls.pentene_xyz = str_to_xyz("""C       2.59641195    0.02702193    0.35517849
+C       1.55649266   -0.45011185   -0.34019100
+C       0.28007233    0.30645401   -0.57170725
+C       0.04468782    0.55537225   -2.06168554
+C      -1.25397601    1.30979243   -2.30079594
+H       3.49268046   -0.56997648    0.49329893
+H       2.58045167    1.01722396    0.79978111
+H       1.61937159   -1.45105923   -0.76272287
+H       0.29443842    1.26323448   -0.03540148
+H      -0.54969821   -0.27814213   -0.15664760
+H       0.87715349    1.13263575   -2.48220230
+H       0.00910731   -0.39828344   -2.60239249
+H      -1.23835041    2.28510111   -1.80393815
+H      -2.11144789    0.74437291   -1.92214689
+H      -1.40347894    1.47681937   -3.37209501""")
+        cls.pentene = ARCSpecies(label='pentene', smiles='C=CCCC', xyz=cls.pentene_xyz)
 
     def test_returns_xyz_dict(self):
         """The builder returns a valid XYZ dict for the retroene 6-membered ring motif."""
         ts = build_retroene_ts(self.r_xyz, self.r.mol,
-                               breaking_bonds=[(3, 4), (5, 13)], forming_bonds=[(3, 13)])
+                               breaking_bonds=self.bb, forming_bonds=self.fb)
         self.assertIsNotNone(ts)
         self.assertEqual(ts['symbols'], self.r_xyz['symbols'])
         self.assertEqual(len(ts['coords']), len(self.r_xyz['coords']))
         self.assertFalse(colliding_atoms(ts), 'TS has colliding atoms')
 
     def test_ring_distances(self):
-        """The 6-membered ring TS has stretched breaking bonds and a migrating H."""
+        """The migrating H bridges the donor C5 and the recipe acceptor O2, not the ester O3."""
         ts = build_retroene_ts(self.r_xyz, self.r.mol,
-                               breaking_bonds=[(3, 4), (5, 13)], forming_bonds=[(3, 13)])
+                               breaking_bonds=self.bb, forming_bonds=self.fb)
         self.assertIsNotNone(ts)
         coords = np.array(ts['coords'], dtype=float)
-        # O3-C4 sigma is stretched (breaking): target ~2.5 Å.
+        d_ch = get_single_bond_length('C', 'H') + PAULING_DELTA
+        d_oh = get_single_bond_length('O', 'H') + PAULING_DELTA
+
         d_o3c4 = float(np.linalg.norm(coords[3] - coords[4]))
-        self.assertGreater(d_o3c4, 1.8,
-                           msg=f'O3-C4 sigma not stretched: {d_o3c4:.3f}')
-        # Migrating H13 sits between donor C5 and ester O3 at Pauling-like distances.
+        self.assertGreater(d_o3c4, 1.9, msg=f'O3-C4 sigma not stretched: {d_o3c4:.3f}')
+        d_c4c5 = float(np.linalg.norm(coords[4] - coords[5]))
+        self.assertAlmostEqual(d_c4c5, 1.40, delta=0.05,
+                               msg=f'C4-C5 pi bond not contracted to 1.40: {d_c4c5:.3f}')
+
         d_c5h13 = float(np.linalg.norm(coords[5] - coords[13]))
+        self.assertAlmostEqual(d_c5h13, d_ch, delta=0.05,
+                               msg=f'breaking C5-H13 is {d_c5h13:.3f}, expected {d_ch:.3f}')
+        d_o2h13 = float(np.linalg.norm(coords[2] - coords[13]))
+        self.assertAlmostEqual(d_o2h13, d_oh, delta=0.05,
+                               msg=f'forming O2-H13 is {d_o2h13:.3f}, expected {d_oh:.3f}')
+
         d_o3h13 = float(np.linalg.norm(coords[3] - coords[13]))
-        self.assertLess(d_c5h13, 1.8,
-                        msg=f'migrating C5-H13 too long: {d_c5h13:.3f}')
-        self.assertLess(d_o3h13, 2.5,
-                        msg=f'forming O3-H13 too long: {d_o3h13:.3f}')
+        self.assertGreater(d_o3h13, 2.0,
+                           msg=f'H13 was bonded to the ester O3 instead of the carbonyl O2: {d_o3h13:.3f}')
+        d_o2c4 = float(np.linalg.norm(coords[2] - coords[4]))
+        self.assertGreater(d_o2c4, 2.4,
+                           msg=f'a spurious O2-C4 contact was fabricated: {d_o2c4:.3f}')
+
+    def test_bridge_angle(self):
+        """The C5-H13...O2 bridge is bent to the relaxed 6-ring interior angle."""
+        ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                               breaking_bonds=self.bb, forming_bonds=self.fb)
+        self.assertIsNotNone(ts)
+        angle = calculate_angle(coords=ts, atoms=[5, 13, 2])
+        self.assertAlmostEqual(angle, 126.0, delta=5.0,
+                               msg=f'C5-H13...O2 bridge angle is {angle:.1f}, expected ~126')
+
+    def test_migrating_h_closes_the_ring(self):
+        """The migrating H sits opposite the rest of the ring, in the ring plane."""
+        ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                               breaking_bonds=self.bb, forming_bonds=self.fb)
+        self.assertIsNotNone(ts)
+        coords = np.array(ts['coords'], dtype=float)
+        ring = [2, 1, 3, 4, 5, 13]
+        axis = coords[2] - coords[5]
+        axis /= np.linalg.norm(axis)
+        mid = 0.5 * (coords[2] + coords[5])
+
+        def perpendicular(point):
+            v = point - mid
+            return v - axis * np.dot(v, axis)
+
+        h_perp = perpendicular(coords[13])
+        path_perp = perpendicular(coords[[1, 3, 4]].mean(axis=0))
+        cos_sep = np.dot(h_perp, path_perp) / (np.linalg.norm(h_perp) * np.linalg.norm(path_perp))
+        separation = float(np.degrees(np.arccos(np.clip(cos_sep, -1.0, 1.0))))
+        self.assertGreater(separation, 150.0,
+                           msg=f'H13 is {separation:.1f} deg from opposite the ring path, not closing the ring')
+
+        centered = coords[ring] - coords[ring].mean(axis=0)
+        normal = np.linalg.svd(centered)[2][-1]
+        h_out_of_plane = abs(float(np.dot(centered[5], normal)))
+        self.assertLess(h_out_of_plane, 0.15,
+                        msg=f'H13 sits {h_out_of_plane:.3f} A out of the ring plane')
+
+    def test_returns_none_when_the_ring_does_not_close(self):
+        """The builder returns None rather than emitting a guess whose forming bond never formed."""
+        with patch('arc.job.adapters.ts.linear_utils.families.ring_closure_xyz', return_value=None):
+            ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                                   breaking_bonds=self.bb, forming_bonds=self.fb)
+        self.assertIsNone(ts)
+
+    def test_returns_none_when_acceptor_is_not_two_bonds_from_sigma_partner(self):
+        """The builder returns None when the acceptor cannot close the *1-*2-*3 ring path."""
+        ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                               breaking_bonds=self.bb, forming_bonds=[(6, 13)])
+        self.assertIsNone(ts)
+
+    def test_non_ester_retroene(self):
+        """The builder handles an all-carbon retro-ene, where the acceptor *1 is a carbon."""
+        ts = build_retroene_ts(self.pentene_xyz, self.pentene.mol,
+                               breaking_bonds=[(4, 12), (2, 3)], forming_bonds=[(0, 12)])
+        self.assertIsNotNone(ts)
+        self.assertFalse(colliding_atoms(ts), 'TS has colliding atoms')
+        coords = np.array(ts['coords'], dtype=float)
+        d_ch = get_single_bond_length('C', 'H') + PAULING_DELTA
+
+        d_forming = float(np.linalg.norm(coords[0] - coords[12]))
+        self.assertAlmostEqual(d_forming, d_ch, delta=0.05,
+                               msg=f'forming C0-H12 is {d_forming:.3f}, expected the C-H value {d_ch:.3f}')
+        d_breaking = float(np.linalg.norm(coords[4] - coords[12]))
+        self.assertAlmostEqual(d_breaking, d_ch, delta=0.05,
+                               msg=f'breaking C4-H12 is {d_breaking:.3f}, expected {d_ch:.3f}')
+        d_sigma = float(np.linalg.norm(coords[2] - coords[3]))
+        self.assertGreater(d_sigma, 1.9, msg=f'C2-C3 sigma not stretched: {d_sigma:.3f}')
+        angle = calculate_angle(coords=ts, atoms=[4, 12, 0])
+        self.assertAlmostEqual(angle, 126.0, delta=5.0,
+                               msg=f'C4-H12...C0 bridge angle is {angle:.1f}, expected ~126')
 
     def test_returns_none_when_bond_counts_wrong(self):
         """The builder returns None when bb has != 2 entries or fb has != 1."""
         ts = build_retroene_ts(self.r_xyz, self.r.mol,
-                               breaking_bonds=[(3, 4)], forming_bonds=[(3, 13)])
+                               breaking_bonds=[(3, 4)], forming_bonds=self.fb)
         self.assertIsNone(ts)
         ts = build_retroene_ts(self.r_xyz, self.r.mol,
-                               breaking_bonds=[(3, 4), (5, 13)], forming_bonds=[(3, 13), (2, 4)])
+                               breaking_bonds=self.bb, forming_bonds=[(2, 13), (2, 4)])
+        self.assertIsNone(ts)
+
+    def test_returns_none_when_acceptor_is_hydrogen(self):
+        """The builder returns None when the forming bond does not name a heavy acceptor."""
+        ts = build_retroene_ts(self.r_xyz, self.r.mol,
+                               breaking_bonds=self.bb, forming_bonds=[(12, 13)])
         self.assertIsNone(ts)
 
 

--- a/arc/job/adapters/ts/linear_utils/local_geometry.py
+++ b/arc/job/adapters/ts/linear_utils/local_geometry.py
@@ -260,6 +260,7 @@ def clean_migrating_h(xyz: dict,
                       donor: int,
                       acceptor: int,
                       h_idx: int,
+                      ref_pos: np.ndarray | None = None,
                       ) -> dict:
     """
     Re-place a migrating H at the triangulated TS position between ``donor`` and ``acceptor``.
@@ -270,11 +271,20 @@ def clean_migrating_h(xyz: dict,
     the new H position depends only on (donor_pos, acceptor_pos,
     sbl(D,H), sbl(A,H)), not on the H's own current location.
 
+    The donor-H and acceptor-H distances fix the H to a circle around the
+    donor-acceptor axis; ``ref_pos`` selects the point on that circle, which
+    is the side ``ref_pos`` itself lies on. It defaults to the H's current
+    position, which keeps the H on the side it already occupies. A caller
+    that knows where the H belongs -- a ring closure, where the H must sit
+    opposite the rest of the ring -- passes that point instead.
+
     Args:
         xyz: TS guess XYZ dict.
         donor: Donor heavy-atom index.
         acceptor: Acceptor heavy-atom index.
         h_idx: Migrating H atom index.
+        ref_pos: Point selecting the side of the donor-acceptor axis the H is
+            placed on. Defaults to the H's current position.
 
     Returns:
         A new XYZ dict with the migrating H re-placed.
@@ -296,7 +306,8 @@ def clean_migrating_h(xyz: dict,
     d_AH = float(sbl_ah) + PAULING_DELTA
 
     ideal = two_sphere_intersection(
-        coords[donor], d_DH, coords[acceptor], d_AH, coords[h_idx])
+        coords[donor], d_DH, coords[acceptor], d_AH,
+        coords[h_idx] if ref_pos is None else np.asarray(ref_pos, dtype=float))
     if ideal is None:
         return xyz
     coords[h_idx] = ideal

--- a/arc/job/adapters/ts/linear_utils/local_geometry_test.py
+++ b/arc/job/adapters/ts/linear_utils/local_geometry_test.py
@@ -187,6 +187,17 @@ class TestCleanMigratingH(unittest.TestCase):
         h_pos_2 = np.array(out2['coords'][2])
         self.assertTrue(np.allclose(h_pos_1, h_pos_2, atol=1e-10))
 
+    def test_ref_pos_selects_the_side_of_the_donor_acceptor_axis(self):
+        xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
+            'coords': ((0.0, 0.0, 0.0), (2.5, 0.0, 0.0), (1.0, 0.5, 0.0))}
+        default = np.array(clean_migrating_h(xyz, donor=0, acceptor=1, h_idx=2)['coords'][2])
+        self.assertGreater(default[1], 0.0)
+        flipped = np.array(clean_migrating_h(xyz, donor=0, acceptor=1, h_idx=2,
+                                             ref_pos=np.array([1.0, -0.5, 0.0]))['coords'][2])
+        self.assertLess(flipped[1], 0.0)
+        self.assertAlmostEqual(default[0], flipped[0], places=10)
+        self.assertAlmostEqual(default[1], -flipped[1], places=10)
+
     def test_h_distance_to_donor_matches_target(self):
         xyz = {'symbols': ('C', 'N', 'H'), 'isotopes': (12, 14, 1),
             'coords': ((0.0, 0.0, 0.0), (2.5, 0.0, 0.0), (1.0, 0.5, 0.0))}


### PR DESCRIPTION
`build_retroene_ts()` placed the migrating hydrogen on the ester oxygen. The family recipe puts it on
the carbonyl oxygen.

## The recipe

`RMG-database/input/kinetics/families/Retroene/groups.py:20-28`:

```python
recipe(actions=[
    ['CHANGE_BOND', '*1', -1, '*2'],
    ['BREAK_BOND', '*5', 1, '*6'],
    ['BREAK_BOND', '*3', 1, '*4'],
    ['FORM_BOND', '*1', 1, '*6'],
    ['CHANGE_BOND', '*2', 1, '*3'],
    ['CHANGE_BOND', '*4', 1, '*5'],
])
```

`*6` is the migrant and `FORM_BOND *1 *6` bonds it to `*1`, the terminus of the multiple bond with
`*2` — the carbonyl oxygen for an ester. `*3`, the ester oxygen, is disqualified by the Root group,
which requires it to carry two heavy neighbours (`1 *3 R!H u0 {2,S} {3,[S,D]}`). The remaining
actions are the Ei product: `CHANGE_BOND *1 *2 -1` breaks the C=O, `CHANGE_BOND *2 *3 +1` forms the
new one.

## What the builder did

It used `forming_bonds` only to identify which hydrogen migrates, then re-derived the acceptor
structurally as the member of the breaking sigma bond not bonded to the donor — which is `*3` by
construction. Passing the correct `forming_bonds` produced byte-identical output, so the argument was
being discarded entirely.

For `CC(=O)OCC(C)C ⇌ CC(=O)O + C=C(C)C`, whose family machinery generates `forming_bonds = [(2, 13)]`:

| | distance |
| --- | --- |
| d(C5–H13) breaking C–H | 1.510 |
| **d(O2–H13) the recipe's forming bond** | **2.763** |
| d(O3–H13) the bond the builder made | 1.380 |
| d(O3–C4) breaking sigma | 2.500 |
| d(O2–C4) a contact in no recipe action | 2.199 |

The guess reached the ESS. `linear` is in the default `ts_adapters` and `Retroene` is registered for
it; `interpolate_addition` ends at `_finalize_ts_guesses(..., path_spec=None)`, which applies only
`colliding_atoms`. `has_misdirected_migrating_h` would have rejected it — by 3.2 mÅ — but runs in a
different pipeline. The remaining check is NMD, which takes the recipe first and demands the O2–H13
mode, so rejection came after a full TS optimisation and frequency job.

## The fix

The acceptor comes from `forming_bonds[0]`. The `carbonyl_c` / `carbonyl_o` search is removed in
favour of the recipe's own constraint, and the hard-coded `C–H` and `O–H` radii are taken from the
actual elements.

Step 1, which stretches the breaking sigma by repositioning the leaving carbon, is unchanged — that
is a recipe bond.

Step 2's ring closure targets the donor–acceptor pair. It cannot be removed: without it the gap stays
at 4.193 Å for the ester and 4.850 Å for 1-pentene, outside `two_sphere_intersection`'s window, and
the hydrogen lands collinear 2.68 Å from the acceptor. Targeting the recipe pair directly is also
unusable, because `ring_closure_xyz` only approximates its target and the implied gap comes out
molecule-dependent — 2.785 Å on isobutyl acetate against 2.954 Å on ethyl acetate. Targeting
`(acceptor, donor)` reproduces its target to within 0.03 Å on every substrate tested.

Making the donor a ring endpoint exposed `ring_closure_xyz`'s substituent rotation, which left the
hydrogen 91.6° from closing the ring and 0.42 Å out of plane; `clean_migrating_h` gained an optional
`ref_pos` so the azimuth is taken from the ring, giving 180.0° and 0.00 Å. A failed fold now returns
`None` rather than a silently bad guess, and the caller's acceptor is checked for adjacency.

The bridge angle is 126°. At the seed distances this builder currently works from, a wider angle
compresses the donor angle below its physical range — 152° drives it to 76.5° against a measured
95–105°.

## Non-ester retro-ene

Taking the acceptor from the recipe also reaches substrates the structural search could not. 1-pentene
⇌ propene + ethylene previously returned `None`; it now yields C···H···C at 1.510 / 1.510, sigma 2.500,
bridge 125.7°.

## Tests

Both existing tests encoded the old behaviour — the unit test hard-coded `forming_bonds=[(3, 13)]`,
and the integration test asserted "H13 migrating from C5 toward O3" plus a requirement on the
spurious O2···C4 contact. Both are rewritten against the generated bonds, and the integration test's
byte-exact `expected_ts` golden is replaced with tolerance-based assertions on the distances that
matter.

779 pass across `arc/job/adapters/ts/`. Validated by mutation: seven mutants, each killed by a test —
acceptor reverted to the ester oxygen, radii reverted to hard-coded C/H and O/H, Step 2 deleted,
Step 2 retargeted, the azimuth reference dropped, the triangulability guard removed, the adjacency
guard removed. The last of these initially survived, since no fixture fails ring closure, and is now
covered by a mocked test.

## Reuse

Searched before writing: `get_code_context` for existing migrating-hydrogen placement, `git grep -n`
for the `PAULING_DELTA` use sites, and `arc/species/vectors.py` for the geometry primitives. The
azimuth fix reuses `clean_migrating_h` rather than adding a fourth open-coded copy of that placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbGeU8wLpafo3YFzTky2ho
