### PR TITLE
Fix Gaussian 1D scan angles losing direction and gaining a spurious 360

### DIFF
--- a/arc/parser/adapters/gaussian.py
+++ b/arc/parser/adapters/gaussian.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import re
 
-from arc.common import SYMBOL_BY_NUMBER, is_same_pivot
+from arc.common import SYMBOL_BY_NUMBER, get_angle_in_180_range, is_same_pivot
 from arc.constants import E_h_kJmol, bohr_to_angstrom
 from arc.species.converter import str_to_xyz, xyz_from_data
 from arc.parser.adapter import ESSAdapter
@@ -326,6 +326,13 @@ class GaussianParser(ESSAdapter, ABC):
         """
         Parse the 1D torsion scan energies from an ESS log file.
 
+        The reported angles are the cumulative rotation relative to the first scan point,
+        accumulated from the per-step displacements of the raw dihedral values.
+        They start at zero, retain the sign of the scan direction (negative for a scan with a
+        negative step size), and are not folded into the 0-360 degree range, so a sweep that
+        completes a full turn ends at +/-360 degrees. Consecutive scan points recorded in the log
+        are assumed to be less than 180 degrees apart.
+
         Returns: tuple[list[float] | None, list[float] | None]
             The electronic energy in kJ/mol and the dihedral scan angle in degrees.
         """
@@ -376,11 +383,8 @@ class GaussianParser(ESSAdapter, ABC):
             angle = np.array(angle, float)
             if len(angle) != len(vlist):
                 return None, None
-            angle -= angle[0]
-            angle[angle < 0] += 360.0
-            if len(angle) > 1 and angle[-1] < 2 * (angle[1] - angle[0]):
-                angle[-1] += 360.0
-            angle = angle.tolist()
+            steps = [get_angle_in_180_range(step, round_to=None) for step in np.diff(angle)]
+            angle = np.concatenate(([0.0], np.cumsum(steps))).tolist() if len(steps) else [0.0]
 
         vlist = np.array(vlist, float)
         vlist -= np.min(vlist)

