### PR TITLE
Report a requested atom map that yields no Linear TS guess

### DIFF
--- a/arc/job/adapters/ts/linear.py
+++ b/arc/job/adapters/ts/linear.py
@@ -796,6 +796,9 @@ class LinearAdapter(JobAdapter):
     derivation (it is only consulted by the degraded fallback paths), and the adapter logs a
     warning when it encounters one. To request guesses for one specific reactants-to-products
     correspondence, pass it via the ``atom_map`` argument, which overrides the derived map.
+    A requested map for which no guess survives validation is reported: it is appended to
+    ``self.atom_maps_without_guesses``, recorded on the reaction as an unsuccessful ``TSGuess``,
+    and logged as a warning.
 
     Args:
         project (str): The project's name. Used for setting the remote path.
@@ -896,6 +899,8 @@ class LinearAdapter(JobAdapter):
         self.job_adapter = 'linear'
         # Explicitly requested atom map(s); ``None`` means "derive a map per reaction path".
         self.forced_atom_maps = normalize_atom_maps(atom_map)
+        # Requested atom maps for which no TS guess survived, in the order they were processed.
+        self.atom_maps_without_guesses: list[list[int]] = list()
         self.command = None
         self.execution_type = 'incore'  # incore-only (no server); ignore any execution_type the scheduler passes
 
@@ -1050,6 +1055,8 @@ class LinearAdapter(JobAdapter):
                         # the degraded fallback paths honor the requested correspondence too.
                         rxn._atom_map = list(forced_atom_map)
                     map_suffix = f', map={map_i}' if len(forced_atom_maps) > 1 else ''
+                    map_t0 = datetime.datetime.now()
+                    guesses_before = len(rxn.ts_species.ts_guesses)
                     # Per-map memo: atom maps and the wider-family-set scan
                     # outcome are weight-invariant, so compute them once per map
                     # instead of once per weight iteration.
@@ -1093,6 +1100,27 @@ class LinearAdapter(JobAdapter):
                                          comment=f'Linear w={w:.2f}, {xyz_i}{map_suffix}, family: {rxn.family}',
                                          )
 
+                    if forced_atom_map is not None and len(rxn.ts_species.ts_guesses) == guesses_before:
+                        # An explicitly requested map that yields nothing is a distinct outcome from a
+                        # derived map that happened not to work: the caller asked for this specific
+                        # correspondence and must be able to tell that it came back empty. Record it
+                        # both on the reaction (an unsuccessful TSGuess, which is persisted) and on the
+                        # adapter, so neither a human reading the log nor a caller iterating over maps
+                        # has to infer it from a guess count.
+                        self.atom_maps_without_guesses.append(list(forced_atom_map))
+                        rxn.ts_species.append_ts_guess(TSGuess(method=f'Linear (map={map_i})',
+                                                              method_index=map_i,
+                                                              t0=map_t0,
+                                                              execution_time=datetime.datetime.now() - map_t0,
+                                                              success=False,
+                                                              family=rxn.family,
+                                                              ))
+                        logger.warning(f'The linear TS search adapter generated no TS guess for the requested '
+                                       f'atom map {forced_atom_map} of {rxn.label}: every guess built for this '
+                                       f'correspondence was discarded by the geometry validators. Run with a DEBUG '
+                                       f'log level for the per-strategy rejection reasons. Another atom map '
+                                       f'describing the same reaction center may still produce a guess.')
+
             except Exception as e:
                 logger.error(f'Linear TS adapter failed for {rxn.label}: {e}', exc_info=True)
                 continue
@@ -1106,10 +1134,15 @@ class LinearAdapter(JobAdapter):
 
             if len(self.reactions) < 5:
                 successes = len([tsg for tsg in rxn.ts_species.ts_guesses if tsg.success and 'linear' in tsg.method.lower()])
+                requested = len(self.forced_atom_maps) if self.forced_atom_maps is not None else 0
+                # Only the requested maps of this reaction, not those of reactions processed before it.
+                empty = len([atom_map for atom_map in self.atom_maps_without_guesses
+                             if atom_map in (self.forced_atom_maps or list())])
+                suffix = f' ({requested - empty} of {requested} requested atom maps)' if requested else ''
                 if successes:
-                    logger.info(f'Linear successfully found {successes} TS guesses for {rxn.label}.')
+                    logger.info(f'Linear successfully found {successes} TS guesses for {rxn.label}{suffix}.')
                 else:
-                    logger.info(f'Linear did not find any successful TS guesses for {rxn.label}.')
+                    logger.info(f'Linear did not find any successful TS guesses for {rxn.label}{suffix}.')
         self.final_time = datetime.datetime.now()
 
     def execute_queue(self):

--- a/arc/job/adapters/ts/linear_test.py
+++ b/arc/job/adapters/ts/linear_test.py
@@ -6407,5 +6407,91 @@ class TestLinearAdapterForcedAtomMap(unittest.TestCase):
 
 
 
