### PR TITLE
Correct the G4 frequency scale factor, and pair each composite with the frequency level it prescribes

### DIFF
--- a/arc/level.py
+++ b/arc/level.py
@@ -13,6 +13,7 @@ from arc.imports import settings
 logger = get_logger()
 
 levels_ess, supported_ess = settings['levels_ess'], settings['supported_ess']
+default_levels_of_theory = settings['default_levels_of_theory']
 
 
 class Level(object):
@@ -462,6 +463,50 @@ class Level(object):
             for ess in supported_ess:
                 if ess in ess_methods and self.method in ess_methods[ess]:
                     self.compatible_ess.append(ess)
+
+
+def get_freq_level_for_composite_method(composite_method: str | Level) -> str:
+    """
+    Get the frequency level of theory prescribed by a composite method.
+
+    Each composite protocol defines its own frequency level, and the scale factor stored for it in
+    ``data/freq_scale_factors.yml`` is that protocol's own ZPE scale factor times 1.014. Computing
+    the frequencies at some other level therefore applies a factor fitted against a different
+    basis, in a job that converges and terminates normally, so this mapping raises on an unknown
+    composite rather than falling back to an arbitrary default.
+
+    Args:
+        composite_method (str | Level): The composite method.
+
+    Raises:
+        ValueError: If the prescribed frequency level for ``composite_method`` is not known.
+
+    Returns:
+        str: The frequency level of theory to use with this composite method.
+    """
+    method = composite_method.method if isinstance(composite_method, Level) else str(composite_method).lower()
+    freq_levels = default_levels_of_theory['freq_for_composite']
+    if isinstance(freq_levels, str):
+        # A local ~/.arc/settings.py that overrides default_levels_of_theory predates this mapping
+        # and still carries a single level for every composite. Honor it rather than breaking the
+        # user's run, but say plainly what it costs: this is the mispairing the mapping exists to
+        # prevent, and it cannot be detected from the output of the job it corrupts.
+        logger.warning(f'Your local ~/.arc/settings.py sets default_levels_of_theory["freq_for_composite"] '
+                       f'to the single level {freq_levels!r}, which predates per-composite frequency '
+                       f'levels. Using it for {method!r}.\nIf {method!r} does not prescribe that level, its '
+                       f'frequency scale factor is being applied to frequencies from a different basis. '
+                       f'Update ~/.arc/settings.py to a {{composite: level}} mapping, or set `freq_level` '
+                       f'explicitly in the input file.')
+        return freq_levels
+    if method not in freq_levels:
+        raise ValueError(f'Cannot determine the frequency level prescribed by the composite method '
+                         f'{method!r}: it is not in default_levels_of_theory["freq_for_composite"] '
+                         f'(known: {sorted(freq_levels.keys())}).\n'
+                         f'ARC will not guess one, since the frequency scale factor stored for a composite '
+                         f'method is that protocol\'s own ZPE scale factor and pairing it with another '
+                         f'protocol\'s frequency level fails silently.\n'
+                         f'Specify `freq_level` explicitly in the input file to proceed.')
+    return freq_levels[method]
 
 
 def assign_frequency_scale_factor(level: str | Level) -> float | None:

--- a/arc/level_test.py
+++ b/arc/level_test.py
@@ -7,9 +7,10 @@ This module contains unit tests for the arc.lot module
 
 import os
 import unittest
+from unittest import mock
 
 from arc.common import ARC_PATH, read_yaml_file
-from arc.level import Level, assign_frequency_scale_factor
+from arc.level import Level, assign_frequency_scale_factor, get_freq_level_for_composite_method
 
 
 class TestLevel(unittest.TestCase):
@@ -255,6 +256,44 @@ class TestLevel(unittest.TestCase):
                       'no/such, software: nonesuch, solvent: water']:
             with self.assertRaises(ValueError):
                 Level(repr=repr_)