--- a/arc/parser/parser_test.py
+++ b/arc/parser/parser_test.py
@@ -1031,6 +1031,39 @@ H      -1.69381305    0.40788834    0.90078104"""
                                       -205.51540006, -205.52742038, -205.53811826, -205.5472153 ,
                                       -205.55449977, -205.55981412, -205.56304759, -205.56413261])
 
+    def test_parse_1d_scan_energies_gaussian_scan_direction(self):
+        """Test that Gaussian 1D scan angles stay monotonic and keep the scan direction"""
+        forward_wrapping_path = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'H2O2.out')
+        energies, angles = parser.parse_1d_scan_energies(log_file_path=forward_wrapping_path)
+        self.assertEqual(len(angles), len(energies))
+        self.assertEqual(len(angles), 37)
+        np.testing.assert_almost_equal(angles, np.arange(0.0, 360.1, 10.0), 3)
+        self.assertGreater(min(np.diff(angles)), 0)
+
+        reverse_path = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'H2O2_reverse_scan.out')
+        energies_rev, angles_rev = parser.parse_1d_scan_energies(log_file_path=reverse_path)
+        self.assertEqual(len(angles_rev), len(energies_rev))
+        self.assertEqual(len(angles_rev), 37)
+        np.testing.assert_almost_equal(angles_rev, np.arange(0.0, -360.1, -10.0), 3)
+        self.assertLess(max(np.diff(angles_rev)), 0)
+        self.assertAlmostEqual(angles_rev[-1], -360.0, 3)
+
+        two_point_path = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'H2O2_two_point_scan.out')
+        energies_2, angles_2 = parser.parse_1d_scan_energies(log_file_path=two_point_path)
+        self.assertEqual(len(angles_2), 2)
+        np.testing.assert_almost_equal(angles_2, [0.0, 10.0], 3)
+
+        short_forward_path = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'TS_errored.out')
+        energies_3, angles_3 = parser.parse_1d_scan_energies(log_file_path=short_forward_path)
+        self.assertEqual(len(angles_3), 3)
+        np.testing.assert_almost_equal(angles_3, [0.0, 30.0, 60.0], 3)
+
+        non_uniform_path = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'l103_err.out')
+        energies_4, angles_4 = parser.parse_1d_scan_energies(log_file_path=non_uniform_path)
+        self.assertEqual(len(angles_4), len(energies_4))
+        np.testing.assert_almost_equal(angles_4, [0.0, 24.0, 32.0, 40.0], 3)
+        self.assertGreater(min(np.diff(angles_4)), 0)
+
     def test_parse_nd_scan_energies(self):
         """Test parsing an ND scan output file"""
         path1 = os.path.join(ARC_TESTING_PATH, 'rotor_scans', 'scan_2D_relaxed_OCdOO.log')

--- a/arc/testing/rotor_scans/H2O2_reverse_scan.out
+++ b/arc/testing/rotor_scans/H2O2_reverse_scan.out
@@ -1,0 +1,244 @@
+ Entering Gaussian System, Link 0=g03
+ Input=input.gjf
+ Output=input.log
+ Initial command:
+ /opt/g03/l1.exe /scratch/alongd/Gau-19672.inp -scrdir=/scratch/alongd/
+ Entering Link 1 = /opt/g03/l1.exe PID=     19674.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2004, Gaussian, Inc.
+                  All Rights Reserved.
+  
+ This is the Gaussian(R) 03 program.  It is based on the
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 03, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, J. A. Montgomery, Jr., T. Vreven, 
+ K. N. Kudin, J. C. Burant, J. M. Millam, S. S. Iyengar, J. Tomasi, 
+ V. Barone, B. Mennucci, M. Cossi, G. Scalmani, N. Rega, 
+ G. A. Petersson, H. Nakatsuji, M. Hada, M. Ehara, K. Toyota, 
+ R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, 
+ H. Nakai, M. Klene, X. Li, J. E. Knox, H. P. Hratchian, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ P. Y. Ayala, K. Morokuma, G. A. Voth, P. Salvador, J. J. Dannenberg, 
+ V. G. Zakrzewski, S. Dapprich, A. D. Daniels, M. C. Strain, 
+ O. Farkas, D. K. Malick, A. D. Rabuck, K. Raghavachari, 
+ J. B. Foresman, J. V. Ortiz, Q. Cui, A. G. Baboul, S. Clifford, 
+ J. Cioslowski, B. B. Stefanov, G. Liu, A. Liashenko, P. Piskorz, 
+ I. Komaromi, R. L. Martin, D. J. Fox, T. Keith, M. A. Al-Laham, 
+ C. Y. Peng, A. Nanayakkara, M. Challacombe, P. M. W. Gill, 
+ B. Johnson, W. Chen, M. W. Wong, C. Gonzalez, and J. A. Pople, 
+ Gaussian, Inc., Wallingford CT, 2004.
+ 
+ ******************************************
+ Gaussian 03:  AM64L-G03RevD.01 13-Oct-2005
+                31-Jan-2019 
+ ******************************************
+ %chk=check.chk
+ %mem=1500mb
+ %nproc=8
+ Will use up to    8 processors via shared memory.
+ --------------------------------------------------------------------
+ # opt=(modredundant, calcfc, noeigentest) b3lyp/6-311+g(d,p) scf=xqc
+
+ The following ModRedundant input section has been read:
+ D    3    1    2    4 S  36 -10.000
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ NAtoms=    4 NActive=    4 NUniq=    2 SFac= 3.00D+00 NAtFMM=   80 NAOKFM=F Big=F
+ One-electron integrals computed using PRISM.
+
+ SCF Done:  E(RB+HF-LYP) =  -151.602059305     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            118.8736         -DE/DX =    0.0003              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601869908     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            108.8736         -DE/DX =    0.0019              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601365079     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             98.8736         -DE/DX =    0.0039              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.600517481     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             88.8736         -DE/DX =    0.0058              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.599341829     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             78.8736         -DE/DX =    0.0076              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.597876940     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             68.8736         -DE/DX =    0.0091              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.596190515     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             58.8736         -DE/DX =    0.0101              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.594380469     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             48.8736         -DE/DX =    0.0105              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.592582691     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             38.8736         -DE/DX =    0.01                !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.590952335     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             28.8736         -DE/DX =    0.0086              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.589650462     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             18.8736         -DE/DX =    0.0062              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.588823637     A.U. after    6 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)              8.8736         -DE/DX =    0.0031              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.588581295     A.U. after    6 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)             -1.1264         -DE/DX =   -0.0004              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.588962051     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -11.1264         -DE/DX =   -0.0039              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.589907026     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -21.1264         -DE/DX =   -0.0068              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.591296703     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -31.1264         -DE/DX =   -0.009               !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.592978726     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -41.1264         -DE/DX =   -0.0102              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.594792509     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -51.1264         -DE/DX =   -0.0105              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.596585295     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -61.1264         -DE/DX =   -0.01                !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.598229143     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -71.1264         -DE/DX =   -0.0088              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.599633708     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -81.1264         -DE/DX =   -0.0072              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.600738015     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            -91.1264         -DE/DX =   -0.0054              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601508532     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -101.1264         -DE/DX =   -0.0034              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601938238     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -111.1264         -DE/DX =   -0.0015              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.602064496     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -121.1264         -DE/DX =    0.0                 !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601958140     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -131.1264         -DE/DX =    0.0011              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601709454     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -141.1264         -DE/DX =    0.0017              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601403058     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -151.1264         -DE/DX =    0.0018              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601118037     A.U. after   10 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -161.1264         -DE/DX =    0.0014              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.600924159     A.U. after   11 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)           -171.1264         -DE/DX =    0.0008              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.600864848     A.U. after   10 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            178.8736         -DE/DX =   -0.0001              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.600957616     A.U. after    6 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            168.8736         -DE/DX =   -0.0009              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601177264     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            158.8736         -DE/DX =   -0.0015              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601472935     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            148.8736         -DE/DX =   -0.0018              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601773366     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            138.8736         -DE/DX =   -0.0016              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601997808     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            128.8736         -DE/DX =   -0.0009              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.602059309     A.U. after    6 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            118.8736         -DE/DX =    0.0003              !
+
+ Normal termination of Gaussian 03 at Thu Jan 31 07:15:02 2019.

--- a/arc/testing/rotor_scans/H2O2_two_point_scan.out
+++ b/arc/testing/rotor_scans/H2O2_two_point_scan.out
@@ -1,0 +1,104 @@
+ Entering Gaussian System, Link 0=g03
+ Input=input.gjf
+ Output=input.log
+ Initial command:
+ /opt/g03/l1.exe /scratch/alongd/Gau-19672.inp -scrdir=/scratch/alongd/
+ Entering Link 1 = /opt/g03/l1.exe PID=     19674.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2004, Gaussian, Inc.
+                  All Rights Reserved.
+  
+ This is the Gaussian(R) 03 program.  It is based on the
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 03, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, J. A. Montgomery, Jr., T. Vreven, 
+ K. N. Kudin, J. C. Burant, J. M. Millam, S. S. Iyengar, J. Tomasi, 
+ V. Barone, B. Mennucci, M. Cossi, G. Scalmani, N. Rega, 
+ G. A. Petersson, H. Nakatsuji, M. Hada, M. Ehara, K. Toyota, 
+ R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, 
+ H. Nakai, M. Klene, X. Li, J. E. Knox, H. P. Hratchian, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ P. Y. Ayala, K. Morokuma, G. A. Voth, P. Salvador, J. J. Dannenberg, 
+ V. G. Zakrzewski, S. Dapprich, A. D. Daniels, M. C. Strain, 
+ O. Farkas, D. K. Malick, A. D. Rabuck, K. Raghavachari, 
+ J. B. Foresman, J. V. Ortiz, Q. Cui, A. G. Baboul, S. Clifford, 
+ J. Cioslowski, B. B. Stefanov, G. Liu, A. Liashenko, P. Piskorz, 
+ I. Komaromi, R. L. Martin, D. J. Fox, T. Keith, M. A. Al-Laham, 
+ C. Y. Peng, A. Nanayakkara, M. Challacombe, P. M. W. Gill, 
+ B. Johnson, W. Chen, M. W. Wong, C. Gonzalez, and J. A. Pople, 
+ Gaussian, Inc., Wallingford CT, 2004.
+ 
+ ******************************************
+ Gaussian 03:  AM64L-G03RevD.01 13-Oct-2005
+                31-Jan-2019 
+ ******************************************
+ %chk=check.chk
+ %mem=1500mb
+ %nproc=8
+ Will use up to    8 processors via shared memory.
+ --------------------------------------------------------------------
+ # opt=(modredundant, calcfc, noeigentest) b3lyp/6-311+g(d,p) scf=xqc
+
+ The following ModRedundant input section has been read:
+ D    3    1    2    4 S   1 10.000
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ NAtoms=    4 NActive=    4 NUniq=    2 SFac= 3.00D+00 NAtFMM=   80 NAOKFM=F Big=F
+ One-electron integrals computed using PRISM.
+
+ SCF Done:  E(RB+HF-LYP) =  -151.602059309     A.U. after    6 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            118.8736         -DE/DX =    0.0003              !
+
+ SCF Done:  E(RB+HF-LYP) =  -151.601997808     A.U. after    7 cycles
+ Optimization completed.
+ ! D1    D(3,1,2,4)            128.8736         -DE/DX =   -0.0009              !
+
+ Normal termination of Gaussian 03 at Thu Jan 31 07:15:02 2019.


### PR DESCRIPTION
Gaussian 1D scan angles lost their direction on a reversed scan and gained a spurious 360 degrees on a
short one.

## The defect

`arc/parser/adapters/gaussian.py` normalised a scan's dihedrals by subtracting the first angle,
lifting negatives by 360, then adding 360 to the last point if it looked too small:

```python
angle -= angle[0]
angle[angle < 0] += 360.0
if len(angle) > 1 and angle[-1] < 2 * (angle[1] - angle[0]):
    angle[-1] += 360.0
```

**Reversed scans.** A scan with a negative step produces decreasing dihedrals, so after the
subtraction they are negative and the second line lifts the whole interior — not just the endpoint.
The H₂O₂ series read backwards came out as `[0, 350, 340, …, 20, 10, 360]`: not monotone, and the
direction is gone. On a reversed sBuOH scan the final point reached **719.999**.

**Short scans.** With two points, `angle[0]` is 0 after the subtraction, so the guard reduces to
`angle[1] < 2 * angle[1]` and holds for every positive angle. A 10 degree step parsed as `[0, 370]`.

Three points are not unconditionally affected — uniform steps give `60 < 60`, which is false. But
`arc/testing/rotor_scans/TS_errored.out`, already in the repository, has raw steps of 30.0001 and
29.9999 and therefore parses to `[0, 30, 420]` today.

That last case points at the origin: the heuristic is a mis-port of Arkane's, which compares against
the **declared** step size from the log (`arkane/ess/gaussian.py:520`). ARC substituted the first
**observed** step, which makes it sensitive to the printed precision of the dihedral.

## What the heuristic was protecting

A forward sweep completing a full turn. Gaussian reports dihedrals in (-180, 180], so the last point
of a 360 degree scan equals the first and reads as approximately 0, which would appear to run
backwards. `sBuOH.out` (46 points) and `H2O2.out` (37 points) are exactly this case; both still end
at 360, bit for bit unchanged.

## The fix

Per-step phase unwrapping. Each raw consecutive difference is wrapped into ±180 with
`arc.common.get_angle_in_180_range(step, round_to=None)` and cumulatively summed from zero. This
reads the direction from every raw step before any transformation, rather than inferring it from one
transformed step, and it subsumes direction handling instead of branching on it.

`round_to=None` is required: the default rounds to two decimal places, and rounding per step
accumulates across a long sweep.

Values are deliberately not folded into [0, 360). A sweep may legitimately exceed 360 where that
keeps it monotone, and monotonicity is the property callers rely on.

Verified identical to the previous behaviour on all eleven well-formed Gaussian 1D fixtures; the
output differs only where the previous answer was wrong.

## Consumers

Only one consumer reads the angles: `scheduler.py:3283` passes them to
`plotter.plot_1d_rotor_scan`, whose x-axis is already labelled "Dihedral angle increment".
`output.py:654`, `species.py:3026`, `species.py:3121` (`determine_rotor_symmetry`, which walks
energies by index) and `trsh.py`'s `scan_quality_check` all take element `[0]` — energies only. No
physical quantity changes. Arkane is unaffected: ARC hands it the raw log and RMG-Py performs its own
fold. `parse_1d_scan_energies_from_specific_angle` now yields a monotone absolute series for a
reversed scan where it previously yielded a scrambled one.

## Reuse

`np.unwrap(angle, period=360.0) - angle[0]` was considered and measured. It is numerically identical
on all fifteen fixtures, so the two differ only on an exactly-180-degree step — and there it is
backwards for real Gaussian input. Gaussian records such a scan as `[118.87, -61.13, 118.87]`, steps
of -180 and +180; `np.unwrap`'s asymmetric half-period rule gives `[0, -180, 0]`, which is not
monotone, where per-step unwrapping gives `[0, -180, -360]`.

`signed_angular_diff` was the other candidate and is semantically the closer name, but it has no
`round_to` passthrough, so it would reintroduce the accumulating rounding.

## Tests

`arc/parser/` — 44 passed, serially and under `-n 6 --dist worksteal`. Consumers: 238 passed across
`trsh_test`, `output_test`, `ase_test`, `plotter_test` and `species_test`.

Validated by mutation rather than coverage — five mutants, each killed by a test: the original
condition restored, direction handling dropped, values folded into [0, 360), a uniform-step
strawman, and the non-optimised-point deletion moved before the unwrap.

The repository had no genuine negative-step or two-point Gaussian log, so both fixtures are derived
from real per-point blocks of `H2O2.out` (reversed and truncated respectively, with the ModRedundant
directive changed to match). For H₂O₂ this is faithful: with four atoms, every non-scanned degree of
freedom has a unique minimum at each dihedral, so a genuine reversed scan gives the same energies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbGeU8wLpafo3YFzTky2ho
