### PR TITLE
Fix bi-rad singlet composite jobs silently running a restricted reference

### DIFF
--- a/arc/job/adapters/common.py
+++ b/arc/job/adapters/common.py
@@ -660,21 +660,28 @@ def is_species_restricted(obj: JobAdapter,
         bool: Whether to run as restricted (``True``) or not (``False``).
     """
 
-    if obj.level.method_type in REFERENCE_AGNOSTIC_METHOD_TYPES:
-        return True
-
     multiplicity = obj.multiplicity if species is None else species.multiplicity
     species_obj = obj.species[0] if species is None else species
     number_of_radicals = species_obj.number_of_radicals
     species_label = species_obj.label
-    if multiplicity > 1 or (number_of_radicals is not None and number_of_radicals > 1):
-        # run an unrestricted electronic structure calculation if the spin multiplicity is greater than one,
-        # or if it is one but the number of radicals is greater than one (e.g., bi-rad singlet)
-        # don't run unrestricted for composite methods such as CBS-QB3, it'll be done automatically if the
-        # multiplicity is greater than one, but do specify uCBS-QB3 for example for bi-rad singlets.
-        if number_of_radicals is not None and number_of_radicals > 1:
-            logger.info(f'Using an unrestricted method for species {species_label} which has '
-                        f'{number_of_radicals} radicals and multiplicity {multiplicity}.')
+
+    if number_of_radicals is not None and number_of_radicals > 1:
+        # A declared number_of_radicals > 1 with multiplicity 1 (e.g., a bi-rad singlet) always
+        # needs an unrestricted reference, *even for a reference-agnostic method type* such as a
+        # composite method (e.g., CBS-QB3, G4): for those, an unrestricted reference is applied
+        # automatically when the multiplicity is greater than one, but a bi-rad singlet's
+        # multiplicity of one gives the method no such signal, so ARC must still specify it
+        # explicitly (e.g., uCBS-QB3, uG4). This check must therefore run before the
+        # REFERENCE_AGNOSTIC_METHOD_TYPES early return below, not after it.
+        logger.info(f'Using an unrestricted method for species {species_label} which has '
+                    f'{number_of_radicals} radicals and multiplicity {multiplicity}.')
+        return False
+
+    if obj.level.method_type in REFERENCE_AGNOSTIC_METHOD_TYPES:
+        return True
+
+    if multiplicity > 1:
+        # run an unrestricted electronic structure calculation if the spin multiplicity is greater than one
         return False
     if adopted_reference_is_unrestricted(species_obj):
         if not level_admits_a_broken_symmetry_reference(obj.level):

--- a/arc/job/adapters/common_test.py
+++ b/arc/job/adapters/common_test.py
@@ -5,6 +5,8 @@
 This module contains unit tests of the arc.job.adapters.common module
 """
 
+import glob
+import os
 import shutil
 import tempfile
 import unittest
@@ -184,6 +186,50 @@ H      0.00000000   -0.76336400   -0.47261500"""
         job.species[0].derived_stability_verdict = {'verdict': 'external_instability', 'restricted': True}
         self.assertEqual(job.level.method_type, 'composite')
         self.assertTrue(common.is_species_restricted(job))
+
+    def test_a_bi_rad_singlet_composite_job_is_unrestricted(self):
+        """Test that a declared bi-rad singlet (multiplicity 1, number_of_radicals 2) is run
+        unrestricted even for a composite method, whose reference-agnostic early return would
+        otherwise make it restricted (the u prefix, e.g. uCBS-QB3/uG4, must still be specified)"""
+        for method in ['cbs-qb3', 'g4']:
+            job = self._singlet_job(method=method, number_of_radicals=2)
+            self.assertEqual(job.level.method_type, 'composite')
+            self.assertFalse(common.is_species_restricted(job),
+                             msg=f'a bi-rad singlet at {method} was not run unrestricted')
+
+    def test_a_closed_shell_singlet_composite_job_stays_restricted(self):
+        """Test that an ordinary closed-shell singlet composite job is unaffected by the fix"""
+        job = self._singlet_job(method='cbs-qb3', number_of_radicals=None)
+        self.assertEqual(job.level.method_type, 'composite')
+        self.assertTrue(common.is_species_restricted(job))
+
+    def test_a_composite_job_above_singlet_multiplicity_is_unchanged(self):
+        """Test that a composite job at multiplicity > 1 keeps returning restricted, as it did
+        before the fix: the method itself is expected to go unrestricted automatically"""
+        job = self._singlet_job(method='cbs-qb3', multiplicity=3, number_of_radicals=None)
+        self.assertEqual(job.level.method_type, 'composite')
+        self.assertTrue(common.is_species_restricted(job))
+
+    def test_a_bi_rad_singlet_composite_job_writes_the_u_prefix_in_the_route_section(self):
+        """End-to-end: a bi-rad singlet composite job's generated Gaussian input carries the u prefix"""
+        species = ARCSpecies(label='O2_a1Dg', xyz=['O 0 0 0', 'O 0 0 1.2'], multiplicity=1, number_of_radicals=2)
+        project_directory = tempfile.mkdtemp(prefix='arc_test_common_')
+        self.addCleanup(shutil.rmtree, project_directory, ignore_errors=True)
+        job = GaussianAdapter(execution_type='incore',
+                              job_type='composite',
+                              level=Level(method='g4'),
+                              project='test',
+                              project_directory=project_directory,
+                              species=[species],
+                              testing=True,
+                              )
+        job.write_input_file()
+        input_files = glob.glob(os.path.join(project_directory, '**', 'input.gjf'), recursive=True)
+        self.assertEqual(len(input_files), 1)
+        with open(input_files[0], 'r') as f:
+            content = f.read()
+        self.assertIn('ug4', content)
+        self.assertNotIn(' g4', content)
 
     def test_a_correlated_single_point_is_not_flipped_by_an_adopted_verdict(self):
         """Test that an adopted verdict decides no reference for a correlated wavefunction level"""


### PR DESCRIPTION
## What

`is_species_restricted()` returned early for `REFERENCE_AGNOSTIC_METHOD_TYPES` (composite,
force-field, semiempirical) **before** reading `number_of_radicals`, so the bi-rad-singlet branch
below it was unreachable for exactly those method types. Move the `number_of_radicals > 1` check
ahead of that early return.

## Why

An open-shell singlet biradical is declared in ARC as an `ARCSpecies` with `multiplicity=1` and
`number_of_radicals=2` — that is what the `ARCSpecies` docstring prescribes, and it is the only way
to express the state. The existing code already knew what to do with it; its own comment says so:

```python
# don't run unrestricted for composite methods such as CBS-QB3, it'll be done automatically if the
# multiplicity is greater than one, but do specify uCBS-QB3 for example for bi-rad singlets.
```

That comment describes a case the function could never reach. Composite methods take
`method_type == 'composite'`, so `G4`/`CBS-QB3` returned `True` (restricted) at the top, and the
branch the comment documents never ran. A declared bi-rad singlet therefore went out as plain `g4`
with a **restricted** reference — no `u` prefix — and converged to the wrong electronic state
without warning. Nothing errors; the thermochemistry is simply wrong.

The asymmetry is the whole point: for a composite method an unrestricted reference is applied
automatically when multiplicity > 1, but a bi-rad singlet's multiplicity **is** 1, so the method
gets no signal and ARC has to say `uG4` explicitly.

## What changed

`arc/job/adapters/common.py` — `number_of_radicals > 1` is now evaluated first and returns
unrestricted, then the reference-agnostic early return, then the `multiplicity > 1` case. The
existing `# don't run unrestricted for composite methods...` comment is replaced by one that
explains why the order matters, so the next reader does not "simplify" it back.

Unaffected: plain closed-shell singlets (`number_of_radicals` unset or 1) and composite jobs at
multiplicity > 1 both take exactly the paths they did before.

## Testing

`arc/job/adapters/common_test.py` — 61 passed, with new cases covering a composite bi-rad singlet
(unrestricted), a composite closed-shell singlet (restricted), and a composite triplet (unchanged).

Verified end to end on the route section: a `g4` job for a species with `multiplicity: 1,
number_of_radicals: 2` now writes `ug4`.