+
+    # Patched rather than read live: a local ~/.arc/settings.py overlays default_levels_of_theory
+    # (see arc/imports.py), so an unpatched test would assert against whatever the developer's
+    # machine happens to carry -- passing in CI and failing locally, or worse, the reverse.
+    MAPPING = {'cbs-qb3': 'B3LYP/CBSB7',
+               'cbs-qb3-paraskevas': 'B3LYP/CBSB7',
+               'g4': 'B3LYP/6-31G(2df,p)',
+               }
+
+    def test_get_freq_level_for_composite_method(self):
+        """Test that each composite method resolves to the frequency level it prescribes."""
+        with mock.patch.dict('arc.level.default_levels_of_theory', {'freq_for_composite': self.MAPPING}):
+            # G4 prescribes B3LYP/6-31G(2df,p); its scale factor (0.9854 * 1.014) is defined against it.
+            self.assertEqual(get_freq_level_for_composite_method('g4'), 'B3LYP/6-31G(2df,p)')
+            # CBS-QB3 prescribes B3LYP/CBSB7, unchanged by this mapping.
+            self.assertEqual(get_freq_level_for_composite_method('cbs-qb3'), 'B3LYP/CBSB7')
+            self.assertEqual(get_freq_level_for_composite_method('cbs-qb3-paraskevas'), 'B3LYP/CBSB7')
+            # Case-insensitive, and a Level is accepted as well as a string.
+            self.assertEqual(get_freq_level_for_composite_method('G4'), 'B3LYP/6-31G(2df,p)')
+            self.assertEqual(get_freq_level_for_composite_method(Level(repr='CBS-QB3')), 'B3LYP/CBSB7')
+
+    def test_get_freq_level_for_composite_method_raises(self):
+        """Test that a composite with no prescribed frequency level raises instead of defaulting.
+
+        Falling back would pair the composite's own ZPE-derived scale factor with another
+        protocol's frequencies -- wrong, and silent, since such a job converges normally.
+        """
+        with mock.patch.dict('arc.level.default_levels_of_theory', {'freq_for_composite': self.MAPPING}):
+            for method in ['g3', 'cbs-4m', 'w1bd']:
+                with self.assertRaises(ValueError):
+                    get_freq_level_for_composite_method(method)
+
+    def test_get_freq_level_for_composite_method_legacy_str(self):
+        """Test that a pre-mapping local settings override is honored, with a warning, not a crash."""
+        with mock.patch.dict('arc.level.default_levels_of_theory', {'freq_for_composite': 'B3LYP/CBSB7'}):
+            with self.assertLogs('arc', level='WARNING') as cm:
+                self.assertEqual(get_freq_level_for_composite_method('g4'), 'B3LYP/CBSB7')
+            self.assertIn('predates per-composite frequency levels', ' '.join(cm.output))
 
 
 if __name__ == '__main__':

--- a/arc/main.py
+++ b/arc/main.py
@@ -29,7 +29,7 @@ from arc.common import (VERSION,
                         )
 from arc.exceptions import InputError, SettingsError, SpeciesError
 from arc.imports import settings
-from arc.level import Level, assign_frequency_scale_factor
+from arc.level import Level, assign_frequency_scale_factor, get_freq_level_for_composite_method
 from arc.job.factory import _registered_job_adapters
 from arc.job.ssh import check_servers_known_hosts, delete_check_files_on_servers
 from arc.job.ssh_pool import borrow_ssh_client, reset_default_pool
@@ -1061,7 +1061,9 @@ class ARC(object):
             self.opt_level, self.sp_level = None, None
 
             if not self.freq_level:
-                self.freq_level = default_levels_of_theory['freq_for_composite']
+                # Prescribed by the composite protocol, not a global default: the scale factor
+                # stored for a composite is that protocol's own ZPE factor (see level.py).
+                self.freq_level = get_freq_level_for_composite_method(self.composite_method)
                 default_flag = ' (composite default)'
             else:
                 default_flag = ''

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -23,7 +23,7 @@ from arc.job.adapters.common import (adopted_reference_is_unrestricted, default_
                                       REFERENCE_AGNOSTIC_METHOD_TYPES, REFERENCE_CHANGE_AVAILABLE_KEY,
                                       ts_adapters_by_rmg_family, ts_adapters_for_unknown_unimolecular)
 from arc.job.factory import job_factory
