### PR TITLE
Write the Molpro command that exists for each open-shell method

### DIFF
--- a/arc/job/adapters/molpro.py
+++ b/arc/job/adapters/molpro.py
@@ -35,6 +35,15 @@ default_job_settings, global_ess_settings, input_filenames, output_filenames, se
     settings['default_job_settings'], settings['global_ess_settings'], settings['input_filenames'], \
     settings['output_filenames'], settings['servers'], settings['submit_filenames']
 
+MOLPRO_OPEN_SHELL_METHOD_NAMES = {'mp2': 'rmp2',
+                                  'df-mp2': 'df-rmp2',
+                                  'mp2-f12': 'rmp2-f12',
+                                  'df-mp2-f12': 'df-rmp2-f12',
+                                  'casscf': 'casscf',
+                                  }
+
+MOLPRO_SUFFIX_WITHOUT_AN_OPEN_SHELL_FORM = '-f12c'
+
 input_template = """***,${label}
 memory,Total=${memory},m;
 
@@ -52,7 +61,7 @@ int;
  wf,spin=${spin},charge=${charge};
 }
 
-${restricted}${method}
+${method}
 
 ${job_type_1}
 ${job_type_2}${block}
@@ -214,7 +223,6 @@ class MolproAdapter(JobAdapter):
                     'keywords',
                     'memory',
                     'method',
-                    'restricted',
                     ]:
             input_dict[key] = ''
         input_dict['auxiliary_basis'] = self.level.auxiliary_basis or ''
@@ -230,8 +238,10 @@ class MolproAdapter(JobAdapter):
         input_dict['xyz'] = xyz_to_str(self.xyz)
         input_dict['orbitals'] = '\ngprint,orbitals;\n'
 
-        if not is_restricted(self):
-            input_dict['restricted'] = 'u'
+        restricted = is_restricted(self)
+        multireference = 'mrci' in self.level.method or 'rs2' in self.level.method
+        if not restricted and not multireference:
+            input_dict['method'] = f'{get_open_shell_method(self.level.method)};'
 
         # Job type specific options
         if self.job_type in ['opt', 'optfreq', 'conf_opt']:
@@ -252,9 +262,8 @@ class MolproAdapter(JobAdapter):
         if 'IGNORE_ERROR in the ORBITAL directive' in self.args['trsh'].keys():
             keywords.append(' ORBITAL,IGNORE_ERROR;')
 
-        if 'mrci' in self.level.method or 'rs2' in self.level.method:
+        if multireference:
             active = self.species[0].active
-            input_dict['restricted'] = ''
             if '_' in self.level.method:
                 methods = self.level.method.split('_')
                 input_dict['method'] = ''
@@ -370,6 +379,33 @@ class MolproAdapter(JobAdapter):
         Execute a job to the server's queue.
         """
         self.legacy_queue_execution()
+
+
+def get_open_shell_method(method: str) -> str:
+    """
+    Get the Molpro command that computes ``method`` for an open-shell species on top of the
+    spin-restricted Hartree-Fock reference this adapter writes.
+
+    Args:
+        method (str): The method of the requested level of theory.
+
+    Returns:
+        str: The corresponding open-shell Molpro command.
+
+    Raises:
+        NotImplementedError: If Molpro has no open-shell implementation of ``method``.
+    """
+    method = method.lower()
+    if method.endswith(MOLPRO_SUFFIX_WITHOUT_AN_OPEN_SHELL_FORM):
+        raise NotImplementedError(f'Molpro does not implement {method} for open-shell species, its F12c '
+                                  f'(CCSD(F12*)) programs are closed-shell only. Either request {method} only '
+                                  f'for closed-shell species, or use {method[:-1]} instead.')
+    if method not in MOLPRO_OPEN_SHELL_METHOD_NAMES:
+        return f'u{method}'
+    open_shell_method = MOLPRO_OPEN_SHELL_METHOD_NAMES[method]
+    logger.warning(f'Molpro has no "u{method}" command. Writing "{open_shell_method}" instead, '
+                   f'which is the Molpro command for {method} with an open-shell reference.')
+    return open_shell_method
 
 
 register_job_adapter('molpro', MolproAdapter)

--- a/arc/job/adapters/molpro_test.py
+++ b/arc/job/adapters/molpro_test.py
@@ -7,6 +7,7 @@ This module contains unit tests of the arc.job.adapters.molpro module
 
 import os
 import shutil
+import tempfile
 import unittest
 
 from arc.common import ARC_TESTING_PATH
@@ -471,6 +472,137 @@ int;
         for attr in vars(cls).values():
             if isinstance(attr, MolproAdapter):
                 shutil.rmtree(attr.project_directory, ignore_errors=True)
