### PR TITLE
Stop the rotor bond graph from inventing rings around branched centres

### DIFF
--- a/arc/job/adapters/ase_test.py
+++ b/arc/job/adapters/ase_test.py
@@ -269,6 +269,34 @@ class TestASEAdapter(unittest.TestCase):
         with self.assertRaises(ValueError):
             rotor_top(ts_like, 0, 1, pivot_mult=1.0)
 
+    def test_rotor_top_does_not_invent_a_ring_from_1_3_neighbours(self):
+        """A branched centre must not fuse its own substituents into a ring.
+
+        1,1-dimethylhydrazine at its UMA geometry: three heavy atoms hang off the central N, and
+        their mutual 1-3 distances are 2.33-2.38 A against covalent-radii sums of 1.47-1.52. ASE's
+        default 0.3 A per-atom `skin` adds 0.6 A to the pair cutoff on top of `mult`, which was
+        just enough to call every one of those pairs a bond -- fusing C-N-C into a triangle and
+        rejecting EVERY rotor in the molecule as "part of a ring". Ethane above cannot catch this;
+        it has no branched centre and so no 1-3 heavy-atom pair at all.
+        """
+        dimethylhydrazine = Atoms(symbols=('C', 'N', 'C', 'N', 'H', 'H', 'H', 'H', 'H', 'H', 'H', 'H'),
+                                  positions=((-1.118847, -0.669646, -0.028393),
+                                             (-0.009246, 0.167280, -0.447017),
+                                             (1.247329, -0.422511, -0.022045),
+                                             (-0.142324, 1.426467, 0.275443),
+                                             (-1.185280, -0.789891, 1.055869),
+                                             (-2.055637, -0.216790, -0.352617),
+                                             (-1.038689, -1.652379, -0.494636),
+                                             (1.377564, -1.399658, -0.494636),
+                                             (2.086537, 0.213596, -0.334188),
+                                             (1.293624, -0.549481, 1.069229),
+                                             (0.602477, 2.019935, -0.081734),
+                                             (-0.994088, 1.851965, -0.082191)))
+        # the C-N pivot: the rotating top is that methyl, and nothing else
+        self.assertEqual(rotor_top(dimethylhydrazine, 1, 0), [0, 4, 5, 6])
+        # and the N-N pivot, the one the whole probe exists to scan
+        self.assertEqual(rotor_top(dimethylhydrazine, 1, 3), [3, 10, 11])
+
     def test_relaxed_torsion_scan(self):
         """Test a full 1D relaxed torsional scan on the machinery (EMT keeps it hermetic)"""
         atoms = Atoms(symbols=ETHANE_XYZ['symbols'], positions=ETHANE_XYZ['coords'])

--- a/arc/job/adapters/scripts/ase_script.py
+++ b/arc/job/adapters/scripts/ase_script.py
@@ -170,8 +170,16 @@ def rotor_top(atoms: Atoms, pivot_1: int, pivot_2: int, mult: float = 1.2,
     Returns:
         list: The sorted 0-indexed atoms of the rotating group.
     """
+    # skin=0.0 is load-bearing, not tidying. ASE's default skin is 0.3 Angstrom PER ATOM, a
+    # rebuild buffer that is nonetheless added to the neighbour test, so a pair counts as bonded
+    # at d < mult * sum_r + 0.6 rather than the d < mult * sum_r this function reasons in and the
+    # pivot check below applies literally. On 1,1-dimethylhydrazine that 0.6 was the difference
+    # between a correct graph and one where every 1-3 pair around the central N (C-C at 2.38 A,
+    # C-N at 2.33 A) became a bond: the three heavy neighbours fused into a spurious ring and
+    # every rotor in the molecule was rejected as "part of a ring". Real bonds here sit at
+    # d/sum_r <= 1.03 against a 1.2 threshold, so the tolerance was never the tight part.
     nl = build_neighbor_list(atoms, natural_cutoffs(atoms, mult=mult),
-                             self_interaction=False, bothways=True)
+                             self_interaction=False, bothways=True, skin=0.0)
     adj = {i: set(nl.get_neighbors(i)[0]) for i in range(len(atoms))}
     if pivot_2 not in adj[pivot_1]:
         numbers = atoms.get_atomic_numbers()


### PR DESCRIPTION
## What

`rotor_top()` in `arc/job/adapters/scripts/ase_script.py` builds its bond graph with
`build_neighbor_list(...)` and never sets `skin`, so it inherits ASE's default of **0.3 Å per
atom**. That buffer enters the neighbour test itself, making a pair "bonded" at

```
d < mult * sum_of_covalent_radii + 0.6
```

instead of the `d < mult * sum_r` the function reasons in throughout — and which the
pivot-distance check ten lines below applies literally. One decision, two cutoffs.

One line changes: `skin=0.0`.

## Why it matters

0.6 Å is enough to promote **1-3 pairs** to bonds. On 1,1-dimethylhydrazine (`CN(C)N`) at its
optimized geometry the three heavy atoms around the central nitrogen sit 2.33–2.38 Å apart
against covalent-radii sums of 1.47–1.52:

| pair | d (Å) | Σr (Å) | d/Σr |
|---|---|---|---|
| C0–N1 (real bond) | 1.452 | 1.470 | 0.99 |
| N1–N3 (real bond) | 1.458 | 1.420 | 1.03 |
| C0–C2 (1-3) | 2.379 | 1.520 | 1.57 |
| C0–N3 (1-3) | 2.332 | 1.470 | 1.59 |

With the default skin all three 1-3 pairs become bonds, C–N–C closes into a triangle, and every
rotor in the molecule is rejected:

```
Torsion scan failed: The pivot bond 0-1 is part of a ring; a 1D rotor scan is ill-defined.
```

The molecule is acyclic. **The message is true about the graph and false about the chemistry**,
which is the part worth guarding against: it is a chemically plausible sentence, so the natural
response on any other species is to drop that rotor and carry on — silently losing the torsional
contribution rather than failing. Any branched heavy atom is exposed, which is most of a real
corpus.

Real bonds here are at d/Σr ≤ 1.03 against the 1.2 threshold, so the tolerance was never the tight
part. `pivot_mult`, the stretched-TS allowance, is untouched.

## Testing

`arc/job/adapters/ase_test.py` — 18 passed.

The existing `test_rotor_top` **cannot** catch this class: ethane has no branched centre, so it has
no heavy-atom 1-3 pair anywhere in the fixture. Added
`test_rotor_top_does_not_invent_a_ring_from_1_3_neighbours` on the real geometry, which fails
without the change.

## Notes

Found by running a queued UMA rotor scan on a cluster, where all three rotors of the probe molecule
came back rejected. Orthogonal to #985 (the ASE queue-submission path) — that PR touches
`ase_script.py` only in `apply_constraints`, and leaves this line as it is on `main`.