### PR TITLE
Stop a short method-type marker from matching inside an unrelated method name

### DIFF
--- a/arc/level.py
+++ b/arc/level.py
@@ -346,9 +346,13 @@ class Level(object):
         Determine the model chemistry type:
         DFT, wavefunction, force field, semi-empirical, or composite
         """
+        # Markers are matched as substrings, so a short one fires inside an unrelated name.
+        # The wave function markers are the shortest and are matched last for that reason;
+        # the semi-empirical ones are spelled out in full ('am1' rather than 'am', which also
+        # matches 'cam-b3lyp' and 'amber').
         wave_function_methods = ['hf', 'cc', 'ci', 'mp2', 'mp3', 'cp', 'cep', 'nevpt', 'dmrg', 'ri', 'cas', 'ic', 'mr',
                                  'bd', 'mbpt']
-        semiempirical_methods = ['am', 'pm', 'zindo', 'mndo', 'xtb', 'nddo']
+        semiempirical_methods = ['am1', 'pm3', 'pm6', 'pm7', 'zindo', 'mndo', 'xtb', 'nddo']
         force_field_methods = ['amber', 'mmff', 'dreiding', 'uff', 'qmdff', 'gfn', 'gaff', 'ghemical', 'charmm', 'ani']
         # all composite methods supported by Gaussian
         composite_methods = ['cbs-4m', 'cbs-qb3', 'cbs-qb3-paraskevas', 'rocbs-qb3', 'cbs-apno', 'w1u', 'w1ro', 'w1bd',
@@ -360,12 +364,12 @@ class Level(object):
         elif self.method in ['m06hf', 'm06-hf']:
             self.method_type = 'dft'
         # General cases
-        elif any(wf_method in self.method for wf_method in wave_function_methods):
-            self.method_type = 'wavefunction'
-        elif any(sm_method in self.method for sm_method in semiempirical_methods):
-            self.method_type = 'semiempirical'
         elif any(ff_method in self.method for ff_method in force_field_methods):
             self.method_type = 'force_field'
+        elif any(sm_method in self.method for sm_method in semiempirical_methods):
+            self.method_type = 'semiempirical'
+        elif any(wf_method in self.method for wf_method in wave_function_methods):
+            self.method_type = 'wavefunction'
         else:
             # assume DFT
             self.method_type = 'dft'

--- a/arc/level_test.py
+++ b/arc/level_test.py
@@ -194,6 +194,52 @@ class TestLevel(unittest.TestCase):
                 self.assertIsInstance(method, str)
         self.assertIn('gaussian', list(ess_methods.keys()))
 
+    def test_deduce_method_type(self):
+        """Test deducing the method type of a level of theory"""
+        def method_type(method: str) -> str:
+            """Deduce a method type without also deducing a software for the method."""
+            level = object.__new__(Level)
+            level.method, level.method_type = method.lower(), None
+            level.deduce_method_type()
+            return level.method_type
+
+        # Trivial cases, one per type.
+        self.assertEqual(method_type('b3lyp'), 'dft')
+        self.assertEqual(method_type('ccsd(t)'), 'wavefunction')
+        self.assertEqual(method_type('am1'), 'semiempirical')
+        self.assertEqual(method_type('uff'), 'force_field')
+        self.assertEqual(method_type('cbs-qb3'), 'composite')
+
+        # Common cases.
+        for method in ['wb97xd', 'm06-2x', 'b2plyp', 'wb97m-v', 'pbe0']:
+            self.assertEqual(method_type(method), 'dft', msg=f'{method} should be dft')
+        for method in ['hf', 'mp2', 'dlpno-ccsd(t)', 'caspt2', 'nevpt2']:
+            self.assertEqual(method_type(method), 'wavefunction', msg=f'{method} should be a wavefunction method')
+        for method in ['pm3', 'pm6', 'pm7', 'xtb', 'zindo', 'mndo']:
+            self.assertEqual(method_type(method), 'semiempirical', msg=f'{method} should be semiempirical')
+        for method in ['mmff94', 'gaff', 'amber', 'ghemical', 'torchani']:
+            self.assertEqual(method_type(method), 'force_field', msg=f'{method} should be a force field')
+
+        # A marker must not match inside an unrelated name: 'am' sits inside every Coulomb-attenuated
+        # functional, and 'ic' inside 'ghemical'. Typing a functional as semiempirical makes ARC run a
+        # radical restricted and drop the TS keywords from a Gaussian optimization.
+        for method in ['cam-b3lyp', 'camb3lyp', 'camh-b3lyp', 'cam-qtp00', 'lc-camb3lyp', 'am05']:
+            self.assertEqual(method_type(method), 'dft', msg=f'{method} should be dft')
+
+        # A marker that legitimately sits inside a longer name must still match.
+        for method in ['bccd(t)', 'qcisd(t)', 'fci', 'lccsd', 'lt-df-lcc2', 'uccsd(t)-f12', 'rohf']:
+            self.assertEqual(method_type(method), 'wavefunction', msg=f'{method} should be a wavefunction method')
+
+        # Every method ARC registers types as something, and the composite list wins over the markers
+        # ('g3mp2' contains 'mp2', 'rocbs-qb3' contains 'cbs').
+        ess_methods = read_yaml_file(path=os.path.join(ARC_PATH, 'data', 'ess_methods.yml'))
+        for methods in ess_methods.values():
+            for method in methods:
+                self.assertIn(method_type(method),
+                              ['dft', 'wavefunction', 'semiempirical', 'force_field', 'composite'])
+        self.assertEqual(method_type('g3mp2'), 'composite')
+        self.assertEqual(method_type('rocbs-qb3'), 'composite')
+
     def test_copy(self):
         """Test copying the object"""
         level_1 = Level(repr='wB97xd/def2-tzvp')


### PR DESCRIPTION
Fixes #1049.

`Level.deduce_method_type()` matches its markers as raw substrings, so `'am'` fires inside every Coulomb-attenuated functional. `cam-b3lyp` and `camb3lyp` are both registered in `data/ess_methods.yml`, so an ordinary input file reaches this.

The type then decides how the job is written, and every consequence points the same way:

- `is_species_restricted()` early-returns `True` for a semi-empirical method **before** it reads the multiplicity, so a radical ran restricted.
- The Gaussian adapter gates its optimization keywords on the type, so a **TS optimization emitted a bare `opt`** — no `ts`, no `calcfc`, no `noeigentest` — and searched for a minimum instead of a saddle point.
- `fine` silently dropped its `integral=(grid=ultrafine)` / `scf=(tight,direct)` block.
- A dispersion correction on such a level raised `ValueError`.
- Orca did not get its `KS` method class or DFT grid, and `deduce_software()` used the wrong ESS preference order.

Generated Gaussian route lines, same species and settings, before this PR:

```
b3lyp      #P opt=(calcfc,maxcycle=100,maxstep=5,tight)  guess=mix ub3lyp/def2tzvp  integral=(grid=ultrafine, Acc2E=12) ... scf=(direct,tight)
cam-b3lyp  #P opt  guess=mix cam-b3lyp/def2tzvp

b3lyp      #P opt=(calcfc,maxcycle=100,maxstep=5,noeigentest,tight,ts)  guess=mix b3lyp/def2tzvp  integral=(grid=ultrafine, Acc2E=12) ... scf=(direct,tight)   <- TS
cam-b3lyp  #P opt  guess=mix cam-b3lyp/def2tzvp                                                                                                              <- TS
```

and after:

```
cam-b3lyp  #P opt=(calcfc,maxcycle=100,maxstep=5,tight)  guess=mix ucam-b3lyp/def2tzvp  integral=(grid=ultrafine, Acc2E=12) ... scf=(direct,tight)
cam-b3lyp  #P opt=(calcfc,maxcycle=100,maxstep=5,noeigentest,tight,ts)  guess=mix cam-b3lyp/def2tzvp  integral=(grid=ultrafine, Acc2E=12) ... scf=(direct,tight)   <- TS
```

## The change

Two lines of it, for two independent problems.

`'am'` and `'pm'` are abbreviations of the methods they stand for, so they are spelled out: `am1`, `pm3`, `pm6`, `pm7`.

The wave function markers are the shortest and most promiscuous of the four sets (`cc`, `ci`, `ri`, `ic`, `mr`, `bd`, `cp`) and were matched **first**. Matching them last lets the longer, more specific force field and semi-empirical names win. That also repairs `amber` (typed semi-empirical, same `'am'`) and `ghemical` (typed as a wave function method, for the `'ic'` in `ghemICAl`).

**Matching on token boundaries instead was tried and rejected.** It looks like the principled fix and it re-types six registered methods that carry their marker mid-token: `BCCD`, `BCCD(T)`, `QCISD`, `QCISD(T)`, `FCI`, `LCCD`, `LCCSD`, `LT-DF-LCC2` all become `dft`, and `torchani` loses `force_field`. That would have been a worse bug than the one being fixed, and the sweep below is what caught it.

## Verification

The verifier is exhaustive rather than sampled: every one of the 180 methods registered in `data/ess_methods.yml` is typed before and after. The complete diff is the four intended corrections and nothing else:

```
amber      semiempirical  -> force_field
cam-b3lyp  semiempirical  -> dft
camb3lyp   semiempirical  -> dft
ghemical   wavefunction   -> force_field
```

`test_deduce_method_type` is new and covers one method per type, the common cases, the false positives being fixed (`cam-*`, `am05`), and the mid-token matches that must keep working (`bccd(t)`, `qcisd(t)`, `fci`, `lccsd`, `lt-df-lcc2`, `uccsd(t)-f12`, `rohf`). It fails on `main` and passes here. It also asserts that every registered method types as something, so a future marker edit is checked against the whole registry.

Full unit suite: `3295 passed, 12 skipped` (the skips are `uma_env` and `rmg_env` guards, unrelated).

## Note for #1014

Found while reviewing #1014, whose broken-symmetry adoption gate reads the same typing: before this PR a CAM functional reaches that gate as `REFERENCE_AGNOSTIC` and is denied a broken-symmetry reference it should be offered. That direction is conservative, it is not a defect in #1014, and this PR corrects it at the source. The two PRs touch disjoint files.
