### PR TITLE
Don't kill the whole run on a monoatomic composite species

### DIFF
--- a/arc/scheduler.py
+++ b/arc/scheduler.py
@@ -3430,8 +3430,16 @@ class Scheduler(object):
                 plotter.draw_structure(species=self.species_dict[label],
                                        project_directory=self.project_directory,
                                        method='draw_3d')
-            frequencies = parser.parse_frequencies(job.local_path_to_output_file, job.job_adapter)
-            freq_ok, _ = self.check_negative_freq(label=label, job=job, vibfreqs=frequencies)
+            if self.species_dict[label].is_monoatomic():
+                # A single atom has no vibrational modes (3N-6 = 0 at N = 1), so there are no
+                # frequencies in the log to parse and nothing for check_negative_freq() to judge.
+                # Without this guard parse_frequencies() raises ParserError, which escapes
+                # Scheduler.__init__ and takes down the entire run rather than one species.
+                # Monoatomics are already special-cased elsewhere in this file.
+                freq_ok = True
+            else:
+                frequencies = parser.parse_frequencies(job.local_path_to_output_file, job.job_adapter)
+                freq_ok, _ = self.check_negative_freq(label=label, job=job, vibfreqs=frequencies)
             if freq_ok:
                 # Update restart dictionary and save a restart file:
                 self.save_restart_dict()

--- a/arc/scheduler_test.py
+++ b/arc/scheduler_test.py
@@ -4151,5 +4151,61 @@ class TestGetServerJobIds(unittest.TestCase):
         borrow.assert_called_once_with('atlas')
 
 
+class TestParseCompositeGeoMonoatomic(unittest.TestCase):
+    """A monoatomic species has no frequencies to parse, and must not take the whole run down."""
+
+    @staticmethod
+    def _sched(is_monoatomic):
+        """A stand-in carrying only what the frequency branch of parse_composite_geo() reads."""
+        species = MagicMock()
+        species.is_monoatomic.return_value = is_monoatomic
+        species.is_ts = False
+        species.rxn_label = None
+        return SimpleNamespace(species_dict={'spc': species},
+                               output={'spc': {'job_types': {}, 'paths': {}, 'info': ''}},
+                               job_dict={'spc': {}},
+                               project_directory='',
+                               composite_method=None,
+                               job_types={'fine': False, 'orbitals': False, 'onedmin': False, 'rotors': False},
+                               save_restart_dict=MagicMock(),
+                               post_sp_actions=MagicMock(),
+                               check_negative_freq=MagicMock(return_value=(True, None)),
+                               )
+
+    def _run(self, is_monoatomic):
+        """Drive parse_composite_geo() over a converged composite job and return the parser mock."""
+        sched = self._sched(is_monoatomic)
+        job = MagicMock(is_ts=False, local_path_to_output_file='does_not_exist.log')
+        # The whole body is gated on this; without it nothing under test is reached at all.
+        job.job_status = [None, {'status': 'done'}]
+        with patch('arc.scheduler.parser') as parser_mock, \
+                patch('arc.scheduler.plotter'), \
+                patch('arc.scheduler.xyz_to_str', return_value=''):
+            parser_mock.parse_frequencies.return_value = [1000.0, 2000.0]
+            try:
+                Scheduler.parse_composite_geo(sched, label='spc', job=job)
+            except Exception:
+                # Downstream of the frequency branch this stand-in is deliberately thin; these
+                # tests assert only on whether the parser was consulted.
+                pass
+        return parser_mock
+
+    def test_monoatomic_does_not_parse_frequencies(self):
+        """[C] has 3N-6 = 0 modes, so parse_frequencies() must never be reached for it.
+
+        Before the guard it WAS reached, raised ParserError, and the exception escaped
+        Scheduler.__init__ -- killing the whole run rather than one species.
+        """
+        self._run(is_monoatomic=True).parse_frequencies.assert_not_called()
+
+    def test_polyatomic_still_parses_frequencies(self):
+        """Control: the guard must not silence the check for species that do have modes.
+
+        This is what proves the monoatomic assertion above means something -- without it, a
+        stand-in that never reaches the branch at all would pass that test for the wrong reason.
+        """
+        self._run(is_monoatomic=False).parse_frequencies.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))


### PR DESCRIPTION
## The bug

`parse_composite_geo()` calls `parser.parse_frequencies()` unconditionally once a composite job converges. A monoatomic species has **no vibrational modes** (3N−6 = 0 at N = 1), so there is nothing in the log to parse — the parser raises `ParserError`.

Because `parse_composite_geo()` is reached from `Scheduler.__init__` via `schedule_jobs()`, that exception escapes the constructor and **takes down the entire run**, every other species with it.

## How it showed up

A 24-species G4 batch died on `[C]`. Its own composite job had *succeeded* — the optimized geometry was printed — and the run then crashed at the frequency parse, after 6 species had finished:

```
Ending job composite_a3992 for carbon_atom (run time: 0:00:29)
Optimized geometry for carbon_atom at g4:
C       0.00000000    0.00000000    0.00000000
...
arc.exceptions.ParserError: Could not parse frequencies from .../carbon_atom/composite_a3992/input.log
  File "arc/scheduler.py", line 794, in schedule_jobs
    success = self.parse_composite_geo(label=label, job=job)
  File "arc/scheduler.py", line 2626, in parse_composite_geo
    frequencies = parser.parse_frequencies(...)
```

(Line numbers from the `future` branch where it was hit; on `main` the call is at 3398.)

## The fix

Monoatomics are **already** special-cased elsewhere in this same file — one such site's comment reads *"No need to run opt/freq jobs for a monoatomic species, only run sp (or composite if relevant)"*. This branch was simply the omission. For a monoatomic species, treat the frequency check as passed: there are no frequencies to judge, and `check_negative_freq()` has nothing to say about a species with no modes.

## Tests

Two cases driving `parse_composite_geo()` over a converged composite job with a thin stand-in.

The polyatomic case is a **deliberate control**, and it earned its place: the first draft of this test passed while never reaching the branch at all, because the stand-in's `job_status` never said `'done'` and the whole method body is gated on that. Without the control, the monoatomic assertion would have been satisfied for the wrong reason. I also verified the monoatomic test **fails** with the guard neutralised and passes with it restored, so it genuinely guards the defect rather than the implementation.

Run locally: `2 passed`. Note that the rest of `scheduler_test.py` cannot run on a machine with a populated `~/.arc/settings.py`, because `arc/imports.py` overlays it and the real `servers` dict replaces the fixture's `server1` (`KeyError: 'server1'` at `arc/job/adapter.py:439`). That is unrelated to this change, but it is why these tests use an unbound-call stand-in in the style of `TestGetServerJobIds` rather than the class fixture — they run either way.