+
+
+class TestMolproAdapterOpenShellMethodNames(unittest.TestCase):
+    """
+    Contains unit tests for the Molpro command name written for open-shell species.
+    """
+
+    OPEN_SHELL_XYZ = ['O       0.00000000    0.00000000    1.00000000']
+    CLOSED_SHELL_XYZ = ["""O       0.00000000    0.00000000    0.11779000
+H       0.00000000    0.75545000   -0.47116000
+H       0.00000000   -0.75545000   -0.47116000"""]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A method that is run before all unit tests in this class.
+        """
+        cls.maxDiff = None
+        cls.project_directory = tempfile.mkdtemp()
+        cls.addClassCleanup(shutil.rmtree, cls.project_directory, ignore_errors=True)
+
+    def render(self, method, basis='cc-pVTZ-f12', multiplicity=3):
+        """
+        Instantiate a Molpro job for a species of the given multiplicity and return its input file content.
+
+        Args:
+            method (str): The method of the level of theory.
+            basis (str, optional): The basis set of the level of theory.
+            multiplicity (int, optional): The spin multiplicity of the species.
+
+        Returns:
+            str: The content of the rendered Molpro input file.
+        """
+        job = MolproAdapter(execution_type='queue',
+                            job_type='sp',
+                            level=Level(method=method, basis=basis),
+                            project='test',
+                            project_directory=self.project_directory,
+                            species=[ARCSpecies(label='spc',
+                                                xyz=self.OPEN_SHELL_XYZ if multiplicity > 1 else self.CLOSED_SHELL_XYZ,
+                                                multiplicity=multiplicity)],
+                            testing=True,
+                            )
+        with open(os.path.join(job.local_path, input_filenames[job.job_adapter]), 'r') as f:
+            return f.read()
+
+    def test_open_shell_coupled_cluster_methods_get_the_u_prefix(self):
+        """Test that open-shell coupled cluster methods are written with Molpro's u prefix"""
+        for method, command in [('CCSD(T)-F12', 'uccsd(t)-f12'),
+                                ('CCSD-F12', 'uccsd-f12'),
+                                ('DCSD-F12', 'udcsd-f12'),
+                                ('CCSD(T)', 'uccsd(t)'),
+                                ]:
+            content = self.render(method=method)
+            self.assertIn(f'\n{command};\n', content)
+
+    def test_open_shell_mp2_is_written_as_rmp2(self):
+        """Test that open-shell MP2 is written as Molpro's RMP2 command, which uses the RHF reference"""
+        with self.assertLogs('arc', level='WARNING') as cm:
+            content = self.render(method='MP2', basis='cc-pVTZ')
+        self.assertIn('\nrmp2;\n', content)
+        self.assertNotIn('ump2', content)
+        substitutions = [record for record in cm.output if 'Molpro has no' in record]
+        self.assertEqual(len(substitutions), 1)
+        self.assertIn('ump2', substitutions[0])
+        self.assertIn('rmp2', substitutions[0])
+
+    def test_open_shell_mp2_f12_is_written_as_rmp2_f12(self):
+        """Test that open-shell MP2-F12 is written as Molpro's RMP2-F12 command"""
+        with self.assertLogs('arc', level='WARNING') as cm:
+            content = self.render(method='MP2-F12')
+        self.assertIn('\nrmp2-f12;\n', content)
+        self.assertNotIn('ump2-f12', content)
+        substitutions = [record for record in cm.output if 'Molpro has no' in record]
+        self.assertEqual(len(substitutions), 1)
+        self.assertIn('ump2-f12', substitutions[0])
+        self.assertIn('rmp2-f12', substitutions[0])
+
+    def test_open_shell_df_mp2_f12_is_written_as_df_rmp2_f12(self):
+        """Test that open-shell DF-MP2-F12 is written as Molpro's DF-RMP2-F12 command"""
+        with self.assertLogs('arc', level='WARNING') as cm:
+            content = self.render(method='DF-MP2-F12')
+        self.assertIn('\ndf-rmp2-f12;\n', content)
+        self.assertNotIn('udf-mp2-f12', content)
+        substitutions = [record for record in cm.output if 'Molpro has no' in record]
+        self.assertEqual(len(substitutions), 1)
+        self.assertIn('udf-mp2-f12', substitutions[0])
+        self.assertIn('df-rmp2-f12', substitutions[0])
+
+    def test_open_shell_casscf_is_written_without_a_prefix(self):
+        """Test that open-shell CASSCF is written as Molpro's CASSCF command"""
+        with self.assertLogs('arc', level='WARNING') as cm:
+            content = self.render(method='CASSCF', basis='aug-cc-pVTZ')
+        self.assertIn('\ncasscf;\n', content)
+        self.assertNotIn('ucasscf', content)
+        substitutions = [record for record in cm.output if 'Molpro has no' in record]
+        self.assertEqual(len(substitutions), 1)
+        self.assertIn('ucasscf', substitutions[0])
+
+    def test_open_shell_f12c_methods_are_refused(self):
+        """Test that methods Molpro has no open-shell implementation of raise NotImplementedError"""
+        for method in ['CCSD(T)-F12c', 'CCSD-F12c', 'DF-CCSD(T)-F12c', 'MP2-F12c']:
+            with self.assertRaises(NotImplementedError):
+                self.render(method=method)
+
+    def test_unrecognized_open_shell_methods_keep_the_u_prefix(self):
+        """Test that a method with no entry in the open-shell table keeps the u prefix"""
+        content = self.render(method='DCSD', basis='cc-pVTZ')
+        self.assertIn('\nudcsd;\n', content)
+
+    def test_closed_shell_methods_are_not_modified(self):
+        """Test that the method of a closed-shell species is written as requested"""
+        for method in ['CCSD(T)-F12', 'MP2', 'MP2-F12', 'DF-MP2-F12', 'CASSCF', 'CCSD(T)-F12c', 'CCSD-F12c', 'DCSD']:
+            content = self.render(method=method, multiplicity=1)
+            self.assertIn(f'\n{method.lower()};\n', content)
+
+    def test_multireference_methods_are_not_prefixed(self):
+        """Test that the multireference branch is unaffected by the open-shell method decision"""
+        content = self.render(method='MRCI-F12', basis='aug-cc-pVTZ-F12')
+        self.assertIn('{mrci-f12;\n', content)
+        self.assertNotIn('umrci', content)
+
+        content = self.render(method='MP2_CASSCF_RS2C', basis='aug-cc-pVTZ')
+        self.assertIn('{mp2;\n', content)
+        self.assertIn('{rs2c;\n', content)
+        self.assertNotIn('ump2', content)
+
+    def test_multireference_methods_do_not_reach_the_open_shell_table(self):
+        """Test that a multireference method is neither substituted nor refused by the open-shell table"""
+        content = self.render(method='MRCI-F12c', basis='aug-cc-pVTZ-F12')
+        self.assertIn('{mrci-f12;\n', content)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## The defect