+class TestLinearAdapterAtomMapWithoutGuesses(unittest.TestCase):
+    """Test reporting a requested atom map for which no TS guess survives (issue #1045)."""
+
+    # Two atom maps of [CH2]C(C)CC <=> CC(C)[CH]C describing the *same* reaction center
+    # (H12 moves from C3 to C0) and differing only in how the spectator hydrogens are
+    # permuted. The second one is the map whose guesses are all rejected by the geometry
+    # validators, so it comes back empty.
+    MAP_WITH_GUESSES = [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 5, 13, 14, 15]
+    MAP_WITHOUT_GUESSES = [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 7, 13, 14, 15]
+
+    @staticmethod
+    def _make_rxn() -> ARCReaction:
+        """
+        Construct a fresh 2-methylbutyl intra_H_migration reaction.
+
+        Returns:
+            ARCReaction: The reaction.
+        """
+        return ARCReaction(r_species=[ARCSpecies(label='r', smiles='[CH2]C(C)CC')],
+                           p_species=[ARCSpecies(label='p', smiles='CC(C)[CH]C')])
+
+    def _run(self, atom_map) -> tuple[ARCReaction, LinearAdapter]:
+        """
+        Execute the Linear adapter for a fresh reaction with the given requested atom map(s).
+
+        Args:
+            atom_map (list[int] | list[list[int]]): The atom map(s) to request.
+
+        Returns:
+            tuple[ARCReaction, LinearAdapter]: The processed reaction and the adapter.
+        """
+        rxn = self._make_rxn()
+        project_directory = tempfile.mkdtemp(prefix='arc_linear_test_')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        adapter = LinearAdapter(job_type='tsg',
+                                reactions=[rxn],
+                                testing=True,
+                                project='test',
+                                project_directory=project_directory,
+                                atom_map=atom_map,
+                                )
+        adapter.execute()
+        return rxn, adapter
+
+    def test_empty_requested_map_is_reported(self):
+        """Test that a requested map yielding no guess is reported rather than silently dropped."""
+        with self.assertLogs(logger='arc', level='WARNING') as cm:
+            rxn, adapter = self._run(atom_map=list(self.MAP_WITHOUT_GUESSES))
+        self.assertEqual(adapter.atom_maps_without_guesses, [self.MAP_WITHOUT_GUESSES])
+        self.assertTrue(any('generated no TS guess for the requested atom map' in line for line in cm.output))
+        # The reaction itself records the outcome, so it survives into the restart file.
+        self.assertEqual([tsg.success for tsg in rxn.ts_species.ts_guesses], [False])
+        self.assertEqual(len([tsg for tsg in rxn.ts_species.ts_guesses if tsg.success]), 0)
+
+    def test_successful_map_is_not_reported_as_empty(self):
+        """Test that a requested map which does produce guesses is not reported as empty."""
+        rxn, adapter = self._run(atom_map=list(self.MAP_WITH_GUESSES))
+        self.assertEqual(adapter.atom_maps_without_guesses, list())
+        self.assertGreater(len([tsg for tsg in rxn.ts_species.ts_guesses if tsg.success]), 0)
+        self.assertTrue(all(tsg.success for tsg in rxn.ts_species.ts_guesses))
+
+    def test_only_the_empty_map_of_several_is_reported(self):
+        """Test that requesting both maps distinguishes the empty one from the successful one."""
+        rxn, adapter = self._run(atom_map=[list(self.MAP_WITH_GUESSES), list(self.MAP_WITHOUT_GUESSES)])
+        self.assertEqual(adapter.atom_maps_without_guesses, [self.MAP_WITHOUT_GUESSES])
+        self.assertGreater(len([tsg for tsg in rxn.ts_species.ts_guesses if tsg.success]), 0)
+        failed = [tsg for tsg in rxn.ts_species.ts_guesses if not tsg.success]
+        self.assertEqual([tsg.method for tsg in failed], ['linear (map=1)'])
+
+    def test_no_report_without_a_requested_map(self):
+        """Test that the default (derived-map) mode never reports an empty requested map."""
+        rxn = self._make_rxn()
+        project_directory = tempfile.mkdtemp(prefix='arc_linear_test_')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        adapter = LinearAdapter(job_type='tsg',
+                                reactions=[rxn],
+                                testing=True,
+                                project='test',
+                                project_directory=project_directory,
+                                )
+        adapter.execute()
+        self.assertEqual(adapter.atom_maps_without_guesses, list())
+        self.assertTrue(all(tsg.success for tsg in rxn.ts_species.ts_guesses))
+
+
+
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
## Summary

A requested atom map for which no TS guess survives validation is now a distinct outcome instead of a smaller result set: it is appended to `LinearAdapter.atom_maps_without_guesses`, recorded on the reaction as an unsuccessful `TSGuess` (so it persists into the restart file), and logged as a warning, with the summary line reporting how many of the requested maps produced guesses.

Investigating the reported case: nothing raises - `interpolate_isomerization` returns empty, every candidate having been discarded by the H-migration validators. Near-identity maps are not the trigger; over the 7 enumerated maps of `[CH2]C(C)CC -> CC(C)[CH]C` the most identity-like map (11/16 fixed points) does produce a guess. The two maps that matter share an identical reaction center (formed `(0, 12)`, broken `(3, 12)`) and differ only in the permutation of the spectator hydrogens, yet one yields 3 guesses and the other none - the ordered-product geometry is built by reordering P through the map, so spectator labeling changes the Z-matrix blend. That sensitivity is a property of the interpolation path rather than of the explicit-map argument, and is left for a separate change; the warning notes that another map with the same reaction center may still produce a guess.

Based on #1044.

Closes #1045
