### PR TITLE
Skip the TS-GCN installer in the CI install lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,11 @@ jobs:
             bash ARC/devtools/install_rits.sh --cpu
           fi
 
-      - name: Set TS-GCN and AutoTST in PYTHONPATH
+      - name: Set AutoTST in PYTHONPATH
         shell: micromamba-shell {0}
         working-directory: ARC
         run: |
-          echo "PYTHONPATH=$(realpath ../TS-GCN):$(realpath ../AutoTST):$PYTHONPATH" >> $GITHUB_ENV
+          echo "PYTHONPATH=$(realpath ../AutoTST):$PYTHONPATH" >> $GITHUB_ENV
 
       - name: Compile ARC molecule
         shell: micromamba-shell {0}

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ install:
 	bash $(DEVTOOLS_DIR)/install_all.sh
 
 install-ci:
-	@echo "Installing all external ARC dependencies for CI (no clean, no GoFlow, no RitS — each runs in its own CI lane)..."
-	bash $(DEVTOOLS_DIR)/install_all.sh --no-clean --no-goflow --no-rits
+	@echo "Installing all external ARC dependencies for CI (no clean, no GoFlow, no RitS, no TS-GCN — the first two run in their own CI lanes; CI never runs the ts_gcn environment)..."
+	bash $(DEVTOOLS_DIR)/install_all.sh --no-clean --no-goflow --no-rits --no-gcn
 
 install-lite:
 	@echo "Installing ARC's lite version (no external dependencies)..."

--- a/devtools/install_all.sh
+++ b/devtools/install_all.sh
@@ -28,6 +28,7 @@ SKIP_EXT=false
 SKIP_ARC=false
 SKIP_GOFLOW=false
 SKIP_RITS=false
+SKIP_GCN=false
 RMG_ARGS=()
 ARC_ARGS=()
 EXT_ARGS=()
@@ -40,6 +41,7 @@ while [[ $# -gt 0 ]]; do
         --no-arc)    SKIP_ARC=true  ;;
         --no-goflow) SKIP_GOFLOW=true ;;
         --no-rits)   SKIP_RITS=true ;;
+        --no-gcn)    SKIP_GCN=true ;;
         --rmg-*)    RMG_ARGS+=("--${1#--rmg-}") ;;
         --arc-*)    ARC_ARGS+=("--${1#--arc-}") ;;
         --ext-*)    EXT_ARGS+=("--${1#--ext-}") ;;
@@ -50,6 +52,7 @@ Usage: $0 [global-flags] [--rmg-xxx] [--arc-yyy] [--ext-zzz]
   --no-ext            Skip external tools (AutoTST, KinBot, …)
   --no-goflow         Skip the GoFlow installer (heavy ML stack — usually run in its own CI lane)
   --no-rits           Skip the RitS installer (heavy ML stack — usually run in its own CI lane)
+  --no-gcn            Skip the TS-GCN installer (its wheels come from a third-party host that CI does not need)
   --rmg-path          Forward '--path' to RMG installer
   --rmg-pip           Forward '--pip'  to RMG installer
   ...
@@ -118,6 +121,13 @@ if [[ $SKIP_EXT == false ]]; then
     if [[ $SKIP_RITS == true ]]; then
         unset 'EXT_INSTALLERS[RitS]'
         echo "ℹ️  --no-rits: skipping RitS installer (run \`make install-rits\` or the rits CI lane separately)"
+    fi
+
+    # Optionally drop TS-GCN — used by `make install-ci`: its tests mock the ts_gcn interpreter, and the
+    # PyTorch Geometric wheels it pulls are served by a host outside our control
+    if [[ $SKIP_GCN == true ]]; then
+        unset 'EXT_INSTALLERS[GCN CPU]'
+        echo "ℹ️  --no-gcn: skipping TS-GCN installer (run \`make install-gcn\` separately)"
     fi
 
         # installer-specific flag whitelists


### PR DESCRIPTION
## Why CI is red

Every CI run since 2026-09-02 fails in `make install-ci` before a single test executes, on `main` and on every open PR. The GCN installer builds the `ts_gcn` environment from `devtools/gcn_environment.yml`, whose PyTorch Geometric wheels (`torch-scatter`, `torch-sparse`, `torch-cluster`, `torch-spline-conv`) are linked from `pytorch-geometric.com/whl/torch-1.7.1+cpu.html` to `data.pyg.org`. That host stopped resolving on 2026-09-02 (dangling CNAME to a retired CloudFront distribution; tracked upstream at pyg-team/pyg-lib#719 with no ETA). `install_all.sh` runs under `set -euo pipefail`, so the failed pip step aborts the whole install.

## What we realised along the way

TS-GCN is not tested anywhere in our CI flow. `gcn_test.py` patches `TS_GCN_PYTHON` and mocks the subprocess boundary, `settings.py` resolves `TS_GCN_PYTHON` to `None` when the environment is absent, and `gcn_available()` already handles that. No workflow step runs the `ts_gcn` interpreter. CI has been building a heavyweight environment on every run and never using it.

## Change

- `devtools/install_all.sh` gains `--no-gcn`, the same shape as `--no-goflow` and `--no-rits`.
- `make install-ci` passes it. `make install` and `make install-gcn` still build the environment for real deployments.
- The workflow's PYTHONPATH step now adds only AutoTST. Nothing clones `../TS-GCN` on the runner any more, so the old line would print a `realpath` error on every run.

Verified that no other installer still in the CI lane fetches from the dead host (`install_goflow.sh` and `install_rits.sh` reference it but were already outside `install-ci`), that `docker_build.yml` never calls `install_all.sh`, and that the associative-array `unset` behaves under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155RJ4VFRKpXQPEUBU2G4ho