-from arc.level import Level
+from arc.level import Level, get_freq_level_for_composite_method
 from arc.plotter import save_conformers_file
 from arc.scheduler import (COLLAPSED_REFERENCE_MESSAGE, INVALID_ANALYTIC_FREQ_MESSAGE, MAX_S_SQUARED_DEVIATION,
                            MIXED_SCF_REFERENCE_MESSAGE, SPIN_CONTAMINATION_MESSAGE, STABILITY_ANALYSIS_ADAPTERS,
@@ -175,8 +175,8 @@ H      -1.82570782    0.42754384   -0.56130718"""
                                species_list=[cls.spc1],
                                composite_method=Level(repr='CBS-QB3'),
                                conformer_opt_level=Level(repr=default_levels_of_theory['conformer']),
-                               opt_level=Level(repr=default_levels_of_theory['freq_for_composite']),
-                               freq_level=Level(repr=default_levels_of_theory['freq_for_composite']),
+                               opt_level=Level(repr=get_freq_level_for_composite_method('cbs-qb3')),
+                               freq_level=Level(repr=get_freq_level_for_composite_method('cbs-qb3')),
                                scan_level=Level(repr=default_levels_of_theory['scan_for_composite']),
                                ts_guess_level=Level(repr=default_levels_of_theory['ts_guesses']),
                                project_directory=cls.project_directory,

--- a/arc/settings/settings.py
+++ b/arc/settings/settings.py
@@ -235,7 +235,17 @@ default_levels_of_theory = {'conformer': 'wb97xd/def2svp',  # it's recommended t
                             'irc': 'wb97xd/def2tzvp',  # should be the same level as opt
                             'orbitals': 'wb97x-d3/def2tzvp',  # save orbitals for visualization
                             'scan_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of CBS-QB3
-                            'freq_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of CBS-QB3
+                            # Keyed by composite method. Each composite protocol prescribes its own
+                            # frequency level, and data/freq_scale_factors.yml stores that protocol's
+                            # own ZPE scale factor x 1.014 (see the 'note' fields there). Pairing a
+                            # composite with another protocol's frequency level therefore applies a
+                            # factor fitted against a different basis -- silently, in a job that
+                            # converges and terminates normally. A composite absent from this mapping
+                            # raises rather than defaulting; set `freq_level` explicitly to override.
+                            'freq_for_composite': {'cbs-qb3': 'B3LYP/CBSB7',
+                                                   'cbs-qb3-paraskevas': 'B3LYP/CBSB7',
+                                                   'g4': 'B3LYP/6-31G(2df,p)',  # G4's prescribed level
+                                                   },
                             'irc_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of CBS-QB3
                             'orbitals_for_composite': 'B3LYP/CBSB7',  # This is the frequency level of CBS-QB3
                             }

--- a/data/freq_scale_factors.yml
+++ b/data/freq_scale_factors.yml
@@ -6,6 +6,7 @@ sources:
   3: 'http://comp.chem.umn.edu/freqscale/190107_Database_of_Freq_Scale_Factors_v4.pdf'
   4: 'Calculated as described in 10.1021/ct100326h'
   5: 'J.A. Montgomery, M.J. Frisch, J. Chem. Phys. 1999, 110, 2822-2827, DOI: 10.1063/1.477924'
+  6: 'L.A. Curtiss, P.C. Redfern, K. Raghavachari, J. Chem. Phys. 2007, 126, 084108, DOI: 10.1063/1.2436888'
 
 freq_scale_factors:
   'hf/sto3g, software: gaussian':
@@ -179,9 +180,9 @@ freq_scale_factors:
     source: 5
     note: 'Same as cbs-qb3, added for consistency with Arkane'
   'g4, software: gaussian':
-    factor: 0.994
-    source: 4
-    note: '0.980 * 1.014, the 0.980 value is the ZPE scale factor of G4, fitted with Truhlar''s method over the 15-species standard set'
+    factor: 0.9992
+    source: 6
+    note: '0.9854 * 1.014, the 0.9854 value is the ZPE scale factor of G4'
   'ccsd/cc-pvdz, software: molpro':
     factor: 0.947
     source: 2


### PR DESCRIPTION
## What

Two related corrections to how ARC scales harmonic frequencies for composite methods.

**1. The G4 value was wrong.** `data/freq_scale_factors.yml` carried `0.994`, derived as `0.980 * 1.014` with the 0.980 fitted by Truhlar's method over the 15-species standard set. G4's prescribed ZPE scale factor is Curtiss's **0.9854**, giving **0.9992**.

**2. The value was being applied to the wrong frequencies.** The factor stored for a composite is that protocol's *own* prescribed ZPE scale factor x 1.014 -- the existing notes say so:

```yaml
'cbs-qb3, ...': note: '0.99 * 1.014, the 0.99 value is the ZPE scale factor of CBS-QB3'
'g4, ...':      note: '0.9854 * 1.014, the 0.9854 value is the ZPE scale factor of G4'
```

But `default_levels_of_theory['freq_for_composite']` was a single global `'B3LYP/CBSB7'` for *every* composite, while G4 prescribes **B3LYP/6-31G(2df,p)**. So ARC scaled CBSB7 frequencies with a constant defined against a different basis.

Keying the *factor lookup* on the composite method (`main.py`) is therefore correct by design and is left untouched -- the defect is the frequency level handed to it. `freq_for_composite` becomes a `{composite: level}` mapping, resolved by the new `get_freq_level_for_composite_method()`.

## Behaviour change worth review

**An unmapped composite now raises instead of defaulting to CBSB7.** This affects the 14 composites ARC recognises that have no scale-factor entry (`cbs-4m`, `g3`, `w1bd`, ...). The rationale: the failure it replaces cannot be seen from the output of the job it corrupts -- a mispaired factor still converges, terminates normally, passes ARC's sanity checks, and yields a plausible enthalpy for the wrong quantity. A loud stop beats a silent guess. Setting `freq_level` explicitly in the input file remains the override, and the error message says so.

Happy to soften this to a warning-and-default if maintainers prefer; it is the one judgment call here.

## Compatibility

A local `~/.arc/settings.py` that overrides `default_levels_of_theory` predates the mapping and still holds a string. That is honoured with a warning naming the mispairing risk, rather than crashing the user's run.

## Testing

New cases in `arc/level_test.py`: G4 -> `B3LYP/6-31G(2df,p)`, CBS-QB3 -> `B3LYP/CBSB7` unchanged, `Level` and case-insensitive input, unmapped composites raise, and the legacy-string path warns and proceeds. They patch the mapping explicitly rather than reading it live, because `arc/imports.py` overlays `~/.arc/settings.py` over the repo defaults -- an unpatched test asserts against whatever the developer's machine happens to carry.

## Note for reviewers

`scan_for_composite`, `irc_for_composite` and `orbitals_for_composite` have the same single-global shape and arguably the same defect -- `'scan'`'s own comment says it "should be the same level as freq (to project out rotors)", which no longer holds for G4 once freq moves. Deliberately left out of scope here to keep this reviewable; happy to follow up.