`arc/job/adapters/molpro.py` prefixed `u` to the method for any unrestricted species, unconditionally:

```python
if not is_restricted(self):
    input_dict['restricted'] = 'u'
```

`u<method>` is a Molpro command for some methods and not for others, so ARC could write an input Molpro has no command for.

## What changes

A per-method table decides the open-shell command, with a suffix rule for the methods Molpro does not implement open-shell at all.

| requested method | ARC wrote | ARC now writes | basis |
| --- | --- | --- | --- |
| `ccsd-f12`, `ccsd(t)-f12`, `dcsd` | `uccsd(t)-f12` | unchanged | "Open-shell unrestricted UCCSD-F12 approximations ... Restricted open-shell Hartree-Fock (RHF) orbitals are used" |
| `mp2`, `df-mp2`, `mp2-f12`, `df-mp2-f12` | `ump2-f12` | `rmp2-f12` | no `UMP2-F12` command exists; "all methods except `ump2` use spin-restricted Hartree-Fock (RHF) reference functions" |
| anything ending `-f12c` | `uccsd(t)-f12c` | `NotImplementedError` | "Currently CCSD-F12c is not available for open-shell cases" |
| `casscf` | `ucasscf` | `casscf` | "The program is invoked by the command MULTI, MCSCF, CASSCF, or CASCI"; no `UCASSCF` exists |
| anything else | `u<method>` | `u<method>` | see below |

A rewrite is logged at warning level naming both forms, since it changes the command from the one the user wrote. The substitution is the same theory: `RMP2-F12` is open-shell MP2-F12, and the mapping is density-fitting consistent on both rows.

Unrecognised methods keep the `u` prefix deliberately rather than by omission. It is correct for the whole coupled-cluster and configuration-interaction family, and defaulting to no prefix would silently select Molpro's **closed-shell** program — a worse failure than an invalid command.

The refusal keys on the `-f12c` suffix rather than two exact names, so `df-ccsd(t)-f12c` and `mp2-f12c` are covered too. It raises `NotImplementedError` from job construction, matching the existing precedent for Molpro plus IRC in `check_argument_consistency`.

The multireference path is unaffected: `mrci`/`rs2` already clears the prefix and builds its own command. A test fails if that guard is removed.

## Not a change: the `u` prefix on coupled cluster is correct

Worth stating, because it looks like the same class of problem and is not. Molpro's `HF`/`RHF` is the spin-restricted program, and ARC's template hardcodes `{hf; ... wf,spin=N,charge=C;}`, so ARC never requests UHF orbitals. The `u` selects the open-shell correlation ansatz on an RHF reference, giving `RHF-UCCSD(T)-F12`, which the manual requires for open-shell F12. ARC's own checked-in output confirms it: `arc/testing/sp/TS_x118_sp_CCSD(T).out` pairs `wf,spin=2` with `uccsd(t)-f12;` and reports `!RHF-UCCSD(T)-F12a energy`. ARC's default single point, `ccsd(t)-f12/cc-pvtz-f12`, was correct before this change and is unchanged by it.

## Tests

`arc/job/adapters/molpro_test.py` gains coverage of each class above for an open-shell species, the closed-shell counterpart in every case, the multireference path, and an unrecognised method. Assertions are on the rendered Molpro input where the method name appears.

Five of the new tests fail against the previous unconditional prefix.

- `molpro_test.py`, `level_test.py`, `common_test.py`: 88 passed
- `arc/job/` and `arc/parser/`: 1516 passed, 36 skipped (5 pre-existing `torch_ani_test.py` failures, reproduced with this change reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MndwJm4BEs4DN3vJQsEwD3


